### PR TITLE
fix: handle None level in SystemMessage title

### DIFF
--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2074,7 +2074,8 @@ class Renderer:
     # Override in subclasses for format-specific titles (e.g., HTML with icons).
 
     def title_SystemMessage(self, content: SystemMessage, _: TemplateMessage) -> str:
-        return f"System {content.level.title()}"
+        level = content.level or "unknown"
+        return f"System {level.title()}"
 
     def title_HookSummaryMessage(
         self, _content: HookSummaryMessage, _: TemplateMessage


### PR DESCRIPTION
## Summary

- `title_SystemMessage` in `renderer.py` crashes when `content.level` is `None`
- Error: `AttributeError: 'NoneType' object has no attribute 'title'`
- This causes entire projects to fail processing with a `Warning: Failed to process` message

## Root cause

Some Claude Code session logs contain system messages where the `level` field is missing/null. The current code calls `.title()` directly on `content.level` without a null check.

## Fix

Fall back to `"unknown"` when `content.level` is `None`:

```python
level = content.level or "unknown"
return f"System {level.title()}"
```

## Reproduction

Affected projects all share the same traceback:

```
File "renderer.py", line 2077, in title_SystemMessage
    return f"System {content.level.title()}"
AttributeError: 'NoneType' object has no attribute 'title'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system message title generation to properly handle missing level information, now displaying "System Unknown" instead of potentially causing errors or incorrect titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->