### PR TITLE
Improve message styling consistency

### DIFF
--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -296,8 +296,7 @@
 
 /* Slash command prompts (isMeta=true, LLM-generated content) */
 .user.slash-command {
-    border-left-color: var(--user-dimmed);
-    opacity: 0.85;
+    border-left-color: var(--user-color);
 }
 
 .assistant {
@@ -388,8 +387,8 @@
 
 /* Command output styling */
 .command-output {
-    background-color: #1e1e1e11;
-    border-left-color: var(--warning-dimmed);
+    background-color: var(--highlight-light);
+    border-left-color: var(--user-color);
 }
 
 .command-output-content {
@@ -414,6 +413,10 @@
 .command-output-content th {
     text-align: left;
     padding: 0 1em;
+}
+
+.content pre.command-output-content {
+    padding: .5em;
 }
 
 /* Bash command styling (user-initiated, right-aligned) */

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -89,7 +89,7 @@ def get_message_emoji(msg: "TemplateMessage") -> str:
             return ""
         return "🤷"
     elif msg_type == "bash-input":
-        return "🤷"
+        return "💻"
     elif msg_type == "assistant":
         if msg.modifiers.is_sidechain:
             return "🔗"

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -672,7 +672,7 @@ def _process_local_command_output(
     # If parsing fails, content will be None and caller will handle fallback
 
     message_type = "user"
-    message_title = "Command output"
+    message_title = ""
     return modifiers, content, message_type, message_title
 
 
@@ -702,7 +702,7 @@ def _process_bash_output(
     # If parsing fails, content will be None - caller/renderer handles empty output
 
     message_type = "bash-output"
-    message_title = "Command output"
+    message_title = ""
     return modifiers, content, message_type, message_title
 
 

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -2388,8 +2388,7 @@
   
   /* Slash command prompts (isMeta=true, LLM-generated content) */
   .user.slash-command {
-      border-left-color: var(--user-dimmed);
-      opacity: 0.85;
+      border-left-color: var(--user-color);
   }
   
   .assistant {
@@ -2480,8 +2479,8 @@
   
   /* Command output styling */
   .command-output {
-      background-color: #1e1e1e11;
-      border-left-color: var(--warning-dimmed);
+      background-color: var(--highlight-light);
+      border-left-color: var(--user-color);
   }
   
   .command-output-content {
@@ -2506,6 +2505,10 @@
   .command-output-content th {
       text-align: left;
       padding: 0 1em;
+  }
+  
+  .content pre.command-output-content {
+      padding: .5em;
   }
   
   /* Bash command styling (user-initiated, right-aligned) */
@@ -7186,8 +7189,7 @@
   
   /* Slash command prompts (isMeta=true, LLM-generated content) */
   .user.slash-command {
-      border-left-color: var(--user-dimmed);
-      opacity: 0.85;
+      border-left-color: var(--user-color);
   }
   
   .assistant {
@@ -7278,8 +7280,8 @@
   
   /* Command output styling */
   .command-output {
-      background-color: #1e1e1e11;
-      border-left-color: var(--warning-dimmed);
+      background-color: var(--highlight-light);
+      border-left-color: var(--user-color);
   }
   
   .command-output-content {
@@ -7304,6 +7306,10 @@
   .command-output-content th {
       text-align: left;
       padding: 0 1em;
+  }
+  
+  .content pre.command-output-content {
+      padding: .5em;
   }
   
   /* Bash command styling (user-initiated, right-aligned) */
@@ -9842,7 +9848,7 @@
       
       <div class='message user command-output pair_last session-edge_cases' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
-              <span>Command output</span>
+              <span></span>
               <div class='header-info'>
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:02:20Z'>2025-06-14 11:02:20</span>
@@ -12074,8 +12080,7 @@
   
   /* Slash command prompts (isMeta=true, LLM-generated content) */
   .user.slash-command {
-      border-left-color: var(--user-dimmed);
-      opacity: 0.85;
+      border-left-color: var(--user-color);
   }
   
   .assistant {
@@ -12166,8 +12171,8 @@
   
   /* Command output styling */
   .command-output {
-      background-color: #1e1e1e11;
-      border-left-color: var(--warning-dimmed);
+      background-color: var(--highlight-light);
+      border-left-color: var(--user-color);
   }
   
   .command-output-content {
@@ -12192,6 +12197,10 @@
   .command-output-content th {
       text-align: left;
       padding: 0 1em;
+  }
+  
+  .content pre.command-output-content {
+      padding: .5em;
   }
   
   /* Bash command styling (user-initiated, right-aligned) */
@@ -17010,8 +17019,7 @@
   
   /* Slash command prompts (isMeta=true, LLM-generated content) */
   .user.slash-command {
-      border-left-color: var(--user-dimmed);
-      opacity: 0.85;
+      border-left-color: var(--user-color);
   }
   
   .assistant {
@@ -17102,8 +17110,8 @@
   
   /* Command output styling */
   .command-output {
-      background-color: #1e1e1e11;
-      border-left-color: var(--warning-dimmed);
+      background-color: var(--highlight-light);
+      border-left-color: var(--user-color);
   }
   
   .command-output-content {
@@ -17128,6 +17136,10 @@
   .command-output-content th {
       text-align: left;
       padding: 0 1em;
+  }
+  
+  .content pre.command-output-content {
+      padding: .5em;
   }
   
   /* Bash command styling (user-initiated, right-aligned) */


### PR DESCRIPTION
## Summary
- Make thinking content styling cleaner with italic font and smaller size
- Normalize command output styling between slash commands and bash outputs

## Test plan
- [ ] Visual inspection of thinking blocks in generated HTML
- [ ] Verify command output styling is consistent across message types

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling for slash commands and command outputs (color, background, padding) for clearer hierarchy.
  * Simplified thinking content to italic, smaller text with restored emphasis formatting.
  * Removed visible "Command output" labels for cleaner messages.

* **UI**
  * Changed bash input indicator icon to 💻.

* **Tests**
  * Updated HTML snapshots to reflect presentational changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->