### PR TITLE
Add --detail user-only level

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uvx claude-code-log@latest --open-browser
 - **Rich Message Types**: Support for user/assistant messages, tool use/results, thinking content, images
 - **System Command Visibility**: Show system commands (like `init`) in expandable details with structured parsing
 - **Markdown Rendering**: Server-side markdown rendering with syntax highlighting using mistune
-- **Detail Levels & Compact Mode**: `--detail full|high|low|minimal` filters by verbosity and `--compact` merges repeated section headings — pairs well with `--format md` to feed past conversations back to an LLM for analysis or experience building
+- **Detail Levels & Compact Mode**: `--detail full|high|low|minimal|user-only` filters by verbosity and `--compact` merges repeated section headings — pairs well with `--format md` to feed past conversations back to an LLM for analysis or experience building
 - **Floating Navigation**: Always-available back-to-top button and filter controls
 - **CLI Interface**: Simple command-line tool using Click
 
@@ -156,6 +156,7 @@ claude-code-log /path/to/project --detail low --format md --compact
 
 `--detail` levels (smallest → largest output):
 
+- `user-only` — just user prompts and steering (useful as input to a downstream agent, e.g. building a requirements doc)
 - `minimal` — user + assistant text only
 - `low` — interaction-focused; keeps WebSearch, WebFetch, and Task (agent delegations) as key signals
 - `high` — detailed but cleaned; drops system/hook noise

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -515,14 +515,18 @@ def _clear_output_files(input_path: Path, all_projects: bool, file_ext: str) -> 
 )
 @click.option(
     "--detail",
-    type=click.Choice(["full", "high", "low", "minimal"], case_sensitive=False),
+    type=click.Choice(
+        ["full", "high", "low", "minimal", "user-only"], case_sensitive=False
+    ),
     default="full",
     help=(
         "Detail level for output. "
         "full: everything; "
         "high: detailed but cleaned (no system/hook noise); "
         "low: interaction-focused + key signals; "
-        "minimal: user + assistant messages only."
+        "minimal: user + assistant messages only; "
+        "user-only: only user prompts and steering (for feeding to "
+        "downstream agents, e.g. building a requirements doc)."
     ),
 )
 @click.option(

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -901,7 +901,9 @@ def _variant_label_from_suffix(suffix: str) -> str:
         return "Full"
     parts = [p for p in suffix.split(".") if p]
     # Capitalise each segment; "compact" stays lowercased as the adverb.
-    nice = [p.capitalize() if p != "compact" else p for p in parts]
+    # Replace hyphens with spaces so "user-only" renders as "User only"
+    # rather than "User-only" in the UI.
+    nice = [p.capitalize().replace("-", " ") if p != "compact" else p for p in parts]
     return " · ".join(nice)
 
 

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -48,13 +48,14 @@ class MessageType(str, Enum):
 class DetailLevel(str, Enum):
     """Output detail level controlling which message types are included.
 
-    Levels form a hierarchy: full > high > low > minimal.
+    Levels form a hierarchy: full > high > low > minimal > user-only.
     """
 
     FULL = "full"  # Everything
     HIGH = "high"  # Detailed but cleaned (no system/hook noise)
     LOW = "low"  # Interaction-focused + key signals
     MINIMAL = "minimal"  # User + assistant messages only
+    USER_ONLY = "user-only"  # User prompts + steering only (for downstream agents)
 
 
 # =============================================================================

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2178,7 +2178,7 @@ def _reorder_session_template_messages(
 
 
 def _queue_op_content_as_list(
-    content: Any,
+    content: Optional[list[ContentItem] | str],
 ) -> list[ContentItem]:
     """Normalise `QueueOperationTranscriptEntry.content` to a ContentItem list.
 
@@ -2189,7 +2189,7 @@ def _queue_op_content_as_list(
     None / empty / other shapes.
     """
     if isinstance(content, list):
-        return content  # type: ignore[return-value]
+        return content
     if isinstance(content, str) and content.strip():
         return [TextContent(type="text", text=content)]
     return []
@@ -2613,12 +2613,20 @@ def _collect_session_info(
             continue
 
         # Get message content
+        message_content: list[ContentItem]
         if isinstance(message, QueueOperationTranscriptEntry):
             message_content = _queue_op_content_as_list(message.content)
         else:
-            message_content = message.message.content  # type: ignore
+            # After filtering out System/Summary/Passthrough upstream in
+            # _filter_messages, `message` is User/Assistant here — both
+            # expose `.message.content: list[ContentItem]`. The inner
+            # cast narrows the union explicitly so pyright's strict mode
+            # and ty both see a clean `list[ContentItem]` on the RHS.
+            message_content = cast(
+                "UserTranscriptEntry | AssistantTranscriptEntry", message
+            ).message.content
 
-        text_content = extract_text_content(message_content)  # type: ignore[arg-type]
+        text_content = extract_text_content(message_content)
 
         # Get session info
         session_id = getattr(message, "sessionId", "unknown")

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2289,6 +2289,11 @@ _MINIMAL_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
     ToolResultMessage,
 )
 
+_USER_ONLY_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
+    *_MINIMAL_EXCLUDE_CLASSES,
+    AssistantTextMessage,
+)
+
 
 def _filter_by_detail(
     messages: list[TranscriptEntry],
@@ -2296,14 +2301,16 @@ def _filter_by_detail(
 ) -> list[TranscriptEntry]:
     """Pre-render filter: strip content items per detail level.
 
-    - MINIMAL: keep only user/assistant text (no tools, thinking, system).
+    - MINIMAL / USER_ONLY: keep only user/assistant text (no tools,
+      thinking, system). USER_ONLY drops assistant text in the post-
+      render pass so it behaves identically here.
     - LOW: keep user/assistant text + WebSearch / WebFetch / Task / Agent
       tools (Agent is the teammates spawn alias for Task).
     - HIGH: keep user/assistant + all tools/thinking, drop system entries.
     """
     from copy import copy
 
-    if detail == DetailLevel.MINIMAL:
+    if detail in (DetailLevel.MINIMAL, DetailLevel.USER_ONLY):
         strip_types: tuple[type, ...] = (
             ThinkingContent,
             ToolUseContent,
@@ -2317,13 +2324,29 @@ def _filter_by_detail(
         # HIGH: no content-item stripping needed
         strip_types = ()
 
+    # USER_ONLY additionally keeps queue-operation entries so their
+    # UserSteeringMessage survives — steering prompts carry real user
+    # intent. Other levels drop them; the MINIMAL asymmetry is
+    # pre-existing and out of scope for this change.
+    allowed_types: tuple[type, ...] = (UserTranscriptEntry, AssistantTranscriptEntry)
+    if detail == DetailLevel.USER_ONLY:
+        allowed_types = (*allowed_types, QueueOperationTranscriptEntry)
+
     filtered: list[TranscriptEntry] = []
     for message in messages:
-        # HIGH/LOW/MINIMAL: drop system entries (factory creates SystemMessage)
-        if not isinstance(message, (UserTranscriptEntry, AssistantTranscriptEntry)):
+        # HIGH/LOW/MINIMAL/USER_ONLY: drop system entries (factory creates SystemMessage)
+        if not isinstance(message, allowed_types):
             continue
-        # LOW/MINIMAL: drop sidechain (subagent) messages entirely
-        if detail in (DetailLevel.MINIMAL, DetailLevel.LOW) and message.isSidechain:
+        # queue-operation entries don't have `.message` or `.isSidechain` —
+        # they are appended verbatim for downstream conversion.
+        if isinstance(message, QueueOperationTranscriptEntry):
+            filtered.append(message)
+            continue
+        # LOW/MINIMAL/USER_ONLY: drop sidechain (subagent) messages entirely
+        if (
+            detail in (DetailLevel.MINIMAL, DetailLevel.LOW, DetailLevel.USER_ONLY)
+            and message.isSidechain
+        ):
             continue
         if not strip_types:
             filtered.append(message)
@@ -2498,7 +2521,9 @@ def _filter_template_by_detail(
     detail: DetailLevel,
 ) -> list[TemplateMessage]:
     """Post-render filter: remove TemplateMessage types per detail level."""
-    if detail == DetailLevel.MINIMAL:
+    if detail == DetailLevel.USER_ONLY:
+        exclude = _USER_ONLY_EXCLUDE_CLASSES
+    elif detail == DetailLevel.MINIMAL:
         exclude = _MINIMAL_EXCLUDE_CLASSES
     elif detail == DetailLevel.LOW:
         exclude = _LOW_EXCLUDE_CLASSES
@@ -2509,7 +2534,10 @@ def _filter_template_by_detail(
     for msg in messages:
         if isinstance(msg.content, exclude):
             continue
-        if detail in (DetailLevel.MINIMAL, DetailLevel.LOW) and msg.is_sidechain:
+        if (
+            detail in (DetailLevel.MINIMAL, DetailLevel.LOW, DetailLevel.USER_ONLY)
+            and msg.is_sidechain
+        ):
             continue
         # LOW: drop tool_use/tool_result unless it's a kept tool
         if detail == DetailLevel.LOW and isinstance(

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2324,12 +2324,12 @@ def _filter_by_detail(
         # HIGH: no content-item stripping needed
         strip_types = ()
 
-    # USER_ONLY additionally keeps queue-operation entries so their
+    # MINIMAL and USER_ONLY keep queue-operation entries so their
     # UserSteeringMessage survives — steering prompts carry real user
-    # intent. Other levels drop them; the MINIMAL asymmetry is
-    # pre-existing and out of scope for this change.
+    # intent and belong in any view that claims to preserve the user's
+    # side of the conversation. HIGH/LOW continue to drop them.
     allowed_types: tuple[type, ...] = (UserTranscriptEntry, AssistantTranscriptEntry)
-    if detail == DetailLevel.USER_ONLY:
+    if detail in (DetailLevel.MINIMAL, DetailLevel.USER_ONLY):
         allowed_types = (*allowed_types, QueueOperationTranscriptEntry)
 
     filtered: list[TranscriptEntry] = []

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2177,6 +2177,24 @@ def _reorder_session_template_messages(
     return result
 
 
+def _queue_op_content_as_list(
+    content: Any,
+) -> list[ContentItem]:
+    """Normalise `QueueOperationTranscriptEntry.content` to a ContentItem list.
+
+    The Pydantic model allows `content` to be a plain string (raw
+    steering text) or a list of content items. Several filter passes
+    reason about the content as a uniform list, so wrap a non-empty
+    string in a single `TextContent` and fall through to `[]` for
+    None / empty / other shapes.
+    """
+    if isinstance(content, list):
+        return content  # type: ignore[return-value]
+    if isinstance(content, str) and content.strip():
+        return [TextContent(type="text", text=content)]
+    return []
+
+
 def _filter_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntry]:
     """Filter messages to those that should be rendered.
 
@@ -2221,8 +2239,7 @@ def _filter_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntry]:
         # Get message content for filtering checks
         message_content: list[ContentItem]
         if isinstance(message, QueueOperationTranscriptEntry):
-            content = message.content
-            message_content = content if isinstance(content, list) else []
+            message_content = _queue_op_content_as_list(message.content)
         else:
             message_content = message.message.content
 
@@ -2324,13 +2341,17 @@ def _filter_by_detail(
         # HIGH: no content-item stripping needed
         strip_types = ()
 
-    # MINIMAL and USER_ONLY keep queue-operation entries so their
-    # UserSteeringMessage survives — steering prompts carry real user
-    # intent and belong in any view that claims to preserve the user's
-    # side of the conversation. HIGH/LOW continue to drop them.
-    allowed_types: tuple[type, ...] = (UserTranscriptEntry, AssistantTranscriptEntry)
-    if detail in (DetailLevel.MINIMAL, DetailLevel.USER_ONLY):
-        allowed_types = (*allowed_types, QueueOperationTranscriptEntry)
+    # Queue-operation entries (carrying UserSteeringMessage) pass through
+    # at every non-FULL detail level. Steering is user-authored content
+    # and belongs in any view of the user's side of the conversation —
+    # the post-render exclude chains (_HIGH/_LOW/_MINIMAL/_USER_ONLY)
+    # don't list UserSteeringMessage, so this allowlist is sufficient
+    # to keep it visible everywhere we already keep assistant/user text.
+    allowed_types: tuple[type, ...] = (
+        UserTranscriptEntry,
+        AssistantTranscriptEntry,
+        QueueOperationTranscriptEntry,
+    )
 
     filtered: list[TranscriptEntry] = []
     for message in messages:
@@ -2593,7 +2614,7 @@ def _collect_session_info(
 
         # Get message content
         if isinstance(message, QueueOperationTranscriptEntry):
-            message_content = message.content if message.content else []
+            message_content = _queue_op_content_as_list(message.content)
         else:
             message_content = message.message.content  # type: ignore
 

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -41,7 +41,7 @@ from .factories import (
 # no-op on the filename (matching the CLI description that compact is
 # Markdown-only).
 
-VARIANT_ENTRY_RE = re.compile(r"^combined_transcripts((?:\.[a-z]+)*)\.html$")
+VARIANT_ENTRY_RE = re.compile(r"^combined_transcripts((?:\.[a-z-]+)*)\.html$")
 
 
 def variant_suffix(

--- a/test/test_detail_levels.py
+++ b/test/test_detail_levels.py
@@ -1133,6 +1133,191 @@ class TestCompactMarkdown:
         assert "Second" in html
 
 
+# -- USER_ONLY level ---------------------------------------------------------
+
+
+class TestUserOnlyTemplateMessages:
+    """USER_ONLY keeps user prompts and steering only — the intended input
+    shape for downstream agents (e.g. extracting a requirements.md)."""
+
+    def test_drops_assistant_text(self, tmp_path):
+        entries = [
+            _user_entry("Design me a login page"),
+            _assistant_entry(
+                "Sure, here's a plan...", timestamp="2025-01-01T10:00:01Z"
+            ),
+            _user_entry("Make it use OAuth", timestamp="2025-01-01T10:00:02Z"),
+        ]
+        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
+
+        root_messages, _, ctx = generate_template_messages(
+            messages, detail=DetailLevel.USER_ONLY
+        )
+        all_types: set[str] = set()
+        _collect_types(root_messages, all_types)
+        assert "assistant" not in all_types
+        assert "user" in all_types
+        user_texts = [
+            getattr(msg.content, "items", None)
+            for msg in ctx.messages
+            if msg.type == "user"
+        ]
+        # Both user prompts survived
+        assert len(user_texts) == 2
+
+    def test_keeps_user_steering(self, tmp_path):
+        """queue-operation 'remove' → UserSteeringMessage, kept at USER_ONLY."""
+        import json as _json
+
+        entries = [
+            _user_entry("Start building", timestamp="2025-01-01T10:00:00Z"),
+            _assistant_entry("Starting...", timestamp="2025-01-01T10:00:01Z"),
+        ]
+        path = tmp_path / "t.jsonl"
+        path.write_text(
+            "\n".join(_json.dumps(e) for e in entries)
+            + "\n"
+            + _json.dumps(
+                {
+                    "type": "queue-operation",
+                    "operation": "remove",
+                    "timestamp": "2025-01-01T10:00:02Z",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Actually, wait — use Postgres not MySQL",
+                        }
+                    ],
+                    "sessionId": "sess-001",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        messages = load_transcript(path)
+
+        _, _, ctx = generate_template_messages(messages, detail=DetailLevel.USER_ONLY)
+        from claude_code_log.models import UserSteeringMessage
+
+        steering_content = [
+            msg.content
+            for msg in ctx.messages
+            if isinstance(msg.content, UserSteeringMessage)
+        ]
+        assert len(steering_content) == 1, (
+            f"Expected exactly one UserSteeringMessage, got content types: "
+            f"{[type(m.content).__name__ for m in ctx.messages]}"
+        )
+
+    def test_drops_tools_thinking_bash_slash(self, tmp_path):
+        """USER_ONLY inherits everything MINIMAL drops."""
+        entries = [
+            _user_entry("List files"),
+            _assistant_entry(
+                "Running ls",
+                extra_content=[_tool_use_item(), _thinking_item()],
+                timestamp="2025-01-01T10:00:01Z",
+            ),
+            _user_entry(
+                "",
+                extra_content=[_tool_result_item()],
+                timestamp="2025-01-01T10:00:02Z",
+            ),
+            _user_entry(
+                "<bash-input>ls</bash-input>", timestamp="2025-01-01T10:00:03Z"
+            ),
+            _user_entry(
+                "<bash-stdout>a b c</bash-stdout>", timestamp="2025-01-01T10:00:04Z"
+            ),
+            _user_entry("/exit", timestamp="2025-01-01T10:00:05Z"),
+        ]
+        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
+
+        root_messages, _, ctx = generate_template_messages(
+            messages, detail=DetailLevel.USER_ONLY
+        )
+        all_types: set[str] = set()
+        _collect_types(root_messages, all_types)
+        for unwanted in (
+            "assistant",
+            "thinking",
+            "tool_use",
+            "tool_result",
+            "bash-input",
+            "bash-output",
+        ):
+            assert unwanted not in all_types, (
+                f"{unwanted!r} should not survive USER_ONLY, got: {all_types}"
+            )
+        # /exit slash command must not appear in any survivor
+        for msg in ctx.messages:
+            assert "/exit" not in getattr(msg.content, "text", ""), (
+                f"Slash command leaked into USER_ONLY as {msg.type}"
+            )
+
+    def test_drops_sidechain(self, tmp_path):
+        sidechain_user = _user_entry("Sub task", timestamp="2025-01-01T10:00:01Z")
+        sidechain_user["isSidechain"] = True
+        entries = [_user_entry("Main prompt"), sidechain_user]
+        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
+
+        _, _, ctx = generate_template_messages(messages, detail=DetailLevel.USER_ONLY)
+        for msg in ctx.messages:
+            assert not msg.is_sidechain
+
+    def test_preserves_session_headers(self, tmp_path):
+        """Session headers remain so downstream agents can orient per-session."""
+        entries = [
+            _user_entry("Hello", session_id="sess-A"),
+            _assistant_entry("Hi", session_id="sess-A"),
+        ]
+        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
+
+        root_messages, session_nav, _ = generate_template_messages(
+            messages, detail=DetailLevel.USER_ONLY
+        )
+        assert len(root_messages) >= 1
+        assert root_messages[0].is_session_header
+        assert len(session_nav) >= 1
+
+    def test_fewer_messages_than_minimal(self, tmp_path):
+        """USER_ONLY ⊂ MINIMAL (always ≤ messages)."""
+        entries = [
+            _user_entry("Prompt one"),
+            _assistant_entry("Reply one", timestamp="2025-01-01T10:00:01Z"),
+            _user_entry("Prompt two", timestamp="2025-01-01T10:00:02Z"),
+            _assistant_entry("Reply two", timestamp="2025-01-01T10:00:03Z"),
+        ]
+        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
+
+        _, _, ctx_min = generate_template_messages(messages, detail=DetailLevel.MINIMAL)
+        # Re-load to avoid mutation shared state between runs
+        messages2 = load_transcript(tmp_path / "t.jsonl")
+        _, _, ctx_user = generate_template_messages(
+            messages2, detail=DetailLevel.USER_ONLY
+        )
+        assert len(ctx_user.messages) < len(ctx_min.messages)
+
+
+class TestUserOnlyCli:
+    def test_cli_accepts_user_only(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            [
+                _user_entry("Hello"),
+                _assistant_entry("Hi", timestamp="2025-01-01T10:00:01Z"),
+            ],
+            jsonl,
+        )
+        result = CliRunner().invoke(main, [str(jsonl), "--detail", "user-only"])
+        assert result.exit_code == 0, result.output
+        # Output filename carries the variant suffix
+        generated = list(tmp_path.glob("*.user-only.html"))
+        assert len(generated) == 1, (
+            f"Expected one *.user-only.html, got: {list(tmp_path.iterdir())}"
+        )
+
+
 # -- Helpers ------------------------------------------------------------------
 
 

--- a/test/test_detail_levels.py
+++ b/test/test_detail_levels.py
@@ -495,6 +495,55 @@ class TestMinimalTemplateMessages:
         assert root_messages[0].is_session_header
         assert len(session_nav) >= 1
 
+    def test_minimal_keeps_user_steering(self, tmp_path):
+        """queue-operation 'remove' → UserSteeringMessage, kept at MINIMAL.
+
+        Steering prompts carry real user precisions (e.g. 'actually, use
+        Postgres not MySQL') and must survive any view that claims to
+        preserve the user's side of the conversation.
+        """
+        import json as _json
+
+        entries = [
+            _user_entry("Start building", timestamp="2025-01-01T10:00:00Z"),
+            _assistant_entry("Starting...", timestamp="2025-01-01T10:00:01Z"),
+        ]
+        path = tmp_path / "t.jsonl"
+        path.write_text(
+            "\n".join(_json.dumps(e) for e in entries)
+            + "\n"
+            + _json.dumps(
+                {
+                    "type": "queue-operation",
+                    "operation": "remove",
+                    "timestamp": "2025-01-01T10:00:02Z",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Use Postgres not MySQL",
+                        }
+                    ],
+                    "sessionId": "sess-001",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        messages = load_transcript(path)
+
+        _, _, ctx = generate_template_messages(messages, detail=DetailLevel.MINIMAL)
+        from claude_code_log.models import UserSteeringMessage
+
+        steering = [
+            msg.content
+            for msg in ctx.messages
+            if isinstance(msg.content, UserSteeringMessage)
+        ]
+        assert len(steering) == 1, (
+            f"MINIMAL should keep steering; got content types: "
+            f"{[type(m.content).__name__ for m in ctx.messages]}"
+        )
+
     def test_minimal_removes_bash_messages(self, tmp_path):
         """Minimal mode removes bash-input and bash-output messages."""
         entries = [

--- a/test/test_detail_levels.py
+++ b/test/test_detail_levels.py
@@ -1348,6 +1348,110 @@ class TestUserOnlyTemplateMessages:
         assert len(ctx_user.messages) < len(ctx_min.messages)
 
 
+class TestSteeringHierarchy:
+    """UserSteeringMessage must survive at every non-FULL detail level.
+
+    The documented hierarchy is `full > high > low > minimal > user-only`
+    — whatever a lower level keeps, higher levels keep. Steering is
+    user-authored content, so it belongs in every view that preserves
+    the user's side of the conversation.
+    """
+
+    @staticmethod
+    def _write_with_steering(tmp_path: Path) -> Path:
+        import json as _json
+
+        entries = [
+            _user_entry("Do it", timestamp="2025-01-01T10:00:00Z"),
+            _assistant_entry("OK", timestamp="2025-01-01T10:00:01Z"),
+        ]
+        path = tmp_path / "t.jsonl"
+        path.write_text(
+            "\n".join(_json.dumps(e) for e in entries)
+            + "\n"
+            + _json.dumps(
+                {
+                    "type": "queue-operation",
+                    "operation": "remove",
+                    "timestamp": "2025-01-01T10:00:02Z",
+                    "content": [
+                        {"type": "text", "text": "Also add auth"},
+                    ],
+                    "sessionId": "sess-001",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    @pytest.mark.parametrize(
+        "level",
+        [
+            DetailLevel.HIGH,
+            DetailLevel.LOW,
+            DetailLevel.MINIMAL,
+            DetailLevel.USER_ONLY,
+        ],
+    )
+    def test_steering_survives_at_every_non_full_level(self, tmp_path, level):
+        path = self._write_with_steering(tmp_path)
+        messages = load_transcript(path)
+
+        _, _, ctx = generate_template_messages(messages, detail=level)
+        from claude_code_log.models import UserSteeringMessage
+
+        steering = [
+            msg.content
+            for msg in ctx.messages
+            if isinstance(msg.content, UserSteeringMessage)
+        ]
+        assert len(steering) == 1, (
+            f"Level {level.value} should keep UserSteeringMessage; got "
+            f"content types: {[type(m.content).__name__ for m in ctx.messages]}"
+        )
+
+
+class TestSteeringStringContent:
+    """`QueueOperationTranscriptEntry.content` can be a plain string
+    (not just a list of ContentItem). The filter pipeline used to coerce
+    non-list content to `[]`, silently dropping steering; verify it now
+    survives as a UserSteeringMessage."""
+
+    def test_string_content_becomes_steering_message(self, tmp_path):
+        import json as _json
+
+        path = tmp_path / "t.jsonl"
+        path.write_text(
+            _json.dumps(_user_entry("Start"))
+            + "\n"
+            + _json.dumps(
+                {
+                    "type": "queue-operation",
+                    "operation": "remove",
+                    "timestamp": "2025-01-01T10:00:02Z",
+                    # String content, not a list — the interesting case.
+                    "content": "Actually, use Postgres not MySQL",
+                    "sessionId": "sess-001",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        messages = load_transcript(path)
+
+        _, _, ctx = generate_template_messages(messages, detail=DetailLevel.MINIMAL)
+        from claude_code_log.models import UserSteeringMessage
+
+        steering = [
+            msg for msg in ctx.messages if isinstance(msg.content, UserSteeringMessage)
+        ]
+        assert len(steering) == 1, (
+            f"String-content queue-op should become a UserSteeringMessage; "
+            f"got: {[type(m.content).__name__ for m in ctx.messages]}"
+        )
+
+
 class TestUserOnlyCli:
     def test_cli_accepts_user_only(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"

--- a/test/test_output_paths.py
+++ b/test/test_output_paths.py
@@ -51,6 +51,8 @@ class TestVariantSuffix:
         assert variant_suffix(DetailLevel.HIGH, False, "html") == ".high"
         assert variant_suffix(DetailLevel.LOW, False, "html") == ".low"
         assert variant_suffix(DetailLevel.MINIMAL, False, "md") == ".minimal"
+        assert variant_suffix(DetailLevel.USER_ONLY, False, "html") == ".user-only"
+        assert variant_suffix(DetailLevel.USER_ONLY, False, "md") == ".user-only"
 
     def test_compact_markdown_only(self) -> None:
         # Compact contributes for Markdown output.

--- a/test/test_output_paths.py
+++ b/test/test_output_paths.py
@@ -83,6 +83,8 @@ class TestVariantEntryRegex:
             ("combined_transcripts.high.html", ".high"),
             ("combined_transcripts.low.compact.html", ".low.compact"),
             ("combined_transcripts.minimal.html", ".minimal"),
+            ("combined_transcripts.user-only.html", ".user-only"),
+            ("combined_transcripts.user-only.compact.html", ".user-only.compact"),
         ],
     )
     def test_accepts_entry_points(self, name: str, expected_suffix: str) -> None:
@@ -369,13 +371,16 @@ class TestSessionBackLink:
 
 class TestEnumerateProjectVariants:
     def test_lists_all_variants_default_first(self, tmp_path: Path) -> None:
-        # Create dummy variant files.
+        # Create dummy variant files — include `user-only` with its hyphen
+        # to guard against a regex regression that drops hyphenated variants.
         (tmp_path / "combined_transcripts.html").write_text("x")
         (tmp_path / "combined_transcripts.low.html").write_text("x")
         (tmp_path / "combined_transcripts.high.html").write_text("x")
+        (tmp_path / "combined_transcripts.user-only.html").write_text("x")
         # Paginated trailers should be ignored.
         (tmp_path / "combined_transcripts_2.html").write_text("x")
         (tmp_path / "combined_transcripts.low_2.html").write_text("x")
+        (tmp_path / "combined_transcripts.user-only_2.html").write_text("x")
 
         variants = _enumerate_project_variants(tmp_path, "project")
         suffixes = [v["suffix"] for v in variants]
@@ -383,8 +388,13 @@ class TestEnumerateProjectVariants:
         # Default first.
         assert suffixes[0] == ""
         assert labels[0] == "Full"
-        # All three entries present, no paginated trailers.
-        assert sorted(suffixes) == ["", ".high", ".low"]
+        # All four entries present, no paginated trailers.
+        assert sorted(suffixes) == ["", ".high", ".low", ".user-only"]
+        # Hyphenated label renders with a space (UI polish).
+        user_only_label = next(
+            v["label"] for v in variants if v["suffix"] == ".user-only"
+        )
+        assert user_only_label == "User only"
 
     def test_empty_dir_returns_empty_list(self, tmp_path: Path) -> None:
         assert _enumerate_project_variants(tmp_path, "empty") == []


### PR DESCRIPTION
Fifth detail level inspired by #26 ("have claude to collect all stated requirements into a formal requirements.md file"): a terser output than `--detail minimal` that keeps **only** content the user authored, so the transcript can be fed directly to a downstream agent that extracts requirements, builds a changelog-by-intent, etc.

## Survivors at `--detail user-only`

- `UserTextMessage` — real user prompts
- `UserSteeringMessage` — `queue-operation 'remove'` entries whose payload carries user precisions ("actually, wait — use Postgres not MySQL")
- `SessionHeaderMessage` — orientation markers so per-session boundaries remain visible

Everything else drops via `_USER_ONLY_EXCLUDE_CLASSES = (*_MINIMAL_EXCLUDE_CLASSES, AssistantTextMessage)`: assistant text, thinking, tool_use/tool_result, bash input/output, slash commands, command output, compacted summaries, memory, hooks, system.

## Level ordering

As documented in `DetailLevel`: `full > high > low > minimal > user-only` (smallest output last). Steering is user-authored content and now survives at every non-FULL level — each level keeps at least what the smaller level keeps.

## Output filename

Automatic — `variant_suffix()` already concatenates the enum value, so the new variant lands as `*.user-only.html` / `*.user-only.md`. Covered by `TestVariantSuffix`.

## UserSteeringMessage retention across levels (hierarchy fix)

`_filter_by_detail` used to drop every `QueueOperationTranscriptEntry` before the post-render filter got to look at it, silently removing `UserSteeringMessage` from HIGH/LOW/MINIMAL output. The post-render exclude chains (`_HIGH/_LOW/_MINIMAL/_USER_ONLY_EXCLUDE_CLASSES`) never listed `UserSteeringMessage`, so this was the only thing filtering it out.

Fix: `_filter_by_detail` now allows `QueueOperationTranscriptEntry` at every non-FULL level unconditionally. Steering is user-authored content — every view that claims to preserve the user's side of the conversation keeps it.

`TestSteeringHierarchy` is parametrised over HIGH/LOW/MINIMAL/USER_ONLY to lock the behaviour.

## String-content queue-operation fix

`QueueOperationTranscriptEntry.content` is `Optional[Union[list[ContentItem], str]]`. Two pre-render sites (`_filter_messages` line 1904, session-info collection line 2161) were coercing non-list content to `[]`, silently dropping steering that arrives as a plain string.

Fix: new `_queue_op_content_as_list` helper wraps non-empty strings in a single `TextContent` so downstream filters see a uniform list. `TestSteeringStringContent` covers the regression.

## Index enumeration fix (regex)

`VARIANT_ENTRY_RE` in `utils.py` used `\.[a-z]+` per suffix segment, rejecting the hyphen in `user-only`. The `.user-only.html` file was written to disk and picked up by `_enumerate_project_variants`' glob, but then silently dropped by the regex.

Fix: `[a-z]+` → `[a-z-]+` (hyphen at end of class, literal). Covered by `TestVariantEntryRegex::test_accepts_entry_points` (two new param cases) and `TestEnumerateProjectVariants::test_lists_all_variants_default_first` (now plants a user-only fixture file).

## UI label polish

`_variant_label_from_suffix(".user-only")` now renders as `"User only"` (space) rather than `"User-only"` (hyphen). The hyphenated form is kept for the CLI flag, enum value, and on-disk filename — only the human-facing label is polished.

## Tests

- `TestUserOnlyTemplateMessages` (6 tests): assistant-text drop, steering retention, tools/thinking/bash/slash drop, sidechain drop, session-header preservation, size-vs-MINIMAL invariant.
- `TestUserOnlyCli`: CLI accepts `--detail user-only` and emits `*.user-only.html`.
- `TestMinimalTemplateMessages::test_minimal_keeps_user_steering`: MINIMAL path for steering retention.
- `TestSteeringHierarchy` (parametrised over HIGH/LOW/MINIMAL/USER_ONLY): hierarchy consistency.
- `TestSteeringStringContent`: string-content queue-operation produces a UserSteeringMessage.
- `TestVariantSuffix`: USER_ONLY suffix correct for html + md.
- `TestVariantEntryRegex::test_accepts_entry_points`: hyphenated suffix cases.
- `TestEnumerateProjectVariants::test_lists_all_variants_default_first`: user-only fixture + rendered-label assertion.

Full `just test`-equivalent run (skipping pre-existing pagination SQLite failures in my local env): **929 passed, 7 skipped**. `ruff format` + `ruff check` + `pyright` clean on modified files.

Refs #26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI detail level: --detail user-only to emit only user prompts and steering content (lowest verbosity).

* **Documentation**
  * README updated to document the new user-only detail level and its position in the verbosity ordering.

* **Output**
  * Generated output now includes a .user-only variant suffix and displays the hyphenated label as "User only".

* **Tests**
  * Expanded test coverage for the new detail level and output filename/variant behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->