### PR TITLE
Don't truncate first user message

### DIFF
--- a/claude_code_log/templates/components/session_nav.html
+++ b/claude_code_log/templates/components/session_nav.html
@@ -28,7 +28,7 @@
             </div>
             {% if session.first_user_message %}
             <pre class='session-preview' style='font-size: 0.75em; line-height: 1.3; padding-bottom: 0;'>
-                {{- session.first_user_message[:500]|e -}}{% if session.first_user_message|length > 500 %}...{% endif %}
+                {{- session.first_user_message|e -}}
             </pre>
             {% endif %}
         </a>


### PR DESCRIPTION
I want to copy out my initial prompts and to do that it would be more convenient to have them all here, not truncated.  They're not that long.

Signed-off-by: Edward Yang <ezyang@meta.com>
