### PR TITLE
Fix search broken when HTML saved with different filename

### DIFF
--- a/claude_code_log/html/templates/components/search.html
+++ b/claude_code_log/html/templates/components/search.html
@@ -88,6 +88,11 @@
 
         // Initialize UI state
         updateSearchInputState();
+
+        // Re-index when filters change (transcript pages only)
+        if (!searchState.isIndexPage) {
+            setupTranscriptFilterObserver();
+        }
     }
 
     // Build search index from current page
@@ -733,8 +738,7 @@
     }
 
     // Re-index when filters change (for transcript pages)
-    if (!searchState.isIndexPage) {
-        // Listen for filter changes
+    function setupTranscriptFilterObserver() {
         let isUpdatingFilters = false;
         const observer = new MutationObserver((mutations) => {
             // Only react to filtered-hidden class changes, not search highlights

--- a/claude_code_log/html/templates/components/search.html
+++ b/claude_code_log/html/templates/components/search.html
@@ -54,9 +54,7 @@
         currentMatchIndex: 0,
         matches: [],
         searchIndex: null,
-        isIndexPage: window.location.pathname.includes('index.html') ||
-                      window.location.pathname.endsWith('projects/') ||
-                      (!window.location.pathname.includes('.html') && window.location.pathname.endsWith('/'))
+        isIndexPage: null
     };
 
     // DOM elements
@@ -76,6 +74,9 @@
 
     // Initialize search
     function initSearch() {
+        // Detect page type by content rather than URL so it works regardless of filename
+        searchState.isIndexPage = document.querySelector('.project-list') !== null;
+
         // Build search index from page content
         buildSearchIndex();
 

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -930,9 +930,7 @@
           currentMatchIndex: 0,
           matches: [],
           searchIndex: null,
-          isIndexPage: window.location.pathname.includes('index.html') ||
-                        window.location.pathname.endsWith('projects/') ||
-                        (!window.location.pathname.includes('.html') && window.location.pathname.endsWith('/'))
+          isIndexPage: null
       };
   
       // DOM elements
@@ -952,6 +950,9 @@
   
       // Initialize search
       function initSearch() {
+          // Detect page type by content rather than URL so it works regardless of filename
+          searchState.isIndexPage = document.querySelector('.project-list') !== null;
+  
           // Build search index from page content
           buildSearchIndex();
   
@@ -963,6 +964,11 @@
   
           // Initialize UI state
           updateSearchInputState();
+  
+          // Re-index when filters change (transcript pages only)
+          if (!searchState.isIndexPage) {
+              setupTranscriptFilterObserver();
+          }
       }
   
       // Build search index from current page
@@ -1608,8 +1614,7 @@
       }
   
       // Re-index when filters change (for transcript pages)
-      if (!searchState.isIndexPage) {
-          // Listen for filter changes
+      function setupTranscriptFilterObserver() {
           let isUpdatingFilters = false;
           const observer = new MutationObserver((mutations) => {
               // Only react to filtered-hidden class changes, not search highlights
@@ -6134,9 +6139,7 @@
           currentMatchIndex: 0,
           matches: [],
           searchIndex: null,
-          isIndexPage: window.location.pathname.includes('index.html') ||
-                        window.location.pathname.endsWith('projects/') ||
-                        (!window.location.pathname.includes('.html') && window.location.pathname.endsWith('/'))
+          isIndexPage: null
       };
   
       // DOM elements
@@ -6156,6 +6159,9 @@
   
       // Initialize search
       function initSearch() {
+          // Detect page type by content rather than URL so it works regardless of filename
+          searchState.isIndexPage = document.querySelector('.project-list') !== null;
+  
           // Build search index from page content
           buildSearchIndex();
   
@@ -6167,6 +6173,11 @@
   
           // Initialize UI state
           updateSearchInputState();
+  
+          // Re-index when filters change (transcript pages only)
+          if (!searchState.isIndexPage) {
+              setupTranscriptFilterObserver();
+          }
       }
   
       // Build search index from current page
@@ -6812,8 +6823,7 @@
       }
   
       // Re-index when filters change (for transcript pages)
-      if (!searchState.isIndexPage) {
-          // Listen for filter changes
+      function setupTranscriptFilterObserver() {
           let isUpdatingFilters = false;
           const observer = new MutationObserver((mutations) => {
               // Only react to filtered-hidden class changes, not search highlights
@@ -11202,9 +11212,7 @@
           currentMatchIndex: 0,
           matches: [],
           searchIndex: null,
-          isIndexPage: window.location.pathname.includes('index.html') ||
-                        window.location.pathname.endsWith('projects/') ||
-                        (!window.location.pathname.includes('.html') && window.location.pathname.endsWith('/'))
+          isIndexPage: null
       };
   
       // DOM elements
@@ -11224,6 +11232,9 @@
   
       // Initialize search
       function initSearch() {
+          // Detect page type by content rather than URL so it works regardless of filename
+          searchState.isIndexPage = document.querySelector('.project-list') !== null;
+  
           // Build search index from page content
           buildSearchIndex();
   
@@ -11235,6 +11246,11 @@
   
           // Initialize UI state
           updateSearchInputState();
+  
+          // Re-index when filters change (transcript pages only)
+          if (!searchState.isIndexPage) {
+              setupTranscriptFilterObserver();
+          }
       }
   
       // Build search index from current page
@@ -11880,8 +11896,7 @@
       }
   
       // Re-index when filters change (for transcript pages)
-      if (!searchState.isIndexPage) {
-          // Listen for filter changes
+      function setupTranscriptFilterObserver() {
           let isUpdatingFilters = false;
           const observer = new MutationObserver((mutations) => {
               // Only react to filtered-hidden class changes, not search highlights
@@ -16311,9 +16326,7 @@
           currentMatchIndex: 0,
           matches: [],
           searchIndex: null,
-          isIndexPage: window.location.pathname.includes('index.html') ||
-                        window.location.pathname.endsWith('projects/') ||
-                        (!window.location.pathname.includes('.html') && window.location.pathname.endsWith('/'))
+          isIndexPage: null
       };
   
       // DOM elements
@@ -16333,6 +16346,9 @@
   
       // Initialize search
       function initSearch() {
+          // Detect page type by content rather than URL so it works regardless of filename
+          searchState.isIndexPage = document.querySelector('.project-list') !== null;
+  
           // Build search index from page content
           buildSearchIndex();
   
@@ -16344,6 +16360,11 @@
   
           // Initialize UI state
           updateSearchInputState();
+  
+          // Re-index when filters change (transcript pages only)
+          if (!searchState.isIndexPage) {
+              setupTranscriptFilterObserver();
+          }
       }
   
       // Build search index from current page
@@ -16989,8 +17010,7 @@
       }
   
       // Re-index when filters change (for transcript pages)
-      if (!searchState.isIndexPage) {
-          // Listen for filter changes
+      function setupTranscriptFilterObserver() {
           let isUpdatingFilters = false;
           const observer = new MutationObserver((mutations) => {
               // Only react to filtered-hidden class changes, not search highlights
@@ -21283,9 +21303,7 @@
           currentMatchIndex: 0,
           matches: [],
           searchIndex: null,
-          isIndexPage: window.location.pathname.includes('index.html') ||
-                        window.location.pathname.endsWith('projects/') ||
-                        (!window.location.pathname.includes('.html') && window.location.pathname.endsWith('/'))
+          isIndexPage: null
       };
   
       // DOM elements
@@ -21305,6 +21323,9 @@
   
       // Initialize search
       function initSearch() {
+          // Detect page type by content rather than URL so it works regardless of filename
+          searchState.isIndexPage = document.querySelector('.project-list') !== null;
+  
           // Build search index from page content
           buildSearchIndex();
   
@@ -21316,6 +21337,11 @@
   
           // Initialize UI state
           updateSearchInputState();
+  
+          // Re-index when filters change (transcript pages only)
+          if (!searchState.isIndexPage) {
+              setupTranscriptFilterObserver();
+          }
       }
   
       // Build search index from current page
@@ -21961,8 +21987,7 @@
       }
   
       // Re-index when filters change (for transcript pages)
-      if (!searchState.isIndexPage) {
-          // Listen for filter changes
+      function setupTranscriptFilterObserver() {
           let isUpdatingFilters = false;
           const observer = new MutationObserver((mutations) => {
               // Only react to filtered-hidden class changes, not search highlights


### PR DESCRIPTION
## Summary
- The `isIndexPage` detection in search relied on `window.location.pathname` matching specific URL patterns (`index.html`, `projects/`, etc.)
- When the generated HTML is saved/downloaded with a different filename (e.g. browser "Save As"), the detection fails and search indexes zero items, completely breaking search functionality
- Replaced URL-based detection with DOM-based detection (`document.querySelectorAll('.project-card').length > 0`), which correctly identifies the page type regardless of filename or serving context

## Test plan
- [ ] Generate an index page and verify search works normally
- [ ] Save the index page with a different filename (e.g. "My Projects.html") and verify search still works
- [ ] Verify search still works on transcript pages (non-index pages)
- [ ] Run existing snapshot tests (snapshot will need updating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable page detection for search so index pages show grouped project/session results and transcript pages highlight messages in-place; result-panel display, navigation, and transcript linking behave correctly.
  * Transcript pages now re-index when filters change, ensuring search results stay up to date and only when applicable.

* **Style**
  * Minor snapshot/CSS adjustments affecting error/display formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->