### PR TITLE
Fix WebSearch and WebFetch rendering in agent transcripts

### DIFF
--- a/claude_code_log/factories/tool_factory.py
+++ b/claude_code_log/factories/tool_factory.py
@@ -652,14 +652,15 @@ def parse_webfetch_output(
                 code_text=tool_use_result.get("codeText"),
                 duration_ms=tool_use_result.get("durationMs"),
             )
-
-    # Fallback: try to extract from tool_result content
-    content = _extract_tool_result_text(tool_result)
-    if not content:
+        # Structured data present but incomplete — don't fall through
         return None
 
-    # For fallback, we don't have the rich metadata, just the result text
-    # We also don't have the URL, so return None (will use generic formatter)
+    # Fallback: use text content as result (agent progress entries lack toolUseResult).
+    # URL comes from the tool_use input title, not needed here for rendering.
+    content = _extract_tool_result_text(tool_result)
+    if content:
+        return WebFetchOutput(url="", result=content)
+
     return None
 
 

--- a/test/test_webfetch_rendering.py
+++ b/test/test_webfetch_rendering.py
@@ -114,11 +114,23 @@ class TestWebFetchOutput:
         assert output.code is None
 
     def test_parse_webfetch_output_no_tool_use_result(self):
-        """Test parsing WebFetch output without toolUseResult returns None."""
+        """Test parsing WebFetch output without toolUseResult uses text fallback."""
         tool_result = ToolResultContent(
             type="tool_result",
             tool_use_id="toolu_test",
             content="Some content",
+        )
+        output = parse_webfetch_output(tool_result, None, None)
+        assert output is not None
+        assert output.url == ""
+        assert output.result == "Some content"
+
+    def test_parse_webfetch_output_no_tool_use_result_empty(self):
+        """Test parsing WebFetch output without toolUseResult and no content returns None."""
+        tool_result = ToolResultContent(
+            type="tool_result",
+            tool_use_id="toolu_test",
+            content="",
         )
         output = parse_webfetch_output(tool_result, None, None)
         assert output is None


### PR DESCRIPTION
## Summary

Agent progress entries lack the structured `toolUseResult` field that the WebSearch and WebFetch parsers rely on for specialized rendering. This caused both tool types to fall back to generic preformatted text display when used inside sub-agents.

## Changes

**WebSearch** (`tool_factory.py`): Added `_parse_websearch_from_text()` fallback that extracts query, links JSON, and summary from the text content format (`Web search results for query: "..."\n\nLinks: [{...}]\n\nSummary...`).

**WebFetch** (`tool_factory.py`): When `toolUseResult` is absent, use the text content directly as the markdown result. The URL is already shown in the tool_use title. When `toolUseResult` is present but incomplete, don't fall through to the text fallback.

## Test plan

- [x] `just test` — all 695 tests pass
- [x] `uv run pyright` / `uv run ty check` — clean
- [x] Visual check on a project with agent WebSearch/WebFetch calls — results render with clickable links and markdown formatting instead of raw `<pre>` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web search result parsing with enhanced fallback handling for incomplete data.
  * Enhanced web fetch output handling with robust fallback mechanisms when structured data is unavailable or incomplete.
  * Better content extraction from textual sources when structured results are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->