### PR TITLE
Integrate agent transcripts into the DAG (Phase C)

### DIFF
--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -570,7 +570,7 @@ def deduplicate_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntr
 
         # For system messages, include level to differentiate info/warning/error
         if isinstance(message, SystemTranscriptEntry):
-            level = getattr(message, "level", "info")
+            level = message.level or "info"
             message_type = f"system-{level}"
 
         # Get timestamp

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1144,6 +1144,9 @@ def convert_jsonl_to(
         # Repair progress chain gaps for single-file mode
         progress_chain = _scan_progress_chains(input_path)
         _repair_parent_chains(messages, progress_chain)
+        # Parent agent entries and assign synthetic session IDs (same as
+        # directory mode) so DAG-based ordering handles sidechain placement.
+        _integrate_agent_entries(messages)
         title = f"Claude Transcript - {input_path.stem}"
         cache_was_updated = False  # No cache in single file mode
     else:

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -428,16 +428,25 @@ def _integrate_agent_entries(messages: list[TranscriptEntry]) -> None:
 
     Mutates entries in place (Pydantic v2 models are mutable by default).
     """
-    # Build agentId -> anchor UUID map from main-session entries
+    # Build agentId -> anchor UUID map.
+    # An anchor is any entry whose agentId references a sidechain transcript.
+    # Prefer non-sidechain anchors (main session), but also accept sidechain
+    # anchors (nested agents: agent A spawns agent B, so B's anchor lives
+    # inside A's sidechain).
     agent_anchors: dict[str, str] = {}
+    agent_anchors_from_sidechain: dict[str, str] = {}
     for msg in messages:
         if not isinstance(msg, BaseTranscriptEntry):
             continue
-        if msg.isSidechain:
+        if not msg.agentId:
             continue
-        # Main-session entries with agentId reference an agent transcript
-        if msg.agentId:
+        if msg.isSidechain:
+            agent_anchors_from_sidechain.setdefault(msg.agentId, msg.uuid)
+        else:
             agent_anchors[msg.agentId] = msg.uuid
+    # Merge: non-sidechain anchors take priority
+    for agent_id, uuid in agent_anchors_from_sidechain.items():
+        agent_anchors.setdefault(agent_id, uuid)
 
     if not agent_anchors:
         return
@@ -1561,13 +1570,14 @@ def _collect_project_sessions(messages: list[TranscriptEntry]) -> list[dict[str,
             ):
                 session_summaries[uuid_to_session_backup[leaf_uuid]] = message.summary
 
-    # Group messages by session (excluding warmup-only sessions)
+    # Group messages by session (excluding warmup-only sessions,
+    # coalescing agent sessions into their parent)
     sessions: dict[str, dict[str, Any]] = {}
     for message in messages:
         if hasattr(message, "sessionId") and not isinstance(
             message, SummaryTranscriptEntry
         ):
-            session_id = getattr(message, "sessionId", "")
+            session_id = get_parent_session_id(getattr(message, "sessionId", ""))
             if not session_id or session_id in warmup_session_ids:
                 continue
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -32,6 +32,7 @@ from .parser import parse_timestamp
 from .factories import create_transcript_entry
 from .models import (
     BaseTranscriptEntry,
+    PassthroughTranscriptEntry,
     TranscriptEntry,
     AssistantTranscriptEntry,
     QueueOperationTranscriptEntry,
@@ -130,24 +131,37 @@ def _repair_parent_chains(
     messages: list[TranscriptEntry],
     progress_chain: dict[str, Optional[str]],
 ) -> None:
-    """Repair parentUuid fields that point to progress entries.
+    """Repair parentUuid fields that point to dropped progress entries.
 
     Walks the progress chain to find the nearest non-progress ancestor.
+    Only repairs links to progress entries that are NOT in the messages
+    list (i.e. those that were truly dropped, not preserved as
+    PassthroughTranscriptEntry).
     Mutates entries in place (Pydantic v2 models are mutable by default).
     """
     if not progress_chain:
         return
+    # Filter out progress UUIDs that are present as parsed entries —
+    # those are PassthroughTranscriptEntry nodes in the DAG and valid parents.
+    present_uuids = {getattr(m, "uuid", None) for m in messages}
+    dropped_progress = {
+        uuid: parent
+        for uuid, parent in progress_chain.items()
+        if uuid not in present_uuids
+    }
+    if not dropped_progress:
+        return
     for msg in messages:
         parent = getattr(msg, "parentUuid", None)
-        if parent and parent in progress_chain:
+        if parent and parent in dropped_progress:
             current: Optional[str] = parent
             seen: set[str] = set()
-            while current is not None and current in progress_chain:
+            while current is not None and current in dropped_progress:
                 if current in seen:
                     current = None
                     break
                 seen.add(current)
-                current = progress_chain[current]
+                current = dropped_progress[current]
             msg.parentUuid = current  # type: ignore[union-attr]
 
 
@@ -312,19 +326,20 @@ def load_transcript(
                         # Parse using Pydantic models
                         entry = create_transcript_entry(entry_dict)
                         messages.append(entry)
-                    elif (
-                        entry_type
-                        in [
-                            "file-history-snapshot",  # Internal Claude Code file backup metadata
-                            "progress",  # Real-time progress updates (hook_progress, bash_progress)
-                        ]
-                    ):
-                        # Silently skip internal message types we don't render
-                        pass
-                    else:
-                        display_line = line[:1000] + "..." if len(line) > 1000 else line
-                        print(
-                            f"Line {line_no} of {jsonl_path} is not a recognised message type: {display_line}"
+                    elif entry_dict.get("uuid") and entry_dict.get("sessionId"):
+                        # Unknown type with DAG-relevant fields — create a
+                        # PassthroughTranscriptEntry to preserve DAG chain
+                        # continuity (e.g. "attachment", "permission-mode").
+                        messages.append(
+                            PassthroughTranscriptEntry(
+                                uuid=entry_dict["uuid"],
+                                parentUuid=entry_dict.get("parentUuid"),
+                                sessionId=entry_dict["sessionId"],
+                                timestamp=entry_dict.get("timestamp", ""),
+                                type=entry_type,
+                                isSidechain=entry_dict.get("isSidechain", False),
+                                agentId=entry_dict.get("agentId"),
+                            )
                         )
                 except json.JSONDecodeError as e:
                     print(
@@ -436,7 +451,7 @@ def _integrate_agent_entries(messages: list[TranscriptEntry]) -> None:
     agent_anchors: dict[str, str] = {}
     agent_anchors_from_sidechain: dict[str, str] = {}
     for msg in messages:
-        if not isinstance(msg, BaseTranscriptEntry):
+        if not isinstance(msg, (BaseTranscriptEntry, PassthroughTranscriptEntry)):
             continue
         if not msg.agentId:
             continue
@@ -453,7 +468,7 @@ def _integrate_agent_entries(messages: list[TranscriptEntry]) -> None:
 
     # Process sidechain entries: parent roots and assign synthetic sessionIds
     for msg in messages:
-        if not isinstance(msg, BaseTranscriptEntry):
+        if not isinstance(msg, (BaseTranscriptEntry, PassthroughTranscriptEntry)):
             continue
         if not msg.isSidechain or not msg.agentId:
             continue
@@ -794,7 +809,7 @@ def _build_session_data_from_messages(
     sessions: Dict[str, Dict[str, Any]] = {}
     for message in messages:
         if not hasattr(message, "sessionId") or isinstance(
-            message, SummaryTranscriptEntry
+            message, (SummaryTranscriptEntry, PassthroughTranscriptEntry)
         ):
             continue
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from .utils import (
     format_timestamp_range,
+    get_parent_session_id,
     get_project_display_name,
     is_agent_session,
     should_use_as_session_starter,
@@ -788,10 +789,8 @@ def _build_session_data_from_messages(
         ):
             continue
 
-        session_id = getattr(message, "sessionId", "")
+        session_id = get_parent_session_id(getattr(message, "sessionId", ""))
         if not session_id or session_id in warmup_session_ids:
-            continue
-        if is_agent_session(session_id):
             continue
 
         if session_id not in sessions:
@@ -926,11 +925,7 @@ def _generate_paginated_html(
     for msg in messages:
         session_id = getattr(msg, "sessionId", None)
         if session_id:
-            key = (
-                session_id.split("#agent-")[0]
-                if is_agent_session(session_id)
-                else session_id
-            )
+            key = get_parent_session_id(session_id)
             if key not in messages_by_session:
                 messages_by_session[key] = []
             messages_by_session[key].append(msg)
@@ -1432,8 +1427,8 @@ def _update_cache_with_session_data(
         if hasattr(message, "sessionId") and not isinstance(
             message, SummaryTranscriptEntry
         ):
-            session_id = getattr(message, "sessionId", "")
-            if not session_id or is_agent_session(session_id):
+            session_id = get_parent_session_id(getattr(message, "sessionId", ""))
+            if not session_id:
                 continue
 
             if session_id not in sessions_cache_data:
@@ -1469,7 +1464,7 @@ def _update_cache_with_session_data(
         if message.type == "assistant" and hasattr(message, "message"):
             assistant_message = getattr(message, "message")
             request_id = getattr(message, "requestId", None)
-            session_id = getattr(message, "sessionId", "")
+            session_id = get_parent_session_id(getattr(message, "sessionId", ""))
 
             if (
                 hasattr(assistant_message, "usage")

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -583,15 +583,19 @@ def deduplicate_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntr
         session_id = getattr(message, "sessionId", "")
 
         # Get content key for differentiating concurrent messages
-        # - For assistant messages: use message.id (same for stutters, different for different msgs)
+        # - For assistant messages: use message.id + content block types
+        #   (stutters share the same message.id AND content types;
+        #   split content blocks share message.id but have distinct types)
         # - For user messages with tool results: use first tool_use_id
-        # - For user text messages: use empty string (deduplicate by timestamp alone)
+        # - For user text messages: use uuid (DAG parent references must stay valid)
         # - For summary messages: use leafUuid (summaries have no timestamp/uuid)
+        # - For system messages: use uuid (different system events can share a timestamp)
+        # - For passthrough entries: use uuid (DAG chain nodes)
         content_key = ""
         is_user_text = False
         if isinstance(message, AssistantTranscriptEntry):
-            # For assistant messages, use the message id
-            content_key = message.message.id
+            block_types = ":".join(c.type for c in message.message.content)
+            content_key = f"{message.message.id}:{block_types}"
         elif isinstance(message, UserTranscriptEntry):
             # For user messages, check for tool results
             for item in message.message.content:
@@ -600,16 +604,12 @@ def deduplicate_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntr
                     break
             else:
                 # No tool result found - this is a user text message.
-                # Use uuid to keep distinct messages (even at same timestamp)
-                # so DAG parent references remain valid.
                 is_user_text = True
                 content_key = message.uuid
         elif isinstance(message, SummaryTranscriptEntry):
             # Summaries have no timestamp or uuid - use leafUuid to keep them distinct
             content_key = message.leafUuid
-        elif isinstance(message, PassthroughTranscriptEntry):
-            # Passthrough entries are DAG chain nodes — use uuid to prevent
-            # false dedup of entries with the same timestamp (e.g. attachments)
+        elif isinstance(message, (SystemTranscriptEntry, PassthroughTranscriptEntry)):
             content_key = message.uuid
 
         # Create deduplication key

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 from .utils import (
     format_timestamp_range,
     get_project_display_name,
+    is_agent_session,
     should_use_as_session_starter,
     create_session_preview,
     get_warmup_session_ids,
@@ -790,6 +791,8 @@ def _build_session_data_from_messages(
         session_id = getattr(message, "sessionId", "")
         if not session_id or session_id in warmup_session_ids:
             continue
+        if is_agent_session(session_id):
+            continue
 
         if session_id not in sessions:
             sessions[session_id] = {
@@ -917,14 +920,20 @@ def _generate_paginated_html(
             if orphan_path.exists():
                 orphan_path.unlink()
 
-    # Group messages by session for fast lookup
+    # Group messages by session for fast lookup (agent messages grouped
+    # under their parent session since they don't have their own pages)
     messages_by_session: Dict[str, List[TranscriptEntry]] = {}
     for msg in messages:
         session_id = getattr(msg, "sessionId", None)
         if session_id:
-            if session_id not in messages_by_session:
-                messages_by_session[session_id] = []
-            messages_by_session[session_id].append(msg)
+            key = (
+                session_id.split("#agent-")[0]
+                if is_agent_session(session_id)
+                else session_id
+            )
+            if key not in messages_by_session:
+                messages_by_session[key] = []
+            messages_by_session[key].append(msg)
 
     first_page_path = output_dir / _get_page_html_path(1)
 
@@ -1225,7 +1234,11 @@ def convert_jsonl_to(
             current_session_ids: set[str] = set()
             for message in messages:
                 session_id = getattr(message, "sessionId", "")
-                if session_id and session_id not in warmup_session_ids:
+                if (
+                    session_id
+                    and session_id not in warmup_session_ids
+                    and not is_agent_session(session_id)
+                ):
                     current_session_ids.add(session_id)
             session_data = {
                 session_id: session_cache
@@ -1420,7 +1433,7 @@ def _update_cache_with_session_data(
             message, SummaryTranscriptEntry
         ):
             session_id = getattr(message, "sessionId", "")
-            if not session_id:
+            if not session_id or is_agent_session(session_id):
                 continue
 
             if session_id not in sessions_cache_data:
@@ -1667,7 +1680,7 @@ def _generate_individual_session_files(
             if (
                 session_id
                 and session_id not in warmup_session_ids
-                and "#agent-" not in session_id
+                and not is_agent_session(session_id)
             ):
                 session_ids.add(session_id)
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -411,6 +411,49 @@ def load_transcript(
     return messages
 
 
+def _integrate_agent_entries(messages: list[TranscriptEntry]) -> None:
+    """Parent agent entries and assign synthetic session IDs.
+
+    Agent (sidechain) entries share sessionId with their parent session
+    but form separate conversation threads. This function:
+
+    1. Builds a map of agentId -> anchor UUID (the main-session User entry
+       whose agentId matches, i.e. the tool_result that references the agent)
+    2. For each agent's root entry (parentUuid=None, isSidechain=True),
+       sets parentUuid to the anchor UUID
+    3. Assigns a synthetic sessionId ("{sessionId}#agent-{agentId}") to all
+       agent entries so they form separate DAG-lines
+
+    Mutates entries in place (Pydantic v2 models are mutable by default).
+    """
+    # Build agentId -> anchor UUID map from main-session entries
+    agent_anchors: dict[str, str] = {}
+    for msg in messages:
+        if not isinstance(msg, BaseTranscriptEntry):
+            continue
+        if msg.isSidechain:
+            continue
+        # Main-session entries with agentId reference an agent transcript
+        if msg.agentId:
+            agent_anchors[msg.agentId] = msg.uuid
+
+    if not agent_anchors:
+        return
+
+    # Process sidechain entries: parent roots and assign synthetic sessionIds
+    for msg in messages:
+        if not isinstance(msg, BaseTranscriptEntry):
+            continue
+        if not msg.isSidechain or not msg.agentId:
+            continue
+        agent_id = msg.agentId
+        # Assign synthetic session ID to separate from main session
+        msg.sessionId = f"{msg.sessionId}#agent-{agent_id}"
+        # Parent the root entry to the anchor
+        if msg.parentUuid is None and agent_id in agent_anchors:
+            msg.parentUuid = agent_anchors[agent_id]
+
+
 def load_directory_transcripts(
     directory_path: Path,
     cache_manager: Optional["CacheManager"] = None,
@@ -441,31 +484,28 @@ def load_directory_transcripts(
     progress_chain = _scan_progress_chains(directory_path)
     _repair_parent_chains(all_messages, progress_chain)
 
-    # Partition: sidechain entries excluded from DAG (Phase C scope)
-    sidechain_entries = [e for e in all_messages if getattr(e, "isSidechain", False)]
-    main_entries = [e for e in all_messages if not getattr(e, "isSidechain", False)]
+    # Parent agent entries and assign synthetic session IDs so they
+    # form separate DAG-lines spliced at their anchor points.
+    _integrate_agent_entries(all_messages)
 
-    # Collect sidechain UUIDs so DAG build can suppress orphan warnings
-    # for parents that exist in sidechain data (will be integrated in Phase C)
-    sidechain_uuids: set[str] = {
-        e.uuid for e in sidechain_entries if isinstance(e, BaseTranscriptEntry)
-    }
-    # Also scan unloaded subagent files (e.g. aprompt_suggestion agents
-    # that are never referenced via agentId in the main session)
-    sidechain_uuids |= _scan_sidechain_uuids(directory_path)
+    # Collect UUIDs from unloaded subagent files (e.g. aprompt_suggestion
+    # agents never referenced via agentId) to suppress orphan warnings
+    unloaded_sidechain_uuids = _scan_sidechain_uuids(directory_path)
 
     # Build DAG and traverse (entries grouped by session, depth-first)
-    tree = build_dag_from_entries(main_entries, sidechain_uuids=sidechain_uuids)
+    tree = build_dag_from_entries(
+        all_messages, sidechain_uuids=unloaded_sidechain_uuids
+    )
     dag_ordered = traverse_session_tree(tree)
 
     # Re-add summaries/queue-ops (excluded from DAG since they lack uuid)
     non_dag_entries: list[TranscriptEntry] = [
         e
-        for e in main_entries
+        for e in all_messages
         if isinstance(e, (SummaryTranscriptEntry, QueueOperationTranscriptEntry))
     ]
 
-    return dag_ordered + sidechain_entries + non_dag_entries, tree
+    return dag_ordered + non_dag_entries, tree
 
 
 # =============================================================================
@@ -1619,12 +1659,16 @@ def _generate_individual_session_files(
     # Pre-compute warmup sessions to exclude them
     warmup_session_ids = get_warmup_session_ids(messages)
 
-    # Find all unique session IDs (excluding warmup sessions)
+    # Find all unique session IDs (excluding warmup and agent sessions)
     session_ids: set[str] = set()
     for message in messages:
         if hasattr(message, "sessionId"):
             session_id: str = getattr(message, "sessionId")
-            if session_id and session_id not in warmup_session_ids:
+            if (
+                session_id
+                and session_id not in warmup_session_ids
+                and "#agent-" not in session_id
+            ):
                 session_ids.add(session_id)
 
     # Get session data from cache for better titles

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -607,6 +607,10 @@ def deduplicate_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntr
         elif isinstance(message, SummaryTranscriptEntry):
             # Summaries have no timestamp or uuid - use leafUuid to keep them distinct
             content_key = message.leafUuid
+        elif isinstance(message, PassthroughTranscriptEntry):
+            # Passthrough entries are DAG chain nodes — use uuid to prevent
+            # false dedup of entries with the same timestamp (e.g. attachments)
+            content_key = message.uuid
 
         # Create deduplication key
         dedup_key = (message_type, timestamp, is_meta, session_id, content_key)

--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -49,6 +49,7 @@ class SessionDAGLine:
     attachment_uuid: Optional[str] = None  # UUID in parent where this attaches
     is_branch: bool = False  # True for within-session fork branches
     original_session_id: Optional[str] = None  # Original session_id before fork split
+    is_sidechain: bool = False  # True for agent transcript sessions
 
 
 @dataclass
@@ -138,8 +139,9 @@ def build_dag(
     """Populate children_uuids on each node. Mutates nodes in place.
 
     Warns about orphan nodes (parentUuid points outside loaded data)
-    and validates acyclicity. Parents known to be in sidechain data
-    (Phase C scope) are silently promoted to root without warning.
+    and validates acyclicity. Parents known to be in unloaded sidechain
+    data (e.g. aprompt_suggestion agents) are silently promoted to root
+    without warning.
     """
     _sidechain_uuids = sidechain_uuids or set()
 
@@ -639,7 +641,8 @@ def build_dag_from_entries(
 
     Convenience function that runs Steps 1-4 in sequence.
     ``sidechain_uuids`` suppresses orphan warnings for parents known
-    to be in sidechain data (not yet integrated, Phase C scope).
+    to be in unloaded sidechain data (e.g. aprompt_suggestion agents
+    that are never referenced via agentId in the main session).
     """
     nodes = build_message_index(entries)
     build_dag(nodes, sidechain_uuids=sidechain_uuids)

--- a/claude_code_log/factories/system_factory.py
+++ b/claude_code_log/factories/system_factory.py
@@ -83,5 +83,5 @@ def create_system_message(
 
     # Create structured system content
     meta = create_meta(transcript)
-    level = getattr(transcript, "level", "info")
+    level = transcript.level or "info"
     return SystemMessage(level=level, text=transcript.content, meta=meta)

--- a/claude_code_log/factories/transcript_factory.py
+++ b/claude_code_log/factories/transcript_factory.py
@@ -24,6 +24,7 @@ from ..models import (
     # Transcript entry types
     AssistantTranscriptEntry,
     MessageType,
+    PassthroughTranscriptEntry,
     QueueOperationTranscriptEntry,
     SummaryTranscriptEntry,
     SystemTranscriptEntry,
@@ -233,6 +234,17 @@ def create_transcript_entry(data: dict[str, Any]) -> TranscriptEntry:
     """
     entry_type = data.get("type")
     creator = ENTRY_CREATORS.get(entry_type)  # type: ignore[arg-type]
-    if creator is None:
-        raise ValueError(f"Unknown transcript entry type: {entry_type}")
-    return creator(data)
+    if creator is not None:
+        return creator(data)
+    # Fall back to PassthroughTranscriptEntry for unknown types with DAG fields
+    if data.get("uuid") and data.get("sessionId"):
+        return PassthroughTranscriptEntry(
+            uuid=data["uuid"],
+            parentUuid=data.get("parentUuid"),
+            sessionId=data["sessionId"],
+            timestamp=data.get("timestamp", ""),
+            type=entry_type,
+            isSidechain=data.get("isSidechain", False),
+            agentId=data.get("agentId"),
+        )
+    raise ValueError(f"Unknown transcript entry type: {entry_type}")

--- a/claude_code_log/html/system_formatters.py
+++ b/claude_code_log/html/system_formatters.py
@@ -90,6 +90,15 @@ def format_session_header_content(content: SessionHeaderMessage) -> str:
     escaped_title = html.escape(content.title)
     if content.is_branch and content.parent_message_index is not None:
         # Branch header: compact with back-reference to fork point
+        # Show session info for cross-session branches (different real session)
+        session_info = ""
+        if content.original_session_id and content.parent_session_id:
+            parent_real_sid = content.parent_session_id.split("@")[0]
+            if content.original_session_id != parent_real_sid:
+                esc_sid = html.escape(content.original_session_id[:8])
+                session_info = (
+                    f' <span class="branch-session">(in Session {esc_sid})</span>'
+                )
         fork_backref = ""
         if content.parent_session_summary:
             escaped_fork = html.escape(content.parent_session_summary)
@@ -106,7 +115,7 @@ def format_session_header_content(content: SessionHeaderMessage) -> str:
                 f'class="branch-backlink">'
                 f"&#x2442; Fork point</a></div>"
             )
-        return f"{escaped_title}{fork_backref}"
+        return f"{escaped_title}{session_info}{fork_backref}"
     if content.parent_session_id:
         parent_label = content.parent_session_summary or content.parent_session_id[:8]
         escaped_parent = html.escape(parent_label)

--- a/claude_code_log/html/system_formatters.py
+++ b/claude_code_log/html/system_formatters.py
@@ -89,23 +89,24 @@ def format_session_header_content(content: SessionHeaderMessage) -> str:
     """
     escaped_title = html.escape(content.title)
     if content.is_branch and content.parent_message_index is not None:
-        # Branch header: backlink to fork point with context
-        fork_label = "fork point"
+        # Branch header: compact with back-reference to fork point
+        fork_backref = ""
         if content.parent_session_summary:
-            escaped_summary = html.escape(content.parent_session_summary)
-            fork_label = escaped_summary
-        # Show original session ID for context
-        orig_id = ""
-        if content.original_session_id:
-            orig_id = html.escape(content.original_session_id[:8])
-        link = (
-            f'<a href="#msg-d-{content.parent_message_index}" '
-            f'class="session-backlink branch-backlink">'
-            f"&#x21b3; branched from {fork_label}</a>"
-        )
-        return (
-            f"{orig_id} {link}{escaped_title}" if orig_id else f"{link}{escaped_title}"
-        )
+            escaped_fork = html.escape(content.parent_session_summary)
+            fork_backref = (
+                f'<div class="branch-from">'
+                f'from <a href="#msg-d-{content.parent_message_index}" '
+                f'class="branch-backlink">'
+                f"&#x2442; Fork point &bull; {escaped_fork}</a></div>"
+            )
+        else:
+            fork_backref = (
+                f'<div class="branch-from">'
+                f'from <a href="#msg-d-{content.parent_message_index}" '
+                f'class="branch-backlink">'
+                f"&#x2442; Fork point</a></div>"
+            )
+        return f"{escaped_title}{fork_backref}"
     if content.parent_session_id:
         parent_label = content.parent_session_summary or content.parent_session_id[:8]
         escaped_parent = html.escape(parent_label)

--- a/claude_code_log/html/templates/components/global_styles.css
+++ b/claude_code_log/html/templates/components/global_styles.css
@@ -38,6 +38,10 @@
     --system-error-color: #f44336;
     --tool-use-color: #4caf50;
 
+    /* Fork/branch structural colors */
+    --fork-point-color: #adb5bd;
+    --branch-point-color: #adb5bd;
+
     /* Question/answer tool colors */
     --question-accent: #f5a623;
     --question-bg: #fffbf0;

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -571,7 +571,7 @@
     background-color: transparent;
     box-shadow: none;
     border: none;
-    border-left: 3px solid #adb5bd;
+    border-left: 3px solid var(--branch-point-color);
     padding: 8px 14px;
     margin: 2em 0 1em 0;
 }
@@ -581,8 +581,8 @@
     margin-bottom: 0;
 }
 
-.branch-header .fold-bar-section.folded {
-    border-bottom-color: #adb5bd;
+.branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
+    border-bottom-color: var(--branch-point-color);
 }
 
 .session-subtitle {

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -573,12 +573,16 @@
     border: none;
     border-left: 3px solid #adb5bd;
     padding: 8px 14px;
-    margin: 4px 0 8px 0;
+    margin: 2em 0 1em 0;
 }
 
 .branch-header .header {
     font-size: 1em;
     margin-bottom: 0;
+}
+
+.branch-header .fold-bar-section.folded {
+    border-bottom-color: #adb5bd;
 }
 
 .session-subtitle {

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -567,6 +567,19 @@
 
 /* Branch headers (within-session forks) — indent set via inline
    style based on tree depth (margin-left: depth*2em). */
+.branch-header {
+    background-color: transparent;
+    box-shadow: none;
+    border: none;
+    border-left: 3px solid #adb5bd;
+    padding: 8px 14px;
+    margin: 4px 0 8px 0;
+}
+
+.branch-header .header {
+    font-size: 1em;
+    margin-bottom: 0;
+}
 
 .session-subtitle {
     font-size: 0.9em;

--- a/claude_code_log/html/templates/components/session_nav_styles.css
+++ b/claude_code_log/html/templates/components/session_nav_styles.css
@@ -127,11 +127,12 @@ a.session-backlink:hover {
 
 /* Fork point element — standalone structural element after a fork message */
 .fork-point {
-    margin: 8px 0 4px 0;
+    margin: 8px 0 2em 0;
     padding: 8px 14px;
     font-size: 0.85em;
     color: var(--text-muted, #6c757d);
     border-left: 3px solid #adb5bd;
+    border-radius: 8px;
 }
 
 .fork-point-header {

--- a/claude_code_log/html/templates/components/session_nav_styles.css
+++ b/claude_code_log/html/templates/components/session_nav_styles.css
@@ -131,7 +131,7 @@ a.session-backlink:hover {
     padding: 8px 14px;
     font-size: 0.85em;
     color: var(--text-muted, #6c757d);
-    border-left: 3px solid #adb5bd;
+    border-left: 3px solid var(--fork-point-color);
     border-radius: 8px;
 }
 

--- a/claude_code_log/html/templates/components/session_nav_styles.css
+++ b/claude_code_log/html/templates/components/session_nav_styles.css
@@ -125,32 +125,55 @@ a.session-backlink:hover {
     line-height: 1.3;
 }
 
-/* Within-session fork styles */
-.junction-forward-links {
+/* Fork point element — standalone structural element after a fork message */
+.fork-point {
+    margin: 8px 0 4px 0;
+    padding: 8px 14px;
+    font-size: 0.85em;
+    color: var(--text-muted, #6c757d);
+    border-left: 3px solid #adb5bd;
+}
+
+.fork-point-header {
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: var(--text-secondary, #495057);
+}
+
+.fork-point-branches {
     display: flex;
-    gap: 8px;
-    margin-top: 6px;
-    padding: 4px 8px;
-    font-size: 0.8em;
+    flex-direction: column;
+    gap: 2px;
+    padding-left: 12px;
 }
 
-.junction-link {
-    color: #6c757d;
+.fork-point-branch {
+    display: block;
     text-decoration: none;
-    padding: 2px 6px;
-    border: 1px dashed #adb5bd;
-    border-radius: 3px;
-    transition: background-color 0.2s;
+    color: var(--text-muted, #6c757d);
+    padding: 2px 0;
+    transition: color 0.2s;
 }
 
-.junction-link:hover {
-    background-color: #e9ecef;
-    color: var(--text-secondary);
+.fork-point-branch:hover {
+    color: var(--text-secondary, #495057);
+}
+
+/* Branch header back-reference to fork point */
+.branch-from {
+    font-size: 0.85em;
+    color: var(--text-muted, #6c757d);
+    margin-top: 2px;
 }
 
 .branch-backlink {
-    border-left: 2px dashed #888;
-    padding-left: 6px;
+    text-decoration: none;
+    color: var(--text-muted, #6c757d);
+    transition: color 0.2s;
+}
+
+.branch-backlink:hover {
+    color: var(--text-secondary, #495057);
 }
 
 /* Fork point and branch nav items — lightweight text links, not cards */

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -98,9 +98,9 @@
 
     {% for message, message_title, html_content, formatted_timestamp in messages %}
     {% if is_session_header(message) %}
-    <div class="session-divider"></div>
+    {% if not message.is_branch_header %}<div class="session-divider"></div>{% endif %}
     <div class='message session-header{% if message.is_branch_header %} branch-header{% endif %}' data-message-id='{{ message.message_id }}' data-session-id='{{ message.session_id }}' id='msg-{{ message.message_id }}'{% if message.branch_depth %} style='margin-left: {{ message.branch_depth * 2 }}em'{% endif %}>
-        <div class='header'>Session: {{ html_content|safe }}</div>
+        <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}</div>
         {% if message.has_children %}
         <div class='fold-bar' data-message-id='{{ message.message_id }}' data-border-color='session-header'>
             {% if message.immediate_children_count == message.total_descendants_count %}
@@ -143,13 +143,6 @@
         </div>
         {% if message.meta %}<div class='debug-info'>{{ message.meta.uuid[:12] }}{% if message.meta.parent_uuid %} &rarr; {{ message.meta.parent_uuid[:12] }}{% endif %}</div>{% endif %}
         <div class='content{% if markdown %} markdown{% endif %}'>{{ html_content | safe }}</div>
-        {% if message.junction_forward_links %}
-        <div class='junction-forward-links'>
-            {% for branch_sid, branch_idx in message.junction_forward_links %}
-            <a href='#msg-d-{{ branch_idx }}' class='junction-link'>&#x2192; {{ branch_sid.split('@')[-1][:8] }}</a>
-            {% endfor %}
-        </div>
-        {% endif %}
         {% if message.has_children %}
         <div class='fold-bar' data-message-id='{{ message.message_id }}' data-border-color='{{ msg_css_class }}'>
             {% if message.immediate_children_count == message.total_descendants_count %}
@@ -171,6 +164,17 @@
             {% endif %}
         </div>
         {% endif %}
+    </div>
+    {% endif %}
+    {% if message.junction_forward_links %}
+    {# Fork point element — rendered OUTSIDE the message box as a structural navigation element #}
+    <div class='fork-point{% for ancestor_index in message.ancestry %} d-{{ ancestor_index }}{% endfor %}'>
+        <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
+        <div class='fork-point-branches'>
+            {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
+            <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
+            {% endfor %}
+        </div>
     </div>
     {% endif %}
     {% endfor %}

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -220,12 +220,31 @@ class QueueOperationTranscriptEntry(BaseModel):
     )
 
 
+class PassthroughTranscriptEntry(BaseModel):
+    """Structural-only entry for DAG chain continuity.
+
+    Captures entries like "attachment", "permission-mode", etc. that have
+    uuid/parentUuid and participate in the DAG chain but are not rendered.
+    Without these, messages whose parentUuid points to a dropped entry
+    become false roots in the DAG.
+    """
+
+    uuid: str
+    parentUuid: Optional[str] = None
+    sessionId: str
+    timestamp: str
+    type: Optional[str] = None  # Original type (e.g. "attachment")
+    isSidechain: bool = False
+    agentId: Optional[str] = None
+
+
 TranscriptEntry = Union[
     UserTranscriptEntry,
     AssistantTranscriptEntry,
     SummaryTranscriptEntry,
     SystemTranscriptEntry,
     QueueOperationTranscriptEntry,
+    PassthroughTranscriptEntry,
 ]
 
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -851,6 +851,9 @@ def prepare_session_navigation(
     session_nav: list[dict[str, Any]] = []
 
     for session_id in session_order:
+        # Skip agent sidechain sessions (they appear inline, not in nav)
+        if "#agent-" in session_id:
+            continue
         session_info = sessions[session_id]
 
         # Skip empty sessions (agent-only, no user messages)
@@ -2019,6 +2022,14 @@ def _render_messages(
     for message in messages:
         message_type = message.type
 
+        # Determine if this message belongs to an agent sidechain session.
+        # Agent messages use the parent session's render_session_id so they
+        # stay grouped with the main session (no separate session header).
+        msg_session_id = getattr(message, "sessionId", "") or ""
+        agent_parent_session: Optional[str] = (
+            msg_session_id.split("#agent-")[0] if "#agent-" in msg_session_id else None
+        )
+
         # Check if this message starts a new branch (within-session fork)
         # Must happen before system/summary handling so branch state is
         # correct when tagging those messages with render_session_id.
@@ -2101,8 +2112,9 @@ def _render_messages(
             system_content = create_system_message(message)
             if system_content:
                 system_msg = TemplateMessage(system_content)
-                if current_render_session:
-                    system_msg.render_session_id = current_render_session
+                effective_session = agent_parent_session or current_render_session
+                if effective_session:
+                    system_msg.render_session_id = effective_session
                 ctx.register(system_msg)
             continue
 
@@ -2148,43 +2160,46 @@ def _render_messages(
         session_summary = sessions.get(session_id, {}).get("summary")
 
         # Add session header if this is a new session
+        # Skip headers for agent sidechain sessions (they appear inline)
+        is_agent_session = "#agent-" in session_id
         if session_id not in seen_sessions:
             seen_sessions.add(session_id)
-            current_session_summary = session_summary
-            session_title = (
-                f"{current_session_summary} • {session_id[:8]}"
-                if current_session_summary
-                else session_id[:8]
-            )
+            if not is_agent_session:
+                current_session_summary = session_summary
+                session_title = (
+                    f"{current_session_summary} • {session_id[:8]}"
+                    if current_session_summary
+                    else session_id[:8]
+                )
 
-            # Create meta with session_id for the session header
-            session_header_meta = MessageMeta(
-                session_id=session_id,
-                timestamp="",
-                uuid="",
-            )
-            hier = (session_hierarchy or {}).get(session_id, {})
-            parent_sid = hier.get("parent_session_id")
-            parent_msg_idx = (
-                ctx.session_first_message.get(parent_sid) if parent_sid else None
-            )
-            session_header_content = SessionHeaderMessage(
-                session_header_meta,
-                title=session_title,
-                session_id=session_id,
-                summary=current_session_summary,
-                parent_session_id=parent_sid,
-                parent_session_summary=(session_summaries or {}).get(parent_sid)
-                if parent_sid
-                else None,
-                parent_message_index=parent_msg_idx,
-                depth=hier.get("depth", 0),
-                attachment_uuid=hier.get("attachment_uuid"),
-            )
-            # Register and track session's first message
-            session_header = TemplateMessage(session_header_content)
-            msg_index = ctx.register(session_header)
-            ctx.session_first_message[session_id] = msg_index
+                # Create meta with session_id for the session header
+                session_header_meta = MessageMeta(
+                    session_id=session_id,
+                    timestamp="",
+                    uuid="",
+                )
+                hier = (session_hierarchy or {}).get(session_id, {})
+                parent_sid = hier.get("parent_session_id")
+                parent_msg_idx = (
+                    ctx.session_first_message.get(parent_sid) if parent_sid else None
+                )
+                session_header_content = SessionHeaderMessage(
+                    session_header_meta,
+                    title=session_title,
+                    session_id=session_id,
+                    summary=current_session_summary,
+                    parent_session_id=parent_sid,
+                    parent_session_summary=(session_summaries or {}).get(parent_sid)
+                    if parent_sid
+                    else None,
+                    parent_message_index=parent_msg_idx,
+                    depth=hier.get("depth", 0),
+                    attachment_uuid=hier.get("attachment_uuid"),
+                )
+                # Register and track session's first message
+                session_header = TemplateMessage(session_header_content)
+                msg_index = ctx.register(session_header)
+                ctx.session_first_message[session_id] = msg_index
 
         # Extract token usage for assistant messages
         # Only show token usage for the first message with each requestId to avoid duplicates
@@ -2242,8 +2257,9 @@ def _render_messages(
                     continue
 
                 chunk_msg = TemplateMessage(content_model)
-                if current_render_session:
-                    chunk_msg.render_session_id = current_render_session
+                effective_session = agent_parent_session or current_render_session
+                if effective_session:
+                    chunk_msg.render_session_id = effective_session
                 ctx.register(chunk_msg)
 
             else:
@@ -2292,8 +2308,9 @@ def _render_messages(
                     continue
 
                 tool_msg = TemplateMessage(tool_result.content)
-                if current_render_session:
-                    tool_msg.render_session_id = current_render_session
+                effective_session = agent_parent_session or current_render_session
+                if effective_session:
+                    tool_msg.render_session_id = effective_session
                 ctx.register(tool_msg)
 
     return ctx

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -668,11 +668,6 @@ def generate_template_messages(
     with log_timing("Reorder paired messages", t_start):
         template_messages = _reorder_paired_messages(template_messages)
 
-    # Reorder sidechains to appear after their Task results
-    # This must happen AFTER pair reordering, since that moves tool_results
-    with log_timing("Reorder sidechain messages", t_start):
-        template_messages = _reorder_sidechain_template_messages(template_messages)
-
     # Build hierarchy (message_id and ancestry) based on final order
     # This must happen AFTER all reordering to get correct parent-child relationships
     with log_timing("Build message hierarchy", t_start):
@@ -1703,82 +1698,6 @@ def _reorder_session_template_messages(
     for sid, msgs in session_messages_map.items():
         if sid not in used_sessions:
             result.extend(msgs)
-
-    return result
-
-
-def _reorder_sidechain_template_messages(
-    messages: list[TemplateMessage],
-) -> list[TemplateMessage]:
-    """Reorder template messages to place sidechains immediately after their Task results.
-
-    When parallel Task agents run, their sidechain messages may appear in arbitrary
-    order based on when each agent finishes. This function reorders messages so that
-    each sidechain's messages appear right after the Task result that references them.
-
-    Note: Deduplication of sidechain content (first user message = Task input,
-    last assistant message = Task output) is handled later by _cleanup_sidechain_duplicates
-    after the tree structure is built.
-
-    This must be called AFTER _reorder_paired_messages, since that function moves
-    tool_results next to their tool_uses, which changes where the agentId-bearing
-    messages end up.
-
-    Args:
-        messages: Template messages including sidechains
-
-    Returns:
-        Reordered messages with sidechains properly placed after their Task results
-    """
-    # First pass: extract sidechains grouped by agent_id
-    main_messages: list[TemplateMessage] = []
-    sidechain_map: dict[str, list[TemplateMessage]] = {}
-
-    for message in messages:
-        is_sidechain = message.is_sidechain
-        agent_id = message.agent_id
-
-        if is_sidechain and agent_id:
-            # Group sidechain messages by agent_id
-            if agent_id not in sidechain_map:
-                sidechain_map[agent_id] = []
-            sidechain_map[agent_id].append(message)
-        else:
-            main_messages.append(message)
-
-    # If no sidechains, return original order
-    if not sidechain_map:
-        return messages
-
-    # Second pass: insert sidechains after their Task result messages
-    result: list[TemplateMessage] = []
-    used_agents: set[str] = set()
-
-    for message in main_messages:
-        result.append(message)
-
-        # Check if this is a Task tool_result that references a sidechain (via agent_id)
-        # We only insert after tool_result (not tool_use) to avoid duplicates if
-        # tool_use ever gets agent_id in the future
-        agent_id = message.agent_id
-
-        # Only insert sidechain if not already inserted (handles case where
-        # multiple tool_results have the same agent_id)
-        if (
-            agent_id
-            and message.type == MessageType.TOOL_RESULT
-            and agent_id in sidechain_map
-            and agent_id not in used_agents
-        ):
-            # Insert the sidechain messages for this agent right after this message
-            # Note: ancestry will be rebuilt by _build_message_hierarchy() later
-            result.extend(sidechain_map[agent_id])
-            used_agents.add(agent_id)
-
-    # Append any sidechains that weren't matched (shouldn't happen normally)
-    for agent_id, sidechain_msgs in sidechain_map.items():
-        if agent_id not in used_agents:
-            result.extend(sidechain_msgs)
 
     return result
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2024,11 +2024,18 @@ def _render_messages(
 
         # Determine if this message belongs to an agent sidechain session.
         # Agent messages use the parent session's render_session_id so they
-        # stay grouped with the main session (no separate session header).
+        # stay grouped with the correct session (trunk or branch).
         msg_session_id = getattr(message, "sessionId", "") or ""
-        agent_parent_session: Optional[str] = (
-            msg_session_id.split("#agent-")[0] if "#agent-" in msg_session_id else None
-        )
+        agent_parent_session: Optional[str] = None
+        if "#agent-" in msg_session_id:
+            # Use session hierarchy to find the actual parent (may be a branch
+            # pseudo-session if the anchor is inside a within-session fork)
+            if session_hierarchy:
+                hier = session_hierarchy.get(msg_session_id, {})
+                agent_parent_session = hier.get("parent_session_id")
+            if not agent_parent_session:
+                # Fallback: extract original session from synthetic ID
+                agent_parent_session = msg_session_id.split("#agent-")[0]
 
         # Check if this message starts a new branch (within-session fork)
         # Must happen before system/summary handling so branch state is

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -67,6 +67,7 @@ from .utils import (
     format_timestamp,
     format_timestamp_range,
     get_project_display_name,
+    is_agent_session,
     should_skip_message,
     should_use_as_session_starter,
     create_session_preview,
@@ -852,7 +853,7 @@ def prepare_session_navigation(
 
     for session_id in session_order:
         # Skip agent sidechain sessions (they appear inline, not in nav)
-        if "#agent-" in session_id:
+        if is_agent_session(session_id):
             continue
         session_info = sessions[session_id]
 
@@ -2027,7 +2028,7 @@ def _render_messages(
         # stay grouped with the correct session (trunk or branch).
         msg_session_id = getattr(message, "sessionId", "") or ""
         agent_parent_session: Optional[str] = None
-        if "#agent-" in msg_session_id:
+        if is_agent_session(msg_session_id):
             # Use session hierarchy to find the actual parent (may be a branch
             # pseudo-session if the anchor is inside a within-session fork)
             if session_hierarchy:
@@ -2168,10 +2169,10 @@ def _render_messages(
 
         # Add session header if this is a new session
         # Skip headers for agent sidechain sessions (they appear inline)
-        is_agent_session = "#agent-" in session_id
+        is_agent = is_agent_session(session_id)
         if session_id not in seen_sessions:
             seen_sessions.add(session_id)
-            if not is_agent_session:
+            if not is_agent:
                 current_session_summary = session_summary
                 session_title = (
                     f"{current_session_summary} • {session_id[:8]}"

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2093,6 +2093,7 @@ def _render_messages(
         if session_id not in seen_sessions:
             seen_sessions.add(session_id)
             if not is_agent:
+                current_render_session = None  # Reset branch tracking
                 current_session_summary = session_summary
                 session_title = (
                     f"{current_session_summary} • {session_id[:8]}"

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -20,6 +20,7 @@ from .models import (
     MessageType,
     TranscriptEntry,
     AssistantTranscriptEntry,
+    PassthroughTranscriptEntry,
     SystemTranscriptEntry,
     SummaryTranscriptEntry,
     QueueOperationTranscriptEntry,
@@ -1749,6 +1750,10 @@ def _filter_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntry]:
     for message in messages:
         # Skip summary messages
         if isinstance(message, SummaryTranscriptEntry):
+            continue
+
+        # Skip passthrough entries (structural DAG nodes, not rendered)
+        if isinstance(message, PassthroughTranscriptEntry):
             continue
 
         # Skip most queue operations - only process 'remove' for counts

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -66,6 +66,7 @@ from .factories import (
 from .utils import (
     format_timestamp,
     format_timestamp_range,
+    get_parent_session_id,
     get_project_display_name,
     is_agent_session,
     should_skip_message,
@@ -2036,7 +2037,7 @@ def _render_messages(
                 agent_parent_session = hier.get("parent_session_id")
             if not agent_parent_session:
                 # Fallback: extract original session from synthetic ID
-                agent_parent_session = msg_session_id.split("#agent-")[0]
+                agent_parent_session = get_parent_session_id(msg_session_id)
 
         # Check if this message starts a new branch (within-session fork)
         # Must happen before system/summary handling so branch state is

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -194,9 +194,12 @@ class TemplateMessage:
         # Within-session fork tracking: effective session/branch ID for grouping
         self._render_session_id: Optional[str] = None
 
-        # Junction forward links: [(branch_session_id, branch_header_msg_index)]
+        # Junction forward links: [(branch_sid, branch_header_msg_index, branch_preview)]
         # Set on messages that are fork points, for rendering forward links
-        self.junction_forward_links: list[tuple[str, Optional[int]]] = []
+        self.junction_forward_links: list[tuple[str, Optional[int], str]] = []
+
+        # Fork point preview text (short excerpt of fork point message content)
+        self.fork_point_preview: str = ""
 
     # -- Properties derived from content/meta --
 
@@ -633,18 +636,37 @@ def generate_template_messages(
     if ctx.junction_targets:
         # Build UUID → TemplateMessage index for fast lookup
         uuid_to_msg: dict[str, TemplateMessage] = {}
+        # Build msg_index → TemplateMessage for branch preview lookup
+        idx_to_msg: dict[int, TemplateMessage] = {}
         for msg in ctx.messages:
             if msg.meta.uuid:
                 uuid_to_msg[msg.meta.uuid] = msg
+            if msg.message_index is not None:
+                idx_to_msg[msg.message_index] = msg
         for uuid, target_sids in ctx.junction_targets.items():
             # Only add forward links for within-session fork branches
             branch_targets = [sid for sid in target_sids if "@" in sid]
             if branch_targets and uuid in uuid_to_msg:
                 fork_msg = uuid_to_msg[uuid]
+                fork_msg.fork_point_preview = _fork_point_preview(fork_msg, ctx)
                 for branch_sid in branch_targets:
                     branch_idx = ctx.session_first_message.get(branch_sid)
                     if branch_idx is not None:
-                        fork_msg.junction_forward_links.append((branch_sid, branch_idx))
+                        # Get branch preview from the branch header title
+                        branch_preview = ""
+                        branch_header = idx_to_msg.get(branch_idx)
+                        if branch_header and isinstance(
+                            branch_header.content, SessionHeaderMessage
+                        ):
+                            # Extract preview from branch title (e.g. "Branch • preview...")
+                            title = branch_header.content.title
+                            if " • " in title:
+                                branch_preview = title.split(" • ", 1)[1]
+                            else:
+                                branch_preview = title
+                        fork_msg.junction_forward_links.append(
+                            (branch_sid, branch_idx, branch_preview)
+                        )
 
     # Prepare session navigation data (uses ctx for session header indices)
     session_nav: list[dict[str, Any]] = []

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -662,12 +662,19 @@ def generate_template_messages(
                             # Extract preview from branch title (e.g. "Branch • preview...")
                             title = branch_header.content.title
                             if " • " in title:
-                                branch_preview = title.split(" • ", 1)[1]
-                            else:
-                                branch_preview = title
+                                preview = title.split(" • ", 1)[1]
+                                # Distinguish real content from UUID fallback
+                                uuid_fragment = branch_sid.split("@")[-1][:8]
+                                if preview != uuid_fragment:
+                                    branch_preview = preview
                         fork_msg.junction_forward_links.append(
                             (branch_sid, branch_idx, branch_preview)
                         )
+                # Elide fork points without at least 2 non-empty branches
+                non_empty = sum(1 for _, _, p in fork_msg.junction_forward_links if p)
+                if non_empty < 2:
+                    fork_msg.junction_forward_links.clear()
+                    fork_msg.fork_point_preview = ""
 
     # Prepare session navigation data (uses ctx for session header indices)
     session_nav: list[dict[str, Any]] = []

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -288,6 +288,15 @@ def _compact_ide_tags_for_preview(text_content: str) -> str:
     return text_content
 
 
+def is_agent_session(session_id: str) -> bool:
+    """Check if a session ID is a synthetic agent session.
+
+    Agent sessions use the format ``{sessionId}#agent-{agentId}``,
+    assigned by ``_integrate_agent_entries()`` during DAG construction.
+    """
+    return "#agent-" in session_id
+
+
 def get_warmup_session_ids(messages: list[TranscriptEntry]) -> set[str]:
     """Get set of session IDs that are warmup-only sessions.
 

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -297,6 +297,15 @@ def is_agent_session(session_id: str) -> bool:
     return "#agent-" in session_id
 
 
+def get_parent_session_id(session_id: str) -> str:
+    """Return the parent session ID for an agent session, or the ID itself.
+
+    For ``{sessionId}#agent-{agentId}`` returns ``{sessionId}``.
+    For non-agent sessions returns the input unchanged.
+    """
+    return session_id.split("#agent-")[0] if "#agent-" in session_id else session_id
+
+
 def get_warmup_session_ids(messages: list[TranscriptEntry]) -> set[str]:
     """Get set of session IDs that are warmup-only sessions.
 

--- a/dev-docs/dag.md
+++ b/dev-docs/dag.md
@@ -350,12 +350,16 @@ validate DAG construction against known transcripts.
 4. Generate session headers with navigation links (forward/back)
 5. Update session index from flat to hierarchical
 
-### Phase C: Agent Transcript Rework
+### Phase C: Agent Transcript Rework (Steps 1-2 done)
 
-1. Implement parenting strategies for each agent type
-2. Replace `_reorder_sidechain_template_messages` with DAG-line splicing
+1. ~~Implement parenting strategies for each agent type~~ — Done:
+   `_integrate_agent_entries()` parents agent roots to anchors and assigns
+   synthetic session IDs (`{sessionId}#agent-{agentId}`)
+2. ~~Replace `_reorder_sidechain_template_messages` with DAG-line splicing~~
+   — Done: agents are now DAG-ordered; the old function is kept as fallback
 3. Simplify or remove `_cleanup_sidechain_duplicates` (dedup now
-   happens at DAG level)
+   happens at DAG level) — TODO
+4. Agent tool renderer (separate PR, `dev/user-sidechain` branch) — TODO
 
 ### Phase D: Async Agent and Teammate Support
 

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -391,11 +391,12 @@
   
   /* Fork point element — standalone structural element after a fork message */
   .fork-point {
-      margin: 8px 0 4px 0;
+      margin: 8px 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid #adb5bd;
+      border-radius: 8px;
   }
   
   .fork-point-header {
@@ -2847,12 +2848,16 @@
       border: none;
       border-left: 3px solid #adb5bd;
       padding: 8px 14px;
-      margin: 4px 0 8px 0;
+      margin: 2em 0 1em 0;
   }
   
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  .branch-header .fold-bar-section.folded {
+      border-bottom-color: #adb5bd;
   }
   
   .session-subtitle {
@@ -3434,11 +3439,12 @@
   
   /* Fork point element — standalone structural element after a fork message */
   .fork-point {
-      margin: 8px 0 4px 0;
+      margin: 8px 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid #adb5bd;
+      border-radius: 8px;
   }
   
   .fork-point-header {
@@ -7999,12 +8005,16 @@
       border: none;
       border-left: 3px solid #adb5bd;
       padding: 8px 14px;
-      margin: 4px 0 8px 0;
+      margin: 2em 0 1em 0;
   }
   
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  .branch-header .fold-bar-section.folded {
+      border-bottom-color: #adb5bd;
   }
   
   .session-subtitle {
@@ -8586,11 +8596,12 @@
   
   /* Fork point element — standalone structural element after a fork message */
   .fork-point {
-      margin: 8px 0 4px 0;
+      margin: 8px 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid #adb5bd;
+      border-radius: 8px;
   }
   
   .fork-point-header {
@@ -13250,12 +13261,16 @@
       border: none;
       border-left: 3px solid #adb5bd;
       padding: 8px 14px;
-      margin: 4px 0 8px 0;
+      margin: 2em 0 1em 0;
   }
   
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  .branch-header .fold-bar-section.folded {
+      border-bottom-color: #adb5bd;
   }
   
   .session-subtitle {
@@ -13837,11 +13852,12 @@
   
   /* Fork point element — standalone structural element after a fork message */
   .fork-point {
-      margin: 8px 0 4px 0;
+      margin: 8px 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid #adb5bd;
+      border-radius: 8px;
   }
   
   .fork-point-header {
@@ -18558,12 +18574,16 @@
       border: none;
       border-left: 3px solid #adb5bd;
       padding: 8px 14px;
-      margin: 4px 0 8px 0;
+      margin: 2em 0 1em 0;
   }
   
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  .branch-header .fold-bar-section.folded {
+      border-bottom-color: #adb5bd;
   }
   
   .session-subtitle {
@@ -19145,11 +19165,12 @@
   
   /* Fork point element — standalone structural element after a fork message */
   .fork-point {
-      margin: 8px 0 4px 0;
+      margin: 8px 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid #adb5bd;
+      border-radius: 8px;
   }
   
   .fork-point-header {

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -50,6 +50,10 @@
       --system-error-color: #f44336;
       --tool-use-color: #4caf50;
   
+      /* Fork/branch structural colors */
+      --fork-point-color: #adb5bd;
+      --branch-point-color: #adb5bd;
+  
       /* Question/answer tool colors */
       --question-accent: #f5a623;
       --question-bg: #fffbf0;
@@ -395,7 +399,7 @@
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--fork-point-color);
       border-radius: 8px;
   }
   
@@ -2061,6 +2065,10 @@
       --system-error-color: #f44336;
       --tool-use-color: #4caf50;
   
+      /* Fork/branch structural colors */
+      --fork-point-color: #adb5bd;
+      --branch-point-color: #adb5bd;
+  
       /* Question/answer tool colors */
       --question-accent: #f5a623;
       --question-bg: #fffbf0;
@@ -2846,7 +2854,7 @@
       background-color: transparent;
       box-shadow: none;
       border: none;
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--branch-point-color);
       padding: 8px 14px;
       margin: 2em 0 1em 0;
   }
@@ -2856,8 +2864,8 @@
       margin-bottom: 0;
   }
   
-  .branch-header .fold-bar-section.folded {
-      border-bottom-color: #adb5bd;
+  .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
+      border-bottom-color: var(--branch-point-color);
   }
   
   .session-subtitle {
@@ -3443,7 +3451,7 @@
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--fork-point-color);
       border-radius: 8px;
   }
   
@@ -7218,6 +7226,10 @@
       --system-error-color: #f44336;
       --tool-use-color: #4caf50;
   
+      /* Fork/branch structural colors */
+      --fork-point-color: #adb5bd;
+      --branch-point-color: #adb5bd;
+  
       /* Question/answer tool colors */
       --question-accent: #f5a623;
       --question-bg: #fffbf0;
@@ -8003,7 +8015,7 @@
       background-color: transparent;
       box-shadow: none;
       border: none;
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--branch-point-color);
       padding: 8px 14px;
       margin: 2em 0 1em 0;
   }
@@ -8013,8 +8025,8 @@
       margin-bottom: 0;
   }
   
-  .branch-header .fold-bar-section.folded {
-      border-bottom-color: #adb5bd;
+  .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
+      border-bottom-color: var(--branch-point-color);
   }
   
   .session-subtitle {
@@ -8600,7 +8612,7 @@
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--fork-point-color);
       border-radius: 8px;
   }
   
@@ -12474,6 +12486,10 @@
       --system-error-color: #f44336;
       --tool-use-color: #4caf50;
   
+      /* Fork/branch structural colors */
+      --fork-point-color: #adb5bd;
+      --branch-point-color: #adb5bd;
+  
       /* Question/answer tool colors */
       --question-accent: #f5a623;
       --question-bg: #fffbf0;
@@ -13259,7 +13275,7 @@
       background-color: transparent;
       box-shadow: none;
       border: none;
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--branch-point-color);
       padding: 8px 14px;
       margin: 2em 0 1em 0;
   }
@@ -13269,8 +13285,8 @@
       margin-bottom: 0;
   }
   
-  .branch-header .fold-bar-section.folded {
-      border-bottom-color: #adb5bd;
+  .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
+      border-bottom-color: var(--branch-point-color);
   }
   
   .session-subtitle {
@@ -13856,7 +13872,7 @@
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--fork-point-color);
       border-radius: 8px;
   }
   
@@ -17787,6 +17803,10 @@
       --system-error-color: #f44336;
       --tool-use-color: #4caf50;
   
+      /* Fork/branch structural colors */
+      --fork-point-color: #adb5bd;
+      --branch-point-color: #adb5bd;
+  
       /* Question/answer tool colors */
       --question-accent: #f5a623;
       --question-bg: #fffbf0;
@@ -18572,7 +18592,7 @@
       background-color: transparent;
       box-shadow: none;
       border: none;
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--branch-point-color);
       padding: 8px 14px;
       margin: 2em 0 1em 0;
   }
@@ -18582,8 +18602,8 @@
       margin-bottom: 0;
   }
   
-  .branch-header .fold-bar-section.folded {
-      border-bottom-color: #adb5bd;
+  .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
+      border-bottom-color: var(--branch-point-color);
   }
   
   .session-subtitle {
@@ -19169,7 +19189,7 @@
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
-      border-left: 3px solid #adb5bd;
+      border-left: 3px solid var(--fork-point-color);
       border-radius: 8px;
   }
   

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -389,32 +389,55 @@
       line-height: 1.3;
   }
   
-  /* Within-session fork styles */
-  .junction-forward-links {
+  /* Fork point element — standalone structural element after a fork message */
+  .fork-point {
+      margin: 8px 0 4px 0;
+      padding: 8px 14px;
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      border-left: 3px solid #adb5bd;
+  }
+  
+  .fork-point-header {
+      font-weight: 600;
+      margin-bottom: 4px;
+      color: var(--text-secondary, #495057);
+  }
+  
+  .fork-point-branches {
       display: flex;
-      gap: 8px;
-      margin-top: 6px;
-      padding: 4px 8px;
-      font-size: 0.8em;
+      flex-direction: column;
+      gap: 2px;
+      padding-left: 12px;
   }
   
-  .junction-link {
-      color: #6c757d;
+  .fork-point-branch {
+      display: block;
       text-decoration: none;
-      padding: 2px 6px;
-      border: 1px dashed #adb5bd;
-      border-radius: 3px;
-      transition: background-color 0.2s;
+      color: var(--text-muted, #6c757d);
+      padding: 2px 0;
+      transition: color 0.2s;
   }
   
-  .junction-link:hover {
-      background-color: #e9ecef;
-      color: var(--text-secondary);
+  .fork-point-branch:hover {
+      color: var(--text-secondary, #495057);
+  }
+  
+  /* Branch header back-reference to fork point */
+  .branch-from {
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      margin-top: 2px;
   }
   
   .branch-backlink {
-      border-left: 2px dashed #888;
-      padding-left: 6px;
+      text-decoration: none;
+      color: var(--text-muted, #6c757d);
+      transition: color 0.2s;
+  }
+  
+  .branch-backlink:hover {
+      color: var(--text-secondary, #495057);
   }
   
   /* Fork point and branch nav items — lightweight text links, not cards */
@@ -2818,6 +2841,19 @@
   
   /* Branch headers (within-session forks) — indent set via inline
      style based on tree depth (margin-left: depth*2em). */
+  .branch-header {
+      background-color: transparent;
+      box-shadow: none;
+      border: none;
+      border-left: 3px solid #adb5bd;
+      padding: 8px 14px;
+      margin: 4px 0 8px 0;
+  }
+  
+  .branch-header .header {
+      font-size: 1em;
+      margin-bottom: 0;
+  }
   
   .session-subtitle {
       font-size: 0.9em;
@@ -3396,32 +3432,55 @@
       line-height: 1.3;
   }
   
-  /* Within-session fork styles */
-  .junction-forward-links {
+  /* Fork point element — standalone structural element after a fork message */
+  .fork-point {
+      margin: 8px 0 4px 0;
+      padding: 8px 14px;
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      border-left: 3px solid #adb5bd;
+  }
+  
+  .fork-point-header {
+      font-weight: 600;
+      margin-bottom: 4px;
+      color: var(--text-secondary, #495057);
+  }
+  
+  .fork-point-branches {
       display: flex;
-      gap: 8px;
-      margin-top: 6px;
-      padding: 4px 8px;
-      font-size: 0.8em;
+      flex-direction: column;
+      gap: 2px;
+      padding-left: 12px;
   }
   
-  .junction-link {
-      color: #6c757d;
+  .fork-point-branch {
+      display: block;
       text-decoration: none;
-      padding: 2px 6px;
-      border: 1px dashed #adb5bd;
-      border-radius: 3px;
-      transition: background-color 0.2s;
+      color: var(--text-muted, #6c757d);
+      padding: 2px 0;
+      transition: color 0.2s;
   }
   
-  .junction-link:hover {
-      background-color: #e9ecef;
-      color: var(--text-secondary);
+  .fork-point-branch:hover {
+      color: var(--text-secondary, #495057);
+  }
+  
+  /* Branch header back-reference to fork point */
+  .branch-from {
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      margin-top: 2px;
   }
   
   .branch-backlink {
-      border-left: 2px dashed #888;
-      padding-left: 6px;
+      text-decoration: none;
+      color: var(--text-muted, #6c757d);
+      transition: color 0.2s;
+  }
+  
+  .branch-backlink:hover {
+      color: var(--text-secondary, #495057);
   }
   
   /* Fork point and branch nav items — lightweight text links, not cards */
@@ -5291,6 +5350,7 @@
       
       
       
+      
       <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -5304,7 +5364,6 @@
           <div class='debug-info'>msg_001</div>
           <div class='content'><pre>Hello Claude! Can you help me understand how Python decorators work?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-1' data-border-color='user'>
               
               
@@ -5316,6 +5375,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -5355,8 +5415,8 @@
   </code></pre>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -5374,7 +5434,6 @@
           <div class='debug-info'>msg_003</div>
           <div class='content'><pre>Great! Can you also show me how to create a decorator that takes parameters?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-3' data-border-color='user'>
               
               
@@ -5386,6 +5445,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -5403,8 +5463,8 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
-          
       </div>
+      
       
       
       
@@ -5422,8 +5482,8 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -5456,8 +5516,8 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -5475,7 +5535,6 @@
           <div class='debug-info'>msg_007</div>
           <div class='content'><pre>Can you run that example to show the output?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-7' data-border-color='user'>
               
               
@@ -5487,6 +5546,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -5504,8 +5564,8 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
-          
       </div>
+      
       
       
       
@@ -5525,8 +5585,8 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -5555,8 +5615,8 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -5574,8 +5634,8 @@
           <div class='debug-info'>msg_011</div>
           <div class='content'><pre>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div>
           
-          
       </div>
+      
       
       
   
@@ -7933,6 +7993,19 @@
   
   /* Branch headers (within-session forks) — indent set via inline
      style based on tree depth (margin-left: depth*2em). */
+  .branch-header {
+      background-color: transparent;
+      box-shadow: none;
+      border: none;
+      border-left: 3px solid #adb5bd;
+      padding: 8px 14px;
+      margin: 4px 0 8px 0;
+  }
+  
+  .branch-header .header {
+      font-size: 1em;
+      margin-bottom: 0;
+  }
   
   .session-subtitle {
       font-size: 0.9em;
@@ -8511,32 +8584,55 @@
       line-height: 1.3;
   }
   
-  /* Within-session fork styles */
-  .junction-forward-links {
+  /* Fork point element — standalone structural element after a fork message */
+  .fork-point {
+      margin: 8px 0 4px 0;
+      padding: 8px 14px;
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      border-left: 3px solid #adb5bd;
+  }
+  
+  .fork-point-header {
+      font-weight: 600;
+      margin-bottom: 4px;
+      color: var(--text-secondary, #495057);
+  }
+  
+  .fork-point-branches {
       display: flex;
-      gap: 8px;
-      margin-top: 6px;
-      padding: 4px 8px;
-      font-size: 0.8em;
+      flex-direction: column;
+      gap: 2px;
+      padding-left: 12px;
   }
   
-  .junction-link {
-      color: #6c757d;
+  .fork-point-branch {
+      display: block;
       text-decoration: none;
-      padding: 2px 6px;
-      border: 1px dashed #adb5bd;
-      border-radius: 3px;
-      transition: background-color 0.2s;
+      color: var(--text-muted, #6c757d);
+      padding: 2px 0;
+      transition: color 0.2s;
   }
   
-  .junction-link:hover {
-      background-color: #e9ecef;
-      color: var(--text-secondary);
+  .fork-point-branch:hover {
+      color: var(--text-secondary, #495057);
+  }
+  
+  /* Branch header back-reference to fork point */
+  .branch-from {
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      margin-top: 2px;
   }
   
   .branch-backlink {
-      border-left: 2px dashed #888;
-      padding-left: 6px;
+      text-decoration: none;
+      color: var(--text-muted, #6c757d);
+      transition: color 0.2s;
+  }
+  
+  .branch-backlink:hover {
+      color: var(--text-secondary, #495057);
   }
   
   /* Fork point and branch nav items — lightweight text links, not cards */
@@ -10406,6 +10502,7 @@
       
       
       
+      
       <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -10419,7 +10516,6 @@
           <div class='debug-info'>edge_001</div>
           <div class='content'><pre>Here&#x27;s a message with some **markdown** formatting, `inline code`, and even a [link](https://example.com). Let&#x27;s see how it renders!</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-1' data-border-color='user'>
               
               
@@ -10431,6 +10527,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -10489,8 +10586,8 @@
   <p>The markdown renderer handles all of this automatically!</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -10508,7 +10605,6 @@
           <div class='debug-info'>edge_003</div>
           <div class='content'><pre>Let&#x27;s test a very long message to see how it handles text wrapping and layout. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-3' data-border-color='user'>
               
               
@@ -10520,6 +10616,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -10542,8 +10639,8 @@
               </tr>
           </table></div>
           
-          
       </div>
+      
       
       
       
@@ -10561,8 +10658,8 @@
           <div class='debug-info'>edge_005</div>
           <div class='content'><pre>Error: Tool execution failed with error: Command not found</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -10582,8 +10679,8 @@
   line breaks
   </pre></div>
           
-          
       </div>
+      
       
       
       
@@ -10606,7 +10703,6 @@
   Status: SUCCESS
   Timestamp: 2025-06-14T11:02:20Z</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-7' data-border-color='user command-output'>
               
               
@@ -10622,6 +10718,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -10642,7 +10739,6 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>I see the long Lorem ipsum text wraps nicely! Long text handling is important for readability. The CSS should handle word wrapping automatically.</p>
   </div></div>
           
-          
           <div class='fold-bar' data-message-id='d-8' data-border-color='assistant'>
               
               
@@ -10654,6 +10750,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -10671,8 +10768,8 @@
           <div class='debug-info'>edge_009</div>
           <div class='content'><div class='multiedit-tool-content'><div class='multiedit-file-path'>📝 /tmp/complex_example.py</div><div class='multiedit-count'>Applying 1 edits</div><div class='multiedit-item'><div class='multiedit-item-header'>Edit #1</div><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>#!/usr/bin/env python3</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>&quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>Complex example with multiple operations.</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>&quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>import json</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>import sys</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>from typing import List, Dict, Any</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def process_data(items: List[Dict[str, Any]]) -&gt; None:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    &quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    Process a list of data items.</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    &quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    for item in items:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        print(f&quot;Processing: {item[&#x27;name&#x27;]}&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        if item.get(&#x27;active&#x27;, False):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            print(f&quot;  Status: Active&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        else:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            print(f&quot;  Status: Inactive&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>if __name__ == &quot;__main__&quot;:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    sample_data = [</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 1&quot;, &quot;active&quot;: True},</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 2&quot;, &quot;active&quot;: False},</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 3&quot;, &quot;active&quot;: True}</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    ]</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    process_data(sample_data)</div></div></div></div></div>
           
-          
       </div>
+      
       
       
       
@@ -10690,8 +10787,8 @@
           <div class='debug-info'>edge_011</div>
           <div class='content'><pre>Testing special characters: café, naïve, résumé, 中文, العربية, русский, 🎉 emojis 🚀 and symbols ∑∆√π∞</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -10709,8 +10806,8 @@
           <div class='debug-info'>edge_010</div>
           <div class='content'><pre>wow error</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -10729,6 +10826,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -10787,8 +10885,8 @@
               </tr>
           </table></div>
           
-          
       </div>
+      
       
       
   
@@ -13146,6 +13244,19 @@
   
   /* Branch headers (within-session forks) — indent set via inline
      style based on tree depth (margin-left: depth*2em). */
+  .branch-header {
+      background-color: transparent;
+      box-shadow: none;
+      border: none;
+      border-left: 3px solid #adb5bd;
+      padding: 8px 14px;
+      margin: 4px 0 8px 0;
+  }
+  
+  .branch-header .header {
+      font-size: 1em;
+      margin-bottom: 0;
+  }
   
   .session-subtitle {
       font-size: 0.9em;
@@ -13724,32 +13835,55 @@
       line-height: 1.3;
   }
   
-  /* Within-session fork styles */
-  .junction-forward-links {
+  /* Fork point element — standalone structural element after a fork message */
+  .fork-point {
+      margin: 8px 0 4px 0;
+      padding: 8px 14px;
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      border-left: 3px solid #adb5bd;
+  }
+  
+  .fork-point-header {
+      font-weight: 600;
+      margin-bottom: 4px;
+      color: var(--text-secondary, #495057);
+  }
+  
+  .fork-point-branches {
       display: flex;
-      gap: 8px;
-      margin-top: 6px;
-      padding: 4px 8px;
-      font-size: 0.8em;
+      flex-direction: column;
+      gap: 2px;
+      padding-left: 12px;
   }
   
-  .junction-link {
-      color: #6c757d;
+  .fork-point-branch {
+      display: block;
       text-decoration: none;
-      padding: 2px 6px;
-      border: 1px dashed #adb5bd;
-      border-radius: 3px;
-      transition: background-color 0.2s;
+      color: var(--text-muted, #6c757d);
+      padding: 2px 0;
+      transition: color 0.2s;
   }
   
-  .junction-link:hover {
-      background-color: #e9ecef;
-      color: var(--text-secondary);
+  .fork-point-branch:hover {
+      color: var(--text-secondary, #495057);
+  }
+  
+  /* Branch header back-reference to fork point */
+  .branch-from {
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      margin-top: 2px;
   }
   
   .branch-backlink {
-      border-left: 2px dashed #888;
-      padding-left: 6px;
+      text-decoration: none;
+      color: var(--text-muted, #6c757d);
+      transition: color 0.2s;
+  }
+  
+  .branch-backlink:hover {
+      color: var(--text-secondary, #495057);
   }
   
   /* Fork point and branch nav items — lightweight text links, not cards */
@@ -15682,6 +15816,7 @@
       
       
       
+      
       <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -15695,7 +15830,6 @@
           <div class='debug-info'>session_b_00</div>
           <div class='content'><pre>This is from a different session file to test multi-session handling.</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-1' data-border-color='user'>
               
               
@@ -15707,6 +15841,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -15727,8 +15862,8 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Indeed! This message is from a different JSONL file, which should help test the session divider logic. Only the first session should show a divider.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -15746,8 +15881,8 @@
           <div class='debug-info'>session_b_00</div>
           <div class='content'><pre>Perfect! This should appear without any session divider above it.</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -15774,6 +15909,7 @@
       
       
       
+      
       <div class='message user d-4' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🤷 User</span>
@@ -15787,7 +15923,6 @@
           <div class='debug-info'>msg_001</div>
           <div class='content'><pre>Hello Claude! Can you help me understand how Python decorators work?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-5' data-border-color='user'>
               
               
@@ -15799,6 +15934,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -15838,8 +15974,8 @@
   </code></pre>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -15857,7 +15993,6 @@
           <div class='debug-info'>msg_003</div>
           <div class='content'><pre>Great! Can you also show me how to create a decorator that takes parameters?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-7' data-border-color='user'>
               
               
@@ -15869,6 +16004,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -15886,8 +16022,8 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
-          
       </div>
+      
       
       
       
@@ -15905,8 +16041,8 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -15939,8 +16075,8 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -15958,7 +16094,6 @@
           <div class='debug-info'>msg_007</div>
           <div class='content'><pre>Can you run that example to show the output?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-11' data-border-color='user'>
               
               
@@ -15970,6 +16105,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -15987,8 +16123,8 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
-          
       </div>
+      
       
       
       
@@ -16008,8 +16144,8 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -16038,8 +16174,8 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -16057,8 +16193,8 @@
           <div class='debug-info'>msg_011</div>
           <div class='content'><pre>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div>
           
-          
       </div>
+      
       
       
   
@@ -18416,6 +18552,19 @@
   
   /* Branch headers (within-session forks) — indent set via inline
      style based on tree depth (margin-left: depth*2em). */
+  .branch-header {
+      background-color: transparent;
+      box-shadow: none;
+      border: none;
+      border-left: 3px solid #adb5bd;
+      padding: 8px 14px;
+      margin: 4px 0 8px 0;
+  }
+  
+  .branch-header .header {
+      font-size: 1em;
+      margin-bottom: 0;
+  }
   
   .session-subtitle {
       font-size: 0.9em;
@@ -18994,32 +19143,55 @@
       line-height: 1.3;
   }
   
-  /* Within-session fork styles */
-  .junction-forward-links {
+  /* Fork point element — standalone structural element after a fork message */
+  .fork-point {
+      margin: 8px 0 4px 0;
+      padding: 8px 14px;
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      border-left: 3px solid #adb5bd;
+  }
+  
+  .fork-point-header {
+      font-weight: 600;
+      margin-bottom: 4px;
+      color: var(--text-secondary, #495057);
+  }
+  
+  .fork-point-branches {
       display: flex;
-      gap: 8px;
-      margin-top: 6px;
-      padding: 4px 8px;
-      font-size: 0.8em;
+      flex-direction: column;
+      gap: 2px;
+      padding-left: 12px;
   }
   
-  .junction-link {
-      color: #6c757d;
+  .fork-point-branch {
+      display: block;
       text-decoration: none;
-      padding: 2px 6px;
-      border: 1px dashed #adb5bd;
-      border-radius: 3px;
-      transition: background-color 0.2s;
+      color: var(--text-muted, #6c757d);
+      padding: 2px 0;
+      transition: color 0.2s;
   }
   
-  .junction-link:hover {
-      background-color: #e9ecef;
-      color: var(--text-secondary);
+  .fork-point-branch:hover {
+      color: var(--text-secondary, #495057);
+  }
+  
+  /* Branch header back-reference to fork point */
+  .branch-from {
+      font-size: 0.85em;
+      color: var(--text-muted, #6c757d);
+      margin-top: 2px;
   }
   
   .branch-backlink {
-      border-left: 2px dashed #888;
-      padding-left: 6px;
+      text-decoration: none;
+      color: var(--text-muted, #6c757d);
+      transition: color 0.2s;
+  }
+  
+  .branch-backlink:hover {
+      color: var(--text-secondary, #495057);
   }
   
   /* Fork point and branch nav items — lightweight text links, not cards */
@@ -20889,6 +21061,7 @@
       
       
       
+      
       <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -20902,7 +21075,6 @@
           <div class='debug-info'>msg_001</div>
           <div class='content'><pre>Hello Claude! Can you help me understand how Python decorators work?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-1' data-border-color='user'>
               
               
@@ -20914,6 +21086,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -20953,8 +21126,8 @@
   </code></pre>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -20972,7 +21145,6 @@
           <div class='debug-info'>msg_003</div>
           <div class='content'><pre>Great! Can you also show me how to create a decorator that takes parameters?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-3' data-border-color='user'>
               
               
@@ -20984,6 +21156,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -21001,8 +21174,8 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
-          
       </div>
+      
       
       
       
@@ -21020,8 +21193,8 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -21054,8 +21227,8 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -21073,7 +21246,6 @@
           <div class='debug-info'>msg_007</div>
           <div class='content'><pre>Can you run that example to show the output?</pre></div>
           
-          
           <div class='fold-bar' data-message-id='d-7' data-border-color='user'>
               
               
@@ -21085,6 +21257,7 @@
           </div>
           
       </div>
+      
       
       
       
@@ -21102,8 +21275,8 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
-          
       </div>
+      
       
       
       
@@ -21123,8 +21296,8 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
-          
       </div>
+      
       
       
       
@@ -21153,8 +21326,8 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
-          
       </div>
+      
       
       
       
@@ -21172,8 +21345,8 @@
           <div class='debug-info'>msg_011</div>
           <div class='content'><pre>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div>
           
-          
       </div>
+      
       
       
   

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -984,3 +984,89 @@ class TestAgentDagIntegration:
         # Two synthetic agent sessions
         agent_sids = [sid for sid in tree.sessions if "#agent-" in sid]
         assert len(agent_sids) == 2
+
+    def test_agent_in_branch(self, tmp_path: Path) -> None:
+        """Agent anchored inside a within-session fork attaches to the branch."""
+        from claude_code_log.renderer import generate_template_messages
+
+        # Trunk: u1 → a1 (fork point)
+        # Branch 1: b1_u (rewind from a1, different timestamp) → b1_a
+        #   with agent anchored at b1_u
+        # Branch 2: b2_u (rewind from a1, different timestamp)
+        main_entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_assistant_entry("a1", "s1", "2025-07-01T10:01:00.000Z", "u1"),
+            # Branch 1: user rewind from a1
+            _make_user_entry(
+                "b1_u",
+                "s1",
+                "2025-07-01T10:02:00.000Z",
+                "a1",
+                "Branch 1",
+                agent_id="agent-b1",
+            ),
+            _make_assistant_entry(
+                "b1_a",
+                "s1",
+                "2025-07-01T10:03:00.000Z",
+                "b1_u",
+            ),
+            # Branch 2: user rewind from a1 (different timestamp = real fork)
+            _make_user_entry(
+                "b2_u",
+                "s1",
+                "2025-07-01T10:04:00.000Z",
+                "a1",
+                "Branch 2",
+            ),
+        ]
+        agent_entries = [
+            _make_user_entry(
+                "ag1",
+                "s1",
+                "2025-07-01T10:02:30.000Z",
+                None,
+                "Agent in branch",
+                is_sidechain=True,
+                agent_id="agent-b1",
+            ),
+            _make_assistant_entry(
+                "ag2",
+                "s1",
+                "2025-07-01T10:02:40.000Z",
+                "ag1",
+                "Agent reply",
+                is_sidechain=True,
+                agent_id="agent-b1",
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", main_entries + agent_entries)
+
+        result, tree = load_directory_transcripts(tmp_path, silent=True)
+
+        # Agent session's parent should be the branch pseudo-session, not trunk
+        agent_sids = [sid for sid in tree.sessions if "#agent-" in sid]
+        assert len(agent_sids) == 1
+        agent_dl = tree.sessions[agent_sids[0]]
+        # The branch pseudo-session has format "s1@{child_uuid[:12]}"
+        assert agent_dl.parent_session_id is not None
+        assert "@" in agent_dl.parent_session_id, (
+            f"Agent should be child of branch, got parent={agent_dl.parent_session_id}"
+        )
+        assert agent_dl.attachment_uuid == "b1_u"
+
+        # End-to-end rendering: agent messages should appear in the branch,
+        # not get regrouped under the trunk
+        messages, session_tree = load_directory_transcripts(tmp_path, silent=True)
+        root_messages, session_nav, context = generate_template_messages(
+            messages, session_tree=session_tree
+        )
+
+        # Verify message ordering: agent messages should be in the branch
+        # block (after b1_u anchor, before branch 2's b2_u)
+        msg_uuids = {m.meta.uuid: m.message_index for m in context.messages}
+        assert "ag1" in msg_uuids
+        assert "b1_u" in msg_uuids
+        assert "b2_u" in msg_uuids
+        assert msg_uuids["b1_u"] < msg_uuids["ag1"] < msg_uuids["b2_u"]  # type: ignore[operator]

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -493,7 +493,13 @@ class TestRepairParentChains:
         assert messages[1].parentUuid == "a"
 
     def test_single_progress_gap(self, tmp_path: Path) -> None:
-        """Single progress gap is bridged."""
+        """Progress entry with uuid+sessionId becomes PassthroughTranscriptEntry.
+
+        With passthrough entries in the DAG, the chain is intact —
+        no repair needed for progress entries that have uuid+sessionId.
+        """
+        from claude_code_log.models import PassthroughTranscriptEntry
+
         entries = [
             _make_progress_entry("p1", None),
             _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", "p1"),
@@ -504,12 +510,16 @@ class TestRepairParentChains:
         messages = load_transcript(tmp_path / "session.jsonl", silent=True)
         progress_chain = {"p1": None}
         _repair_parent_chains(messages, progress_chain)
-        # user(a).parentUuid was "p1" (progress), repaired to None
-        assert isinstance(messages[0], BaseTranscriptEntry)
-        assert messages[0].parentUuid is None
+        # p1 is now a PassthroughTranscriptEntry (not dropped)
+        assert isinstance(messages[0], PassthroughTranscriptEntry)
+        assert messages[0].uuid == "p1"
+        # user(a).parentUuid remains "p1" — chain intact via passthrough
+        user_a = [m for m in messages if getattr(m, "uuid", None) == "a"][0]
+        assert isinstance(user_a, BaseTranscriptEntry)
+        assert user_a.parentUuid == "p1"
 
     def test_chained_progress_gap(self, tmp_path: Path) -> None:
-        """Chain of consecutive progress entries is fully bridged."""
+        """Chain of passthrough progress entries preserves DAG links."""
         # real_parent → progress(p1) → progress(p2) → user(a)
         entries = [
             _make_user_entry("real_parent", "s1", "2025-07-01T10:00:00.000Z", None),
@@ -523,10 +533,10 @@ class TestRepairParentChains:
         messages = load_transcript(tmp_path / "session.jsonl", silent=True)
         progress_chain = {"p1": "real_parent", "p2": "p1"}
         _repair_parent_chains(messages, progress_chain)
-        # user(a).parentUuid was "p2", should walk through p2→p1→real_parent
+        # With passthrough entries, chain is intact: a → p2 → p1 → real_parent
         user_a = [m for m in messages if getattr(m, "uuid", None) == "a"][0]
         assert isinstance(user_a, BaseTranscriptEntry)
-        assert user_a.parentUuid == "real_parent"
+        assert user_a.parentUuid == "p2"  # NOT repaired — p2 is in the DAG
 
 
 class TestProgressChainRepairIntegration:
@@ -549,36 +559,44 @@ class TestProgressChainRepairIntegration:
         )
 
     def test_progress_chain_repair_single_file(self) -> None:
-        """Single-file mode also repairs progress chains."""
+        """Single-file mode: progress entries are PassthroughTranscriptEntry nodes.
+
+        With passthrough entries, progress entries are in the DAG and don't
+        need repair. Entries pointing to them have valid parents.
+        """
         from claude_code_log.converter import (
             load_transcript,
             _scan_progress_chains,
             _repair_parent_chains,
         )
+        from claude_code_log.models import PassthroughTranscriptEntry
 
         single_file = (
             EXPERIMENTS_IDEAS_DIR / "03eb5929-52b3-4b13-ada3-b93ae35806b8.jsonl"
         )
         messages = load_transcript(single_file, silent=True)
 
-        # Before repair: some entries have parentUuid pointing to progress UUIDs
+        # Progress entries are now PassthroughTranscriptEntry in messages
         progress_chain = _scan_progress_chains(single_file)
         assert len(progress_chain) == 11
 
-        # Count entries with progress parents before repair
-        orphan_before = sum(
-            1 for m in messages if getattr(m, "parentUuid", None) in progress_chain
-        )
-        assert orphan_before == 8
+        # Progress entries should be in the messages list
+        passthrough_uuids = {
+            m.uuid
+            for m in messages
+            if isinstance(m, PassthroughTranscriptEntry) and m.type == "progress"
+        }
+        assert len(passthrough_uuids) > 0
 
-        # Repair
+        # Repair should be a no-op since all progress entries are present
         _repair_parent_chains(messages, progress_chain)
 
-        # After repair: no entries should point to progress UUIDs
-        orphan_after = sum(
+        # Entries still point to progress UUIDs (which is correct —
+        # those are valid PassthroughTranscriptEntry nodes in the DAG)
+        entries_with_progress_parents = sum(
             1 for m in messages if getattr(m, "parentUuid", None) in progress_chain
         )
-        assert orphan_after == 0
+        assert entries_with_progress_parents > 0  # Chain intact through passthrough
 
     def test_progress_chain_preserves_entry_count(self) -> None:
         """Repair doesn't add or remove entries, only mutates parentUuid."""
@@ -614,7 +632,9 @@ class TestProgressChainRepairIntegration:
         assert len(tree.nodes) > 0
 
     def test_synthetic_progress_in_directory_mode(self, tmp_path: Path) -> None:
-        """Synthetic test: progress entries in directory mode are bridged."""
+        """Progress entries become passthrough nodes in directory mode."""
+        from claude_code_log.models import PassthroughTranscriptEntry
+
         entries: list[dict[str, Any]] = [
             _make_progress_entry("p1", None),
             _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", "p1", "Start"),
@@ -628,8 +648,13 @@ class TestProgressChainRepairIntegration:
         result, _ = load_directory_transcripts(tmp_path, silent=True)
         uuids = [getattr(e, "uuid", None) for e in result]
 
-        # All 4 real entries should be in DAG order
-        assert uuids == ["a", "b", "c", "d"]
+        # All 6 entries in DAG order (including passthrough progress entries)
+        assert uuids == ["p1", "a", "b", "p2", "c", "d"]
+
+        # Progress entries are PassthroughTranscriptEntry
+        passthrough = [e for e in result if isinstance(e, PassthroughTranscriptEntry)]
+        assert len(passthrough) == 2
+        assert {p.uuid for p in passthrough} == {"p1", "p2"}
 
 
 # =============================================================================
@@ -1192,3 +1217,142 @@ class TestRenderSessionResetAcrossSessions:
                 f"Message {msg.meta.uuid} has render_session_id={msg.render_session_id!r}, "
                 f"expected 's2' — branch tracking from s1 leaked into s2"
             )
+
+
+# =============================================================================
+# Test: PassthroughTranscriptEntry for DAG chain continuity
+# =============================================================================
+
+
+def _make_passthrough_entry(
+    uuid: str,
+    session_id: str,
+    timestamp: str,
+    parent_uuid: str | None = None,
+    entry_type: str = "attachment",
+) -> dict[str, Any]:
+    """Helper to create a passthrough (non-rendered) entry dict."""
+    return {
+        "type": entry_type,
+        "timestamp": timestamp,
+        "parentUuid": parent_uuid,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": session_id,
+        "version": "1.0.0",
+        "uuid": uuid,
+        # No "message" field — this is not a user/assistant entry
+    }
+
+
+class TestPassthroughDagChain:
+    """Test that passthrough entries (attachment, etc.) preserve DAG chain."""
+
+    def test_attachment_preserves_parent_chain(self, tmp_path: Path) -> None:
+        """Assistant whose parentUuid points to an attachment should not be a false root."""
+        entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_passthrough_entry(
+                "att1", "s1", "2025-07-01T10:00:30.000Z", "u1", "attachment"
+            ),
+            _make_assistant_entry(
+                "a1", "s1", "2025-07-01T10:01:00.000Z", "att1", "Reply"
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", entries)
+
+        messages, tree = load_directory_transcripts(tmp_path, silent=True)
+
+        # All three entries should be in the DAG
+        assert "u1" in tree.nodes
+        assert "att1" in tree.nodes
+        assert "a1" in tree.nodes
+
+        # a1's parent should be att1, att1's parent should be u1
+        assert tree.nodes["a1"].parent_uuid == "att1"
+        assert tree.nodes["att1"].parent_uuid == "u1"
+
+        # a1 should NOT be a false root — the session should have only 1 root (u1)
+        s1 = tree.sessions.get("s1")
+        assert s1 is not None
+        assert s1.uuids[0] == "u1", "u1 should be the first entry in the session"
+
+    def test_attachment_not_rendered(self, tmp_path: Path) -> None:
+        """Passthrough entries should not appear in rendered output."""
+        from claude_code_log.renderer import generate_template_messages
+
+        entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Hello"),
+            _make_passthrough_entry(
+                "att1", "s1", "2025-07-01T10:00:30.000Z", "u1", "attachment"
+            ),
+            _make_assistant_entry(
+                "a1", "s1", "2025-07-01T10:01:00.000Z", "att1", "World"
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", entries)
+
+        messages, session_tree = load_directory_transcripts(tmp_path, silent=True)
+        _, _, ctx = generate_template_messages(messages, session_tree=session_tree)
+
+        # No message should have uuid "att1"
+        rendered_uuids = [m.meta.uuid for m in ctx.messages if m.meta.uuid]
+        assert "att1" not in rendered_uuids
+        # But user and assistant should be rendered
+        assert "u1" in rendered_uuids
+        assert "a1" in rendered_uuids
+
+    def test_multiple_passthrough_types(self, tmp_path: Path) -> None:
+        """Various unknown types with uuid should all become passthrough entries."""
+        entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_passthrough_entry(
+                "p1", "s1", "2025-07-01T10:00:10.000Z", "u1", "attachment"
+            ),
+            _make_passthrough_entry(
+                "p2", "s1", "2025-07-01T10:00:20.000Z", "p1", "permission-mode"
+            ),
+            _make_passthrough_entry(
+                "p3", "s1", "2025-07-01T10:00:30.000Z", "p2", "file-history-snapshot"
+            ),
+            _make_assistant_entry(
+                "a1", "s1", "2025-07-01T10:01:00.000Z", "p3", "Reply"
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", entries)
+
+        messages, tree = load_directory_transcripts(tmp_path, silent=True)
+
+        # All should be in DAG
+        for uid in ["u1", "p1", "p2", "p3", "a1"]:
+            assert uid in tree.nodes, f"{uid} should be in DAG"
+
+        # Chain should be intact: u1 → p1 → p2 → p3 → a1
+        assert tree.nodes["a1"].parent_uuid == "p3"
+        assert tree.nodes["p3"].parent_uuid == "p2"
+        assert tree.nodes["p2"].parent_uuid == "p1"
+        assert tree.nodes["p1"].parent_uuid == "u1"
+
+    def test_passthrough_excluded_from_session_data(self, tmp_path: Path) -> None:
+        """Passthrough entries should not inflate session message counts."""
+        entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_passthrough_entry(
+                "att1", "s1", "2025-07-01T10:00:30.000Z", "u1", "attachment"
+            ),
+            _make_assistant_entry(
+                "a1", "s1", "2025-07-01T10:01:00.000Z", "att1", "Reply"
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", entries)
+
+        messages, _ = load_directory_transcripts(tmp_path, silent=True)
+        session_data = _build_session_data_from_messages(messages)
+
+        # Only user + assistant should be counted (not the attachment)
+        assert session_data["s1"].message_count == 2

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from claude_code_log.converter import (
     load_directory_transcripts,
+    _build_session_data_from_messages,
     _scan_progress_chains,
     _repair_parent_chains,
 )
@@ -1070,3 +1071,69 @@ class TestAgentDagIntegration:
         assert "b1_u" in msg_uuids
         assert "b2_u" in msg_uuids
         assert msg_uuids["b1_u"] < msg_uuids["ag1"] < msg_uuids["b2_u"]  # type: ignore[operator]
+
+    def test_agent_messages_coalesced_into_parent_session(self, tmp_path: Path) -> None:
+        """Agent message counts and tokens fold into parent session aggregates.
+
+        Regression test: agent messages must not be dropped from session
+        metadata used for pagination and cache. They should be counted under
+        the parent session.
+        """
+        # Main session: user → assistant(anchor, agentId) → user(next)
+        main_entries = [
+            _make_user_entry("u1", "s1", "2025-01-01T00:00:00Z", text="Hello"),
+            _make_assistant_entry(
+                "a1",
+                "s1",
+                "2025-01-01T00:00:01Z",
+                parent_uuid="u1",
+                agent_id="ag1",
+            ),
+            _make_user_entry(
+                "u2",
+                "s1",
+                "2025-01-01T00:00:05Z",
+                parent_uuid="a1",
+                text="Continue",
+            ),
+        ]
+        # Agent sidechain: 2 entries (user + assistant)
+        agent_entries = [
+            _make_user_entry(
+                "ag_u1",
+                "s1",
+                "2025-01-01T00:00:02Z",
+                is_sidechain=True,
+                agent_id="ag1",
+                text="agent task",
+            ),
+            _make_assistant_entry(
+                "ag_a1",
+                "s1",
+                "2025-01-01T00:00:03Z",
+                parent_uuid="ag_u1",
+                is_sidechain=True,
+                agent_id="ag1",
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", main_entries + agent_entries)
+
+        messages, _tree = load_directory_transcripts(tmp_path, silent=True)
+
+        # Build session data (used for pagination page assignment)
+        session_data = _build_session_data_from_messages(messages)
+
+        # Only the parent session should exist — no agent-synthetic session
+        assert "s1" in session_data
+        assert not any("#agent-" in sid for sid in session_data)
+
+        s1 = session_data["s1"]
+        # message_count should include both main (3) and agent (2) entries
+        assert s1.message_count == 5
+
+        # Token totals should include agent assistant entry (10 input, 5 output)
+        # Main has 1 assistant (a1: 10 input, 5 output)
+        # Agent has 1 assistant (ag_a1: 10 input, 5 output)
+        assert s1.total_input_tokens == 20
+        assert s1.total_output_tokens == 10

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1137,3 +1137,58 @@ class TestAgentDagIntegration:
         # Agent has 1 assistant (ag_a1: 10 input, 5 output)
         assert s1.total_input_tokens == 20
         assert s1.total_output_tokens == 10
+
+
+# =============================================================================
+# Test: current_render_session reset across sessions
+# =============================================================================
+
+
+class TestRenderSessionResetAcrossSessions:
+    """Test that current_render_session is reset when entering a new session.
+
+    Bug: _render_messages() sets current_render_session when entering a
+    within-session fork branch but never clears it on new sessions,
+    causing subsequent session messages to inherit a stale branch ID.
+    """
+
+    def test_second_session_not_polluted_by_first_session_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Messages in session 2 should not inherit session 1's branch render_session_id."""
+        from claude_code_log.renderer import generate_template_messages
+
+        # Session s1 with a fork: u1 → a1, then both u2a and u2b branch from a1
+        s1_entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_assistant_entry("a1", "s1", "2025-07-01T10:01:00.000Z", "u1"),
+            # Fork: two children of a1
+            _make_user_entry("u2a", "s1", "2025-07-01T10:02:00.000Z", "a1", "Branch A"),
+            _make_assistant_entry("a2a", "s1", "2025-07-01T10:03:00.000Z", "u2a"),
+            _make_user_entry("u2b", "s1", "2025-07-01T10:02:01.000Z", "a1", "Branch B"),
+            _make_assistant_entry("a2b", "s1", "2025-07-01T10:03:01.000Z", "u2b"),
+        ]
+
+        # Session s2: separate session, should NOT inherit s1's branch state
+        s2_entries = [
+            _make_user_entry(
+                "u3", "s2", "2025-07-01T11:00:00.000Z", None, "New session"
+            ),
+            _make_assistant_entry("a3", "s2", "2025-07-01T11:01:00.000Z", "u3"),
+        ]
+
+        _write_jsonl(tmp_path / "s1.jsonl", s1_entries)
+        _write_jsonl(tmp_path / "s2.jsonl", s2_entries)
+
+        messages, session_tree = load_directory_transcripts(tmp_path, silent=True)
+        _, _, ctx = generate_template_messages(messages, session_tree=session_tree)
+
+        # Find messages from session s2 by UUID
+        s2_msgs = [m for m in ctx.messages if m.meta.uuid in ("u3", "a3")]
+        assert len(s2_msgs) == 2, f"Expected 2 s2 messages, got {len(s2_msgs)}"
+
+        for msg in s2_msgs:
+            assert msg.render_session_id == "s2", (
+                f"Message {msg.meta.uuid} has render_session_id={msg.render_session_id!r}, "
+                f"expected 's2' — branch tracking from s1 leaked into s2"
+            )

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -63,9 +63,10 @@ def _make_assistant_entry(
     parent_uuid: str | None = None,
     text: str = "reply",
     is_sidechain: bool = False,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     """Helper to create an assistant transcript entry dict."""
-    return {
+    entry: dict[str, Any] = {
         "type": "assistant",
         "timestamp": timestamp,
         "parentUuid": parent_uuid,
@@ -86,6 +87,9 @@ def _make_assistant_entry(
             "usage": {"input_tokens": 10, "output_tokens": 5},
         },
     }
+    if agent_id is not None:
+        entry["agentId"] = agent_id
+    return entry
 
 
 # =============================================================================
@@ -123,7 +127,7 @@ class TestLoadDirectoryDagOrdering:
         assert uuids == ["a", "b", "c", "d", "e", "f", "g", "h"]
 
     def test_load_directory_with_sidechains(self, tmp_path: Path) -> None:
-        """Sidechain entries should be present after DAG-ordered main entries."""
+        """Sidechain entries are integrated into DAG at their structural position."""
         main_entries = [
             _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
             _make_assistant_entry("b", "s1", "2025-07-01T10:01:00.000Z", "a"),
@@ -144,12 +148,9 @@ class TestLoadDirectoryDagOrdering:
         result, _ = load_directory_transcripts(tmp_path, silent=True)
         uuids = [getattr(e, "uuid", None) for e in result]
 
-        # Main entries first (DAG ordered), then sidechain
-        assert "a" in uuids
-        assert "b" in uuids
-        assert "sc1" in uuids
-        # Sidechain should be after main entries
-        assert uuids.index("sc1") > uuids.index("b")
+        # Sidechain is now part of the DAG: sc1 is a child of a (tool-result
+        # side-branch), stitched before the continuation child b
+        assert uuids == ["a", "sc1", "b"]
 
     def test_load_directory_with_summaries(self, tmp_path: Path) -> None:
         """Summary entries should be preserved in output."""
@@ -727,3 +728,259 @@ class TestWithinSessionForkRealData:
         # All entries should be covered
         total_in_daglines = sum(len(dl.uuids) for dl in tree.sessions.values())
         assert total_in_daglines == len(tree.nodes)
+
+
+# =============================================================================
+# Test: Agent transcript DAG integration
+# =============================================================================
+
+
+class TestAgentDagIntegration:
+    """Test that agent (sidechain) transcripts are integrated into the DAG."""
+
+    def test_agent_entries_parented_to_anchor(self, tmp_path: Path) -> None:
+        """Agent root entry gets parentUuid pointing to the anchor tool_result."""
+        # Main session: user → assistant(tool_use Agent) → user(tool_result, agentId)
+        main_entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_assistant_entry("a1", "s1", "2025-07-01T10:01:00.000Z", "u1"),
+            # User entry carrying tool_result with agentId reference
+            _make_user_entry(
+                "u2",
+                "s1",
+                "2025-07-01T10:02:00.000Z",
+                "a1",
+                "tool result",
+                agent_id="agent-abc",
+            ),
+            _make_assistant_entry("a2", "s1", "2025-07-01T10:03:00.000Z", "u2"),
+        ]
+        # Agent file entries (all sidechain)
+        agent_entries = [
+            _make_user_entry(
+                "ag1",
+                "s1",
+                "2025-07-01T10:01:30.000Z",
+                None,
+                "Agent prompt",
+                is_sidechain=True,
+                agent_id="agent-abc",
+            ),
+            _make_assistant_entry(
+                "ag2",
+                "s1",
+                "2025-07-01T10:01:40.000Z",
+                "ag1",
+                "Agent reply",
+                is_sidechain=True,
+                agent_id="agent-abc",
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", main_entries + agent_entries)
+
+        result, tree = load_directory_transcripts(tmp_path, silent=True)
+        uuids = [getattr(e, "uuid", None) for e in result]
+
+        # Agent entries should be in the DAG, placed at the junction point
+        assert "ag1" in uuids
+        assert "ag2" in uuids
+        # Main session entries should be in order
+        assert uuids.index("u1") < uuids.index("a1")
+        assert uuids.index("a1") < uuids.index("u2")
+        assert uuids.index("u2") < uuids.index("a2")
+        # Agent entries should appear between the anchor (u2) and
+        # continuation (a2) — the agent DAG-line is a child session
+        # traversed at the junction point
+        assert uuids.index("u2") < uuids.index("ag1")
+        assert uuids.index("ag2") < uuids.index("a2")
+
+    def test_agent_session_in_tree(self, tmp_path: Path) -> None:
+        """Agent transcript creates a synthetic child session in the tree."""
+        main_entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_user_entry(
+                "u2",
+                "s1",
+                "2025-07-01T10:02:00.000Z",
+                "u1",
+                "tool result",
+                agent_id="agent-xyz",
+            ),
+        ]
+        agent_entries = [
+            _make_user_entry(
+                "ag1",
+                "s1",
+                "2025-07-01T10:01:00.000Z",
+                None,
+                "Agent prompt",
+                is_sidechain=True,
+                agent_id="agent-xyz",
+            ),
+            _make_assistant_entry(
+                "ag2",
+                "s1",
+                "2025-07-01T10:01:10.000Z",
+                "ag1",
+                "Agent reply",
+                is_sidechain=True,
+                agent_id="agent-xyz",
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", main_entries + agent_entries)
+
+        _, tree = load_directory_transcripts(tmp_path, silent=True)
+
+        # Should have synthetic agent session
+        agent_sids = [sid for sid in tree.sessions if "#agent-" in sid]
+        assert len(agent_sids) == 1
+        assert agent_sids[0] == "s1#agent-agent-xyz"
+
+        # Agent session should be a child of the main session
+        agent_dag_line = tree.sessions[agent_sids[0]]
+        assert agent_dag_line.parent_session_id == "s1"
+        assert agent_dag_line.attachment_uuid == "u2"
+
+        # Main session should be a root
+        assert "s1" in tree.roots
+        assert agent_sids[0] not in tree.roots
+
+    def test_agent_no_session_header(self, tmp_path: Path) -> None:
+        """Agent sessions don't generate session headers in rendering."""
+        from claude_code_log.renderer import generate_template_messages
+        from claude_code_log.models import SessionHeaderMessage
+
+        main_entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_user_entry(
+                "u2",
+                "s1",
+                "2025-07-01T10:02:00.000Z",
+                "u1",
+                "tool result",
+                agent_id="agent-xyz",
+            ),
+        ]
+        agent_entries = [
+            _make_user_entry(
+                "ag1",
+                "s1",
+                "2025-07-01T10:01:00.000Z",
+                None,
+                "Agent prompt",
+                is_sidechain=True,
+                agent_id="agent-xyz",
+            ),
+            _make_assistant_entry(
+                "ag2",
+                "s1",
+                "2025-07-01T10:01:10.000Z",
+                "ag1",
+                "Agent reply",
+                is_sidechain=True,
+                agent_id="agent-xyz",
+            ),
+        ]
+
+        _write_jsonl(tmp_path / "session.jsonl", main_entries + agent_entries)
+
+        messages, session_tree = load_directory_transcripts(tmp_path, silent=True)
+        root_messages, session_nav, context = generate_template_messages(
+            messages, session_tree=session_tree
+        )
+
+        # Only one session header (for the main session), not for the agent
+        headers = [
+            m for m in context.messages if isinstance(m.content, SessionHeaderMessage)
+        ]
+        assert len(headers) == 1
+        header_content = headers[0].content
+        assert isinstance(header_content, SessionHeaderMessage)
+        assert header_content.session_id == "s1"
+
+    def test_multiple_agents_ordered(self, tmp_path: Path) -> None:
+        """Multiple agents are each placed at their respective anchor points."""
+        main_entries = [
+            _make_user_entry("u1", "s1", "2025-07-01T10:00:00.000Z", None, "Start"),
+            _make_assistant_entry("a1", "s1", "2025-07-01T10:01:00.000Z", "u1"),
+            # First agent anchor
+            _make_user_entry(
+                "u2",
+                "s1",
+                "2025-07-01T10:02:00.000Z",
+                "a1",
+                "result1",
+                agent_id="agent-1",
+            ),
+            _make_assistant_entry("a2", "s1", "2025-07-01T10:03:00.000Z", "u2"),
+            # Second agent anchor
+            _make_user_entry(
+                "u3",
+                "s1",
+                "2025-07-01T10:04:00.000Z",
+                "a2",
+                "result2",
+                agent_id="agent-2",
+            ),
+            _make_assistant_entry("a3", "s1", "2025-07-01T10:05:00.000Z", "u3"),
+        ]
+        agent1_entries = [
+            _make_user_entry(
+                "ag1-1",
+                "s1",
+                "2025-07-01T10:01:30.000Z",
+                None,
+                "Agent1 prompt",
+                is_sidechain=True,
+                agent_id="agent-1",
+            ),
+            _make_assistant_entry(
+                "ag1-2",
+                "s1",
+                "2025-07-01T10:01:40.000Z",
+                "ag1-1",
+                "Agent1 reply",
+                is_sidechain=True,
+                agent_id="agent-1",
+            ),
+        ]
+        agent2_entries = [
+            _make_user_entry(
+                "ag2-1",
+                "s1",
+                "2025-07-01T10:03:30.000Z",
+                None,
+                "Agent2 prompt",
+                is_sidechain=True,
+                agent_id="agent-2",
+            ),
+            _make_assistant_entry(
+                "ag2-2",
+                "s1",
+                "2025-07-01T10:03:40.000Z",
+                "ag2-1",
+                "Agent2 reply",
+                is_sidechain=True,
+                agent_id="agent-2",
+            ),
+        ]
+
+        _write_jsonl(
+            tmp_path / "session.jsonl",
+            main_entries + agent1_entries + agent2_entries,
+        )
+
+        result, tree = load_directory_transcripts(tmp_path, silent=True)
+        uuids = [getattr(e, "uuid", None) for e in result]
+
+        # Each agent should appear after its anchor and before the next main entry
+        assert uuids.index("ag1-1") > uuids.index("u2")
+        assert uuids.index("ag1-2") < uuids.index("a2")
+        assert uuids.index("ag2-1") > uuids.index("u3")
+        assert uuids.index("ag2-2") < uuids.index("a3")
+
+        # Two synthetic agent sessions
+        agent_sids = [sid for sid in tree.sessions if "#agent-" in sid]
+        assert len(agent_sids) == 2

--- a/work/phase-c-agent-transcripts.md
+++ b/work/phase-c-agent-transcripts.md
@@ -39,15 +39,20 @@ The synthetic ID is only assigned in-memory during `load_directory_transcripts()
   in `_reorder_session_template_messages()`
 - Agent sessions excluded from session navigation and individual file generation
 
-### What Was Kept (Not Removed Yet)
+### What Was Kept
 
-- `_reorder_sidechain_template_messages()` — now a no-op for properly
-  integrated agents (they're already in DAG order), but kept as fallback
-  for any edge cases with old-style data
 - `_cleanup_sidechain_duplicates()` — still needed for Task tool dedup
-  (first user message = Task input, last assistant = Task output)
+  (first user message = Task input, last assistant = Task output).
+  This is content-level dedup that can't be handled at the DAG level.
 - `sidechain_uuids` parameter in `build_dag()` — still needed for unloaded
   subagent files (e.g. aprompt_suggestion agents never referenced via agentId)
+
+### What Was Removed (Step 4)
+
+- `_reorder_sidechain_template_messages()` — removed. With DAG integration,
+  agent messages are already in correct order via DAG traversal. Single-file
+  mode now also calls `_integrate_agent_entries()` so both paths use DAG-based
+  ordering.
 
 ## Remaining Steps
 
@@ -59,13 +64,14 @@ What's left:
 - Verify rendering hierarchy (levels 4/5) works correctly for all cases
 - Test with projects that have nested agents (agent spawning sub-agents)
 
-### Step 4: Rendering Cleanup
+### Step 4: Rendering Cleanup (Done)
 
-Once confident in DAG ordering:
-- Remove `_reorder_sidechain_template_messages()` (currently a no-op for
-  integrated agents)
-- Simplify `_cleanup_sidechain_duplicates()` — dedup may be handleable at
-  DAG level
+- Removed `_reorder_sidechain_template_messages()` — no longer needed with
+  DAG-based ordering. Added `_integrate_agent_entries()` to single-file mode
+  in `converter.py` so both code paths use consistent DAG integration.
+- `_cleanup_sidechain_duplicates()` — kept as-is. Content-level dedup
+  (Task input/output duplicated in sidechain) cannot be handled at the DAG
+  level since it requires text comparison, not structural ordering.
 
 ### Step 5: Agent Tool Renderer (separate PR, `dev/user-sidechain`)
 

--- a/work/phase-c-agent-transcripts.md
+++ b/work/phase-c-agent-transcripts.md
@@ -1,0 +1,81 @@
+# Phase C: Agent Transcript Rework
+
+## Status: Steps 1-2 Complete (DAG Integration)
+
+## What Changed
+
+### Step 1: Agent Data Shapes (Analysis Complete)
+
+Key findings from real data analysis:
+
+- **Agent entries share `sessionId`** with their parent session
+- All agent entries have `isSidechain: true` and `agentId`
+- First entry always has `parentUuid: null` (top-level agents)
+- Internal `parentUuid` chains form the same fork patterns as main sessions
+  (tool-result side-branches)
+- `agentId` reference in main session: either entry-level `agentId` (old Task
+  tool) or `toolUseResult.agentId` (new Agent tool, copied to entry level by
+  converter.py parsing code)
+
+### Step 2: DAG-Level Agent Integration (Implemented)
+
+**`converter.py` — `_integrate_agent_entries()`**:
+1. Builds `agentId -> anchor_uuid` map from main-session entries with `agentId`
+2. For each sidechain entry: assigns synthetic `sessionId`
+   (`{sessionId}#agent-{agentId}`) so agents form separate DAG-lines
+3. Parents root entries (`parentUuid=None`) to the anchor UUID
+
+**Effect**: Agent entries are included in the DAG. The existing DAG machinery
+(build_dag, extract_session_dag_lines, build_session_tree, traverse_session_tree)
+handles them as child sessions of the main session, spliced at the anchor point.
+
+**Key constraint**: `entry.sessionId` on disk / in cache is NEVER mutated.
+The synthetic ID is only assigned in-memory during `load_directory_transcripts()`.
+
+### Renderer Changes
+
+- Agent sessions (`#agent-` in session_id) **don't get session headers**
+- Agent messages use parent session's `render_session_id` for correct grouping
+  in `_reorder_session_template_messages()`
+- Agent sessions excluded from session navigation and individual file generation
+
+### What Was Kept (Not Removed Yet)
+
+- `_reorder_sidechain_template_messages()` — now a no-op for properly
+  integrated agents (they're already in DAG order), but kept as fallback
+  for any edge cases with old-style data
+- `_cleanup_sidechain_duplicates()` — still needed for Task tool dedup
+  (first user message = Task input, last assistant = Task output)
+- `sidechain_uuids` parameter in `build_dag()` — still needed for unloaded
+  subagent files (e.g. aprompt_suggestion agents never referenced via agentId)
+
+## Remaining Steps
+
+### Step 3: Session Tree Integration (Partially Done)
+
+Agent DAG-lines already appear as child sessions in the tree. The
+`traverse_session_tree()` naturally visits them at the junction point.
+What's left:
+- Verify rendering hierarchy (levels 4/5) works correctly for all cases
+- Test with projects that have nested agents (agent spawning sub-agents)
+
+### Step 4: Rendering Cleanup
+
+Once confident in DAG ordering:
+- Remove `_reorder_sidechain_template_messages()` (currently a no-op for
+  integrated agents)
+- Simplify `_cleanup_sidechain_duplicates()` — dedup may be handleable at
+  DAG level
+
+### Step 5: Agent Tool Renderer (separate PR, `dev/user-sidechain`)
+
+- Specialized rendering for Agent tool_use/tool_result (like old Task tool had)
+- Sidechain user messages rendered as markdown (already on `dev/user-sidechain`)
+
+## Test Coverage
+
+4 new integration tests in `TestAgentDagIntegration`:
+- `test_agent_entries_parented_to_anchor` — agent root gets parentUuid to anchor
+- `test_agent_session_in_tree` — synthetic session created, tree structure correct
+- `test_agent_no_session_header` — no session header generated for agents
+- `test_multiple_agents_ordered` — multiple agents placed at respective anchors


### PR DESCRIPTION
## Summary

- Agent (sidechain) entries are now included in the DAG instead of being partitioned out and heuristically reordered
- New `_integrate_agent_entries()` in `converter.py` parents agent roots to their anchor `tool_result` and assigns synthetic session IDs (`{sessionId}#agent-{agentId}`) to form separate DAG-lines
- Agent sessions appear inline (no separate session headers, no individual session files, no nav entries) — visual output unchanged
- 4 new integration tests covering agent parenting, session tree structure, header suppression, and multi-agent ordering

---

The look and feel of fork points and branches is now like this:

<img width="1260" height="825" alt="Screenshot from 2026-04-12 19-26-03" src="https://github.com/user-attachments/assets/80836432-998e-4d47-a044-681b888f5853" />

---

## Details

### How it works

1. **Anchor discovery**: Main-session entries with `agentId` (from entry-level or `toolUseResult.agentId`) become anchors
2. **Parenting**: Agent root entries (`parentUuid=null`) get their `parentUuid` set to the anchor's UUID
3. **Session separation**: Synthetic `sessionId` (`s1#agent-xyz`) separates agents from their parent session in the DAG
4. **Traversal**: Existing DAG machinery (build_session_tree, traverse_session_tree) naturally handles agent sessions as child sessions at junction points

### What's kept (conservative approach)

- `_reorder_sidechain_template_messages()` — now effectively a no-op for integrated agents, kept as fallback
- `_cleanup_sidechain_duplicates()` — still needed for Task tool input/output dedup
- `sidechain_uuids` in `build_dag()` — still needed for unloaded subagent files (e.g. aprompt_suggestion)

### Key constraint

`entry.sessionId` on disk / in cache is **never mutated**. Synthetic IDs are only assigned in-memory during `load_directory_transcripts()`.

## Test plan

- [x] 4 new `TestAgentDagIntegration` tests pass
- [x] Updated `test_load_directory_with_sidechains` for new DAG ordering
- [x] Full test suite (801 passed, 7 skipped)
- [x] Snapshot tests pass (no rendering regression)
- [x] `ty check` and `ruff check` clean
- [x] Visual check with real agent data (`-src-experiments-claude_p`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Agent/sidechain messages are now integrated into parent sessions: they render nested under the parent task, no longer show separate session headers, and are excluded from session navigation and per-session exports.

* **Documentation**
  * Updated docs to reflect DAG-based integration of agent transcripts and next-phase roadmap.

* **Tests**
  * Expanded integration tests for agent transcript ordering, parent-child placement, and rendering/grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->