### PR TITLE
Pair Slash Command with User (slash command) (#126)

### DIFF
--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -440,6 +440,26 @@ class MarkdownRenderer(Renderer):
         # command_name already includes the leading slash
         return f"🤷 Command `{content.command_name}`"
 
+    def title_UserSlashCommandMessage(
+        self, _content: UserSlashCommandMessage, _: TemplateMessage
+    ) -> str:
+        # When paired with a SlashCommand, borrow its `🤷 Command /cmd` title.
+        # Markdown's `_render_message` skips middle and last members entirely,
+        # so for the (UserSlash → Slash) and (UserSlash → Slash → Output)
+        # orderings produced by `/exit`-like flows the SlashCommand's own title
+        # would otherwise be lost. Check pair_middle first (triples) then
+        # pair_last (2-msg pair). Mirrors `title_ThinkingMessage`'s precedent.
+        if _.is_first_in_pair and self._ctx is not None:
+            for partner_idx in (_.pair_middle, _.pair_last):
+                if partner_idx is None:
+                    continue
+                if (partner := self._ctx.get(partner_idx)) and isinstance(
+                    partner.content, SlashCommandMessage
+                ):
+                    return f"🤷 Command `{partner.content.command_name}`"
+        # Fallback to base behaviour ("User (slash command)").
+        return super().title_UserSlashCommandMessage(_content, _)
+
     def format_CommandOutputMessage(
         self, content: CommandOutputMessage, _: TemplateMessage
     ) -> str:
@@ -1147,8 +1167,9 @@ class MarkdownRenderer(Renderer):
 
     def _render_message(self, msg: TemplateMessage, level: int) -> str:
         """Render a message and its children recursively."""
-        # Skip pair_last messages (rendered with pair_first)
-        if msg.is_last_in_pair:
+        # Skip pair_middle and pair_last — both render under pair_first
+        # (pair_first owns the heading and delegates body formatting).
+        if msg.is_middle_in_pair or msg.is_last_in_pair:
             return ""
 
         parts: list[str] = []
@@ -1191,17 +1212,24 @@ class MarkdownRenderer(Renderer):
             if content:
                 parts.append(content)
 
-        # Format paired message content (e.g., tool result)
-        pair_msg = None
-        if msg.is_first_in_pair and msg.pair_last is not None:
-            if pair_msg := (self._ctx.get(msg.pair_last) if self._ctx else None):
-                if pair_content := self.format_content(pair_msg):
-                    parts.append(pair_content)
+        # Format paired message bodies (middle then last, when present).
+        # Triples (slash-command META → CMD → OUT) deliver three bodies
+        # under one heading; standard 2-msg pairs only have pair_last.
+        pair_partners: list[TemplateMessage] = []
+        if msg.is_first_in_pair:
+            for partner_idx in (msg.pair_middle, msg.pair_last):
+                if partner_idx is None or self._ctx is None:
+                    continue
+                if partner := self._ctx.get(partner_idx):
+                    pair_partners.append(partner)
+                    if pair_content := self.format_content(partner):
+                        parts.append(pair_content)
 
-        # Render children at next level (from both this message and paired message)
+        # Render children at next level (from this message and any paired members)
         all_children = list(msg.children)
-        if pair_msg and pair_msg.children:
-            all_children.extend(pair_msg.children)
+        for partner in pair_partners:
+            if partner.children:
+                all_children.extend(partner.children)
         for child in all_children:
             if child_output := self._render_message(child, level + 1):
                 parts.append(child_output)

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -1387,10 +1387,25 @@ def _try_pair_adjacent(
     Returns True if messages were paired, False otherwise.
 
     Adjacent pairing rules:
+    - slash-command invocation + slash-command expanded prompt (either order)
     - user slash-command + user command-output
     - bash-input + bash-output
     - thinking + assistant
     """
+    # Slash command invocation + expanded prompt — represent one logical
+    # event (the typed `/cmd` and the prompt-text the harness sent in its
+    # place) and may appear in either order: `/init` shows Slash → UserSlash,
+    # while `/exit` shows UserSlash (caveat) → Slash.
+    if (
+        isinstance(current.content, SlashCommandMessage)
+        and isinstance(next_msg.content, UserSlashCommandMessage)
+    ) or (
+        isinstance(current.content, UserSlashCommandMessage)
+        and isinstance(next_msg.content, SlashCommandMessage)
+    ):
+        _mark_pair(current, next_msg)
+        return True
+
     # Slash command + command output (both are user messages)
     if isinstance(
         current.content, (SlashCommandMessage, UserSlashCommandMessage)

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -204,8 +204,9 @@ class TemplateMessage:
         # Unique index in RenderingContext.messages (assigned by ctx.register())
         self.message_index: Optional[int] = None
 
-        # Pairing metadata (assigned by _mark_pair())
+        # Pairing metadata (assigned by _mark_pair() / _mark_triple())
         self.pair_first: Optional[int] = None  # Index of first message in pair
+        self.pair_middle: Optional[int] = None  # Index of middle message (triples only)
         self.pair_last: Optional[int] = None  # Index of last message in pair
         self.pair_duration: Optional[str] = None  # Duration string for pair_last
 
@@ -265,18 +266,26 @@ class TemplateMessage:
 
     @property
     def is_paired(self) -> bool:
-        """Check if this message is part of a pair."""
+        """Check if this message is part of a pair (or triple)."""
         return self.pair_first is not None or self.pair_last is not None
 
     @property
     def is_first_in_pair(self) -> bool:
-        """Check if this is the first message in a pair (has pair_last set)."""
-        return self.pair_last is not None
+        """Check if this is the first message in a pair (has pair_last set
+        but no `pair_first`, since the middle of a triple has both)."""
+        return self.pair_last is not None and self.pair_first is None
+
+    @property
+    def is_middle_in_pair(self) -> bool:
+        """Check if this is the middle message in a triple (has both
+        `pair_first` and `pair_last` set, pointing at its surrounding members)."""
+        return self.pair_first is not None and self.pair_last is not None
 
     @property
     def is_last_in_pair(self) -> bool:
-        """Check if this is the last message in a pair (has pair_first set)."""
-        return self.pair_first is not None
+        """Check if this is the last message in a pair (has `pair_first` set
+        but no `pair_last`, since the middle of a triple has both)."""
+        return self.pair_first is not None and self.pair_last is None
 
     @property
     def pair_role(self) -> Optional[str]:
@@ -284,11 +293,14 @@ class TemplateMessage:
 
         Returns:
             "pair_first" if this is the first message in a pair,
+            "pair_middle" if this is the middle message in a triple,
             "pair_last" if this is the last message in a pair,
             None if not paired.
         """
         if self.is_first_in_pair:
             return "pair_first"
+        if self.is_middle_in_pair:
+            return "pair_middle"
         if self.is_last_in_pair:
             return "pair_last"
         return None
@@ -1378,6 +1390,27 @@ def _mark_pair(first: TemplateMessage, last: TemplateMessage) -> None:
         last.pair_first = first_index
 
 
+def _mark_triple(
+    first: TemplateMessage, middle: TemplateMessage, last: TemplateMessage
+) -> None:
+    """Mark three messages as a triple (pair_first → pair_middle → pair_last).
+
+    Used for the `(UserSlash caveat, SlashCommand, CommandOutput)` sequence
+    that wraps every `/cmd`-style invocation in real transcripts: the three
+    messages share one timestamp and represent a single logical event.
+    """
+    first_index = first.message_index
+    middle_index = middle.message_index
+    last_index = last.message_index
+    if first_index is None or middle_index is None or last_index is None:
+        return
+    first.pair_middle = middle_index
+    first.pair_last = last_index
+    middle.pair_first = first_index
+    middle.pair_last = last_index
+    last.pair_first = first_index
+
+
 def _try_pair_adjacent(
     current: TemplateMessage,
     next_msg: TemplateMessage,
@@ -1386,7 +1419,8 @@ def _try_pair_adjacent(
 
     Returns True if messages were paired, False otherwise.
 
-    Adjacent pairing rules:
+    Adjacent pairing rules (2-message — checked after the 3-message rule
+    in `_try_pair_triple`):
     - slash-command invocation + slash-command expanded prompt (either order)
     - user slash-command + user command-output
     - bash-input + bash-output
@@ -1423,6 +1457,32 @@ def _try_pair_adjacent(
         _mark_pair(current, next_msg)
         return True
 
+    return False
+
+
+def _try_pair_triple(
+    a: TemplateMessage, b: TemplateMessage, c: TemplateMessage
+) -> bool:
+    """Try to pair three adjacent messages as a single logical event.
+
+    Returns True if pair_first/pair_middle/pair_last were assigned.
+
+    Triple pairing rules:
+    - `(UserSlashCommand caveat, SlashCommand /cmd, CommandOutput)` — the
+      common `/exit`, `/clear`, `/context`, `/todos`, `/doctor` shape:
+      the harness emits a caveat preamble, the typed slash command, and
+      the command's output as three sibling user messages with a single
+      timestamp. Grouping them keeps the slash-command title authoritative
+      in Markdown and avoids an orphan output that would otherwise lose
+      its rendered body.
+    """
+    if (
+        isinstance(a.content, UserSlashCommandMessage)
+        and isinstance(b.content, SlashCommandMessage)
+        and isinstance(c.content, CommandOutputMessage)
+    ):
+        _mark_triple(a, b, c)
+        return True
     return False
 
 
@@ -1474,7 +1534,17 @@ def _identify_message_pairs(messages: list[TemplateMessage]) -> None:
             i += 1
             continue
 
-        # Try adjacent pairing first (can skip next message if paired)
+        # Try 3-message triple before 2-message adjacent — the triple's
+        # predicate (UserSlash → Slash → CommandOutput) is strictly more
+        # specific than the adjacent slash-command rules, and applying the
+        # adjacent rule first would consume the first two and orphan the
+        # third (the dominant `/exit`-style pattern in real transcripts).
+        if i + 2 < len(messages):
+            if _try_pair_triple(current, messages[i + 1], messages[i + 2]):
+                i += 3
+                continue
+
+        # Try adjacent pairing (can skip next message if paired)
         if i + 1 < len(messages):
             next_msg = messages[i + 1]
             if _try_pair_adjacent(current, next_msg):
@@ -2412,6 +2482,7 @@ def _reindex_filtered_context(
         # Pair linkage is re-established post-filter by
         # `_identify_message_pairs`; clear any stale references first.
         msg.pair_first = None
+        msg.pair_middle = None
         msg.pair_last = None
 
     ctx.messages = filtered

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -1,0 +1,166 @@
+"""Tests for adjacent SlashCommand ↔ UserSlashCommand pairing (issue #126).
+
+A `Slash Command` (the typed `/cmd`) and the corresponding
+`User (slash command)` (expanded prompt or system caveat) represent a
+single logical event and must render as a paired unit. They can appear
+in either order:
+
+    `/init`  →  Slash Command  then  User (slash command)
+    `/exit`  →  User (slash command)  (caveat)  then  Slash Command
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_code_log.models import (
+    CommandOutputMessage,
+    MessageMeta,
+    SlashCommandMessage,
+    UserSlashCommandMessage,
+)
+from claude_code_log.renderer import (
+    RenderingContext,
+    TemplateMessage,
+    _identify_message_pairs,
+    _try_pair_adjacent,
+)
+
+
+# ----------------------------- helpers ---------------------------------------
+
+
+def _meta(uuid: str, *, ts: str = "2026-01-01T00:00:00Z") -> MessageMeta:
+    return MessageMeta(session_id="s", timestamp=ts, uuid=uuid)
+
+
+def _slash(ctx: RenderingContext, uuid: str, name: str = "init") -> TemplateMessage:
+    msg = TemplateMessage(
+        SlashCommandMessage(
+            meta=_meta(uuid),
+            command_name=name,
+            command_args="",
+            command_contents="",
+        )
+    )
+    ctx.register(msg)
+    return msg
+
+
+def _user_slash(
+    ctx: RenderingContext, uuid: str, text: str = "expanded prompt"
+) -> TemplateMessage:
+    meta = _meta(uuid)
+    meta.is_meta = True
+    msg = TemplateMessage(UserSlashCommandMessage(meta=meta, text=text))
+    ctx.register(msg)
+    return msg
+
+
+def _cmd_output(
+    ctx: RenderingContext, uuid: str, stdout: str = "ok"
+) -> TemplateMessage:
+    msg = TemplateMessage(
+        CommandOutputMessage(meta=_meta(uuid), stdout=stdout, is_markdown=False)
+    )
+    ctx.register(msg)
+    return msg
+
+
+@pytest.fixture
+def ctx() -> RenderingContext:
+    return RenderingContext()
+
+
+# ----------------------------- _try_pair_adjacent ----------------------------
+
+
+class TestSlashCommandAdjacentPairing:
+    """Pair the slash invocation and its expanded prompt — symmetric in order."""
+
+    def test_slash_then_user_slash_pairs(self, ctx: RenderingContext) -> None:
+        """`/init` flow: Slash invocation followed by expanded prompt."""
+        slash = _slash(ctx, "u1", name="init")
+        user_slash = _user_slash(ctx, "u2", text="Please analyze...")
+
+        assert _try_pair_adjacent(slash, user_slash) is True
+        assert slash.pair_last == user_slash.message_index
+        assert user_slash.pair_first == slash.message_index
+
+    def test_user_slash_then_slash_pairs(self, ctx: RenderingContext) -> None:
+        """`/exit` flow: caveat (User slash command) then Slash invocation."""
+        caveat = _user_slash(ctx, "v1", text="Caveat: messages below were generated...")
+        slash = _slash(ctx, "v2", name="exit")
+
+        assert _try_pair_adjacent(caveat, slash) is True
+        assert caveat.pair_last == slash.message_index
+        assert slash.pair_first == caveat.message_index
+
+    def test_two_slash_messages_do_not_pair(self, ctx: RenderingContext) -> None:
+        """Two adjacent SlashCommand messages are unrelated; no pair."""
+        a = _slash(ctx, "a1", name="init")
+        b = _slash(ctx, "a2", name="exit")
+        assert _try_pair_adjacent(a, b) is False
+        assert a.pair_last is None and b.pair_first is None
+
+    def test_two_user_slash_messages_do_not_pair(self, ctx: RenderingContext) -> None:
+        a = _user_slash(ctx, "b1", text="one")
+        b = _user_slash(ctx, "b2", text="two")
+        assert _try_pair_adjacent(a, b) is False
+
+
+# ----------------------------- regression: existing rules --------------------
+
+
+class TestExistingPairingRulesPreserved:
+    """The new rule must not regress slash-cmd → command-output pairing."""
+
+    def test_slash_then_output_still_pairs(self, ctx: RenderingContext) -> None:
+        slash = _slash(ctx, "c1", name="context")
+        output = _cmd_output(ctx, "c2", stdout="rendered context")
+        assert _try_pair_adjacent(slash, output) is True
+        assert slash.pair_last == output.message_index
+
+    def test_user_slash_then_output_still_pairs(self, ctx: RenderingContext) -> None:
+        user_slash = _user_slash(ctx, "d1", text="some prompt")
+        output = _cmd_output(ctx, "d2", stdout="rendered")
+        assert _try_pair_adjacent(user_slash, output) is True
+        assert user_slash.pair_last == output.message_index
+
+
+# ----------------------------- full pass: option A orphan --------------------
+
+
+class TestThreeMessageSequence:
+    """Per option A in the implementation plan: when a 3-msg sequence appears
+    (UserSlash caveat → Slash → CommandOutput), the slash-pair wins and the
+    trailing CommandOutput renders standalone. Documented trade-off — revisit
+    if the orphan output ever looks visually broken."""
+
+    def test_caveat_slash_output_orphans_the_output(
+        self, ctx: RenderingContext
+    ) -> None:
+        caveat = _user_slash(ctx, "e1", text="Caveat: ...")
+        slash = _slash(ctx, "e2", name="exit")
+        output = _cmd_output(ctx, "e3", stdout="See ya!")
+
+        _identify_message_pairs([caveat, slash, output])
+
+        # Slash-pair wins.
+        assert caveat.pair_last == slash.message_index
+        assert slash.pair_first == caveat.message_index
+        # Output is unpaired (orphan, by design — option A).
+        assert output.pair_first is None
+        assert output.pair_last is None
+
+    def test_slash_userslash_no_output_pairs_cleanly(
+        self, ctx: RenderingContext
+    ) -> None:
+        """`/init` — no command output — pairs without ambiguity."""
+        slash = _slash(ctx, "f1", name="init")
+        user_slash = _user_slash(ctx, "f2", text="Please analyze...")
+
+        _identify_message_pairs([slash, user_slash])
+
+        assert slash.pair_last == user_slash.message_index
+        assert user_slash.pair_first == slash.message_index

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -128,35 +128,51 @@ class TestExistingPairingRulesPreserved:
         assert user_slash.pair_last == output.message_index
 
 
-# ----------------------------- full pass: option A orphan --------------------
+# ----------------------------- full pass: triples ----------------------------
 
 
 class TestThreeMessageSequence:
-    """Per option A in the implementation plan: when a 3-msg sequence appears
-    (UserSlash caveat → Slash → CommandOutput), the slash-pair wins and the
-    trailing CommandOutput renders standalone. Documented trade-off — revisit
-    if the orphan output ever looks visually broken."""
+    """The dominant `/cmd` shape in real transcripts is three sibling user
+    messages: a UserSlash caveat preamble, the typed SlashCommand, and the
+    CommandOutput, all sharing one timestamp. They group as a triple
+    (pair_first → pair_middle → pair_last) so the slash-command name stays
+    in the rendered title and no message is orphaned."""
 
-    def test_caveat_slash_output_orphans_the_output(
-        self, ctx: RenderingContext
-    ) -> None:
+    def test_caveat_slash_output_binds_as_triple(self, ctx: RenderingContext) -> None:
         caveat = _user_slash(ctx, "e1", text="Caveat: ...")
         slash = _slash(ctx, "e2", name="exit")
         output = _cmd_output(ctx, "e3", stdout="See ya!")
 
         _identify_message_pairs([caveat, slash, output])
 
-        # Slash-pair wins.
-        assert caveat.pair_last == slash.message_index
+        # Triple wiring: pair_first owns pair_middle and pair_last;
+        # the middle and last members back-reference pair_first.
+        assert caveat.pair_middle == slash.message_index
+        assert caveat.pair_last == output.message_index
         assert slash.pair_first == caveat.message_index
-        # Output is unpaired (orphan, by design — option A).
-        assert output.pair_first is None
-        assert output.pair_last is None
+        assert slash.pair_last == output.message_index
+        assert output.pair_first == caveat.message_index
+
+        # Role properties classify each member exclusively.
+        assert caveat.is_first_in_pair
+        assert not caveat.is_middle_in_pair
+        assert not caveat.is_last_in_pair
+        assert slash.is_middle_in_pair
+        assert not slash.is_first_in_pair
+        assert not slash.is_last_in_pair
+        assert output.is_last_in_pair
+        assert not output.is_first_in_pair
+        assert not output.is_middle_in_pair
+
+        # CSS roles emit the right class names for the HTML template.
+        assert caveat.pair_role == "pair_first"
+        assert slash.pair_role == "pair_middle"
+        assert output.pair_role == "pair_last"
 
     def test_slash_userslash_no_output_pairs_cleanly(
         self, ctx: RenderingContext
     ) -> None:
-        """`/init` — no command output — pairs without ambiguity."""
+        """`/init` — no command output — pairs as a 2-msg pair (not triple)."""
         slash = _slash(ctx, "f1", name="init")
         user_slash = _user_slash(ctx, "f2", text="Please analyze...")
 
@@ -164,3 +180,121 @@ class TestThreeMessageSequence:
 
         assert slash.pair_last == user_slash.message_index
         assert user_slash.pair_first == slash.message_index
+        # No middle in a 2-msg pair.
+        assert slash.pair_middle is None
+        assert user_slash.pair_middle is None
+        assert slash.is_first_in_pair
+        assert user_slash.is_last_in_pair
+
+
+# ----------------------------- end-to-end Markdown render --------------------
+
+
+class TestMarkdownRender:
+    """End-to-end Markdown coverage for the dominant `/cmd` triple shape.
+
+    Without the title-borrowing override and `pair_middle` body delegation,
+    Markdown would render as `## User (slash command)` with no `/exit`
+    visible and the trailing CommandOutput body dropped — both regressions
+    surfaced in monk's review of PR #127.
+    """
+
+    def _load_triple(
+        self, tmp_path, *, ts: str = "2026-04-17T01:13:55Z", cmd: str = "exit"
+    ):
+        """Write a 3-msg JSONL fixture and load it into TemplateMessages."""
+        import json
+        from claude_code_log.converter import load_transcript
+
+        lines = [
+            {
+                "type": "user",
+                "uuid": "u1",
+                "timestamp": ts,
+                "sessionId": "s1",
+                "version": "1",
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "user",
+                "cwd": "/x",
+                "isMeta": True,
+                "message": {"role": "user", "content": "Caveat: caveat text."},
+            },
+            {
+                "type": "user",
+                "uuid": "u2",
+                "timestamp": ts,
+                "sessionId": "s1",
+                "version": "1",
+                "parentUuid": "u1",
+                "isSidechain": False,
+                "userType": "user",
+                "cwd": "/x",
+                "message": {
+                    "role": "user",
+                    "content": (
+                        f"<command-name>{cmd}</command-name>"
+                        f"<command-message>{cmd}</command-message>"
+                        f"<command-args></command-args>"
+                    ),
+                },
+            },
+            {
+                "type": "user",
+                "uuid": "u3",
+                "timestamp": ts,
+                "sessionId": "s1",
+                "version": "1",
+                "parentUuid": "u2",
+                "isSidechain": False,
+                "userType": "user",
+                "cwd": "/x",
+                "message": {
+                    "role": "user",
+                    "content": "<local-command-stdout>See ya!</local-command-stdout>",
+                },
+            },
+        ]
+        fn = tmp_path / "t.jsonl"
+        fn.write_text("\n".join(json.dumps(line) for line in lines))
+        return load_transcript(fn)
+
+    def test_triple_renders_command_name_and_output(self, tmp_path) -> None:
+        from claude_code_log.markdown.renderer import MarkdownRenderer
+
+        msgs = self._load_triple(tmp_path, cmd="exit")
+        md = MarkdownRenderer().generate(msgs, "Test")
+
+        # Slash command title borrowed (would otherwise be "User (slash command)").
+        assert "🤷 Command `exit`" in md
+        assert "User (slash command)" not in md
+        # Caveat body kept (delegated from pair_first to itself).
+        assert "Caveat: caveat text." in md
+        # Output body kept (delegated from pair_first to pair_last — would
+        # otherwise be dropped by the orphan empty-title content-skip path).
+        assert "See ya!" in md
+
+    def test_triple_renders_with_pair_css_classes_in_html(self, tmp_path) -> None:
+        """HTML triple emits pair_first / pair_middle / pair_last in document order."""
+        import re
+        from claude_code_log.html.renderer import HtmlRenderer
+
+        msgs = self._load_triple(tmp_path, cmd="exit")
+        html = HtmlRenderer().generate(msgs, "Test")
+
+        # Extract the message-div opening classes in document order, scoped to
+        # the slash-command/command-output blocks.
+        classes = [
+            m.group(1)
+            for m in re.finditer(r"<div class='(message [^']+)'", html)
+            if "slash-command" in m.group(1) or "command-output" in m.group(1)
+        ]
+        assert len(classes) == 3, classes
+        assert "pair_first" in classes[0]
+        assert "pair_middle" in classes[1]
+        assert "pair_last" in classes[2]
+        # Triple still surfaces the three distinct messages — slash-command card
+        # carries the bare command name in its body code tag, command-output
+        # card carries its stdout. Both must remain visible after pairing.
+        assert "<code>exit</code>" in html
+        assert "See ya!" in html


### PR DESCRIPTION
Closes #126.

## Summary

A typed slash invocation (`Slash Command`) and the harness's expanded prompt or caveat preamble (`User (slash command)`) are one logical event and now render as a paired unit, like `tool_use` + `tool_result`.

Two patterns are detected:

- **2-msg pair** (`/init` flow): `Slash Command` then `User (slash command)` (expanded prompt). Order can also be reversed when the harness emits the caveat first.
- **3-msg triple** (the dominant `/cmd` shape: `/clear`, `/exit`, `/context`, `/todos`, `/doctor`, etc.): `User (slash command)` caveat → `Slash Command` → `Command Output`, all sharing one timestamp.

The triple support resurrects the half-removed `pair_middle` slot — `TemplateMessage.pair_middle`, an `is_middle_in_pair` property, a tightened `pair_role`, and a `_mark_triple` helper. `_identify_message_pairs` tries the triple before the 2-msg adjacent rules since the triple predicate is strictly more specific.

## Renderer-side changes

- **HTML**: zero-touch beyond emitting the `pair_middle` CSS class via `pair_role` — the styling rule was already in `message_styles.css` from a prior attempt. The triple renders as three visually-glued cards.
- **Markdown**: `_render_message` skips both `is_middle_in_pair` and `is_last_in_pair`; `pair_first` delegates body formatting to both partners. New `title_UserSlashCommandMessage` override borrows the `🤷 Command \`/cmd\`` title from the partner SlashCommand (mirrors the existing `title_ThinkingMessage` precedent of borrowing its partner's title). The triple renders as one heading + caveat blockquote + output body.

## Test plan

- [x] `uv run pytest -n auto test/test_slash_command_pairing.py` — 10 tests, all pass
  - Both 2-msg orderings pair (Slash → UserSlash and reverse)
  - Same-type pairs reject
  - Existing `slash → output` and `user_slash → output` rules still pair (when no triple precedes)
  - 3-msg `(UserSlash, Slash, CommandOutput)` binds as triple — role-property checks for first/middle/last
  - End-to-end Markdown render: command name appears in heading, caveat + output bodies preserved
  - End-to-end HTML render: triple emits `pair_first` / `pair_middle` / `pair_last` CSS classes in document order
- [x] `just ci` — full unit suite (1157 tests) + ruff + pyright + ty all clean

## Review note

Monk's review of the original PR caught a Markdown title-loss regression on the 3-msg `/exit`-style case. Rather than patching the title-only fix and accepting the orphan-output trade-off, this revision lifts the data model to support proper triples — both regressions resolved, dominant transcript shape rendered correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
