### PR TITLE
Add Grep tool renderer with pattern in title

### DIFF
--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -30,6 +30,7 @@ from ..models import (
     EditInput,
     ExitPlanModeInput,
     GlobInput,
+    GrepInput,
     MultiEditInput,
     ReadInput,
     TaskInput,
@@ -100,6 +101,7 @@ from .tool_formatters import (
     format_task_output,
     format_todowrite_input,
     format_tool_result_content_raw,
+    format_grep_input,
     format_websearch_input,
     format_websearch_output,
     format_webfetch_input,
@@ -310,6 +312,10 @@ class HtmlRenderer(Renderer):
         """Format → empty string (no content)."""
         return format_exitplanmode_input(input)
 
+    def format_GrepInput(self, input: GrepInput, _: TemplateMessage) -> str:
+        """Format → params table (path, glob, type, etc.) without pattern."""
+        return format_grep_input(input)
+
     def format_WebSearchInput(self, input: WebSearchInput, _: TemplateMessage) -> str:
         """Format → search query display."""
         return format_websearch_input(input)
@@ -444,6 +450,10 @@ class HtmlRenderer(Renderer):
         if input.path:
             summary = f"{summary} in {input.path}"
         return self._tool_title(message, "🔍", summary)
+
+    def title_GrepInput(self, input: GrepInput, message: TemplateMessage) -> str:
+        """Title → '🔎 Grep <pattern>'."""
+        return self._tool_title(message, "🔎", input.pattern)
 
     def title_BashInput(self, input: BashInput, message: TemplateMessage) -> str:
         """Title → '💻 Bash <description>'."""

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -36,6 +36,7 @@ from ..models import (
     EditOutput,
     ExitPlanModeInput,
     ExitPlanModeOutput,
+    GrepInput,
     MultiEditInput,
     ReadInput,
     ReadOutput,
@@ -212,6 +213,22 @@ def format_exitplanmode_result(content: str) -> str:
 
     # For errors or other cases, return as-is
     return content
+
+
+# -- Grep Tool ----------------------------------------------------------------
+
+
+def format_grep_input(grep_input: GrepInput) -> str:
+    """Format Grep tool use content as generic params table, minus pattern.
+
+    The pattern is already shown in the title, so we render remaining
+    parameters (path, glob, type, output_mode, -A, -B, etc.) using the
+    generic params table. Returns empty if pattern was the only parameter.
+    """
+    params = grep_input.model_dump(exclude={"pattern"}, exclude_none=True)
+    if not params:
+        return ""
+    return render_params_table(params)
 
 
 # -- WebSearch Tool -----------------------------------------------------------
@@ -833,6 +850,7 @@ __all__ = [
     "format_multiedit_input",
     "format_bash_input",
     "format_task_input",
+    "format_grep_input",
     "format_websearch_input",
     "format_webfetch_input",
     # Tool output formatters (called by HtmlRenderer.format_{OutputClass})

--- a/test/test_grep_rendering.py
+++ b/test/test_grep_rendering.py
@@ -1,0 +1,140 @@
+"""Test cases for Grep tool rendering."""
+
+from claude_code_log.html.tool_formatters import format_grep_input, render_params_table
+from claude_code_log.html.renderer import HtmlRenderer
+from claude_code_log.markdown.renderer import MarkdownRenderer
+from claude_code_log.models import (
+    GrepInput,
+    MessageMeta,
+    ToolUseMessage,
+)
+from claude_code_log.renderer import TemplateMessage
+
+
+def _make_grep_message(grep_input: GrepInput) -> TemplateMessage:
+    """Create a TemplateMessage wrapping a GrepInput for title tests."""
+    content = ToolUseMessage(
+        meta=MessageMeta(
+            uuid="test-uuid", session_id="test", timestamp="2025-01-01T00:00:00Z"
+        ),
+        input=grep_input,
+        tool_use_id="toolu_test",
+        tool_name="Grep",
+    )
+    return TemplateMessage(content)
+
+
+class TestGrepInput:
+    """Test GrepInput model creation."""
+
+    def test_basic_creation(self):
+        inp = GrepInput(pattern="TODO")
+        assert inp.pattern == "TODO"
+        assert inp.path is None
+
+    def test_all_fields(self):
+        inp = GrepInput(
+            pattern="error",
+            path="/src",
+            glob="*.py",
+            type="py",
+            output_mode="content",
+            multiline=True,
+            head_limit=50,
+            offset=10,
+        )
+        assert inp.pattern == "error"
+        assert inp.output_mode == "content"
+
+    def test_extra_fields(self):
+        """Grep allows extra fields like -A, -B, -C, -i, -n."""
+        inp = GrepInput(**{"pattern": "test", "-A": 3, "-B": 2, "-i": True})
+        assert inp.pattern == "test"
+        assert inp.model_extra == {"-A": 3, "-B": 2, "-i": True}
+
+
+class TestFormatGrepInput:
+    """Test HTML input formatting."""
+
+    def test_pattern_only_returns_empty(self):
+        """When pattern is the only param, body should be empty."""
+        inp = GrepInput(pattern="TODO")
+        assert format_grep_input(inp) == ""
+
+    def test_with_path_shows_params_table(self):
+        inp = GrepInput(pattern="error", path="/src/app")
+        html = format_grep_input(inp)
+        assert "tool-params-table" in html
+        assert "path" in html
+        assert "/src/app" in html
+        # Pattern must NOT appear in the body
+        assert "error" not in html
+
+    def test_with_multiple_params(self):
+        inp = GrepInput(
+            pattern="log.*Error",
+            path="/src",
+            glob="*.ts",
+            output_mode="content",
+        )
+        html = format_grep_input(inp)
+        assert "tool-params-table" in html
+        assert "path" in html
+        assert "glob" in html
+        assert "output_mode" in html
+        # Pattern excluded from body
+        assert "log.*Error" not in html
+
+    def test_extra_fields_shown(self):
+        """Extra fields like -A, -B should appear in the params table."""
+        inp = GrepInput(**{"pattern": "test", "-A": 5, "-i": True})
+        html = format_grep_input(inp)
+        assert "tool-params-table" in html
+        assert "-A" in html
+        assert "-i" in html
+
+    def test_html_escaping(self):
+        inp = GrepInput(pattern="<script>", path="/tmp/<dir>")
+        html = format_grep_input(inp)
+        assert "&lt;dir&gt;" in html
+        assert "<dir>" not in html
+
+
+class TestGrepHtmlTitle:
+    """Test HTML title rendering."""
+
+    def test_title_shows_pattern(self):
+        inp = GrepInput(pattern="function\\s+\\w+")
+        msg = _make_grep_message(inp)
+        renderer = HtmlRenderer()
+        title = renderer.title_GrepInput(inp, msg)
+        assert "🔎" in title
+        assert "Grep" in title
+        assert "function\\s+\\w+" in title
+
+    def test_title_escapes_html(self):
+        inp = GrepInput(pattern="<script>alert(1)</script>")
+        msg = _make_grep_message(inp)
+        renderer = HtmlRenderer()
+        title = renderer.title_GrepInput(inp, msg)
+        assert "&lt;script&gt;" in title
+        assert "<script>" not in title
+
+
+class TestGrepMarkdown:
+    """Test Markdown renderer has matching Grep support."""
+
+    def test_markdown_title(self):
+        inp = GrepInput(pattern="TODO", path="/src")
+        msg = _make_grep_message(inp)
+        renderer = MarkdownRenderer()
+        title = renderer.title_GrepInput(inp, msg)
+        assert "Grep" in title
+        assert "TODO" in title
+
+    def test_markdown_format_with_glob(self):
+        inp = GrepInput(pattern="test", glob="*.py")
+        msg = _make_grep_message(inp)
+        renderer = MarkdownRenderer()
+        body = renderer.format_GrepInput(inp, msg)
+        assert "*.py" in body

--- a/test/test_grep_rendering.py
+++ b/test/test_grep_rendering.py
@@ -1,6 +1,6 @@
 """Test cases for Grep tool rendering."""
 
-from claude_code_log.html.tool_formatters import format_grep_input, render_params_table
+from claude_code_log.html.tool_formatters import format_grep_input
 from claude_code_log.html.renderer import HtmlRenderer
 from claude_code_log.markdown.renderer import MarkdownRenderer
 from claude_code_log.models import (
@@ -48,7 +48,9 @@ class TestGrepInput:
 
     def test_extra_fields(self):
         """Grep allows extra fields like -A, -B, -C, -i, -n."""
-        inp = GrepInput(**{"pattern": "test", "-A": 3, "-B": 2, "-i": True})
+        inp = GrepInput.model_validate(
+            {"pattern": "test", "-A": 3, "-B": 2, "-i": True}
+        )
         assert inp.pattern == "test"
         assert inp.model_extra == {"-A": 3, "-B": 2, "-i": True}
 
@@ -87,7 +89,7 @@ class TestFormatGrepInput:
 
     def test_extra_fields_shown(self):
         """Extra fields like -A, -B should appear in the params table."""
-        inp = GrepInput(**{"pattern": "test", "-A": 5, "-i": True})
+        inp = GrepInput.model_validate({"pattern": "test", "-A": 5, "-i": True})
         html = format_grep_input(inp)
         assert "tool-params-table" in html
         assert "-A" in html

--- a/test/test_grep_rendering.py
+++ b/test/test_grep_rendering.py
@@ -134,6 +134,13 @@ class TestGrepMarkdown:
         assert "Grep" in title
         assert "TODO" in title
 
+    def test_markdown_format_without_glob(self):
+        inp = GrepInput(pattern="test")
+        msg = _make_grep_message(inp)
+        renderer = MarkdownRenderer()
+        body = renderer.format_GrepInput(inp, msg)
+        assert body == ""
+
     def test_markdown_format_with_glob(self):
         inp = GrepInput(pattern="test", glob="*.py")
         msg = _make_grep_message(inp)


### PR DESCRIPTION
## Summary

- Show search pattern in the tool title (`🔎 Grep <pattern>`) instead of buried in the body
- Render remaining parameters (path, glob, type, output_mode, -A, -B, etc.) using the existing generic `render_params_table()` — empty body when pattern is the only parameter
- Add 12 tests covering model creation, formatting, title rendering, HTML escaping, and markdown compatibility

## Rationale

Alternative approach to #101, which identified a real issue (Grep shows no parameters and pattern isn't in the title). Rather than hand-coding each Grep field with custom CSS classes (`grep-tool-content`, `grep-tool-field`, `grep-tool-label`), this reuses the existing `render_params_table()` infrastructure — keeping it consistent with how other tools with many parameters are displayed, while still putting the pattern front and center in the title.

The key insight: `GrepInput.model_dump(exclude={"pattern"}, exclude_none=True)` gives us exactly the remaining params to pass to the generic table, with zero custom HTML needed.

## Test plan

- [x] 12 new tests in `test/test_grep_rendering.py` all pass
- [x] Full unit test suite (706 passed, 0 failures)
- [x] `just render-test-data` produces correct output
- [ ] Visual check of rendered Grep tool calls in HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grep tool rendering: titles show a search emoji plus the pattern (HTML/Markdown). Parameters render as a safe, escaped HTML table and deliberately exclude the raw pattern from the params body; unknown/additional parameters are shown.

* **Tests**
  * Added tests for Grep input validation, parameter preservation, HTML escaping, and title/content rendering in both HTML and Markdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->