### PR TITLE
Ignore 'last-prompt' message type

### DIFF
--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -46,6 +46,19 @@ from .dag import SessionTree, build_dag_from_entries, traverse_session_tree
 from .renderer import get_renderer, is_html_outdated
 
 
+# Internal Claude Code message types that carry no DAG fields and are
+# dropped without warning. Unknown types outside this set are surfaced
+# so we notice new kinds worth supporting (see the else branch in
+# load_transcript). `progress` is not here because it has uuid+sessionId
+# and participates in the DAG as a PassthroughTranscriptEntry.
+SILENT_SKIP_TYPES: frozenset[str] = frozenset(
+    {
+        "file-history-snapshot",  # Internal file backup metadata
+        "last-prompt",  # Trailing marker written as the last line of a .jsonl
+    }
+)
+
+
 def get_file_extension(format: str) -> str:
     """Get the file extension for a format.
 
@@ -327,6 +340,9 @@ def load_transcript(
                         # Parse using Pydantic models
                         entry = create_transcript_entry(entry_dict)
                         messages.append(entry)
+                    elif entry_type in SILENT_SKIP_TYPES:
+                        # Internal Claude Code entries with no DAG fields.
+                        pass
                     elif entry_dict.get("uuid") and entry_dict.get("sessionId"):
                         # Unknown type with DAG-relevant fields — create a
                         # PassthroughTranscriptEntry to preserve DAG chain
@@ -342,6 +358,16 @@ def load_transcript(
                                 agentId=entry_dict.get("agentId"),
                             )
                         )
+                    else:
+                        # Unknown type with no DAG fields (e.g. custom-title,
+                        # agent-name). Warn so we notice when Claude Code
+                        # introduces new metadata worth supporting — add to
+                        # SILENT_SKIP_TYPES once confirmed safe to drop.
+                        if not silent:
+                            print(
+                                f"Line {line_no} of {jsonl_path}: unrecognised message type "
+                                f"{entry_type!r} - skipping"
+                            )
                 except json.JSONDecodeError as e:
                     print(
                         f"Line {line_no} of {jsonl_path} | JSON decode error: {str(e)}"

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1322,7 +1322,7 @@ class TestPassthroughDagChain:
                 "p2", "s1", "2025-07-01T10:00:20.000Z", "p1", "permission-mode"
             ),
             _make_passthrough_entry(
-                "p3", "s1", "2025-07-01T10:00:30.000Z", "p2", "file-history-snapshot"
+                "p3", "s1", "2025-07-01T10:00:30.000Z", "p2", "unknown-future-type"
             ),
             _make_assistant_entry(
                 "a1", "s1", "2025-07-01T10:01:00.000Z", "p3", "Reply"

--- a/test/test_silent_skip.py
+++ b/test/test_silent_skip.py
@@ -1,0 +1,190 @@
+"""Regression tests for load_transcript handling of non-conversation types.
+
+Covers:
+- `file-history-snapshot`, `last-prompt`: known-internal types with no DAG
+  fields; silently dropped. Regression for issue #102.
+- `progress`: has uuid+sessionId; preserved as PassthroughTranscriptEntry
+  for DAG continuity (and not rendered).
+- `custom-title`, `agent-name`: unknown types with sessionId but no uuid;
+  warn so new Claude Code metadata surfaces instead of being lost.
+- Unknown type with uuid+sessionId: falls through to
+  PassthroughTranscriptEntry, no warning.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import SILENT_SKIP_TYPES, load_transcript
+from claude_code_log.models import PassthroughTranscriptEntry
+
+
+def _write_jsonl(path: Path, entries: list[dict[str, object]]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+class TestSilentSkipTypes:
+    """Known-internal types are dropped without warnings."""
+
+    def test_constant_covers_issue_102(self) -> None:
+        assert "last-prompt" in SILENT_SKIP_TYPES
+        assert "file-history-snapshot" in SILENT_SKIP_TYPES
+
+    def test_file_history_snapshot_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "type": "file-history-snapshot",
+                    "messageId": "m1",
+                    "snapshot": {
+                        "messageId": "m1",
+                        "trackedFileBackups": {},
+                        "timestamp": "2026-01-01T00:00:00.000Z",
+                    },
+                    "isSnapshotUpdate": False,
+                },
+            ],
+        )
+
+        messages = load_transcript(jsonl, silent=False)
+        captured = capsys.readouterr()
+
+        assert messages == []
+        assert "unrecognised" not in captured.out
+        assert "not a recognised" not in captured.out
+
+    def test_last_prompt_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "type": "last-prompt",
+                    "lastPrompt": "Summarize this file",
+                    "sessionId": "s1",
+                },
+            ],
+        )
+
+        messages = load_transcript(jsonl, silent=False)
+        captured = capsys.readouterr()
+
+        assert messages == []
+        assert "unrecognised" not in captured.out
+        assert "last-prompt" not in captured.out
+
+
+class TestProgressStaysInDag:
+    """`progress` has uuid+parentUuid+sessionId and must survive as a
+    PassthroughTranscriptEntry so the DAG chain stays connected — it is
+    intentionally not in SILENT_SKIP_TYPES."""
+
+    def test_progress_not_in_silent_skip(self) -> None:
+        assert "progress" not in SILENT_SKIP_TYPES
+
+    def test_progress_becomes_passthrough(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "type": "progress",
+                    "uuid": "p1",
+                    "parentUuid": None,
+                    "sessionId": "s1",
+                    "timestamp": "2026-01-01T00:00:00.000Z",
+                    "data": {"type": "hook_progress", "hookEvent": "SessionStart"},
+                },
+            ],
+        )
+
+        messages = load_transcript(jsonl, silent=False)
+        captured = capsys.readouterr()
+
+        assert len(messages) == 1
+        assert isinstance(messages[0], PassthroughTranscriptEntry)
+        assert messages[0].type == "progress"
+        assert messages[0].uuid == "p1"
+        assert "unrecognised" not in captured.out
+
+
+class TestUnrecognisedTypesWarn:
+    """Unknown types with no DAG fields surface a warning so we notice
+    new Claude Code metadata worth supporting (custom-title, agent-name,
+    and anything that arrives later)."""
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"type": "custom-title", "customTitle": "Dave", "sessionId": "s1"},
+            {"type": "agent-name", "agentName": "Dave", "sessionId": "s1"},
+            {"type": "future-metadata-type", "payload": 42},
+        ],
+    )
+    def test_unknown_without_uuid_warns(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        entry: dict[str, object],
+    ) -> None:
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(jsonl, [entry])
+
+        messages = load_transcript(jsonl, silent=False)
+        captured = capsys.readouterr()
+
+        assert messages == []
+        assert "unrecognised message type" in captured.out
+        assert repr(entry["type"]) in captured.out
+
+    def test_silent_mode_suppresses_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(jsonl, [{"type": "custom-title", "customTitle": "x"}])
+
+        messages = load_transcript(jsonl, silent=True)
+        captured = capsys.readouterr()
+
+        assert messages == []
+        assert captured.out == ""
+
+    def test_unknown_with_uuid_becomes_passthrough_silently(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Unknown type with DAG fields → PassthroughTranscriptEntry, no warning.
+        Preserves DAG continuity when Claude Code ships a new conversational
+        type before we add explicit handling."""
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "type": "attachment",
+                    "uuid": "att1",
+                    "parentUuid": None,
+                    "sessionId": "s1",
+                    "timestamp": "2026-01-01T00:00:00.000Z",
+                },
+            ],
+        )
+
+        messages = load_transcript(jsonl, silent=False)
+        captured = capsys.readouterr()
+
+        assert len(messages) == 1
+        assert isinstance(messages[0], PassthroughTranscriptEntry)
+        assert "unrecognised" not in captured.out


### PR DESCRIPTION
Fixes #102. Added `last-prompt` to the silent-skip list in `converter.py` alongside `file-history-snapshot` and `progress`, so Claude Code's new trailing `{type:last-prompt,...}` line no longer triggers a 'not a recognised message type' warning.

Also maintain a small open source tool in the Claude Code space, happy to contribute more if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved transcript import: certain internal metadata entries are now silently ignored and unknown entry types emit a warning during import unless run in silent mode.
* **Tests**
  * Added regression tests covering silent skips, passthrough entries, and warning behavior for unknown transcript entry types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->