### PR TITLE
Preserve agentId anchors in parallel-Task stitch + tool-param UI fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ uvx claude-code-log@latest --open-browser
 - **Rich Message Types**: Support for user/assistant messages, tool use/results, thinking content, images
 - **System Command Visibility**: Show system commands (like `init`) in expandable details with structured parsing
 - **Markdown Rendering**: Server-side markdown rendering with syntax highlighting using mistune
+- **Detail Levels & Compact Mode**: `--detail full|high|low|minimal` filters by verbosity and `--compact` merges repeated section headings — pairs well with `--format md` to feed past conversations back to an LLM for analysis or experience building
 - **Floating Navigation**: Always-available back-to-top button and filter controls
 - **CLI Interface**: Simple command-line tool using Click
 
@@ -57,6 +58,7 @@ This tool helps you answer questions like:
 - **"How can I share my Claude Code conversation with others?"**
 - **"What's the timeline of my project development?"**
 - **"How can I analyse patterns in my Claude Code usage?"**
+- **"How can I feed a past session back to an LLM for analysis or experience building?"**
 
 ## Usage
 
@@ -140,6 +142,27 @@ claude-code-log /path/to/directory --from-date "yesterday" --to-date "today"
 claude-code-log /path/to/directory --from-date "3 days ago" --to-date "yesterday"
 ```
 
+### Feeding Past Conversations to an LLM
+
+The combination `--detail low --format md --compact` produces condensed Markdown suitable as context for an LLM to review or distill patterns from past work:
+
+```bash
+# Session → compact Markdown for LLM review
+claude-code-log transcript.jsonl --detail low --format md --compact -o session.md
+
+# Whole project history
+claude-code-log /path/to/project --detail low --format md --compact
+```
+
+`--detail` levels (smallest → largest output):
+
+- `minimal` — user + assistant text only
+- `low` — interaction-focused; keeps WebSearch, WebFetch, and Task (agent delegations) as key signals
+- `high` — detailed but cleaned; drops system/hook noise
+- `full` — everything (default)
+
+`--compact` merges consecutive same-type sections in Markdown so runs of assistant responses share one heading instead of repeating `### 🤖 Assistant:` for each.
+
 ## Project Hierarchy Output
 
 When processing all projects, the tool generates:
@@ -204,6 +227,7 @@ Markdown export provides a lightweight, portable alternative to HTML:
 - **Code Preservation**: Syntax highlighting hints via fenced code blocks
 - **Embedded Viewer**: TUI includes built-in Markdown viewer with table of contents
 - **Image Support**: Configurable image handling (placeholder, embedded base64, or referenced files)
+- **`--compact` Mode**: Merge consecutive same-type section headings — most useful with `--detail low` or `minimal` where tool stripping creates runs of Assistant or User sections
 
 ## Installation
 

--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -208,6 +208,38 @@ def _collect_descendants(
             _collect_descendants(child, session_uuids, nodes, result)
 
 
+def _collect_agent_anchors(
+    uuid: str,
+    session_uuids: set[str],
+    nodes: dict[str, MessageNode],
+    max_depth: int = 20,
+) -> list[str]:
+    """Find UserTranscriptEntry descendants with an ``agentId`` set.
+
+    These entries anchor subagent sessions: the subagent's sidechain entries
+    list this UUID as their ``parentUuid``, and the session tree attaches the
+    subagent DAG-line at this UUID. When the stitch logic classifies a sibling
+    assistant subtree as dead-end, these anchors would otherwise be dropped;
+    surfacing them keeps the subagent attachments reachable.
+    """
+    anchors: list[str] = []
+    stack: list[tuple[str, int]] = [(uuid, 0)]
+    seen: set[str] = set()
+    while stack:
+        current, depth = stack.pop()
+        if current in seen or current not in session_uuids:
+            continue
+        seen.add(current)
+        if depth >= max_depth:
+            continue
+        entry = nodes[current].entry
+        if isinstance(entry, UserTranscriptEntry) and entry.agentId:
+            anchors.append(current)
+        for c in nodes[current].children_uuids:
+            stack.append((c, depth + 1))
+    return anchors
+
+
 def _is_subtree_dead_end(
     uuid: str,
     session_uuids: set[str],
@@ -354,8 +386,16 @@ def _stitch_tool_results(
         if not _is_subtree_dead_end(uc, session_uuids, nodes):
             return None
 
+    # Agent-anchor preservation: parallel `Task` tool_uses emit sibling
+    # tool_result anchors whose parent assistants are each other's dead-end
+    # subtree. Extracting anchors ensures their subagent sessions stay
+    # attached even when the continuation runs through an outer sibling.
+    extracted_anchors: list[str] = []
+    for ac in assistant_children:
+        extracted_anchors.extend(_collect_agent_anchors(ac, session_uuids, nodes))
+
     # Stitch: dead-end children first, then the continuing user child
-    dead_ends = user_dead + assistant_children
+    dead_ends = user_dead + assistant_children + extracted_anchors
     dead_ends.sort(key=lambda c: nodes[c].timestamp)
     return dead_ends + user_with_cont
 

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -731,8 +731,16 @@ pre > code {
     color: var(--text-primary);
 }
 
-.tool-param-collapsible[open] > summary {
+/* When open, hide the truncated preview text but keep the arrow visible
+   with a "collapse" hint so the user can close the expanded value again. */
+.tool-param-collapsible[open] > summary > .tool-param-preview {
     display: none;
+}
+
+.tool-param-collapsible[open] > summary::after {
+    content: "collapse";
+    color: var(--text-muted);
+    font-style: italic;
 }
 
 .tool-param-full {

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -689,7 +689,7 @@ def render_params_table(params: dict[str, Any]) -> str:
                     preview = escape_html(formatted_value[:100]) + "..."
                     value_html = f"""
                         <details class='tool-param-collapsible'>
-                            <summary>{preview}</summary>
+                            <summary><span class='tool-param-preview'>{preview}</span></summary>
                             <pre class='tool-param-structured'>{escaped_value}</pre>
                         </details>
                     """
@@ -710,7 +710,7 @@ def render_params_table(params: dict[str, Any]) -> str:
                 preview = escape_html(str(value)[:80]) + "..."
                 value_html = f"""
                     <details class='tool-param-collapsible'>
-                        <summary>{preview}</summary>
+                        <summary><span class='tool-param-preview'>{preview}</span></summary>
                         <div class='tool-param-full'>{escaped_value}</div>
                     </details>
                 """

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -3022,8 +3022,16 @@
       color: var(--text-primary);
   }
   
-  .tool-param-collapsible[open] > summary {
+  /* When open, hide the truncated preview text but keep the arrow visible
+     with a "collapse" hint so the user can close the expanded value again. */
+  .tool-param-collapsible[open] > summary > .tool-param-preview {
       display: none;
+  }
+  
+  .tool-param-collapsible[open] > summary::after {
+      content: "collapse";
+      color: var(--text-muted);
+      font-style: italic;
   }
   
   .tool-param-full {
@@ -8232,8 +8240,16 @@
       color: var(--text-primary);
   }
   
-  .tool-param-collapsible[open] > summary {
+  /* When open, hide the truncated preview text but keep the arrow visible
+     with a "collapse" hint so the user can close the expanded value again. */
+  .tool-param-collapsible[open] > summary > .tool-param-preview {
       display: none;
+  }
+  
+  .tool-param-collapsible[open] > summary::after {
+      content: "collapse";
+      color: var(--text-muted);
+      font-style: italic;
   }
   
   .tool-param-full {
@@ -10935,12 +10951,12 @@
                   <td class='tool-param-key'>todos</td>
                   <td class='tool-param-value'>
                           <details class='tool-param-collapsible'>
-                              <summary>[
+                              <summary><span class='tool-param-preview'>[
     &quot;broken_todo&quot;,
     {
       &quot;id&quot;: &quot;2&quot;,
       &quot;content&quot;: &quot;Implement core functionality&quot;,
-      &quot;status&quot;: &quot;...</summary>
+      &quot;status&quot;: &quot;...</span></summary>
                               <pre class='tool-param-structured'>[
     &quot;broken_todo&quot;,
     {
@@ -13541,8 +13557,16 @@
       color: var(--text-primary);
   }
   
-  .tool-param-collapsible[open] > summary {
+  /* When open, hide the truncated preview text but keep the arrow visible
+     with a "collapse" hint so the user can close the expanded value again. */
+  .tool-param-collapsible[open] > summary > .tool-param-preview {
       display: none;
+  }
+  
+  .tool-param-collapsible[open] > summary::after {
+      content: "collapse";
+      color: var(--text-muted);
+      font-style: italic;
   }
   
   .tool-param-full {
@@ -18907,8 +18931,16 @@
       color: var(--text-primary);
   }
   
-  .tool-param-collapsible[open] > summary {
+  /* When open, hide the truncated preview text but keep the arrow visible
+     with a "collapse" hint so the user can close the expanded value again. */
+  .tool-param-collapsible[open] > summary > .tool-param-preview {
       display: none;
+  }
+  
+  .tool-param-collapsible[open] > summary::after {
+      content: "collapse";
+      color: var(--text-muted);
+      font-style: italic;
   }
   
   .tool-param-full {

--- a/test/test_dag.py
+++ b/test/test_dag.py
@@ -1163,6 +1163,144 @@ class TestToolResultStitching:
         assert branch_count == 0
 
 
+def _with_agent_id(entry: dict, agent_id: str) -> dict:
+    """Attach an agentId to a user entry (marks it as a subagent anchor)."""
+    entry["agentId"] = agent_id
+    return entry
+
+
+class TestParallelAgentAnchorPreservation:
+    """Parallel Task/Agent tool_uses produce sibling tool_result anchors.
+
+    When the stitch logic classifies an assistant sibling subtree as
+    dead-end, any UserTranscriptEntry.agentId inside that subtree is the
+    attachment point for a subagent session. Those anchors must survive in
+    the main DAG-line or the subagent sessions can't be spliced in.
+    """
+
+    def test_inner_anchor_preserved_in_dead_end_subtree(self) -> None:
+        """Two parallel Agent tool_uses, inner anchor inside dead-end sibling.
+
+        Shape::
+
+            a → tool1 → tool2 → res2(agentId="agent-2")   [inner anchor]
+                     → res1(agentId="agent-1")
+                        → att1 → cont                    [main continues]
+
+        At the tool1 fork, variant 2 picks res1 as the continuation and
+        tool2 as the dead-end sibling. Without the fix, res2 gets collected
+        as a skipped descendant of tool2, breaking the agent-2 attachment.
+        """
+        data = [
+            _make_entry("user", "a", None, "2025-07-01T10:00:00.000Z"),
+            _make_entry("assistant", "tool1", "a", "2025-07-01T10:01:00.000Z"),
+            _make_entry("assistant", "tool2", "tool1", "2025-07-01T10:01:01.000Z"),
+            _with_agent_id(
+                _make_entry("user", "res2", "tool2", "2025-07-01T10:02:00.000Z"),
+                "agent-2",
+            ),
+            _with_agent_id(
+                _make_entry("user", "res1", "tool1", "2025-07-01T10:02:10.000Z"),
+                "agent-1",
+            ),
+            _make_attachment("att1", "res1", "2025-07-01T10:02:11.000Z"),
+            _make_entry("assistant", "cont", "att1", "2025-07-01T10:03:00.000Z"),
+        ]
+        entries = [create_transcript_entry(d) for d in data]
+        tree = build_dag_from_entries(entries)
+
+        # Both anchors must appear in the main DAG-line
+        uuids = tree.sessions["s1"].uuids
+        assert "res1" in uuids, "outer anchor dropped"
+        assert "res2" in uuids, "inner anchor (agent-2) dropped — fix regression"
+        # No spurious branches — stitch should produce one linear DAG-line
+        branch_count = sum(1 for s in tree.sessions.values() if s.is_branch)
+        assert branch_count == 0
+
+    def test_three_parallel_agents_all_anchors_preserved(self) -> None:
+        """Three parallel Agent tool_uses (the teammates shape).
+
+        Shape mirrors ``experiments/worktrees``: 3 chained Agent tool_uses
+        with tool_results that dead-end at each level, and the main chain
+        continues via an attachment after the outer tool_result.
+        """
+        data = [
+            _make_entry("user", "a", None, "2025-07-01T10:00:00.000Z"),
+            _make_entry("assistant", "tool1", "a", "2025-07-01T10:01:00.000Z"),
+            _make_entry("assistant", "tool2", "tool1", "2025-07-01T10:01:01.000Z"),
+            _make_entry("assistant", "tool3", "tool2", "2025-07-01T10:01:02.000Z"),
+            _with_agent_id(
+                _make_entry("user", "res3", "tool3", "2025-07-01T10:02:00.000Z"),
+                "agent-3",
+            ),
+            _with_agent_id(
+                _make_entry("user", "res2", "tool2", "2025-07-01T10:02:10.000Z"),
+                "agent-2",
+            ),
+            _with_agent_id(
+                _make_entry("user", "res1", "tool1", "2025-07-01T10:02:20.000Z"),
+                "agent-1",
+            ),
+            _make_attachment("att1", "res1", "2025-07-01T10:02:21.000Z"),
+            _make_entry("assistant", "cont", "att1", "2025-07-01T10:03:00.000Z"),
+        ]
+        entries = [create_transcript_entry(d) for d in data]
+        tree = build_dag_from_entries(entries)
+
+        uuids = set(tree.sessions["s1"].uuids)
+        missing = {"res1", "res2", "res3"} - uuids
+        assert not missing, f"anchors missing from main DAG-line: {missing}"
+
+    def test_anchor_attachment_routes_subagent_session(self) -> None:
+        """End-to-end: anchor-bearing tool_result enables subagent splice.
+
+        Builds main + a sidechain session whose entries use ``res2`` as the
+        anchor via ``parentUuid``. After the fix, ``traverse_session_tree``
+        must yield the subagent messages interleaved at the anchor point.
+        """
+        from claude_code_log.converter import _integrate_agent_entries
+
+        data = [
+            _make_entry("user", "a", None, "2025-07-01T10:00:00.000Z"),
+            _make_entry("assistant", "tool1", "a", "2025-07-01T10:01:00.000Z"),
+            _make_entry("assistant", "tool2", "tool1", "2025-07-01T10:01:01.000Z"),
+            _with_agent_id(
+                _make_entry("user", "res2", "tool2", "2025-07-01T10:02:00.000Z"),
+                "agent-2",
+            ),
+            _with_agent_id(
+                _make_entry("user", "res1", "tool1", "2025-07-01T10:02:10.000Z"),
+                "agent-1",
+            ),
+            _make_attachment("att1", "res1", "2025-07-01T10:02:11.000Z"),
+            _make_entry("assistant", "cont", "att1", "2025-07-01T10:03:00.000Z"),
+        ]
+        # Sidechain entries for agent-2 (parentUuid=None, will be reparented
+        # to the res2 anchor by _integrate_agent_entries).
+        sub = {
+            "type": "user",
+            "timestamp": "2025-07-01T10:02:05.000Z",
+            "parentUuid": None,
+            "isSidechain": True,
+            "agentId": "agent-2",
+            "userType": "human",
+            "cwd": "/tmp",
+            "sessionId": "s1",
+            "version": "1.0.0",
+            "uuid": "sub1",
+            "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        }
+        data.append(sub)
+
+        entries = [create_transcript_entry(d) for d in data]
+        _integrate_agent_entries(entries)
+        tree = build_dag_from_entries(entries)
+        traversed_uuids = [getattr(e, "uuid", "") for e in traverse_session_tree(tree)]
+        assert "sub1" in traversed_uuids, (
+            "subagent entry not reached via anchor — agent session not spliced"
+        )
+
+
 class TestStructuralOnlyFork:
     """All-passthrough children should collapse instead of creating forks."""
 


### PR DESCRIPTION
## Summary

- **DAG fix**: Parallel `Task` tool_uses (e.g. teammates orchestrating multiple subagents) produced tool_result anchors nested inside sibling assistant subtrees. The DAG walker's variant 2 stitch classified those subtrees as dead-end and dropped the agentId-bearing anchors, leaving subagent sessions with no attachment point. Only the outermost subagent rendered. Fixes the issue #91 symptom where 4 of 6 subagents were missing from a teammates session.
- **UI fix**: `<details class='tool-param-collapsible'>` had `[open] > summary { display: none }`, hiding the browser's disclosure marker along with the preview — expanded values had no visible collapse affordance.

## Changes

### `claude_code_log/dag.py` + `test/test_dag.py` (commit 6b37e8d)

- New helper `_collect_agent_anchors(uuid, session_uuids, nodes)` walks an assistant subtree to find `UserTranscriptEntry` descendants with `agentId` set.
- In `_stitch_tool_results` variant 2, after dead-end checks pass, extract agent anchors from `assistant_children` subtrees and include them in `dead_ends` (timestamp-sorted). Anchors end up in both the chain (preserving attachment points) and `skipped` (via `_collect_descendants(assistant, ...)`) — that's fine, `walked ∩ skipped` is allowed.
- 3 regression tests: 2-teammate case, 3-teammate case (the `experiments/worktrees` shape), end-to-end splice verifying a subagent entry is reached through the anchor.

### `claude_code_log/html/tool_formatters.py` + CSS (commit a0ed7d7)

- Wrap preview text in `<span class='tool-param-preview'>` at both `render_params_table` call sites (structured JSON and simple string).
- CSS: replace `display: none` on the whole `<summary>` with `display: none` on `.tool-param-preview` only, plus `::after { content: "collapse"; }` for an explicit hint. Summary keeps `list-item` display so the browser's disclosure arrow stays visible.
- Snapshot tests updated (4 snapshots, mechanical CSS + span diff).

## Test plan

- [x] `uv run pytest -n auto -m "not (tui or browser)"` — 864 pass, 7 skip (19 pre-existing pagination failures on main, unrelated)
- [x] `uv run pytest -n auto -m browser` — 29 pass, 1 skip
- [x] `uv run pyright` — 0 errors
- [x] `uv run ty check` — all checks passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Real-data: `experiments/worktrees` regenerates 488K (2 subagents) → 768K (all 6 subagents)
- [x] Playwright check: open state shows arrow + "collapse" hint; closed state shows preview

Relates to #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved collapsible tool-parameter UI: preview text is wrapped for long values and an italic “collapse” hint appears when expanded.

* **Bug Fixes**
  * Preserve agent-anchor nodes during tool-result stitching so anchor entries are not omitted in complex branch scenarios.

* **Tests**
  * Added tests covering preservation of agent anchors across parallel and nested stitching cases.

* **Documentation**
  * CLI docs: new --detail verbosity levels and --compact option for compact Markdown output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->