### PR TITLE
Skill pairing: scope by session_id and only drop the canonical payload

### DIFF
--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -2029,6 +2029,36 @@ def _filter_by_detail(
     return filtered
 
 
+_LAUNCHING_SKILL_PREFIX = "Launching skill:"
+
+
+def _is_launching_skill_payload(output: Any) -> bool:
+    """Whether *output* looks like Claude Code's redundant Skill marker.
+
+    Claude Code emits the literal ``"Launching skill: <name>"`` text for the
+    tool_result that pairs with a Skill tool_use. That pair gets folded into
+    the tool_use card; the tool_result is dropped. Anything else carrying the
+    same tool_use_id (an error result, a repurposed payload in a malformed
+    transcript) stays visible.
+
+    Handles both string- and list-shaped ToolResultContent.content.
+    """
+    if not isinstance(output, ToolResultContent):
+        return False
+    content = output.content
+    if isinstance(content, str):
+        return content.lstrip().startswith(_LAUNCHING_SKILL_PREFIX)
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str) and text.lstrip().startswith(
+                    _LAUNCHING_SKILL_PREFIX
+                ):
+                    return True
+    return False
+
+
 def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
     """Fold the `isMeta=True` user body of a Skill invocation into its tool_use.
 
@@ -2043,16 +2073,26 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
     `skill_body` on the Skill `ToolUseMessage`, drop (2) and (3) from
     `ctx.messages`, and re-index so later passes see a clean slate.
 
+    The lookup is keyed by ``(render_session_id, source_tool_use_id)``:
+    combined transcripts traverse multiple sessions and tool_use ids are
+    only session-unique, so a global key risks folding the wrong body on
+    a stray id collision. Tool_result removal is similarly scoped and only
+    drops the canonical, non-error ``"Launching skill:"`` payload — an
+    error result or a divergent payload sharing the tool_use_id stays
+    visible.
+
     See issue #93.
     """
-    # Build the lookup: tool_use_id -> UserSlashCommandMessage template
-    slash_by_source: dict[str, TemplateMessage] = {}
+    # Build the lookup keyed by (render_session_id, tool_use_id) so combined
+    # transcripts spanning multiple sessions can't cross-pair via stray
+    # tool_use_id collisions.
+    slash_by_source: dict[tuple[str, str], TemplateMessage] = {}
     for msg in ctx.messages:
         if (
             isinstance(msg.content, UserSlashCommandMessage)
             and msg.meta.source_tool_use_id
         ):
-            slash_by_source[msg.meta.source_tool_use_id] = msg
+            slash_by_source[(msg.render_session_id, msg.meta.source_tool_use_id)] = msg
 
     if not slash_by_source:
         return
@@ -2063,7 +2103,7 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
             isinstance(msg.content, ToolUseMessage) and msg.content.tool_name == "Skill"
         ):
             continue
-        slash = slash_by_source.get(msg.content.tool_use_id)
+        slash = slash_by_source.get((msg.render_session_id, msg.content.tool_use_id))
         if slash is None or not isinstance(slash.content, UserSlashCommandMessage):
             continue
         # Fold the body into the Skill tool_use and mark the slash-command consumed.
@@ -2071,14 +2111,21 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
         if slash.message_index is not None:
             consumed_indices.add(slash.message_index)
         # The matching tool_result carries the redundant "Launching skill: ..."
-        # string; drop it too so the tool_use stands alone as one visual unit.
+        # string; drop it. Same-session, non-error, payload-prefix-checked
+        # so a real error result or a divergent payload sharing the
+        # tool_use_id stays visible.
         for other in ctx.messages:
             if (
-                other.type == "tool_result"
-                and other.tool_use_id == msg.content.tool_use_id
-                and other.message_index is not None
+                not isinstance(other.content, ToolResultMessage)
+                or other.render_session_id != msg.render_session_id
+                or other.content.tool_use_id != msg.content.tool_use_id
+                or other.content.is_error
+                or other.message_index is None
             ):
-                consumed_indices.add(other.message_index)
+                continue
+            if not _is_launching_skill_payload(other.content.output):
+                continue
+            consumed_indices.add(other.message_index)
 
     if not consumed_indices:
         return

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -40,13 +40,14 @@ def _user(
     content: list[dict],
     is_meta: bool = False,
     source_tool_use_id: str | None = None,
+    session_id: str = "sess-skill",
 ) -> dict:
     e: dict = {
         "type": "user",
         "uuid": uid,
         "parentUuid": parent,
         "timestamp": ts,
-        "sessionId": "sess-skill",
+        "sessionId": session_id,
         "isSidechain": False,
         "userType": "external",
         "cwd": "/tmp",
@@ -67,13 +68,14 @@ def _assistant_tool_use(
     tool_name: str,
     tool_use_id: str,
     input_obj: dict,
+    session_id: str = "sess-skill",
 ) -> dict:
     return {
         "type": "assistant",
         "uuid": uid,
         "parentUuid": parent,
         "timestamp": ts,
-        "sessionId": "sess-skill",
+        "sessionId": session_id,
         "isSidechain": False,
         "userType": "external",
         "cwd": "/tmp",
@@ -98,13 +100,19 @@ def _assistant_tool_use(
     }
 
 
-def _assistant_text(uid: str, parent: str, ts: str, text: str) -> dict:
+def _assistant_text(
+    uid: str,
+    parent: str,
+    ts: str,
+    text: str,
+    session_id: str = "sess-skill",
+) -> dict:
     return {
         "type": "assistant",
         "uuid": uid,
         "parentUuid": parent,
         "timestamp": ts,
-        "sessionId": "sess-skill",
+        "sessionId": session_id,
         "isSidechain": False,
         "userType": "external",
         "cwd": "/tmp",
@@ -305,6 +313,252 @@ class TestSkillPairing:
         ]
         # No pair found → slash-command is not consumed, renders standalone.
         assert len(slash) == 1
+
+    def test_same_tool_use_id_across_sessions_does_not_cross_pair(
+        self, tmp_path: Path
+    ) -> None:
+        """Two independent sessions reusing the same tool_use_id keep their
+        Skill bodies separate. The lookup key must be (session_id, tool_use_id)
+        — combined transcripts traverse multiple sessions, and Anthropic
+        tool_use ids are only session-unique. A global key would let session
+        B's slash body fold into session A's Skill (or vice versa) on a stray
+        collision.
+        """
+        # Session A: Skill tool_use + body A.
+        session_a = "sess-a"
+        body_a = "# Body A\n\nfrom session A."
+        entries_a = [
+            _user(
+                "ua-001",
+                None,
+                "2026-01-01T10:00:00Z",
+                [{"type": "text", "text": "Go A"}],
+                session_id=session_a,
+            ),
+            _assistant_tool_use(
+                "aa-001",
+                "ua-001",
+                "2026-01-01T10:00:01Z",
+                "Skill",
+                "toolu_DUP",
+                {"skill": "alpha"},
+                session_id=session_a,
+            ),
+            _user(
+                "ua-002",
+                "aa-001",
+                "2026-01-01T10:00:02Z",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_DUP",
+                        "content": "Launching skill: alpha",
+                        "is_error": False,
+                    }
+                ],
+                session_id=session_a,
+            ),
+            _user(
+                "ua-003",
+                "ua-002",
+                "2026-01-01T10:00:03Z",
+                [{"type": "text", "text": body_a}],
+                is_meta=True,
+                source_tool_use_id="toolu_DUP",
+                session_id=session_a,
+            ),
+        ]
+        # Session B: same tool_use_id, different body.
+        session_b = "sess-b"
+        body_b = "# Body B\n\nfrom session B."
+        entries_b = [
+            _user(
+                "ub-001",
+                None,
+                "2026-01-01T11:00:00Z",
+                [{"type": "text", "text": "Go B"}],
+                session_id=session_b,
+            ),
+            _assistant_tool_use(
+                "ab-001",
+                "ub-001",
+                "2026-01-01T11:00:01Z",
+                "Skill",
+                "toolu_DUP",
+                {"skill": "beta"},
+                session_id=session_b,
+            ),
+            _user(
+                "ub-002",
+                "ab-001",
+                "2026-01-01T11:00:02Z",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_DUP",
+                        "content": "Launching skill: beta",
+                        "is_error": False,
+                    }
+                ],
+                session_id=session_b,
+            ),
+            _user(
+                "ub-003",
+                "ub-002",
+                "2026-01-01T11:00:03Z",
+                [{"type": "text", "text": body_b}],
+                is_meta=True,
+                source_tool_use_id="toolu_DUP",
+                session_id=session_b,
+            ),
+        ]
+        # Render both as a combined transcript.
+        messages = load_transcript(
+            _write_jsonl(tmp_path / "combined.jsonl", entries_a + entries_b)
+        )
+        _, _, ctx = generate_template_messages(messages)
+
+        skill_uses_by_session: dict[str, ToolUseMessage] = {}
+        for m in ctx.messages:
+            if isinstance(m.content, ToolUseMessage) and m.content.tool_name == "Skill":
+                skill_uses_by_session[m.meta.session_id] = m.content
+        assert set(skill_uses_by_session) == {session_a, session_b}, (
+            f"Both Skill tool_uses should survive — got {set(skill_uses_by_session)}"
+        )
+        # Each Skill keeps its OWN session's body, not the other session's.
+        assert skill_uses_by_session[session_a].skill_body == body_a
+        assert skill_uses_by_session[session_b].skill_body == body_b
+
+    def test_error_tool_result_with_same_id_is_preserved(self, tmp_path: Path) -> None:
+        """A real error tool_result sharing the Skill's tool_use_id must NOT
+        be silently dropped — even though the canonical 'Launching skill:'
+        result IS dropped. Without the is_error guard, a Skill that failed
+        to launch would lose the error message entirely.
+        """
+        skill_body = "# Real Body\n\npaired with the launch result."
+        entries = [
+            _user(
+                "u-001", None, "2026-01-01T10:00:00Z", [{"type": "text", "text": "Go"}]
+            ),
+            _assistant_tool_use(
+                "a-001",
+                "u-001",
+                "2026-01-01T10:00:01Z",
+                "Skill",
+                "toolu_ERR",
+                {"skill": "broken"},
+            ),
+            # Canonical "Launching skill:" result — should be dropped.
+            _user(
+                "u-002",
+                "a-001",
+                "2026-01-01T10:00:02Z",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_ERR",
+                        "content": "Launching skill: broken",
+                        "is_error": False,
+                    }
+                ],
+            ),
+            # Error result with the SAME tool_use_id — must survive.
+            _user(
+                "u-003",
+                "u-002",
+                "2026-01-01T10:00:03Z",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_ERR",
+                        "content": "Skill 'broken' not found",
+                        "is_error": True,
+                    }
+                ],
+            ),
+            _user(
+                "u-004",
+                "u-003",
+                "2026-01-01T10:00:04Z",
+                [{"type": "text", "text": skill_body}],
+                is_meta=True,
+                source_tool_use_id="toolu_ERR",
+            ),
+        ]
+        messages = load_transcript(_write_jsonl(tmp_path / "t.jsonl", entries))
+        _, _, ctx = generate_template_messages(messages)
+
+        results = [
+            m.content
+            for m in ctx.messages
+            if isinstance(m.content, ToolResultMessage)
+            and m.content.tool_use_id == "toolu_ERR"
+        ]
+        assert len(results) == 1, (
+            "Exactly the error result should survive; the canonical "
+            "'Launching skill:' result should be dropped"
+        )
+        assert results[0].is_error is True
+
+    def test_non_launching_skill_result_with_same_id_is_preserved(
+        self, tmp_path: Path
+    ) -> None:
+        """A tool_result with the Skill's tool_use_id but a payload that
+        does NOT start with 'Launching skill:' must NOT be dropped. The
+        canonical-payload prefix check defends against a malformed transcript
+        where some other content shares the id."""
+        skill_body = "# Body\n\nbody text."
+        entries = [
+            _user(
+                "u-001", None, "2026-01-01T10:00:00Z", [{"type": "text", "text": "Go"}]
+            ),
+            _assistant_tool_use(
+                "a-001",
+                "u-001",
+                "2026-01-01T10:00:01Z",
+                "Skill",
+                "toolu_ODD",
+                {"skill": "weird"},
+            ),
+            # Divergent (non-canonical) tool_result sharing the id — must survive.
+            _user(
+                "u-002",
+                "a-001",
+                "2026-01-01T10:00:02Z",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_ODD",
+                        "content": "Some unrelated payload",
+                        "is_error": False,
+                    }
+                ],
+            ),
+            _user(
+                "u-003",
+                "u-002",
+                "2026-01-01T10:00:03Z",
+                [{"type": "text", "text": skill_body}],
+                is_meta=True,
+                source_tool_use_id="toolu_ODD",
+            ),
+        ]
+        messages = load_transcript(_write_jsonl(tmp_path / "t.jsonl", entries))
+        _, _, ctx = generate_template_messages(messages)
+
+        results = [
+            m.content
+            for m in ctx.messages
+            if isinstance(m.content, ToolResultMessage)
+            and m.content.tool_use_id == "toolu_ODD"
+        ]
+        assert len(results) == 1
+        # The non-canonical payload survived.
+        from claude_code_log.models import ToolResultContent
+
+        output = results[0].output
+        assert isinstance(output, ToolResultContent)
+        assert output.content == "Some unrelated payload"
 
 
 # -- Renderer output ---------------------------------------------------------


### PR DESCRIPTION
Follow-up to #121 addressing CodeRabbit's review (https://github.com/daaain/claude-code-log/pull/121#pullrequestreview-4136579507).

Superseded — fix consolidated directly onto #121's branch (`dev/pair-skill-user-message`) at `a584d7a`. This stacked PR is no longer needed.

## Why this exists

CodeRabbit flagged two failure modes in `_pair_skill_tool_uses` that the
original commit (dc1770a) didn't defend against:

1. **Cross-session pairing collision** — the lookup was keyed on
   `tool_use_id` alone. `RenderingContext.messages` spans combined
   transcripts (multiple sessions), but Anthropic tool_use ids are only
   session-unique. A stray collision would let session B's slash body
   fold into session A's Skill tool_use silently.

2. **Real error tool_results silently dropped** — the original code
   dropped EVERY tool_result with the matching `tool_use_id`, on the
   assumption that only the canonical "Launching skill: <name>" result
   carries that id. A real error result (`is_error=True`) sharing the id
   would get swallowed too.

## What changes

- Lookup keyed by `(render_session_id, source_tool_use_id)`, not bare `tool_use_id`.
- New `_is_launching_skill_payload(output)` helper checks `ToolResultContent.content` for the `"Launching skill:"` prefix (handles both string- and list-shaped content).
- Tool_result removal restricted to: same session, `is_error=False`, payload prefix matches.

## Tests (3 new)

- `test_same_tool_use_id_across_sessions_does_not_cross_pair`
- `test_error_tool_result_with_same_id_is_preserved`
- `test_non_launching_skill_result_with_same_id_is_preserved`

All three fail on the pre-fix code and pass after.

Refs #93 / #121.
