### PR TITLE
docs: add Community Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ uv run claude-code-log
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and architecture documentation.
 
+## Community Extensions
+
+Projects built on top of `claude-code-log`:
+
+- **[archive-session](https://github.com/lifeinchords/claude-code-skills#archive-session-skill--slash-command--optional-hook)** by [@lifeinchords](https://github.com/lifeinchords). Wraps the CLI as three integration surfaces:
+  - a Claude Code [Skill](https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/skills/archive-session/SKILL.md)
+  - a Claude Code slash [Command](https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/commands/archive-session.md) `/archive-session` for explicit in-chat invocation
+  - a Claude Code PreCompact [Hook](https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/hooks/pre-compact-archive.sh) that auto-archives transcripts and subagent logs right before context compaction
+
+Cross-platform (macOS and Windows/MSYS).
+
 ## TODO
 
 - tutorial overlay


### PR DESCRIPTION
## Summary

Adds a short **Community Extensions** section between `## Contributing` and `## TODO`, per your suggestion in #88. One bullet, links to the project, keeps the section structure open for future entries.

The extension ships three integration surfaces on top of the CLI:

- a Claude Code **skill** (auto-invoked or via `/archive-session`)
- a Claude Code **slash command** (same `/archive-session` trigger, installs without the skill system)
- an optional **PreCompact hook** that fires auto-archive right before context compaction, so nothing is lost when the context window fills up

Happy to reword, split, or move if you'd rather the section live elsewhere in the README.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All links in the new section resolve (spot-checked manually)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Community Extensions" section to README showcasing third-party projects built on the platform
  * Documented `archive-session` tool with links to relevant resources and guides
  * Included platform compatibility information for supported operating systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->