### PR TITLE
Improve CSS layout to be responsive for mobile small screens

### DIFF
--- a/claude_code_log/html/templates/components/global_styles.css
+++ b/claude_code_log/html/templates/components/global_styles.css
@@ -229,3 +229,9 @@ pre {
 .timeline-toggle.floating-btn {
     bottom: 200px;
 }
+
+@media (max-width: 1280px) {
+    .header > span:first-child {
+        flex: auto;
+    }
+}

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -917,3 +917,42 @@ details summary {
     border-radius: 4px;
     margin: 10px 0;
 }
+
+@media (max-width: 1280px) {
+    .fold-bar {
+        height: auto;
+    }
+    .user:not(.compacted),
+    .bash-input,
+    .bash-output,
+    .system:not(.system-info):not(.system-warning):not(.system-error) {
+        margin-left: 10%;
+    }
+    .system-error {
+        margin-right: 8%;
+    }
+    .assistant,
+    .thinking {
+        margin-right: 8%;
+    }
+    .tool_use,
+    .tool_result {
+        margin-left: 2%;
+        margin-right: 6%;
+    }
+    .system-warning,
+    .system-info {
+        margin-left: 2%;
+        margin-right: 6%;
+    }
+    .sidechain.assistant,
+    .sidechain.thinking {
+        margin-left: 4%;
+        margin-right: 4%;
+    }
+    .sidechain.tool_use,
+    .sidechain.tool_result {
+        margin-left: 6%;
+        margin-right: 2%;
+    }
+}


### PR DESCRIPTION
```sh
# local testing
uv sync --reinstall-package claude-code-log
claude-code-log
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced responsive behavior for screens 1280px and smaller, improving header layout and message spacing for mobile and tablet users
* **Bug Fixes**
  * Addressed a styling duplication that could cause inconsistent rendering on some devices, ensuring more reliable layout across viewports

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->