### PR TITLE
Add `packaging` to main dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "anthropic>=0.56.0",
     "toml>=0.10.2",
     "textual>=4.0.0",
+    "packaging>=25.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Recent changes to `cache.py` introduced a dependency on the `packaging` package. It is in the `uv.lock` because it is depended on by `pytest`, but if the user does not install the dev dependencies then it does not get installed. The README-recommended `uvx` run command thus results in an import error.