### PR TITLE
Fix slow test hitting real ~/.claude/projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ claude-code-log --from-date "last week"
 
 See @CONTRIBUTING.md for detailed development setup, testing, architecture, and release process.
 
+**Before pushing, always remind the user to run `just ci`.**
+
 ### Claude-Specific Testing Tips
 
 **Always use `-n auto` for parallel test execution:**

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -324,10 +324,16 @@ class TestCLIMainCommand:
         assert "--clear-cache" in result.output
         assert "--open-browser" in result.output
 
-    def test_no_arguments_uses_default_or_cwd(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_arguments_uses_default_or_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         """Running without arguments attempts to find projects."""
+        # Isolate from real ~/.claude/projects (which can be very large)
+        monkeypatch.setattr(
+            "claude_code_log.cli.get_default_projects_dir", lambda: tmp_path
+        )
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "test.db"))
         runner = CliRunner()
-        # Mock to avoid actual file system operations
         result = runner.invoke(main, [])
         # Should either succeed or fail gracefully (no crash)
         assert result.exit_code in (0, 1)


### PR DESCRIPTION
## Summary

- `test_no_arguments_uses_default_or_cwd` invoked `main` with no arguments and no isolation, scanning the real `~/.claude/projects` directory. On systems with large project histories (~5GB) this caused multi-minute hangs during test runs.
- Monkeypatch `get_default_projects_dir` to return `tmp_path` and isolate the cache DB. Test now completes in <1s.
- Also adds a reminder in CLAUDE.md to run `just ci` before pushing.

## Test plan

- [x] Fixed test passes in <1s (`uv run pytest test/test_cli.py::TestCLIMainCommand::test_no_arguments_uses_default_or_cwd -v`)
- [x] Full unit test suite passes (712 passed, ~69s vs ~140s before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development workflow reminder in contribution guidelines.

* **Tests**
  * Improved CLI test isolation to enhance test reliability and prevent environmental interference during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->