### PR TITLE
feat: add --session-id flag for exporting a single 

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -1556,6 +1556,47 @@ def get_all_cached_projects(
     return result
 
 
+def find_session_in_cache(
+    session_id: str,
+    projects_dir: Path,
+    db_path: Optional[Path] = None,
+) -> list[tuple[str, str]]:
+    """Find a session by ID or prefix across all projects in cache.
+
+    Standalone function that queries the cache database directly.
+
+    Args:
+        session_id: Full session ID or prefix to match.
+        projects_dir: Path to the projects directory (for default DB location).
+        db_path: Optional explicit path to the cache database.
+
+    Returns:
+        List of (project_path, full_session_id) tuples for all matches.
+    """
+    actual_db_path = db_path or get_cache_db_path(projects_dir)
+    if not actual_db_path.exists():
+        return []
+
+    try:
+        conn = sqlite3.connect(actual_db_path, timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """SELECT p.project_path, s.session_id
+                   FROM sessions s
+                   JOIN projects p ON s.project_id = p.id
+                   WHERE s.session_id = ? OR s.session_id LIKE ?
+                   ORDER BY s.first_timestamp DESC""",
+                (session_id, f"{session_id}%"),
+            ).fetchall()
+            return [(row["project_path"], row["session_id"]) for row in rows]
+        finally:
+            conn.close()
+    except (sqlite3.Error, OSError) as e:
+        logger.debug("Failed to find session in cache: %s", e)
+        return []
+
+
 __all__ = [
     "CacheManager",
     "CachedFileInfo",
@@ -1563,6 +1604,7 @@ __all__ = [
     "PageCacheData",
     "ProjectCache",
     "SessionCacheData",
+    "find_session_in_cache",
     "get_all_cached_projects",
     "get_cache_db_path",
     "get_library_version",

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -14,6 +14,7 @@ from .converter import (
     convert_jsonl_to,
     convert_jsonl_to_html,
     ensure_fresh_cache,
+    generate_single_session_file,
     get_file_extension,
     process_projects_hierarchy,
 )
@@ -507,6 +508,11 @@ def _clear_output_files(input_path: Path, all_projects: bool, file_ext: str) -> 
     help="Maximum messages per page for combined transcript (default: 2000). Sessions are never split across pages.",
 )
 @click.option(
+    "--session-id",
+    default=None,
+    help="Export a single session by ID (full ID or 8-char prefix). Requires a project directory path.",
+)
+@click.option(
     "--debug",
     is_flag=True,
     default=False,
@@ -528,6 +534,7 @@ def main(
     output_format: str,
     image_export_mode: Optional[str],
     page_size: int,
+    session_id: Optional[str],
     debug: bool,
 ) -> None:
     """Convert Claude transcript JSONL files to HTML or Markdown.
@@ -647,6 +654,38 @@ def main(
                 # Single project directory
                 _launch_tui_with_cache_check(input_path)
                 return
+
+        # Handle --session-id: export a single session by ID
+        if session_id is not None:
+            if input_path is None:
+                click.echo(
+                    "Error: --session-id requires a project directory path as argument",
+                    err=True,
+                )
+                sys.exit(1)
+
+            # Convert project path if needed
+            if not input_path.exists() or (
+                input_path.is_dir() and not list(input_path.glob("*.jsonl"))
+            ):
+                claude_path = convert_project_path_to_claude_dir(
+                    input_path, projects_dir
+                )
+                if claude_path.exists():
+                    input_path = claude_path
+
+            output_path = generate_single_session_file(
+                output_format,
+                input_path,
+                session_id,
+                output,
+                not no_cache,
+                image_export_mode,
+            )
+            click.echo(f"Successfully exported session to {output_path}")
+            if open_browser:
+                click.launch(str(output_path))
+            return
 
         # Handle default case - process all projects hierarchy if no input path and --all-projects flag
         if input_path is None:

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -665,6 +665,7 @@ def main(
                 sys.exit(1)
 
             # Convert project path if needed
+            assert input_path is not None
             if not input_path.exists() or (
                 input_path.is_dir() and not list(input_path.glob("*.jsonl"))
             ):

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -20,6 +20,7 @@ from .converter import (
 )
 from .cache import (
     CacheManager,
+    find_session_in_cache,
     get_all_cached_projects,
     get_cache_db_path,
     get_library_version,
@@ -510,7 +511,7 @@ def _clear_output_files(input_path: Path, all_projects: bool, file_ext: str) -> 
 @click.option(
     "--session-id",
     default=None,
-    help="Export a single session by ID (full ID or prefix). Requires a project directory path.",
+    help="Export a single session by ID (full ID or prefix). Project path is optional — looks up the session globally via cache.",
 )
 @click.option(
     "--debug",
@@ -658,22 +659,41 @@ def main(
         # Handle --session-id: export a single session by ID
         if session_id is not None:
             if input_path is None:
-                click.echo(
-                    "Error: --session-id requires a project directory path as argument",
-                    err=True,
-                )
-                sys.exit(1)
-
-            # Convert project path if needed
-            assert input_path is not None
-            if not input_path.exists() or (
-                input_path.is_dir() and not list(input_path.glob("*.jsonl"))
-            ):
-                claude_path = convert_project_path_to_claude_dir(
-                    input_path, projects_dir
-                )
-                if claude_path.exists():
-                    input_path = claude_path
+                # Global lookup via cache
+                effective_projects_dir = projects_dir or get_default_projects_dir()
+                matches = find_session_in_cache(session_id, effective_projects_dir)
+                if not matches:
+                    click.echo(
+                        f"Error: Session '{session_id}' not found in cache. "
+                        "Try providing a project directory path, or run "
+                        "claude-code-log first to populate the cache.",
+                        err=True,
+                    )
+                    sys.exit(1)
+                if len(matches) > 1:
+                    # Check if all matches resolve to the same session ID
+                    unique_ids = {m[1] for m in matches}
+                    if len(unique_ids) > 1:
+                        click.echo(
+                            f"Error: Ambiguous session ID prefix '{session_id}' "
+                            "matches multiple sessions:",
+                            err=True,
+                        )
+                        for proj_path, sid in matches:
+                            click.echo(f"  {sid[:8]} in {proj_path}", err=True)
+                        sys.exit(1)
+                input_path = Path(matches[0][0])
+                session_id = matches[0][1]
+            else:
+                # Convert project path if needed
+                if not input_path.exists() or (
+                    input_path.is_dir() and not list(input_path.glob("*.jsonl"))
+                ):
+                    claude_path = convert_project_path_to_claude_dir(
+                        input_path, projects_dir
+                    )
+                    if claude_path.exists():
+                        input_path = claude_path
 
             output_path = generate_single_session_file(
                 output_format,

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -510,7 +510,7 @@ def _clear_output_files(input_path: Path, all_projects: bool, file_ext: str) -> 
 @click.option(
     "--session-id",
     default=None,
-    help="Export a single session by ID (full ID or 8-char prefix). Requires a project directory path.",
+    help="Export a single session by ID (full ID or prefix). Requires a project directory path.",
 )
 @click.option(
     "--debug",

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1469,6 +1469,22 @@ def _collect_project_sessions(messages: list[TranscriptEntry]) -> list[dict[str,
     )
 
 
+def build_session_title(
+    project_title: str,
+    session_id: str,
+    session_cache: Optional[Any],
+) -> str:
+    if session_cache:
+        if session_cache.summary:
+            return f"{project_title}: {session_cache.summary}"
+        preview = session_cache.first_user_message
+        if preview:
+            if len(preview) > 50:
+                preview = preview[:50] + "..."
+            return f"{project_title}: {preview}"
+    return f"{project_title}: Session {session_id[:8]}"
+
+
 def _generate_individual_session_files(
     format: str,
     messages: list[TranscriptEntry],
@@ -1520,23 +1536,11 @@ def _generate_individual_session_files(
     # Generate HTML file for each session
     for session_id in session_ids:
         # Create session-specific title using cache data if available
-        if session_id in session_data:
-            session_cache = session_data[session_id]
-            if session_cache.summary:
-                session_title = f"{project_title}: {session_cache.summary}"
-            else:
-                # Fall back to first user message preview
-                preview = session_cache.first_user_message
-                if preview and len(preview) > 50:
-                    preview = preview[:50] + "..."
-                session_title = (
-                    f"{project_title}: {preview}"
-                    if preview
-                    else f"{project_title}: Session {session_id[:8]}"
-                )
-        else:
-            # Fall back to basic session title
-            session_title = f"{project_title}: Session {session_id[:8]}"
+        session_title = build_session_title(
+            project_title,
+            session_id,
+            session_data.get(session_id),
+        )
 
         # Add date range if specified
         if from_date or to_date:
@@ -1638,9 +1642,12 @@ def generate_single_session_file(
         raise FileNotFoundError(f"Project directory not found: {input_path}")
 
     # Setup cache
-    cache_manager = (
-        CacheManager(input_path, get_library_version()) if use_cache else None
-    )
+    cache_manager = None
+    if use_cache:
+        try:
+            cache_manager = CacheManager(input_path, get_library_version())
+        except Exception as e:
+            print(f"Warning: Failed to initialize cache manager: {e}")
 
     # Ensure fresh cache
     ensure_fresh_cache(input_path, cache_manager, silent=True)
@@ -1687,6 +1694,8 @@ def generate_single_session_file(
         if archived:
             session_messages = archived
 
+    session_messages = deduplicate_messages(session_messages)
+
     if not session_messages:
         raise ValueError(f"No messages found for session '{matched_id[:8]}'")
 
@@ -1701,21 +1710,11 @@ def generate_single_session_file(
 
     project_title = get_project_display_name(input_path.name, working_directories)
 
-    if matched_id in session_data:
-        session_cache_data = session_data[matched_id]
-        if session_cache_data.summary:
-            session_title = f"{project_title}: {session_cache_data.summary}"
-        else:
-            preview = session_cache_data.first_user_message
-            if preview and len(preview) > 50:
-                preview = preview[:50] + "..."
-            session_title = (
-                f"{project_title}: {preview}"
-                if preview
-                else f"{project_title}: Session {matched_id[:8]}"
-            )
-    else:
-        session_title = f"{project_title}: Session {matched_id[:8]}"
+    session_title = build_session_title(
+        project_title,
+        matched_id,
+        session_data.get(matched_id),
+    )
 
     # Determine output path
     ext = get_file_extension(format)

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1685,7 +1685,6 @@ def generate_single_session_file(
     if not session_messages and cache_manager:
         archived = cache_manager.load_session_entries(matched_id)
         if archived:
-            messages = archived
             session_messages = archived
 
     if not session_messages:
@@ -1730,7 +1729,7 @@ def generate_single_session_file(
     # Generate content and write
     renderer = get_renderer(format, image_export_mode)
     session_content = renderer.generate_session(
-        messages, matched_id, session_title, cache_manager, output_dir
+        session_messages, matched_id, session_title, cache_manager, output_dir
     )
     assert session_content is not None
     output_file.write_text(session_content, encoding="utf-8")

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1472,7 +1472,7 @@ def _collect_project_sessions(messages: list[TranscriptEntry]) -> list[dict[str,
 def build_session_title(
     project_title: str,
     session_id: str,
-    session_cache: Optional[Any],
+    session_cache: Optional[SessionCacheData],
 ) -> str:
     if session_cache:
         if session_cache.summary:

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1609,6 +1609,135 @@ def _generate_individual_session_files(
     return regenerated_count
 
 
+def generate_single_session_file(
+    format: str,
+    input_path: Path,
+    session_id: str,
+    output: Optional[Path] = None,
+    use_cache: bool = True,
+    image_export_mode: Optional[str] = None,
+) -> Path:
+    """Generate a single session output file for the given session ID.
+
+    Args:
+        format: Output format ('html', 'md', 'markdown')
+        input_path: Project directory containing JSONL files
+        session_id: Full or 8-char prefix session ID
+        output: Optional output file path (defaults to session-{id}.{ext} in input_path)
+        use_cache: Whether to use caching
+        image_export_mode: Image export mode
+
+    Returns:
+        Path to the generated file
+
+    Raises:
+        ValueError: If session ID not found or ambiguous
+        FileNotFoundError: If input_path doesn't exist or is not a directory
+    """
+    if not input_path.exists() or not input_path.is_dir():
+        raise FileNotFoundError(f"Project directory not found: {input_path}")
+
+    # Setup cache
+    cache_manager = (
+        CacheManager(input_path, get_library_version()) if use_cache else None
+    )
+
+    # Ensure fresh cache
+    ensure_fresh_cache(input_path, cache_manager, silent=True)
+
+    # Load messages from JSONL files
+    messages = load_directory_transcripts(input_path, cache_manager)
+
+    # Collect all known session IDs: from loaded messages + cache metadata
+    all_session_ids: set[str] = {
+        getattr(msg, "sessionId")
+        for msg in messages
+        if hasattr(msg, "sessionId") and getattr(msg, "sessionId")
+    }
+    if cache_manager:
+        project_cache = cache_manager.get_cached_project_data()
+        if project_cache:
+            all_session_ids |= set(project_cache.sessions.keys())
+
+    # Resolve short ID prefix to full ID
+    matched_id: Optional[str] = None
+    if session_id in all_session_ids:
+        matched_id = session_id
+    else:
+        matches = [sid for sid in all_session_ids if sid.startswith(session_id)]
+        if len(matches) == 1:
+            matched_id = matches[0]
+        elif len(matches) > 1:
+            raise ValueError(
+                f"Ambiguous session ID prefix '{session_id}' matches multiple sessions: "
+                + ", ".join(sorted(m[:8] for m in matches))
+            )
+
+    if matched_id is None:
+        raise ValueError(f"Session '{session_id}' not found in {input_path}")
+
+    # For archived sessions, load messages from cache if not in JSONL files
+    session_messages = [
+        m
+        for m in messages
+        if hasattr(m, "sessionId") and getattr(m, "sessionId") == matched_id
+    ]
+    if not session_messages and cache_manager:
+        archived = cache_manager.load_session_entries(matched_id)
+        if archived:
+            messages = archived
+            session_messages = archived
+
+    if not session_messages:
+        raise ValueError(f"No messages found for session '{matched_id[:8]}'")
+
+    # Build session title from cache metadata
+    session_data: dict[str, Any] = {}
+    working_directories: list[str] = []
+    if cache_manager:
+        project_cache = cache_manager.get_cached_project_data()
+        if project_cache:
+            session_data = {s.session_id: s for s in project_cache.sessions.values()}
+        working_directories = cache_manager.get_working_directories()
+
+    project_title = get_project_display_name(input_path.name, working_directories)
+
+    if matched_id in session_data:
+        session_cache_data = session_data[matched_id]
+        if session_cache_data.summary:
+            session_title = f"{project_title}: {session_cache_data.summary}"
+        else:
+            preview = session_cache_data.first_user_message
+            if preview and len(preview) > 50:
+                preview = preview[:50] + "..."
+            session_title = (
+                f"{project_title}: {preview}"
+                if preview
+                else f"{project_title}: Session {matched_id[:8]}"
+            )
+    else:
+        session_title = f"{project_title}: Session {matched_id[:8]}"
+
+    # Determine output path
+    ext = get_file_extension(format)
+    output_dir = input_path
+    if output is not None:
+        output_file = output
+        output_dir = output.parent
+    else:
+        output_file = input_path / f"session-{matched_id}.{ext}"
+
+    # Generate content and write
+    renderer = get_renderer(format, image_export_mode)
+    session_content = renderer.generate_session(
+        messages, matched_id, session_title, cache_manager, output_dir
+    )
+    assert session_content is not None
+    output_file.write_text(session_content, encoding="utf-8")
+
+    return output_file
+
+
 def _get_cleanup_period_days() -> Optional[int]:
     """Read cleanupPeriodDays from Claude Code settings.
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1474,6 +1474,11 @@ def build_session_title(
     session_id: str,
     session_cache: Optional[SessionCacheData],
 ) -> str:
+    """Build a display title for a session.
+
+    Uses the session summary if available, otherwise the first user message
+    preview (truncated to 50 chars), falling back to "Session {id[:8]}".
+    """
     if session_cache:
         if session_cache.summary:
             return f"{project_title}: {session_cache.summary}"

--- a/claude_code_log/tui.py
+++ b/claude_code_log/tui.py
@@ -24,6 +24,7 @@ from textual.reactive import reactive
 
 from .cache import CacheManager, SessionCacheData, get_library_version
 from .converter import (
+    build_session_title,
     ensure_fresh_cache,
     get_file_extension,
     load_directory_transcripts,
@@ -1849,15 +1850,7 @@ class SessionBrowser(App[Optional[str]]):
                 self.project_path.name,
                 project_cache.working_directories if project_cache else None,
             )
-            if session_data and session_data.summary:
-                session_title = f"{project_name}: {session_data.summary}"
-            elif session_data and session_data.first_user_message:
-                preview = session_data.first_user_message
-                if len(preview) > 50:
-                    preview = preview[:50] + "..."
-                session_title = f"{project_name}: {preview}"
-            else:
-                session_title = f"{project_name}: Session {session_id[:8]}"
+            session_title = build_session_title(project_name, session_id, session_data)
 
             # Generate session content
             session_content = renderer.generate_session(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -432,15 +432,40 @@ class TestCLIMainCommand:
 class TestSessionIdOption:
     """Tests for --session-id CLI option."""
 
-    def test_session_id_no_path_errors(
+    def test_session_id_no_path_not_in_cache_errors(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ):
-        """--session-id without a project path argument exits with error."""
+        """--session-id without path and no cache match exits with error."""
         monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
         runner = CliRunner()
         result = runner.invoke(main, ["--session-id", "abc12345"])
         assert result.exit_code != 0
-        assert "error" in result.output.lower() or "Error" in result.output
+        assert "not found" in result.output.lower()
+
+    def test_session_id_no_path_global_lookup(
+        self, cli_projects_setup: ProjectsSetup, sample_jsonl_content: list[dict]
+    ):
+        """--session-id without path finds session via cache global lookup."""
+        project_dir = create_project_with_jsonl(
+            cli_projects_setup.projects_dir, "my-project", sample_jsonl_content
+        )
+        runner = CliRunner()
+        # First, generate with path to populate cache
+        result = runner.invoke(main, [str(project_dir), "--session-id", "session-1"])
+        assert result.exit_code == 0
+
+        # Now use --session-id without path, relying on global cache lookup
+        result = runner.invoke(
+            main,
+            [
+                "--session-id",
+                "session-1",
+                "--projects-dir",
+                str(cli_projects_setup.projects_dir),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Successfully exported session" in result.output
 
     def test_session_id_valid_full_id(
         self, cli_projects_setup: ProjectsSetup, sample_jsonl_content: list[dict]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -429,6 +429,82 @@ class TestCLIMainCommand:
         assert output_path.exists()
 
 
+class TestSessionIdOption:
+    """Tests for --session-id CLI option."""
+
+    def test_session_id_no_path_errors(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        """--session-id without a project path argument exits with error."""
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+        runner = CliRunner()
+        result = runner.invoke(main, ["--session-id", "abc12345"])
+        assert result.exit_code != 0
+        assert "error" in result.output.lower() or "Error" in result.output
+
+    def test_session_id_valid_full_id(
+        self, cli_projects_setup: ProjectsSetup, sample_jsonl_content: list[dict]
+    ):
+        """--session-id with a valid full session ID generates file and prints success."""
+        project_dir = create_project_with_jsonl(
+            cli_projects_setup.projects_dir, "my-project", sample_jsonl_content
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, [str(project_dir), "--session-id", "session-1"])
+        assert result.exit_code == 0
+        assert "Successfully exported session" in result.output
+        # Generated file must exist
+        assert len(list(project_dir.glob("session-session-1.*"))) > 0
+
+    def test_session_id_prefix(
+        self, cli_projects_setup: ProjectsSetup, sample_jsonl_content: list[dict]
+    ):
+        """--session-id with a unique prefix resolves to the full ID."""
+        project_dir = create_project_with_jsonl(
+            cli_projects_setup.projects_dir, "my-project", sample_jsonl_content
+        )
+        runner = CliRunner()
+        # "sess" is a valid prefix of "session-1"
+        result = runner.invoke(main, [str(project_dir), "--session-id", "sess"])
+        assert result.exit_code == 0
+        assert "Successfully exported session" in result.output
+
+    def test_session_id_unknown_exits_nonzero(
+        self, cli_projects_setup: ProjectsSetup, sample_jsonl_content: list[dict]
+    ):
+        """--session-id with an unknown ID exits non-zero."""
+        project_dir = create_project_with_jsonl(
+            cli_projects_setup.projects_dir, "my-project", sample_jsonl_content
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, [str(project_dir), "--session-id", "zzzzzzzz-does-not-exist"]
+        )
+        assert result.exit_code != 0
+
+    def test_session_id_with_output_flag(
+        self, cli_projects_setup: ProjectsSetup, sample_jsonl_content: list[dict]
+    ):
+        """--session-id combined with --output writes to the specified path."""
+        project_dir = create_project_with_jsonl(
+            cli_projects_setup.projects_dir, "my-project", sample_jsonl_content
+        )
+        output_path = cli_projects_setup.projects_dir / "custom-session.html"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                str(project_dir),
+                "--session-id",
+                "session-1",
+                "--output",
+                str(output_path),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output_path.exists()
+
+
 class TestCLIErrorHandling:
     """Tests for CLI error handling paths."""
 

--- a/test/test_session_export.py
+++ b/test/test_session_export.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Unit tests for generate_single_session_file() in converter.py."""
+
+import json
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from claude_code_log.converter import generate_single_session_file
+
+# A UUID-style session ID whose 8-char prefix is "abc12345"
+SESSION_ID_A = "abc12345-1111-2222-3333-444444444444"
+SESSION_ID_B = "abc1xxxx-5555-6666-7777-888888888888"
+
+
+def _make_jsonl_entries(session_id: str, user_message: str = "Hello") -> list[dict]:
+    """Minimal valid JSONL entries for a session."""
+    return [
+        {
+            "type": "user",
+            "uuid": f"{session_id}-user",
+            "timestamp": "2023-01-01T10:00:00Z",
+            "sessionId": session_id,
+            "version": "1.0.0",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "user",
+            "cwd": "/test",
+            "message": {"role": "user", "content": user_message},
+        },
+        {
+            "type": "assistant",
+            "uuid": f"{session_id}-asst",
+            "timestamp": "2023-01-01T10:01:00Z",
+            "sessionId": session_id,
+            "version": "1.0.0",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "assistant",
+            "cwd": "/test",
+            "requestId": "req-1",
+            "message": {
+                "id": "msg-1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3",
+                "content": [{"type": "text", "text": "Hi!"}],
+                "usage": {"input_tokens": 5, "output_tokens": 5},
+            },
+        },
+    ]
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    with open(path, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+@pytest.fixture
+def project_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[Path, None, None]:
+    """Isolated project directory with one session (SESSION_ID_A)."""
+    proj = tmp_path / "my-project"
+    proj.mkdir()
+    _write_jsonl(proj / "session-a.jsonl", _make_jsonl_entries(SESSION_ID_A))
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+    yield proj
+
+
+class TestInputValidation:
+    def test_raises_file_not_found_for_missing_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError):
+            generate_single_session_file("html", missing, SESSION_ID_A)
+
+    def test_raises_file_not_found_for_file_not_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+        f = tmp_path / "not-a-dir.jsonl"
+        f.write_text("{}")
+        with pytest.raises(FileNotFoundError):
+            generate_single_session_file("html", f, SESSION_ID_A)
+
+    def test_raises_value_error_for_unknown_session(self, project_dir: Path):
+        with pytest.raises(ValueError, match="not found"):
+            generate_single_session_file(
+                "html", project_dir, "zzzzzzzz-0000-0000-0000-000000000000"
+            )
+
+
+class TestSessionIdResolution:
+    def test_exact_session_id_match(self, project_dir: Path):
+        result = generate_single_session_file("html", project_dir, SESSION_ID_A)
+        assert result.exists()
+
+    def test_short_prefix_match(self, project_dir: Path):
+        # "abc12345" is the first 8 chars of SESSION_ID_A
+        result = generate_single_session_file("html", project_dir, "abc12345")
+        assert result.exists()
+
+    def test_ambiguous_prefix_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        proj = tmp_path / "ambiguous-project"
+        proj.mkdir()
+        # Both IDs start with "abc1" — providing that prefix is ambiguous
+        entries = _make_jsonl_entries(SESSION_ID_A) + _make_jsonl_entries(SESSION_ID_B)
+        _write_jsonl(proj / "sessions.jsonl", entries)
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+
+        with pytest.raises(ValueError, match="[Aa]mbiguous"):
+            generate_single_session_file("html", proj, "abc1")
+
+
+class TestOutputPath:
+    def test_default_output_path(self, project_dir: Path):
+        result = generate_single_session_file("html", project_dir, SESSION_ID_A)
+        expected = project_dir / f"session-{SESSION_ID_A}.html"
+        assert result == expected
+        assert result.exists()
+
+    def test_custom_output_path(self, project_dir: Path, tmp_path: Path):
+        custom = tmp_path / "out" / "my-session.html"
+        custom.parent.mkdir()
+        result = generate_single_session_file(
+            "html", project_dir, SESSION_ID_A, output=custom
+        )
+        assert result == custom
+        assert custom.exists()
+
+    def test_markdown_format_uses_md_extension(self, project_dir: Path):
+        result = generate_single_session_file("md", project_dir, SESSION_ID_A)
+        assert result.suffix == ".md"
+        assert result.exists()
+
+
+class TestNoCacheMode:
+    def test_generates_file_without_cache(self, project_dir: Path):
+        result = generate_single_session_file(
+            "html", project_dir, SESSION_ID_A, use_cache=False
+        )
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+
+class TestSessionTitle:
+    def test_title_uses_summary(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        proj = tmp_path / "proj-summary"
+        proj.mkdir()
+        entries = _make_jsonl_entries(SESSION_ID_A)
+        entries.append(
+            {
+                "type": "summary",
+                "summary": "My special summary",
+                "leafUuid": f"{SESSION_ID_A}-asst",
+            }
+        )
+        _write_jsonl(proj / "session-a.jsonl", entries)
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+
+        result = generate_single_session_file("html", proj, SESSION_ID_A)
+        content = result.read_text(encoding="utf-8")
+        assert "My special summary" in content
+
+    def test_title_uses_first_user_message_truncated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        long_msg = "A" * 60  # > 50 chars, no trailing summary entry
+        proj = tmp_path / "proj-preview"
+        proj.mkdir()
+        _write_jsonl(
+            proj / "session-a.jsonl",
+            _make_jsonl_entries(SESSION_ID_A, user_message=long_msg),
+        )
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
+
+        result = generate_single_session_file("html", proj, SESSION_ID_A)
+        content = result.read_text(encoding="utf-8")
+        # Truncated preview ends with "..."
+        assert "..." in content
+        # The first 50 chars of the long message should appear
+        assert long_msg[:50] in content
+
+    def test_title_falls_back_to_session_short_id(self, project_dir: Path):
+        # use_cache=False means no session metadata → falls back to short ID
+        result = generate_single_session_file(
+            "html", project_dir, SESSION_ID_A, use_cache=False
+        )
+        content = result.read_text(encoding="utf-8")
+        # The first 8 chars of the session ID must appear as the fallback label
+        assert SESSION_ID_A[:8] in content


### PR DESCRIPTION
Hello, this is a PR to propose adding a `--session-id` flag to allow exporting a single conversation by session ID.

Sample usage:
```sh
claude-code-log ~/.claude/projects/-path-to-project -o conversation.md -f md --session-id 73158d47-d83c-4f61-bca4-d62532664301

# just using the prefix is also supported
claude-code-log ~/.claude/projects/-path-to-project -o conversation.md -f md --session-id 73158d47
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a --session-id option to export a single session (supports short‑prefix lookup), with optional automatic opening of the result.
  * Single‑session export can resolve sessions via the cache when a project path isn’t provided.

* **Bug Fixes / Robustness**
  * Clearer errors for missing, ambiguous, or non‑existent session IDs; better handling of user paths and malformed project data.
  * Support for disabling cache during export.

* **Tests**
  * New tests covering single‑session export, ID resolution, outputs, formats, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->