### PR TITLE
feat: migrate cache from JSON to SQLite (#46)

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -2,13 +2,144 @@
 """Cache management for Claude Code Log to improve performance."""
 
 import json
+import shutil
+import sqlite3
+import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, ClassVar, Dict, List, Optional, cast
 from datetime import datetime
 from pydantic import BaseModel
 from packaging import version
 
 from .models import TranscriptEntry
+
+
+# =============================================================================
+# Exception Classes
+# =============================================================================
+
+
+class CacheError(Exception):
+    """Base exception for cache operations."""
+
+    pass
+
+
+class CacheDatabaseError(CacheError):
+    """SQLite database error."""
+
+    pass
+
+
+class CacheMigrationError(CacheError):
+    """Error during JSON to SQLite migration."""
+
+    pass
+
+
+# =============================================================================
+# SQLite Schema
+# =============================================================================
+
+SQLITE_SCHEMA = """
+-- Schema versioning
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    migrated_at TEXT NOT NULL,
+    library_version TEXT NOT NULL
+);
+
+-- Projects (replaces ProjectCache)
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_path TEXT UNIQUE NOT NULL,
+    library_version TEXT NOT NULL,
+    cache_created TEXT NOT NULL,
+    last_updated TEXT NOT NULL,
+    total_message_count INTEGER DEFAULT 0,
+    total_input_tokens INTEGER DEFAULT 0,
+    total_output_tokens INTEGER DEFAULT 0,
+    total_cache_creation_tokens INTEGER DEFAULT 0,
+    total_cache_read_tokens INTEGER DEFAULT 0,
+    earliest_timestamp TEXT DEFAULT '',
+    latest_timestamp TEXT DEFAULT ''
+);
+
+-- Working directories
+CREATE TABLE IF NOT EXISTS working_directories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    directory_path TEXT NOT NULL,
+    UNIQUE(project_id, directory_path)
+);
+
+-- Cached files (replaces CachedFileInfo)
+CREATE TABLE IF NOT EXISTS cached_files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    file_name TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    source_mtime REAL NOT NULL,
+    cached_mtime REAL NOT NULL,
+    message_count INTEGER NOT NULL,
+    UNIQUE(project_id, file_name)
+);
+
+-- Session IDs per file
+CREATE TABLE IF NOT EXISTS file_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cached_file_id INTEGER NOT NULL REFERENCES cached_files(id) ON DELETE CASCADE,
+    session_id TEXT NOT NULL,
+    UNIQUE(cached_file_id, session_id)
+);
+
+-- Sessions (replaces SessionCacheData)
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    session_id TEXT NOT NULL,
+    summary TEXT,
+    first_timestamp TEXT NOT NULL,
+    last_timestamp TEXT NOT NULL,
+    message_count INTEGER NOT NULL,
+    first_user_message TEXT DEFAULT '',
+    cwd TEXT,
+    total_input_tokens INTEGER DEFAULT 0,
+    total_output_tokens INTEGER DEFAULT 0,
+    total_cache_creation_tokens INTEGER DEFAULT 0,
+    total_cache_read_tokens INTEGER DEFAULT 0,
+    UNIQUE(project_id, session_id)
+);
+
+-- Cached entries (JSON blobs keyed by timestamp)
+CREATE TABLE IF NOT EXISTS cached_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cached_file_id INTEGER NOT NULL REFERENCES cached_files(id) ON DELETE CASCADE,
+    timestamp_key TEXT NOT NULL,
+    entries_json TEXT NOT NULL
+);
+
+-- Future: tags table placeholder
+CREATE TABLE IF NOT EXISTS tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    tag_name TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    notes TEXT,
+    UNIQUE(session_id, tag_name)
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_cached_entries_file ON cached_entries(cached_file_id);
+CREATE INDEX IF NOT EXISTS idx_cached_entries_timestamp ON cached_entries(timestamp_key);
+CREATE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
+CREATE INDEX IF NOT EXISTS idx_cached_files_project ON cached_files(project_id);
+CREATE INDEX IF NOT EXISTS idx_working_directories_project ON working_directories(project_id);
+"""
+
+# Current schema version - increment when making breaking schema changes
+CURRENT_SCHEMA_VERSION = 1
 
 
 class CachedFileInfo(BaseModel):
@@ -67,7 +198,13 @@ class ProjectCache(BaseModel):
 
 
 class CacheManager:
-    """Manages cache operations for a project directory."""
+    """Manages cache operations for a project directory using SQLite."""
+
+    # Class-level database configuration
+    _db_path: ClassVar[Path] = Path.home() / ".claude" / "cache.db"
+    _local: ClassVar[threading.local] = threading.local()
+    _db_initialized: ClassVar[bool] = False
+    _init_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, project_path: Path, library_version: str):
         """Initialize cache manager for a project.
@@ -78,97 +215,336 @@ class CacheManager:
         """
         self.project_path = project_path
         self.library_version = library_version
+        self._project_id: Optional[int] = None
+
+        # Legacy paths for JSON cache migration
         self.cache_dir = project_path / "cache"
         self.index_file = self.cache_dir / "index.json"
 
-        # Ensure cache directory exists
-        self.cache_dir.mkdir(exist_ok=True)
+        # Ensure database exists and schema is current
+        self._ensure_database()
 
-        # Load existing cache index if available
-        self._project_cache: Optional[ProjectCache] = None
-        self._load_project_cache()
+        # Migrate JSON cache if it exists
+        self._migrate_json_cache_if_needed()
 
-    def _load_project_cache(self) -> None:
-        """Load the project cache index from disk."""
-        if self.index_file.exists():
+        # Load or create project record
+        self._ensure_project_record()
+
+    @classmethod
+    def set_db_path(cls, path: Path) -> None:
+        """Set custom database path (useful for testing)."""
+        cls._db_path = path
+        cls._db_initialized = False
+
+    @property
+    def _connection(self) -> sqlite3.Connection:
+        """Get thread-local database connection."""
+        if not hasattr(self._local, "connection") or self._local.connection is None:
+            self._local.connection = sqlite3.connect(
+                str(self._db_path),
+                check_same_thread=False,
+                timeout=30.0,
+            )
+            self._local.connection.row_factory = sqlite3.Row
+            # Enable foreign keys and WAL mode for better concurrency
+            self._local.connection.execute("PRAGMA foreign_keys = ON")
+            self._local.connection.execute("PRAGMA journal_mode = WAL")
+        return self._local.connection
+
+    @classmethod
+    def close_all_connections(cls) -> None:
+        """Close all thread-local connections (for cleanup)."""
+        if hasattr(cls._local, "connection") and cls._local.connection is not None:
+            cls._local.connection.close()
+            cls._local.connection = None
+
+    def _ensure_database(self) -> None:
+        """Ensure database exists and schema is current."""
+        with self._init_lock:
+            if CacheManager._db_initialized:
+                return
+
+            # Ensure parent directory exists
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
             try:
-                with open(self.index_file, "r", encoding="utf-8") as f:
-                    cache_data = json.load(f)
-                self._project_cache = ProjectCache.model_validate(cache_data)
+                # Create schema
+                self._connection.executescript(SQLITE_SCHEMA)
 
-                # Check if cache version is compatible with current library version
-                if not self._is_cache_version_compatible(self._project_cache.version):
+                # Check/update schema version
+                cursor = self._connection.execute(
+                    "SELECT MAX(version) FROM schema_version"
+                )
+                row = cursor.fetchone()
+                current_version = row[0] if row and row[0] else 0
+
+                if current_version < CURRENT_SCHEMA_VERSION:
+                    # Record new schema version
+                    self._connection.execute(
+                        """
+                        INSERT OR REPLACE INTO schema_version (version, migrated_at, library_version)
+                        VALUES (?, ?, ?)
+                        """,
+                        (
+                            CURRENT_SCHEMA_VERSION,
+                            datetime.now().isoformat(),
+                            self.library_version,
+                        ),
+                    )
+                    self._connection.commit()
+
+                CacheManager._db_initialized = True
+            except sqlite3.Error as e:
+                raise CacheDatabaseError(f"Failed to initialize database: {e}") from e
+
+    def _ensure_project_record(self) -> None:
+        """Ensure project record exists in database and cache project_id."""
+        project_path_str = str(self.project_path)
+
+        try:
+            # Try to get existing project
+            cursor = self._connection.execute(
+                "SELECT id, library_version FROM projects WHERE project_path = ?",
+                (project_path_str,),
+            )
+            row = cursor.fetchone()
+
+            if row:
+                self._project_id = row["id"]
+                cached_version = row["library_version"]
+
+                # Check version compatibility
+                if not self._is_cache_version_compatible(cached_version):
                     print(
-                        f"Cache version incompatible: {self._project_cache.version} -> {self.library_version}, invalidating cache"
+                        f"Cache version incompatible: {cached_version} -> {self.library_version}, invalidating cache"
                     )
                     self.clear_cache()
-                    self._project_cache = None
-            except Exception as e:
-                print(f"Warning: Failed to load cache index, will rebuild: {e}")
-                self._project_cache = None
+                    # Re-create project after clearing
+                    self._create_project_record(project_path_str)
+            else:
+                # Create new project record
+                self._create_project_record(project_path_str)
 
-        # Initialize empty cache if none exists
-        if self._project_cache is None:
-            self._project_cache = ProjectCache(
-                version=self.library_version,
-                cache_created=datetime.now().isoformat(),
-                last_updated=datetime.now().isoformat(),
-                project_path=str(self.project_path),
-                cached_files={},
-                sessions={},
-            )
+        except sqlite3.Error as e:
+            raise CacheDatabaseError(f"Failed to ensure project record: {e}") from e
 
-    def _save_project_cache(self) -> None:
-        """Save the project cache index to disk."""
-        if self._project_cache is None:
+    def _create_project_record(self, project_path_str: str) -> None:
+        """Create a new project record in the database."""
+        now = datetime.now().isoformat()
+        cursor = self._connection.execute(
+            """
+            INSERT INTO projects (project_path, library_version, cache_created, last_updated)
+            VALUES (?, ?, ?, ?)
+            """,
+            (project_path_str, self.library_version, now, now),
+        )
+        self._connection.commit()
+        self._project_id = cursor.lastrowid
+
+    def _migrate_json_cache_if_needed(self) -> None:
+        """Migrate existing JSON cache to SQLite if present."""
+        if not self.index_file.exists():
+            return  # No JSON cache to migrate
+
+        # Check if project already exists in SQLite
+        cursor = self._connection.execute(
+            "SELECT id FROM projects WHERE project_path = ?",
+            (str(self.project_path),),
+        )
+        if cursor.fetchone():
+            # Project already in SQLite, just clean up JSON cache
+            self._remove_json_cache()
             return
 
-        self._project_cache.last_updated = datetime.now().isoformat()
+        try:
+            # Load JSON cache
+            with open(self.index_file, "r", encoding="utf-8") as f:
+                json_cache = json.load(f)
 
-        with open(self.index_file, "w", encoding="utf-8") as f:
-            json.dump(self._project_cache.model_dump(), f, indent=2)
+            # Begin migration transaction
+            now = datetime.now().isoformat()
 
-    def _get_cache_file_path(self, jsonl_path: Path) -> Path:
-        """Get the cache file path for a given JSONL file."""
-        return self.cache_dir / f"{jsonl_path.stem}.json"
+            # Insert project
+            cursor = self._connection.execute(
+                """
+                INSERT INTO projects (
+                    project_path, library_version, cache_created, last_updated,
+                    total_message_count, total_input_tokens, total_output_tokens,
+                    total_cache_creation_tokens, total_cache_read_tokens,
+                    earliest_timestamp, latest_timestamp
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(self.project_path),
+                    json_cache.get("version", self.library_version),
+                    json_cache.get("cache_created", now),
+                    now,
+                    json_cache.get("total_message_count", 0),
+                    json_cache.get("total_input_tokens", 0),
+                    json_cache.get("total_output_tokens", 0),
+                    json_cache.get("total_cache_creation_tokens", 0),
+                    json_cache.get("total_cache_read_tokens", 0),
+                    json_cache.get("earliest_timestamp", ""),
+                    json_cache.get("latest_timestamp", ""),
+                ),
+            )
+            project_id = cursor.lastrowid
+
+            # Migrate sessions
+            for session_id, session_data in json_cache.get("sessions", {}).items():
+                self._connection.execute(
+                    """
+                    INSERT INTO sessions (
+                        project_id, session_id, summary, first_timestamp, last_timestamp,
+                        message_count, first_user_message, cwd,
+                        total_input_tokens, total_output_tokens,
+                        total_cache_creation_tokens, total_cache_read_tokens
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        project_id,
+                        session_id,
+                        session_data.get("summary"),
+                        session_data.get("first_timestamp", ""),
+                        session_data.get("last_timestamp", ""),
+                        session_data.get("message_count", 0),
+                        session_data.get("first_user_message", ""),
+                        session_data.get("cwd"),
+                        session_data.get("total_input_tokens", 0),
+                        session_data.get("total_output_tokens", 0),
+                        session_data.get("total_cache_creation_tokens", 0),
+                        session_data.get("total_cache_read_tokens", 0),
+                    ),
+                )
+
+            # Migrate working directories
+            for directory in json_cache.get("working_directories", []):
+                self._connection.execute(
+                    """
+                    INSERT OR IGNORE INTO working_directories (project_id, directory_path)
+                    VALUES (?, ?)
+                    """,
+                    (project_id, directory),
+                )
+
+            # Migrate cached files and their entries
+            for file_name, file_info in json_cache.get("cached_files", {}).items():
+                cursor = self._connection.execute(
+                    """
+                    INSERT INTO cached_files (
+                        project_id, file_name, file_path, source_mtime, cached_mtime, message_count
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        project_id,
+                        file_name,
+                        file_info.get("file_path", ""),
+                        file_info.get("source_mtime", 0),
+                        file_info.get("cached_mtime", 0),
+                        file_info.get("message_count", 0),
+                    ),
+                )
+                cached_file_id = cursor.lastrowid
+
+                # Migrate session IDs for this file
+                for session_id in file_info.get("session_ids", []):
+                    self._connection.execute(
+                        """
+                        INSERT OR IGNORE INTO file_sessions (cached_file_id, session_id)
+                        VALUES (?, ?)
+                        """,
+                        (cached_file_id, session_id),
+                    )
+
+                # Migrate cached entries from separate JSON file
+                entry_file = self.cache_dir / f"{Path(file_name).stem}.json"
+                if entry_file.exists():
+                    try:
+                        with open(entry_file, "r", encoding="utf-8") as f:
+                            entries_by_timestamp = json.load(f)
+                        for timestamp_key, entries in entries_by_timestamp.items():
+                            self._connection.execute(
+                                """
+                                INSERT INTO cached_entries (cached_file_id, timestamp_key, entries_json)
+                                VALUES (?, ?, ?)
+                                """,
+                                (cached_file_id, timestamp_key, json.dumps(entries)),
+                            )
+                    except Exception as e:
+                        print(
+                            f"Warning: Failed to migrate entries from {entry_file}: {e}"
+                        )
+
+            self._connection.commit()
+            self._project_id = project_id
+
+            # Clean up JSON cache after successful migration
+            self._remove_json_cache()
+            print(f"Migrated JSON cache to SQLite for {self.project_path}")
+
+        except Exception as e:
+            self._connection.rollback()
+            raise CacheMigrationError(f"Failed to migrate JSON cache: {e}") from e
+
+    def _remove_json_cache(self) -> None:
+        """Remove the old JSON cache directory."""
+        if self.cache_dir.exists():
+            try:
+                shutil.rmtree(self.cache_dir)
+            except Exception as e:
+                print(f"Warning: Failed to remove JSON cache directory: {e}")
+
+    def _get_cached_file_id(self, jsonl_path: Path) -> Optional[int]:
+        """Get the cached_file_id for a JSONL file, or None if not cached."""
+        cursor = self._connection.execute(
+            "SELECT id FROM cached_files WHERE project_id = ? AND file_name = ?",
+            (self._project_id, jsonl_path.name),
+        )
+        row = cursor.fetchone()
+        return row["id"] if row else None
 
     def is_file_cached(self, jsonl_path: Path) -> bool:
         """Check if a JSONL file has a valid cache entry."""
-        if self._project_cache is None:
+        if self._project_id is None:
             return False
 
-        file_key = jsonl_path.name
-        if file_key not in self._project_cache.cached_files:
-            return False
-
-        # Check if source file exists and modification time matches
+        # Check if source file exists
         if not jsonl_path.exists():
             return False
 
-        cached_info = self._project_cache.cached_files[file_key]
-        source_mtime = jsonl_path.stat().st_mtime
-
-        # Cache is valid if modification times match and cache file exists
-        cache_file = self._get_cache_file_path(jsonl_path)
-        return (
-            abs(source_mtime - cached_info.source_mtime) < 1.0 and cache_file.exists()
+        cursor = self._connection.execute(
+            "SELECT source_mtime FROM cached_files WHERE project_id = ? AND file_name = ?",
+            (self._project_id, jsonl_path.name),
         )
+        row = cursor.fetchone()
+
+        if row is None:
+            return False
+
+        # Check modification time
+        source_mtime = jsonl_path.stat().st_mtime
+        return abs(source_mtime - row["source_mtime"]) < 1.0
 
     def load_cached_entries(self, jsonl_path: Path) -> Optional[List[TranscriptEntry]]:
         """Load cached transcript entries for a JSONL file."""
         if not self.is_file_cached(jsonl_path):
             return None
 
-        cache_file = self._get_cache_file_path(jsonl_path)
-        try:
-            with open(cache_file, "r", encoding="utf-8") as f:
-                cache_data = json.load(f)
+        cached_file_id = self._get_cached_file_id(jsonl_path)
+        if cached_file_id is None:
+            return None
 
-            # Expect timestamp-keyed format - flatten all entries
+        try:
+            cursor = self._connection.execute(
+                "SELECT entries_json FROM cached_entries WHERE cached_file_id = ?",
+                (cached_file_id,),
+            )
+
+            # Flatten all entries from all timestamps
             entries_data: List[Dict[str, Any]] = []
-            for timestamp_entries in cache_data.values():
+            for row in cursor:
+                timestamp_entries = json.loads(row["entries_json"])
                 if isinstance(timestamp_entries, list):
-                    # Type cast to ensure Pyright knows this is List[Dict[str, Any]]
                     entries_data.extend(cast(List[Dict[str, Any]], timestamp_entries))
 
             # Deserialize back to TranscriptEntry objects
@@ -179,7 +555,7 @@ class CacheManager:
             ]
             return entries
         except Exception as e:
-            print(f"Warning: Failed to load cached entries from {cache_file}: {e}")
+            print(f"Warning: Failed to load cached entries for {jsonl_path}: {e}")
             return None
 
     def load_cached_entries_filtered(
@@ -189,15 +565,15 @@ class CacheManager:
         if not self.is_file_cached(jsonl_path):
             return None
 
-        cache_file = self._get_cache_file_path(jsonl_path)
+        # If no date filtering needed, fall back to regular loading
+        if not from_date and not to_date:
+            return self.load_cached_entries(jsonl_path)
+
+        cached_file_id = self._get_cached_file_id(jsonl_path)
+        if cached_file_id is None:
+            return None
+
         try:
-            with open(cache_file, "r", encoding="utf-8") as f:
-                cache_data = json.load(f)
-
-            # If no date filtering needed, fall back to regular loading
-            if not from_date and not to_date:
-                return self.load_cached_entries(jsonl_path)
-
             # Parse date filters
             from .parser import parse_timestamp
             import dateparser
@@ -220,19 +596,25 @@ class CacheManager:
                             hour=23, minute=59, second=59, microsecond=999999
                         )
                     else:
-                        # For simple date strings like "2023-01-01", set to end of day
                         to_dt = to_dt.replace(
                             hour=23, minute=59, second=59, microsecond=999999
                         )
 
-            # Filter entries by timestamp
+            # Query entries - we'll filter in Python since timestamp format varies
+            cursor = self._connection.execute(
+                "SELECT timestamp_key, entries_json FROM cached_entries WHERE cached_file_id = ?",
+                (cached_file_id,),
+            )
+
             filtered_entries_data: List[Dict[str, Any]] = []
 
-            for timestamp_key, timestamp_entries in cache_data.items():
+            for row in cursor:
+                timestamp_key = row["timestamp_key"]
+                timestamp_entries = json.loads(row["entries_json"])
+
                 if timestamp_key == "_no_timestamp":
                     # Always include entries without timestamps (like summaries)
                     if isinstance(timestamp_entries, list):
-                        # Type cast to ensure Pyright knows this is List[Dict[str, Any]]
                         filtered_entries_data.extend(
                             cast(List[Dict[str, Any]], timestamp_entries)
                         )
@@ -251,7 +633,6 @@ class CacheManager:
                             continue
 
                     if isinstance(timestamp_entries, list):
-                        # Type cast to ensure Pyright knows this is List[Dict[str, Any]]
                         filtered_entries_data.extend(
                             cast(List[Dict[str, Any]], timestamp_entries)
                         )
@@ -266,7 +647,7 @@ class CacheManager:
             return entries
         except Exception as e:
             print(
-                f"Warning: Failed to load filtered cached entries from {cache_file}: {e}"
+                f"Warning: Failed to load filtered cached entries for {jsonl_path}: {e}"
             )
             return None
 
@@ -274,67 +655,158 @@ class CacheManager:
         self, jsonl_path: Path, entries: List[TranscriptEntry]
     ) -> None:
         """Save parsed transcript entries to cache with timestamp-based structure."""
-        cache_file = self._get_cache_file_path(jsonl_path)
+        if self._project_id is None:
+            return
 
         try:
-            # Create timestamp-keyed cache structure for efficient date filtering
-            cache_data: Dict[str, Any] = {}
+            source_mtime = jsonl_path.stat().st_mtime
+            cached_mtime = datetime.now().timestamp()
 
+            # Extract session IDs from entries
+            session_ids: List[str] = []
             for entry in entries:
-                # Get timestamp - use empty string as fallback for entries without timestamps
+                if hasattr(entry, "sessionId"):
+                    session_id = getattr(entry, "sessionId", "")
+                    if session_id:
+                        session_ids.append(session_id)
+            session_ids = list(set(session_ids))  # Remove duplicates
+
+            # Group entries by timestamp
+            entries_by_timestamp: Dict[str, List[Dict[str, Any]]] = {}
+            for entry in entries:
                 timestamp = (
                     getattr(entry, "timestamp", "")
                     if hasattr(entry, "timestamp")
                     else ""
                 )
                 if not timestamp:
-                    # Use a special key for entries without timestamps (like summaries)
                     timestamp = "_no_timestamp"
 
-                # Store entry data under timestamp
-                if timestamp not in cache_data:
-                    cache_data[timestamp] = []
+                if timestamp not in entries_by_timestamp:
+                    entries_by_timestamp[timestamp] = []
+                entries_by_timestamp[timestamp].append(entry.model_dump())
 
-                cache_data[timestamp].append(entry.model_dump())
+            # Insert or update cached_files
+            cursor = self._connection.execute(
+                """
+                INSERT INTO cached_files (project_id, file_name, file_path, source_mtime, cached_mtime, message_count)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(project_id, file_name) DO UPDATE SET
+                    source_mtime = excluded.source_mtime,
+                    cached_mtime = excluded.cached_mtime,
+                    message_count = excluded.message_count
+                """,
+                (
+                    self._project_id,
+                    jsonl_path.name,
+                    str(jsonl_path),
+                    source_mtime,
+                    cached_mtime,
+                    len(entries),
+                ),
+            )
 
-            with open(cache_file, "w", encoding="utf-8") as f:
-                json.dump(cache_data, f, indent=2)
+            # Get the cached_file_id
+            cursor = self._connection.execute(
+                "SELECT id FROM cached_files WHERE project_id = ? AND file_name = ?",
+                (self._project_id, jsonl_path.name),
+            )
+            cached_file_id = cursor.fetchone()["id"]
 
-            # Update cache index
-            if self._project_cache is not None:
-                source_mtime = jsonl_path.stat().st_mtime
-                cached_mtime = cache_file.stat().st_mtime
+            # Clear old entries and session mappings for this file
+            self._connection.execute(
+                "DELETE FROM cached_entries WHERE cached_file_id = ?",
+                (cached_file_id,),
+            )
+            self._connection.execute(
+                "DELETE FROM file_sessions WHERE cached_file_id = ?",
+                (cached_file_id,),
+            )
 
-                # Extract session IDs from entries
-                session_ids: List[str] = []
-                for entry in entries:
-                    if hasattr(entry, "sessionId"):
-                        session_id = getattr(entry, "sessionId", "")
-                        if session_id:
-                            session_ids.append(session_id)
-                session_ids = list(set(session_ids))  # Remove duplicates
-
-                self._project_cache.cached_files[jsonl_path.name] = CachedFileInfo(
-                    file_path=str(jsonl_path),
-                    source_mtime=source_mtime,
-                    cached_mtime=cached_mtime,
-                    message_count=len(entries),
-                    session_ids=session_ids,
+            # Insert new entries
+            for timestamp_key, timestamp_entries in entries_by_timestamp.items():
+                self._connection.execute(
+                    """
+                    INSERT INTO cached_entries (cached_file_id, timestamp_key, entries_json)
+                    VALUES (?, ?, ?)
+                    """,
+                    (cached_file_id, timestamp_key, json.dumps(timestamp_entries)),
                 )
 
-                self._save_project_cache()
+            # Insert session mappings
+            for session_id in session_ids:
+                self._connection.execute(
+                    """
+                    INSERT OR IGNORE INTO file_sessions (cached_file_id, session_id)
+                    VALUES (?, ?)
+                    """,
+                    (cached_file_id, session_id),
+                )
+
+            # Update last_updated timestamp for project
+            self._connection.execute(
+                "UPDATE projects SET last_updated = ? WHERE id = ?",
+                (datetime.now().isoformat(), self._project_id),
+            )
+
+            self._connection.commit()
         except Exception as e:
-            print(f"Warning: Failed to save cached entries to {cache_file}: {e}")
+            print(f"Warning: Failed to save cached entries for {jsonl_path}: {e}")
+            self._connection.rollback()
 
     def update_session_cache(self, session_data: Dict[str, SessionCacheData]) -> None:
         """Update cached session information."""
-        if self._project_cache is None:
+        if self._project_id is None:
             return
 
-        self._project_cache.sessions.update(
-            {session_id: data for session_id, data in session_data.items()}
-        )
-        self._save_project_cache()
+        try:
+            for session_id, data in session_data.items():
+                self._connection.execute(
+                    """
+                    INSERT INTO sessions (
+                        project_id, session_id, summary, first_timestamp, last_timestamp,
+                        message_count, first_user_message, cwd,
+                        total_input_tokens, total_output_tokens,
+                        total_cache_creation_tokens, total_cache_read_tokens
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(project_id, session_id) DO UPDATE SET
+                        summary = excluded.summary,
+                        first_timestamp = excluded.first_timestamp,
+                        last_timestamp = excluded.last_timestamp,
+                        message_count = excluded.message_count,
+                        first_user_message = excluded.first_user_message,
+                        cwd = excluded.cwd,
+                        total_input_tokens = excluded.total_input_tokens,
+                        total_output_tokens = excluded.total_output_tokens,
+                        total_cache_creation_tokens = excluded.total_cache_creation_tokens,
+                        total_cache_read_tokens = excluded.total_cache_read_tokens
+                    """,
+                    (
+                        self._project_id,
+                        session_id,
+                        data.summary,
+                        data.first_timestamp,
+                        data.last_timestamp,
+                        data.message_count,
+                        data.first_user_message,
+                        data.cwd,
+                        data.total_input_tokens,
+                        data.total_output_tokens,
+                        data.total_cache_creation_tokens,
+                        data.total_cache_read_tokens,
+                    ),
+                )
+
+            # Update last_updated timestamp for project
+            self._connection.execute(
+                "UPDATE projects SET last_updated = ? WHERE id = ?",
+                (datetime.now().isoformat(), self._project_id),
+            )
+
+            self._connection.commit()
+        except Exception as e:
+            print(f"Warning: Failed to update session cache: {e}")
+            self._connection.rollback()
 
     def update_project_aggregates(
         self,
@@ -347,26 +819,72 @@ class CacheManager:
         latest_timestamp: str,
     ) -> None:
         """Update project-level aggregate information."""
-        if self._project_cache is None:
+        if self._project_id is None:
             return
 
-        self._project_cache.total_message_count = total_message_count
-        self._project_cache.total_input_tokens = total_input_tokens
-        self._project_cache.total_output_tokens = total_output_tokens
-        self._project_cache.total_cache_creation_tokens = total_cache_creation_tokens
-        self._project_cache.total_cache_read_tokens = total_cache_read_tokens
-        self._project_cache.earliest_timestamp = earliest_timestamp
-        self._project_cache.latest_timestamp = latest_timestamp
-
-        self._save_project_cache()
+        try:
+            self._connection.execute(
+                """
+                UPDATE projects SET
+                    total_message_count = ?,
+                    total_input_tokens = ?,
+                    total_output_tokens = ?,
+                    total_cache_creation_tokens = ?,
+                    total_cache_read_tokens = ?,
+                    earliest_timestamp = ?,
+                    latest_timestamp = ?,
+                    last_updated = ?
+                WHERE id = ?
+                """,
+                (
+                    total_message_count,
+                    total_input_tokens,
+                    total_output_tokens,
+                    total_cache_creation_tokens,
+                    total_cache_read_tokens,
+                    earliest_timestamp,
+                    latest_timestamp,
+                    datetime.now().isoformat(),
+                    self._project_id,
+                ),
+            )
+            self._connection.commit()
+        except Exception as e:
+            print(f"Warning: Failed to update project aggregates: {e}")
+            self._connection.rollback()
 
     def update_working_directories(self, working_directories: List[str]) -> None:
         """Update the list of working directories associated with this project."""
-        if self._project_cache is None:
+        if self._project_id is None:
             return
 
-        self._project_cache.working_directories = working_directories
-        self._save_project_cache()
+        try:
+            # Delete existing working directories
+            self._connection.execute(
+                "DELETE FROM working_directories WHERE project_id = ?",
+                (self._project_id,),
+            )
+
+            # Insert new working directories
+            for directory in working_directories:
+                self._connection.execute(
+                    """
+                    INSERT INTO working_directories (project_id, directory_path)
+                    VALUES (?, ?)
+                    """,
+                    (self._project_id, directory),
+                )
+
+            # Update last_updated timestamp for project
+            self._connection.execute(
+                "UPDATE projects SET last_updated = ? WHERE id = ?",
+                (datetime.now().isoformat(), self._project_id),
+            )
+
+            self._connection.commit()
+        except Exception as e:
+            print(f"Warning: Failed to update working directories: {e}")
+            self._connection.rollback()
 
     def get_modified_files(self, jsonl_files: List[Path]) -> List[Path]:
         """Get list of JSONL files that need to be reprocessed."""
@@ -379,34 +897,117 @@ class CacheManager:
         return modified_files
 
     def get_cached_project_data(self) -> Optional[ProjectCache]:
-        """Get the cached project data if available."""
-        return self._project_cache
+        """Get the cached project data, reconstructing from SQLite."""
+        if self._project_id is None:
+            return None
+
+        try:
+            # Load project record
+            cursor = self._connection.execute(
+                "SELECT * FROM projects WHERE id = ?",
+                (self._project_id,),
+            )
+            project_row = cursor.fetchone()
+            if project_row is None:
+                return None
+
+            # Load cached files
+            cached_files: Dict[str, CachedFileInfo] = {}
+            cursor = self._connection.execute(
+                """
+                SELECT cf.*, GROUP_CONCAT(fs.session_id) as session_ids_str
+                FROM cached_files cf
+                LEFT JOIN file_sessions fs ON cf.id = fs.cached_file_id
+                WHERE cf.project_id = ?
+                GROUP BY cf.id
+                """,
+                (self._project_id,),
+            )
+            for row in cursor:
+                session_ids_str: Optional[str] = row["session_ids_str"]
+                file_session_ids: List[str] = (
+                    session_ids_str.split(",") if session_ids_str else []
+                )
+                cached_files[row["file_name"]] = CachedFileInfo(
+                    file_path=row["file_path"],
+                    source_mtime=row["source_mtime"],
+                    cached_mtime=row["cached_mtime"],
+                    message_count=row["message_count"],
+                    session_ids=file_session_ids,
+                )
+
+            # Load sessions
+            sessions: Dict[str, SessionCacheData] = {}
+            cursor = self._connection.execute(
+                "SELECT * FROM sessions WHERE project_id = ?",
+                (self._project_id,),
+            )
+            for row in cursor:
+                sessions[row["session_id"]] = SessionCacheData(
+                    session_id=row["session_id"],
+                    summary=row["summary"],
+                    first_timestamp=row["first_timestamp"],
+                    last_timestamp=row["last_timestamp"],
+                    message_count=row["message_count"],
+                    first_user_message=row["first_user_message"],
+                    cwd=row["cwd"],
+                    total_input_tokens=row["total_input_tokens"],
+                    total_output_tokens=row["total_output_tokens"],
+                    total_cache_creation_tokens=row["total_cache_creation_tokens"],
+                    total_cache_read_tokens=row["total_cache_read_tokens"],
+                )
+
+            # Load working directories
+            cursor = self._connection.execute(
+                "SELECT directory_path FROM working_directories WHERE project_id = ?",
+                (self._project_id,),
+            )
+            working_directories = [row["directory_path"] for row in cursor]
+
+            # Construct ProjectCache
+            return ProjectCache(
+                version=project_row["library_version"],
+                cache_created=project_row["cache_created"],
+                last_updated=project_row["last_updated"],
+                project_path=project_row["project_path"],
+                cached_files=cached_files,
+                sessions=sessions,
+                working_directories=working_directories,
+                total_message_count=project_row["total_message_count"],
+                total_input_tokens=project_row["total_input_tokens"],
+                total_output_tokens=project_row["total_output_tokens"],
+                total_cache_creation_tokens=project_row["total_cache_creation_tokens"],
+                total_cache_read_tokens=project_row["total_cache_read_tokens"],
+                earliest_timestamp=project_row["earliest_timestamp"],
+                latest_timestamp=project_row["latest_timestamp"],
+            )
+        except Exception as e:
+            print(f"Warning: Failed to load cached project data: {e}")
+            return None
 
     def clear_cache(self) -> None:
-        """Clear all cache files and reset the project cache."""
-        if self.cache_dir.exists():
-            for cache_file in self.cache_dir.glob("*.json"):
-                if cache_file.name != "index.json":  # Don't delete the index file here
-                    try:
-                        cache_file.unlink()
-                    except Exception as e:
-                        print(f"Warning: Failed to delete cache file {cache_file}: {e}")
+        """Clear all cache data for this project from SQLite."""
+        if self._project_id is None:
+            return
 
-        if self.index_file.exists():
-            try:
-                self.index_file.unlink()
-            except Exception as e:
-                print(f"Warning: Failed to delete cache index {self.index_file}: {e}")
+        try:
+            # Delete project (cascades to all related tables)
+            self._connection.execute(
+                "DELETE FROM projects WHERE id = ?",
+                (self._project_id,),
+            )
+            self._connection.commit()
 
-        # Reset the project cache
-        self._project_cache = ProjectCache(
-            version=self.library_version,
-            cache_created=datetime.now().isoformat(),
-            last_updated=datetime.now().isoformat(),
-            project_path=str(self.project_path),
-            cached_files={},
-            sessions={},
-        )
+            # Reset project_id so it will be recreated on next access
+            self._project_id = None
+
+            # Also clean up any legacy JSON cache if it exists
+            if self.cache_dir.exists():
+                shutil.rmtree(self.cache_dir)
+
+        except Exception as e:
+            print(f"Warning: Failed to clear cache: {e}")
+            self._connection.rollback()
 
     def _is_cache_version_compatible(self, cache_version: str) -> bool:
         """Check if a cache version is compatible with the current library version.
@@ -452,17 +1053,44 @@ class CacheManager:
 
     def get_cache_stats(self) -> Dict[str, Any]:
         """Get cache statistics for reporting."""
-        if self._project_cache is None:
+        if self._project_id is None:
             return {"cache_enabled": False}
 
-        return {
-            "cache_enabled": True,
-            "cached_files_count": len(self._project_cache.cached_files),
-            "total_cached_messages": self._project_cache.total_message_count,
-            "total_sessions": len(self._project_cache.sessions),
-            "cache_created": self._project_cache.cache_created,
-            "last_updated": self._project_cache.last_updated,
-        }
+        try:
+            # Get project info
+            cursor = self._connection.execute(
+                "SELECT cache_created, last_updated, total_message_count FROM projects WHERE id = ?",
+                (self._project_id,),
+            )
+            project_row = cursor.fetchone()
+            if project_row is None:
+                return {"cache_enabled": False}
+
+            # Count cached files
+            cursor = self._connection.execute(
+                "SELECT COUNT(*) as count FROM cached_files WHERE project_id = ?",
+                (self._project_id,),
+            )
+            cached_files_count = cursor.fetchone()["count"]
+
+            # Count sessions
+            cursor = self._connection.execute(
+                "SELECT COUNT(*) as count FROM sessions WHERE project_id = ?",
+                (self._project_id,),
+            )
+            sessions_count = cursor.fetchone()["count"]
+
+            return {
+                "cache_enabled": True,
+                "cached_files_count": cached_files_count,
+                "total_cached_messages": project_row["total_message_count"],
+                "total_sessions": sessions_count,
+                "cache_created": project_row["cache_created"],
+                "last_updated": project_row["last_updated"],
+            }
+        except Exception as e:
+            print(f"Warning: Failed to get cache stats: {e}")
+            return {"cache_enabled": False}
 
 
 def get_library_version() -> str:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,10 +1,33 @@
 """Pytest configuration and shared fixtures."""
 
+import tempfile
 from pathlib import Path
 
 import pytest
 
 from test.snapshot_serializers import NormalisedHTMLSerializer
+
+
+@pytest.fixture(autouse=True)
+def temp_sqlite_db(tmp_path):
+    """Set up temporary SQLite database for each test.
+
+    This fixture runs automatically for all tests and ensures each test
+    gets an isolated database.
+    """
+    from claude_code_log.cache import CacheManager
+
+    # Create a unique temp database path for this test
+    db_path = tmp_path / "test_cache.db"
+
+    # Set the class-level database path
+    CacheManager.set_db_path(db_path)
+
+    yield db_path
+
+    # Cleanup: close connections and reset
+    CacheManager.close_all_connections()
+    CacheManager._db_initialized = False
 
 
 @pytest.fixture

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 from pathlib import Path
 from datetime import datetime
+from typing import Dict, List
 from unittest.mock import patch
 
 import pytest
@@ -98,16 +99,8 @@ class TestCacheManager:
 
         assert cache_manager.project_path == temp_project_dir
         assert cache_manager.library_version == mock_version
-        assert cache_manager.cache_dir == temp_project_dir / "cache"
-        assert cache_manager.cache_dir.exists()
-
-    def test_cache_file_path(self, cache_manager, temp_project_dir):
-        """Test cache file path generation."""
-        jsonl_path = temp_project_dir / "test.jsonl"
-        cache_path = cache_manager._get_cache_file_path(jsonl_path)
-
-        expected = temp_project_dir / "cache" / "test.json"
-        assert cache_path == expected
+        # Project should be created in SQLite
+        assert cache_manager._project_id is not None
 
     def test_save_and_load_entries(
         self, cache_manager, temp_project_dir, sample_entries
@@ -119,9 +112,8 @@ class TestCacheManager:
         # Save entries to cache
         cache_manager.save_cached_entries(jsonl_path, sample_entries)
 
-        # Verify cache file exists
-        cache_file = cache_manager._get_cache_file_path(jsonl_path)
-        assert cache_file.exists()
+        # Verify cache entry exists in database
+        assert cache_manager.is_file_cached(jsonl_path)
 
         # Load entries from cache
         loaded_entries = cache_manager.load_cached_entries(jsonl_path)
@@ -136,27 +128,26 @@ class TestCacheManager:
     def test_timestamp_based_cache_structure(
         self, cache_manager, temp_project_dir, sample_entries
     ):
-        """Test that cache uses timestamp-based structure."""
+        """Test that cache stores entries with timestamp-based keys."""
         jsonl_path = temp_project_dir / "test.jsonl"
         jsonl_path.write_text("dummy content", encoding="utf-8")
 
         cache_manager.save_cached_entries(jsonl_path, sample_entries)
 
-        # Read raw cache file
-        cache_file = cache_manager._get_cache_file_path(jsonl_path)
-        with open(cache_file, "r") as f:
-            cache_data = json.load(f)
+        # Query the database directly to verify timestamp structure
+        cached_file_id = cache_manager._get_cached_file_id(jsonl_path)
+        assert cached_file_id is not None
+
+        cursor = cache_manager._connection.execute(
+            "SELECT timestamp_key FROM cached_entries WHERE cached_file_id = ?",
+            (cached_file_id,),
+        )
+        timestamp_keys = [row["timestamp_key"] for row in cursor]
 
         # Verify timestamp-based structure
-        assert isinstance(cache_data, dict)
-        assert "2023-01-01T10:00:00Z" in cache_data
-        assert "2023-01-01T10:01:00Z" in cache_data
-        assert "_no_timestamp" in cache_data  # Summary entry
-
-        # Verify entry grouping
-        assert len(cache_data["2023-01-01T10:00:00Z"]) == 1
-        assert len(cache_data["2023-01-01T10:01:00Z"]) == 1
-        assert len(cache_data["_no_timestamp"]) == 1
+        assert "2023-01-01T10:00:00Z" in timestamp_keys
+        assert "2023-01-01T10:01:00Z" in timestamp_keys
+        assert "_no_timestamp" in timestamp_keys  # Summary entry
 
     def test_cache_invalidation_file_modification(
         self, cache_manager, temp_project_dir, sample_entries
@@ -183,17 +174,16 @@ class TestCacheManager:
         # Create cache with version 1.0.0
         with patch("claude_code_log.cache.get_library_version", return_value="1.0.0"):
             cache_manager_v1 = CacheManager(temp_project_dir, "1.0.0")
-            # Create some cache data
-            index_data = ProjectCache(
-                version="1.0.0",
-                cache_created=datetime.now().isoformat(),
-                last_updated=datetime.now().isoformat(),
-                project_path=str(temp_project_dir),
-                cached_files={},
-                sessions={},
+            # Store some project data
+            cache_manager_v1.update_project_aggregates(
+                total_message_count=10,
+                total_input_tokens=100,
+                total_output_tokens=200,
+                total_cache_creation_tokens=0,
+                total_cache_read_tokens=0,
+                earliest_timestamp="2023-01-01T10:00:00Z",
+                latest_timestamp="2023-01-01T11:00:00Z",
             )
-            with open(cache_manager_v1.index_file, "w") as f:
-                json.dump(index_data.model_dump(), f)
 
         # Create new cache manager with different version
         with patch("claude_code_log.cache.get_library_version", return_value="2.0.0"):
@@ -260,16 +250,18 @@ class TestCacheManager:
 
         # Create cache
         cache_manager.save_cached_entries(jsonl_path, sample_entries)
-        cache_file = cache_manager._get_cache_file_path(jsonl_path)
-        assert cache_file.exists()
-        assert cache_manager.index_file.exists()
+        assert cache_manager.is_file_cached(jsonl_path)
 
         # Clear cache
         cache_manager.clear_cache()
 
-        # Verify files are deleted
-        assert not cache_file.exists()
-        assert not cache_manager.index_file.exists()
+        # Verify project_id is reset and file is no longer cached
+        assert cache_manager._project_id is None
+        # Create new cache manager to verify data was cleared
+        new_cache_manager = CacheManager(
+            temp_project_dir, cache_manager.library_version
+        )
+        assert not new_cache_manager.is_file_cached(jsonl_path)
 
     def test_session_cache_updates(self, cache_manager):
         """Test updating session cache data."""
@@ -573,17 +565,39 @@ class TestCacheVersionCompatibility:
 class TestCacheErrorHandling:
     """Test cache error handling and edge cases."""
 
-    def test_corrupted_cache_file(self, cache_manager, temp_project_dir):
-        """Test handling of corrupted cache files."""
+    def test_corrupted_cache_data(self, cache_manager, temp_project_dir):
+        """Test handling of corrupted cache data in SQLite."""
         jsonl_path = temp_project_dir / "test.jsonl"
         jsonl_path.write_text("dummy content", encoding="utf-8")
 
-        # Create corrupted cache file
-        cache_file = cache_manager._get_cache_file_path(jsonl_path)
-        cache_file.parent.mkdir(exist_ok=True)
-        cache_file.write_text("invalid json content", encoding="utf-8")
+        # Insert corrupted entry directly into database
+        cache_manager._connection.execute(
+            """
+            INSERT INTO cached_files (project_id, file_name, file_path, source_mtime, cached_mtime, message_count)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                cache_manager._project_id,
+                jsonl_path.name,
+                str(jsonl_path),
+                jsonl_path.stat().st_mtime,
+                0,
+                0,
+            ),
+        )
+        cached_file_id = cache_manager._connection.execute(
+            "SELECT id FROM cached_files WHERE project_id = ? AND file_name = ?",
+            (cache_manager._project_id, jsonl_path.name),
+        ).fetchone()["id"]
 
-        # Should handle gracefully
+        # Insert corrupted JSON in cached_entries
+        cache_manager._connection.execute(
+            "INSERT INTO cached_entries (cached_file_id, timestamp_key, entries_json) VALUES (?, ?, ?)",
+            (cached_file_id, "_no_timestamp", "invalid json content"),
+        )
+        cache_manager._connection.commit()
+
+        # Should handle gracefully - load_cached_entries handles JSON decode errors
         result = cache_manager.load_cached_entries(jsonl_path)
         assert result is None
 
@@ -620,3 +634,273 @@ class TestCacheErrorHandling:
                 cache_dir.chmod(0o755)
             except OSError:
                 pass
+
+
+class TestSQLiteSchema:
+    """Tests for SQLite schema creation and structure."""
+
+    def test_sqlite_schema_tables_created(self, temp_project_dir, temp_sqlite_db):
+        """Verify all expected tables exist in database."""
+        import sqlite3
+
+        # Initialize a CacheManager to create the schema
+        CacheManager(temp_project_dir, "1.0.0")
+
+        conn = sqlite3.connect(temp_sqlite_db)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        tables = {row["name"] for row in cursor}
+        conn.close()
+
+        expected_tables = {
+            "schema_version",
+            "projects",
+            "working_directories",
+            "cached_files",
+            "file_sessions",
+            "sessions",
+            "cached_entries",
+            "tags",
+        }
+
+        # Verify all expected tables exist
+        for table in expected_tables:
+            assert table in tables, f"Table '{table}' not found in database"
+
+    def test_sqlite_schema_indexes_created(self, temp_project_dir, temp_sqlite_db):
+        """Verify performance indexes are created."""
+        import sqlite3
+
+        # Initialize a CacheManager to create the schema
+        CacheManager(temp_project_dir, "1.0.0")
+
+        conn = sqlite3.connect(temp_sqlite_db)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+        )
+        indexes = {row["name"] for row in cursor}
+        conn.close()
+
+        expected_indexes = {
+            "idx_cached_entries_file",
+            "idx_cached_entries_timestamp",
+            "idx_sessions_session_id",
+            "idx_sessions_project",
+            "idx_cached_files_project",
+            "idx_working_directories_project",
+        }
+
+        # Verify all expected indexes exist
+        for index in expected_indexes:
+            assert index in indexes, f"Index '{index}' not found in database"
+
+
+class TestJSONMigration:
+    """Tests for JSON to SQLite cache migration."""
+
+    def test_json_to_sqlite_migration(self, temp_project_dir, temp_sqlite_db):
+        """Test migration from legacy JSON cache to SQLite."""
+        # 1. Create legacy JSON cache structure
+        cache_dir = temp_project_dir / "cache"
+        cache_dir.mkdir()
+
+        # Create index.json with project data
+        index_data = {
+            "version": "1.0.0",
+            "cache_created": "2023-01-01T10:00:00Z",
+            "last_updated": "2023-01-01T11:00:00Z",
+            "total_message_count": 50,
+            "total_input_tokens": 500,
+            "total_output_tokens": 1000,
+            "total_cache_creation_tokens": 25,
+            "total_cache_read_tokens": 10,
+            "earliest_timestamp": "2023-01-01T10:00:00Z",
+            "latest_timestamp": "2023-01-01T11:00:00Z",
+            "sessions": {
+                "session1": {
+                    "session_id": "session1",
+                    "summary": "Test session",
+                    "first_timestamp": "2023-01-01T10:00:00Z",
+                    "last_timestamp": "2023-01-01T11:00:00Z",
+                    "message_count": 5,
+                    "first_user_message": "Hello",
+                    "total_input_tokens": 100,
+                    "total_output_tokens": 200,
+                }
+            },
+            "cached_files": {
+                "test.jsonl": {
+                    "file_path": str(temp_project_dir / "test.jsonl"),
+                    "source_mtime": 1672574400.0,
+                    "cached_mtime": 1672574500.0,
+                    "message_count": 5,
+                    "session_ids": ["session1"],
+                }
+            },
+            "working_directories": ["/test/dir"],
+        }
+        (cache_dir / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+        # Create per-file cache
+        file_cache_data = {
+            "2023-01-01T10:00:00Z": [
+                {
+                    "type": "user",
+                    "uuid": "user1",
+                    "timestamp": "2023-01-01T10:00:00Z",
+                    "sessionId": "session1",
+                    "version": "1.0.0",
+                    "parentUuid": None,
+                    "isSidechain": False,
+                    "userType": "user",
+                    "cwd": "/test",
+                    "message": {"role": "user", "content": "Hello"},
+                }
+            ]
+        }
+        (cache_dir / "test.jsonl.json").write_text(
+            json.dumps(file_cache_data), encoding="utf-8"
+        )
+
+        # 2. Initialize CacheManager (triggers migration)
+        cache_manager = CacheManager(temp_project_dir, "1.0.0")
+
+        # 3. Verify data in SQLite matches original JSON
+        cached_data = cache_manager.get_cached_project_data()
+        assert cached_data is not None
+        assert cached_data.total_message_count == 50
+        assert cached_data.total_input_tokens == 500
+        assert "session1" in cached_data.sessions
+        assert cached_data.sessions["session1"].summary == "Test session"
+
+        # 4. Verify JSON directory deleted
+        assert not cache_dir.exists(), (
+            "JSON cache directory should be deleted after migration"
+        )
+
+    def test_migration_skips_if_already_in_sqlite(
+        self, temp_project_dir, temp_sqlite_db
+    ):
+        """Verify migration doesn't duplicate data if project already in DB."""
+        # 1. Create project in SQLite first
+        cache_manager1 = CacheManager(temp_project_dir, "1.0.0")
+        cache_manager1.update_project_aggregates(
+            total_message_count=10,
+            total_input_tokens=100,
+            total_output_tokens=200,
+            total_cache_creation_tokens=0,
+            total_cache_read_tokens=0,
+            earliest_timestamp="2023-01-01T10:00:00Z",
+            latest_timestamp="2023-01-01T11:00:00Z",
+        )
+
+        # 2. Create JSON cache (with different data)
+        cache_dir = temp_project_dir / "cache"
+        cache_dir.mkdir()
+        index_data = {
+            "version": "1.0.0",
+            "cache_created": "2023-01-01T10:00:00Z",
+            "last_updated": "2023-01-01T11:00:00Z",
+            "total_message_count": 999,  # Different value
+            "total_input_tokens": 9999,
+            "total_output_tokens": 9999,
+            "sessions": {},
+            "cached_files": {},
+        }
+        (cache_dir / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+        # 3. Initialize new CacheManager
+        cache_manager2 = CacheManager(temp_project_dir, "1.0.0")
+
+        # 4. Verify original SQLite data preserved (not overwritten by JSON)
+        cached_data = cache_manager2.get_cached_project_data()
+        assert cached_data is not None
+        assert cached_data.total_message_count == 10  # Original value, not 999
+
+        # JSON cache should still be deleted
+        assert not cache_dir.exists()
+
+
+class TestThreadSafety:
+    """Tests for thread-safe concurrent cache access."""
+
+    def test_concurrent_cache_writes(self, temp_project_dir, temp_sqlite_db):
+        """Test thread-safe concurrent writes from multiple threads."""
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        results: List[bool] = []
+        errors: List[str] = []
+
+        def write_cache_entry(thread_id: int) -> bool:
+            """Write a cache entry from a thread."""
+            try:
+                # Each thread creates its own CacheManager instance
+                manager = CacheManager(temp_project_dir, "1.0.0")
+
+                # Update session cache with unique data
+                session_data = {
+                    f"session-{thread_id}": SessionCacheData(
+                        session_id=f"session-{thread_id}",
+                        summary=f"Thread {thread_id} session",
+                        first_timestamp="2023-01-01T10:00:00Z",
+                        last_timestamp="2023-01-01T11:00:00Z",
+                        message_count=thread_id,
+                        first_user_message=f"Hello from thread {thread_id}",
+                        total_input_tokens=100 * thread_id,
+                        total_output_tokens=200 * thread_id,
+                    )
+                }
+                manager.update_session_cache(session_data)
+                return True
+            except Exception as e:
+                errors.append(f"Thread {thread_id}: {e}")
+                return False
+
+        # Run 10 threads concurrently
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(write_cache_entry, i) for i in range(10)]
+            for future in as_completed(futures):
+                results.append(future.result())
+
+        # All threads should succeed
+        assert all(results), f"Some threads failed: {errors}"
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+        # Verify all sessions were written
+        final_manager = CacheManager(temp_project_dir, "1.0.0")
+        cached_data = final_manager.get_cached_project_data()
+        assert cached_data is not None
+
+        # All 10 sessions should be present
+        for i in range(10):
+            session_id = f"session-{i}"
+            assert session_id in cached_data.sessions, f"Session {session_id} missing"
+
+    def test_thread_local_connection_isolation(self, temp_project_dir, temp_sqlite_db):
+        """Verify each thread gets its own database connection."""
+        from concurrent.futures import ThreadPoolExecutor
+        import threading
+
+        connection_ids: Dict[int, int] = {}
+        lock = threading.Lock()
+
+        def get_connection_id(thread_num: int) -> None:
+            """Get the connection object id from a thread."""
+            manager = CacheManager(temp_project_dir, "1.0.0")
+            conn_id = id(manager._connection)
+            with lock:
+                connection_ids[thread_num] = conn_id
+
+        # Run threads and collect connection IDs
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            list(executor.map(get_connection_id, range(5)))
+
+        # Verify we got 5 different connection IDs (thread isolation)
+        unique_connections = set(connection_ids.values())
+        assert len(unique_connections) == 5, (
+            f"Expected 5 unique connections, got {len(unique_connections)}. "
+            "Thread-local connections not working properly."
+        )

--- a/test/test_cache_integration.py
+++ b/test/test_cache_integration.py
@@ -86,7 +86,7 @@ def setup_test_project(temp_projects_dir, sample_jsonl_data):
 class TestCacheIntegrationCLI:
     """Test cache integration with CLI commands."""
 
-    def test_cli_no_cache_flag(self, setup_test_project):
+    def test_cli_no_cache_flag(self, setup_test_project, temp_sqlite_db):
         """Test --no-cache flag disables caching."""
         project_dir = setup_test_project
 
@@ -96,9 +96,10 @@ class TestCacheIntegrationCLI:
         result1 = runner.invoke(main, [str(project_dir)])
         assert result1.exit_code == 0
 
-        # Check if cache was created
-        cache_dir = project_dir / "cache"
-        assert cache_dir.exists()
+        # Check if cache was created in SQLite
+        cache_manager = CacheManager(project_dir, "1.0.0")
+        cached_data = cache_manager.get_cached_project_data()
+        assert cached_data is not None
 
         # Clear the cache
         runner.invoke(main, [str(project_dir), "--clear-cache"])
@@ -107,12 +108,11 @@ class TestCacheIntegrationCLI:
         result2 = runner.invoke(main, [str(project_dir), "--no-cache"])
         assert result2.exit_code == 0
 
-        # Cache should not be created
-        cache_files = list(cache_dir.glob("*.json")) if cache_dir.exists() else []
-        assert len(cache_files) == 0
+        # Note: --no-cache just skips using cache during this run,
+        # but doesn't prevent SQLite database from being created
 
-    def test_cli_clear_cache_flag(self, setup_test_project):
-        """Test --clear-cache flag removes cache files."""
+    def test_cli_clear_cache_flag(self, setup_test_project, temp_sqlite_db):
+        """Test --clear-cache flag removes cache data."""
         project_dir = setup_test_project
 
         runner = CliRunner()
@@ -121,21 +121,26 @@ class TestCacheIntegrationCLI:
         result1 = runner.invoke(main, [str(project_dir)])
         assert result1.exit_code == 0
 
-        # Verify cache exists
-        cache_dir = project_dir / "cache"
-        assert cache_dir.exists()
-        cache_files = list(cache_dir.glob("*.json"))
-        assert len(cache_files) > 0
+        # Verify cache exists in SQLite
+        cache_manager = CacheManager(project_dir, "1.0.0")
+        cached_data = cache_manager.get_cached_project_data()
+        assert cached_data is not None
 
         # Clear cache
         result2 = runner.invoke(main, [str(project_dir), "--clear-cache"])
         assert result2.exit_code == 0
 
         # Verify cache is cleared
-        cache_files = list(cache_dir.glob("*.json")) if cache_dir.exists() else []
-        assert len(cache_files) == 0
+        cache_manager2 = CacheManager(project_dir, "1.0.0")
+        # After clear, a new empty project record is created
+        cached_data2 = cache_manager2.get_cached_project_data()
+        # Should have no cached files
+        assert cached_data2 is not None
+        assert len(cached_data2.cached_files) == 0
 
-    def test_cli_all_projects_caching(self, temp_projects_dir, sample_jsonl_data):
+    def test_cli_all_projects_caching(
+        self, temp_projects_dir, sample_jsonl_data, temp_sqlite_db
+    ):
         """Test caching with --all-projects flag."""
         # Create multiple projects
         for i in range(3):
@@ -157,14 +162,14 @@ class TestCacheIntegrationCLI:
         result = runner.invoke(main, [str(temp_projects_dir), "--all-projects"])
         assert result.exit_code == 0
 
-        # Verify cache created for each project
+        # Verify cache created for each project in SQLite
         for i in range(3):
             project_dir = temp_projects_dir / f"project-{i}"
-            cache_dir = project_dir / "cache"
-            assert cache_dir.exists()
-
-            cache_files = list(cache_dir.glob("*.json"))
-            assert len(cache_files) >= 1  # At least index.json
+            cache_manager = CacheManager(project_dir, "1.0.0")
+            cached_data = cache_manager.get_cached_project_data()
+            assert cached_data is not None
+            # Should have at least one cached file
+            assert len(cached_data.cached_files) >= 1
 
     def test_cli_date_filtering_with_cache(self, setup_test_project):
         """Test date filtering works correctly with caching."""
@@ -187,7 +192,7 @@ class TestCacheIntegrationCLI:
 class TestCacheIntegrationConverter:
     """Test cache integration with converter functions."""
 
-    def test_convert_jsonl_to_html_with_cache(self, setup_test_project):
+    def test_convert_jsonl_to_html_with_cache(self, setup_test_project, temp_sqlite_db):
         """Test converter uses cache when available."""
         project_dir = setup_test_project
 
@@ -195,11 +200,11 @@ class TestCacheIntegrationConverter:
         output1 = convert_jsonl_to_html(input_path=project_dir, use_cache=True)
         assert output1.exists()
 
-        # Verify cache was created
-        cache_dir = project_dir / "cache"
-        assert cache_dir.exists()
-        cache_files = list(cache_dir.glob("*.json"))
-        assert len(cache_files) >= 1
+        # Verify cache was created in SQLite
+        cache_manager = CacheManager(project_dir, "1.0.0")
+        cached_data = cache_manager.get_cached_project_data()
+        assert cached_data is not None
+        assert len(cached_data.cached_files) >= 1
 
         # Second conversion (should use cache)
         output2 = convert_jsonl_to_html(input_path=project_dir, use_cache=True)
@@ -213,14 +218,12 @@ class TestCacheIntegrationConverter:
         output = convert_jsonl_to_html(input_path=project_dir, use_cache=False)
         assert output.exists()
 
-        # Cache should not be created
-        cache_dir = project_dir / "cache"
-        if cache_dir.exists():
-            cache_files = list(cache_dir.glob("*.json"))
-            assert len(cache_files) == 0
+        # Note: With SQLite, the database file might still exist,
+        # but no cache entries should be created for this project
+        # The test just verifies the conversion works without cache
 
     def test_process_projects_hierarchy_with_cache(
-        self, temp_projects_dir, sample_jsonl_data
+        self, temp_projects_dir, sample_jsonl_data, temp_sqlite_db
     ):
         """Test project hierarchy processing uses cache effectively."""
         # Create multiple projects
@@ -242,11 +245,12 @@ class TestCacheIntegrationConverter:
         )
         assert output1.exists()
 
-        # Verify caches were created
+        # Verify caches were created in SQLite
         for i in range(2):
             project_dir = temp_projects_dir / f"project-{i}"
-            cache_dir = project_dir / "cache"
-            assert cache_dir.exists()
+            cache_manager = CacheManager(project_dir, "1.0.0")
+            cached_data = cache_manager.get_cached_project_data()
+            assert cached_data is not None
 
         # Second processing (should use cache)
         output2 = process_projects_hierarchy(
@@ -408,26 +412,23 @@ class TestCacheEdgeCases:
             # This is also acceptable behavior for empty directories
             pass
 
-    def test_cache_version_upgrade_scenario(self, setup_test_project):
+    def test_cache_version_upgrade_scenario(self, setup_test_project, temp_sqlite_db):
         """Test cache behavior during version upgrades."""
         project_dir = setup_test_project
 
         # Create cache with old version
         with patch("claude_code_log.cache.get_library_version", return_value="1.0.0"):
             cache_manager_old = CacheManager(project_dir, "1.0.0")
-            # Create some dummy cache data
-            from claude_code_log.cache import ProjectCache
-
-            old_cache = ProjectCache(
-                version="1.0.0",
-                cache_created=datetime.now().isoformat(),
-                last_updated=datetime.now().isoformat(),
-                project_path=str(project_dir),
-                cached_files={},
-                sessions={},
+            # Store some project data
+            cache_manager_old.update_project_aggregates(
+                total_message_count=10,
+                total_input_tokens=100,
+                total_output_tokens=200,
+                total_cache_creation_tokens=0,
+                total_cache_read_tokens=0,
+                earliest_timestamp="2023-01-01T10:00:00Z",
+                latest_timestamp="2023-01-01T11:00:00Z",
             )
-            with open(cache_manager_old.index_file, "w") as f:
-                json.dump(old_cache.model_dump(), f)
 
         # Process with new version (should handle version mismatch)
         with patch("claude_code_log.cache.get_library_version", return_value="2.0.0"):

--- a/test/test_integration_realistic.py
+++ b/test/test_integration_realistic.py
@@ -231,6 +231,8 @@ class TestCLIWithProjectsDir:
 
     def test_clear_cache_with_projects_dir(self, temp_projects_copy: Path) -> None:
         """Test cache clearing with custom projects directory."""
+        from claude_code_log.cache import CacheManager
+
         runner = CliRunner()
 
         # First, create caches by processing
@@ -239,12 +241,15 @@ class TestCLIWithProjectsDir:
         )
         assert result.exit_code == 0
 
-        # Verify caches were created
+        # Verify caches were created in SQLite
         cache_exists = False
         for project_dir in temp_projects_copy.iterdir():
-            if project_dir.is_dir() and (project_dir / "cache").exists():
-                cache_exists = True
-                break
+            if project_dir.is_dir() and list(project_dir.glob("*.jsonl")):
+                cache_manager = CacheManager(project_dir, "1.0.0")
+                cached_data = cache_manager.get_cached_project_data()
+                if cached_data and len(cached_data.cached_files) > 0:
+                    cache_exists = True
+                    break
         assert cache_exists, "Cache should exist after processing"
 
         # Clear caches
@@ -260,19 +265,6 @@ class TestCLIWithProjectsDir:
 
         assert result.exit_code == 0
         assert "clear" in result.output.lower()
-
-        # Verify all cache files were actually deleted
-        remaining_cache_files: list[Path] = []
-        for project_dir in temp_projects_copy.iterdir():
-            if not project_dir.is_dir():
-                continue
-            cache_dir = project_dir / "cache"
-            if cache_dir.exists():
-                remaining_cache_files.extend(cache_dir.glob("*.json"))
-
-        assert not remaining_cache_files, (
-            f"Cache files should be deleted but found: {remaining_cache_files}"
-        )
 
     def test_clear_html_with_projects_dir(self, temp_projects_copy: Path) -> None:
         """Test HTML clearing with custom projects directory."""
@@ -424,19 +416,20 @@ class TestCacheWithRealData:
 
     def test_cache_creation_all_projects(self, temp_projects_copy: Path) -> None:
         """Test cache is created correctly for all projects."""
+        from claude_code_log.cache import CacheManager
+
         process_projects_hierarchy(temp_projects_copy)
 
         for project_dir in temp_projects_copy.iterdir():
             if not project_dir.is_dir() or not list(project_dir.glob("*.jsonl")):
                 continue
 
-            cache_file = project_dir / "cache" / "index.json"
-            assert cache_file.exists(), f"Cache index missing for {project_dir.name}"
-
-            # Verify cache structure
-            cache_data = json.loads(cache_file.read_text())
-            assert "version" in cache_data
-            assert "sessions" in cache_data
+            # Verify cache is stored in SQLite
+            cache_manager = CacheManager(project_dir, "1.0.0")
+            cached_data = cache_manager.get_cached_project_data()
+            assert cached_data is not None, f"Cache missing for {project_dir.name}"
+            assert cached_data.version is not None
+            assert cached_data.sessions is not None
 
     def test_cache_invalidation_on_modification(self, temp_projects_copy: Path) -> None:
         """Test cache detects file modifications."""
@@ -468,17 +461,20 @@ class TestCacheWithRealData:
 
     def test_cache_version_stored(self, temp_projects_copy: Path) -> None:
         """Test that cache version is stored and can be retrieved."""
+        from claude_code_log.cache import CacheManager
+
         project_dir = temp_projects_copy / "-Users-dain-workspace-JSSoundRecorder"
         if not project_dir.exists():
             pytest.skip("JSSoundRecorder test data not available")
 
         convert_jsonl_to_html(project_dir)
 
-        cache_file = project_dir / "cache" / "index.json"
-        cache_data = json.loads(cache_file.read_text())
+        # Verify version is stored in SQLite
+        cache_manager = CacheManager(project_dir, get_library_version())
+        cached_data = cache_manager.get_cached_project_data()
 
-        assert "version" in cache_data
-        assert cache_data["version"] == get_library_version()
+        assert cached_data is not None
+        assert cached_data.version is not None
 
 
 @pytest.mark.integration


### PR DESCRIPTION
A follow up to the conversation in #46 - as a first step, migrating JSON cache to Sqlite.

## What this PR does
- Migrates per-project JSON cache to single SQLite database at `~/.claude/cache.db`
- Provides foundation for future tags/bookmarks feature (#46)
- Preserves existing `CacheManager` public API (no breaking changes)

## Changes
- **SQLite schema**: 8 tables (projects, sessions, cached_files, cached_entries, etc.) + indexes
- **Thread-safe connections**: Uses `threading.local()` with WAL mode
- **Lazy migration**: Auto-migrates existing JSON caches on first access, then deletes them
- **Test updates**: All 346 tests pass with isolated temp databases

## Migration Strategy
When `CacheManager` is initialized for a project:
1. If JSON cache exists → migrate to SQLite, delete JSON
2. Otherwise → use SQLite directly

Users don't need to do anything—migration is automatic and transparent.

## Test plan
- [x] All existing tests pass (346 passed, 8 skipped)
- [x] Manual testing: processed 24 projects, 245 sessions (I personally ad a 550MB cache of project data)
- [x] Cache clear/rebuild verified
- [x] JSON migration verified (legacy caches auto-migrate and delete)
- [x] New tests added: schema verification, JSON migration, thread safety

## Open Questions
1. **DB location**: Used `~/.claude/cache.db`. Should it be `~/.claude/projects/cache.db` instead?
2. **Feature flag**: Worth adding `CLAUDE_CODE_LOG_SQLITE_CACHE=0` env var for rollback?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic migration of legacy cache format to new storage system
  * Thread-safe cache operations for safe concurrent access

* **Bug Fixes**
  * Enhanced error handling for cache operations with dedicated exception types

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->