### PR TITLE
Fix timezone-dependent test failures in template data tests

### DIFF
--- a/test/test_template_data.py
+++ b/test/test_template_data.py
@@ -2,6 +2,7 @@
 """Tests for template data structures and generation using existing test data."""
 
 import pytest
+import re
 from pathlib import Path
 from claude_code_log.parser import load_transcript, load_directory_transcripts
 from claude_code_log.renderer import (
@@ -70,7 +71,8 @@ class TestTemplateProject:
         assert project.jsonl_count == 3
         assert project.message_count == 15
         assert project.display_name == "test-project"
-        assert project.formatted_date == "2023-11-14 22:13:20"
+        # Check date format: "2023-11-1[45] HH:MM:SS" where day (14-15) and hour can vary by timezone
+        assert re.match(r"2023-11-1[45] \d{2}:\d{2}:20", project.formatted_date)
 
     def test_template_project_dash_formatting(self):
         """Test TemplateProject display name formatting for dashed names."""
@@ -86,7 +88,8 @@ class TestTemplateProject:
 
         assert project.name == "-user-workspace-my-app"
         assert project.display_name == "user/workspace/my/app"
-        assert project.formatted_date == "2023-11-14 22:15:00"
+        # Check date format: "2023-11-1[45] HH:15:00" where day (14-15) and hour can vary by timezone
+        assert re.match(r"2023-11-1[45] \d{2}:15:00", project.formatted_date)
 
     def test_template_project_no_leading_dash(self):
         """Test TemplateProject display name when no leading dash."""


### PR DESCRIPTION
Hello there,

I wanted to contribute support for the new `/context` system command.

Along the way, I first had to fix tests that failed for me at the current state (this PR):

---

- Replace hardcoded date/time assertions with regex patterns
- Allow day component to vary (14-15) for timezone differences up to UTC+14
- Allow hour component to vary while keeping minute/second validation
- Tests now pass regardless of local timezone settings

🤖 Generated with [Claude Code](https://claude.ai/code)

---

I then added the support for rendering `/context` output (`dev/context-system-command`), but then also noticed that simple bash command output was not rendered either, so I added that as well (`dev/user-command`), then did some refactoring and polish of these two features ([dev/refact-renderer](https://github.com/cboos/claude-code-log/tree/dev/refact-renderer)).

Nothing big (especially given the fact that Claude Code did most of the work, of course ;-) ), but before submitting the above, I prefer to ask first if this would be welcomed, and if yes, in which form: simplest would be 1 PR for the last one, but sometimes people prefer multiple smaller PRs.