### PR TITLE
Robust within-session fork rendering: collapse parallel-tool_use forks, consistent labels

### DIFF
--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -165,12 +165,30 @@ def build_dag(
                 parent.children_uuids.append(node.uuid)
             else:
                 if node.parent_uuid not in _sidechain_uuids:
-                    logger.warning(
-                        "Orphan node %s: parentUuid %s not found in loaded"
-                        " data (promoting to root)",
-                        node.uuid,
-                        node.parent_uuid,
-                    )
+                    # Progress passthroughs are async hooks: their parent
+                    # tool_use is routinely lost to ``/compact`` (the
+                    # spawning turn is in the discarded pre-compaction
+                    # context). Log at debug — the multi-root warning
+                    # already classifies them as expected roots; per-node
+                    # warnings here would just multiply the noise on long
+                    # compacted sessions. See ``_is_expected_root_type``.
+                    if (
+                        isinstance(node.entry, PassthroughTranscriptEntry)
+                        and node.entry.type in _EXPECTED_ROOT_PASSTHROUGH_TYPES
+                    ):
+                        logger.debug(
+                            "Orphan progress hook %s: parentUuid %s not "
+                            "found in loaded data (promoting to root)",
+                            node.uuid,
+                            node.parent_uuid,
+                        )
+                    else:
+                        logger.warning(
+                            "Orphan node %s: parentUuid %s not found in "
+                            "loaded data (promoting to root)",
+                            node.uuid,
+                            node.parent_uuid,
+                        )
                 # Clear the dangling parent so this node becomes a root
                 # and can participate in DAG walks
                 node.parent_uuid = None
@@ -294,7 +312,6 @@ def _is_structural_subtree(
     uuid: str,
     session_uuids: set[str],
     nodes: dict[str, MessageNode],
-    max_depth: int = 20,
 ) -> bool:
     """Check if the subtree below `uuid` contains only structural entries.
 
@@ -308,21 +325,25 @@ def _is_structural_subtree(
     The root itself is not inspected — only its descendants — because this
     check is used to decide whether a child of a fork point represents
     continuing conversation.
+
+    Traversal is bounded by ``session_uuids`` and the ``seen`` set, so a
+    long passthrough chain still terminates without a depth cap. Earlier
+    versions clamped at depth=20 and returned False for deeper chains;
+    that misclassified pure-passthrough tails (e.g. >20 chained
+    ``progress`` callbacks under a parallel-tool_use anchor) as live and
+    suppressed the spurious-fork collapse.
     """
-    stack: list[tuple[str, int]] = [(c, 1) for c in nodes[uuid].children_uuids]
+    stack: list[str] = list(nodes[uuid].children_uuids)
     seen: set[str] = set()
     while stack:
-        current, depth = stack.pop()
+        current = stack.pop()
         if current in seen or current not in session_uuids:
             continue
         seen.add(current)
         entry = nodes[current].entry
         if isinstance(entry, (UserTranscriptEntry, AssistantTranscriptEntry)):
             return False  # Found conversational content
-        if depth >= max_depth:
-            return False  # Too deep to tell — be conservative
-        for c in nodes[current].children_uuids:
-            stack.append((c, depth + 1))
+        stack.extend(nodes[current].children_uuids)
     return True
 
 
@@ -332,11 +353,22 @@ def _is_structural_subtree(
 # noteworthy.
 _EXPECTED_ROOT_SYSTEM_SUBTYPES = frozenset({"compact_boundary", "local_command"})
 
+# Passthrough subtypes that legitimately appear as roots:
+#   - ``progress`` — hook callbacks (``SessionStart``, ``PostToolUse``,
+#     ``UserPromptSubmit``, …) are async by nature. The first hook of a
+#     session has no preceding turn (parentUuid:null naturally). Hooks
+#     still in flight when ``/compact`` fires lose their spawning
+#     tool_use to the discarded pre-compaction context, so ``build_dag``
+#     promotes them to root. Both shapes are routine, not noteworthy.
+_EXPECTED_ROOT_PASSTHROUGH_TYPES = frozenset({"progress"})
+
 
 def _is_expected_root_type(entry: TranscriptEntry) -> bool:
     """Whether a multi-root entry is one of Claude Code's expected patterns."""
     if isinstance(entry, SystemTranscriptEntry):
         return entry.subtype in _EXPECTED_ROOT_SYSTEM_SUBTYPES
+    if isinstance(entry, PassthroughTranscriptEntry):
+        return entry.type in _EXPECTED_ROOT_PASSTHROUGH_TYPES
     return False
 
 
@@ -530,24 +562,65 @@ def _walk_session_with_forks(
                         _collect_descendants(su, session_uuids, nodes, skipped)
                     chain.extend(stitched[:-1])
                     current = nodes[stitched[-1]]
+                    continue
+
+                # Parallel-tool_use chain via passthrough sibling.
+                # When the assistant emits multiple parallel tool_uses,
+                # Claude Code threads them through `progress` passthroughs:
+                # A(tool_use₁) has children U(tool_result₁) and a progress
+                # passthrough that chains to A(tool_use₂), etc. The
+                # passthrough subtree carries assistant continuation; the
+                # User(tool_result) subtree only has structural descendants
+                # (hook callbacks). The earlier structural-collapse path
+                # doesn't catch this because the live continuation IS the
+                # passthrough; _stitch_tool_results doesn't catch it
+                # because there's no assistant sibling at this level.
+                # Distinct from real rewinds, which never include
+                # passthrough children.
+                #
+                # Predicate breadth: the only ``PassthroughTranscriptEntry``
+                # type observed to coexist with a parallel-tool_use anchor
+                # is ``progress`` (async hook callbacks). The check below
+                # accepts *any* passthrough type with a live subtree to
+                # stay forward-compatible if Claude Code adds new
+                # passthrough shapes — but in practice ``progress`` is
+                # the only one that matters today, and a real rewind
+                # produces user/assistant siblings, never passthroughs.
+                passthrough_lives = [
+                    c
+                    for c in same_session_children
+                    if isinstance(nodes[c].entry, PassthroughTranscriptEntry)
+                    and not _is_structural_subtree(c, session_uuids, nodes)
+                ]
+                if len(passthrough_lives) == 1:
+                    live = passthrough_lives[0]
+                    others = [c for c in same_session_children if c != live]
+                    if others and all(
+                        _is_structural_subtree(o, session_uuids, nodes) for o in others
+                    ):
+                        for o in sorted(others, key=lambda c: nodes[c].timestamp):
+                            if is_branch:
+                                nodes[o].session_id = line_id
+                            _collect_descendants(o, session_uuids, nodes, skipped)
+                            chain.append(o)
+                        current = nodes[live]
+                        continue
+
+                unique_timestamps = {nodes[c].timestamp for c in same_session_children}
+                if len(unique_timestamps) == 1:
+                    # Same timestamp = compaction replay: follow only
+                    # the first child (original chain), skip replays
+                    # and all their descendants.
+                    current = nodes[same_session_children[0]]
+                    for sc in same_session_children[1:]:
+                        _collect_descendants(sc, session_uuids, nodes, skipped)
                 else:
-                    unique_timestamps = {
-                        nodes[c].timestamp for c in same_session_children
-                    }
-                    if len(unique_timestamps) == 1:
-                        # Same timestamp = compaction replay: follow only
-                        # the first child (original chain), skip replays
-                        # and all their descendants.
-                        current = nodes[same_session_children[0]]
-                        for sc in same_session_children[1:]:
-                            _collect_descendants(sc, session_uuids, nodes, skipped)
-                    else:
-                        # Different timestamps = real fork (rewind).
-                        # Stop chain here, push each child as a branch.
-                        for child_uuid in same_session_children:
-                            branch_id = f"{line_id}@{child_uuid[:12]}"
-                            queue.append((child_uuid, branch_id, line_id))
-                        current = None
+                    # Different timestamps = real fork (rewind).
+                    # Stop chain here, push each child as a branch.
+                    for child_uuid in same_session_children:
+                        branch_id = f"{line_id}@{child_uuid[:12]}"
+                        queue.append((child_uuid, branch_id, line_id))
+                    current = None
 
         if chain:
             first_ts = nodes[chain[0]].timestamp

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -1289,11 +1289,15 @@ class MarkdownRenderer(Renderer):
         lines = ["## Sessions", ""]
         for session in session_nav:
             session_id = session.get("id", "")
-            # Skip fork-point nav items: they navigate the index in HTML
-            # via ``msg-d-{N}`` anchors, but Markdown only has session-
-            # level ``<a id="…">`` anchors and fork points don't create
-            # one of their own.
-            if session.get("is_fork_point"):
+            # Skip fork-point and compact-point nav items: both navigate
+            # the index in HTML via ``msg-d-{N}`` anchors, but Markdown
+            # only has session-level ``<a id="…">`` anchors and neither
+            # creates one of their own. Compact items also carry an
+            # ``id`` shaped like ``compact-{message_index}`` whose
+            # ``[:8]`` slice (``"compact-"``) collapses to a single
+            # malformed ``session-compact-`` anchor key for every
+            # compact event in a long compacted session.
+            if session.get("is_fork_point") or session.get("is_compaction_point"):
                 continue
             anchor = _session_anchor(session_id)
             summary = session.get("summary")

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -81,6 +81,7 @@ from ..renderer import (
     Renderer,
     RenderingContext,
     TemplateMessage,
+    branch_short_uuid,
     generate_template_messages,
     prepare_projects_index,
     title_for_projects_index,
@@ -150,6 +151,31 @@ def _table_cell(value: Any) -> str:
     None is rendered as an empty cell.
     """
     return str(value or "").replace("\n", "<br>").replace("|", r"\|")
+
+
+def _session_anchor(session_or_id: "SessionHeaderMessage | str") -> str:
+    """Compose a unique Markdown anchor key for a session header.
+
+    Trunk session ids look like ``d602eb5f-...`` and we render them as
+    ``session-d602eb5f``. Branch session ids look like
+    ``d602eb5f-...@0e09007a-cd8`` (or deeper nestings with multiple
+    ``@`` segments). They all *start* with the trunk uuid, so the
+    naive ``session_id[:8]`` collides across every branch under the
+    same trunk and TOC links can only land on the first matching
+    heading.
+
+    Branches use ``branch-<uuid8>`` where ``<uuid8>`` is the first 8
+    chars of the deepest ``@`` segment (the branch root's UUID
+    prefix). Mirrors the visible ``Branch • <uuid8>`` label so a
+    reader can correlate the TOC entry with the inline header.
+
+    Accepts either a ``SessionHeaderMessage`` or a raw session id
+    string.
+    """
+    sid = session_or_id if isinstance(session_or_id, str) else session_or_id.session_id
+    if "@" in sid:
+        return f"branch-{branch_short_uuid(sid)}"
+    return f"session-{sid[:8]}"
 
 
 class _TagProtectingMarkdownRenderer(_MistuneMarkdownRenderer):
@@ -431,15 +457,43 @@ class MarkdownRenderer(Renderer):
     def format_SessionHeaderMessage(
         self, content: SessionHeaderMessage, _: TemplateMessage
     ) -> str:
-        """Format → '<a id="session-abc12345"></a>'."""
-        # Return just the anchor - it will be placed before the heading
-        session_short = content.session_id[:8]
-        return f'<a id="session-{session_short}"></a>'
+        """Format → '<a id="session-abc12345"></a>' (or '<a id="branch-…"></a>')."""
+        # Return just the anchor - it will be placed before the heading.
+        # Branches need a per-branch-unique key because every branch's
+        # session_id starts with the trunk's uuid, so ``session_id[:8]``
+        # collides across branches and the TOC could only land on the
+        # first matching heading.
+        return f'<a id="{_session_anchor(content)}"></a>'
 
     def title_SessionHeaderMessage(
         self, content: SessionHeaderMessage, _: TemplateMessage
     ) -> str:
-        """Title → '📋 Session `abc12345`: summary — Team: `t`'."""
+        """Title → '📋 Session `abc12345`: summary — Team: `t`' (or '🌿 Branch …').
+
+        Branch session headers surface the ``Branch • <uuid8> • <preview>``
+        shape that the renderer's ``_branch_label`` helper composes for
+        HTML output (stored on ``content.title``). Without this, a branch
+        would render as ``📋 Session `<trunk-uuid>`: <summary>``,
+        indistinguishable from the trunk session it forked from — the
+        synthetic branch session_id starts with the trunk's uuid and the
+        ``[:8]`` slice can't see past it.
+        """
+        if content.is_branch:
+            # ``_render_messages`` always composes ``content.title`` via
+            # ``_branch_label``, so the empty-title path is purely
+            # defensive — but if it ever fires we still need a
+            # branch-flavoured heading. Falling through to the trunk
+            # path below would surface ``📋 Session `<trunk-uuid>``` for
+            # a branch (the ``[:8]`` slice can't see past the shared
+            # trunk prefix), which is exactly the duplicate-anchor /
+            # confusable-heading shape we just fixed.
+            if content.title:
+                title = f"🌿 {content.title}"
+            else:
+                title = f"🌿 Branch • {branch_short_uuid(content.session_id)}"
+            if content.team_name:
+                title = f"{title} — Team: {_inline_code(content.team_name)}"
+            return title
         session_short = content.session_id[:8]
         if content.summary:
             title = f"📋 Session `{session_short}`: {content.summary}"
@@ -1235,15 +1289,35 @@ class MarkdownRenderer(Renderer):
         lines = ["## Sessions", ""]
         for session in session_nav:
             session_id = session.get("id", "")
-            session_short = session_id[:8]
-            anchor = f"session-{session_short}"
+            # Skip fork-point nav items: they navigate the index in HTML
+            # via ``msg-d-{N}`` anchors, but Markdown only has session-
+            # level ``<a id="…">`` anchors and fork points don't create
+            # one of their own.
+            if session.get("is_fork_point"):
+                continue
+            anchor = _session_anchor(session_id)
             summary = session.get("summary")
-            # Use summary if available, otherwise just the session ID
-            label = (
-                f"Session `{session_short}`: {summary}"
-                if summary
-                else f"Session `{session_short}`"
-            )
+            if session.get("is_branch"):
+                # Branches reuse the rich ``Branch • <uuid8> • <preview>``
+                # label that ``prepare_session_navigation`` already
+                # composed via ``_branch_label`` and stored on
+                # ``first_user_message`` — keeps the TOC entry aligned
+                # with the body branch header and the HTML index nav.
+                # Fallback (defensive — ``first_user_message`` is always
+                # populated for branches today) mirrors the
+                # ``_branch_label`` shape rather than diverging into a
+                # backtick-quoted variant.
+                label = session.get(
+                    "first_user_message",
+                    f"Branch • {branch_short_uuid(session_id)}",
+                )
+            else:
+                session_short = session_id[:8]
+                label = (
+                    f"Session `{session_short}`: {summary}"
+                    if summary
+                    else f"Session `{session_short}`"
+                )
             lines.append(f"- [{label}](#{anchor})")
         lines.append("")
         return "\n".join(lines)

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -766,6 +766,13 @@ class SessionHeaderMessage(MessageContent):
     is_branch: bool = False  # True for within-session fork branches
     original_session_id: Optional[str] = None  # Original session_id before fork split
     first_uuid: Optional[str] = None  # First UUID in this branch (for forward links)
+    # Branch preview text *before* it is composed into ``title`` by
+    # ``_branch_label``. Stored separately so downstream sites
+    # (fork-point box per-branch link, session/graph index nav) can
+    # recompose the label from ``(session_id, preview)`` rather than
+    # parsing the title string. Empty / None means "no preview" — the
+    # composed title is then ``Branch • <uuid8>`` only.
+    preview: Optional[str] = None
     # Teammates feature — set when the session was active in a team. Sourced
     # from the first non-None ``teamName`` of any entry in the session.
     team_name: Optional[str] = None

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -706,6 +706,17 @@ def generate_template_messages(
     with log_timing("Pair Skill tool_uses", t_start):
         _pair_skill_tool_uses(ctx)
 
+    # Branch headers were composed by ``_render_messages`` based on the
+    # branch's first message — but real branches sometimes start with an
+    # assistant entry (e.g. "No response requested." after a `/exit`),
+    # leaving the body header bare ``Branch • <uuid8>``. Walk the branch
+    # contents now that ``ctx.messages`` is final, lift the first
+    # UserTextMessage's text as the preview, and re-label the branch
+    # header. This keeps the body header, the session/graph index, and
+    # the fork-point box all carrying the same ``Branch • <uuid8> •
+    # <preview>`` string.
+    _enrich_branch_titles(ctx)
+
     # Populate junction forward links on fork-point messages
     if ctx.junction_targets:
         # Build UUID → TemplateMessage index for fast lookup
@@ -726,26 +737,40 @@ def generate_template_messages(
                 for branch_sid in branch_targets:
                     branch_idx = ctx.session_first_message.get(branch_sid)
                     if branch_idx is not None:
-                        # Get branch preview from the branch header title
-                        branch_preview = ""
+                        # Read the branch's preview directly from the
+                        # SessionHeaderMessage rather than parsing its
+                        # composed title — the body header, the index
+                        # nav and this fork-point box all read the same
+                        # raw ``preview`` field and re-compose via
+                        # ``_branch_label`` / ``_branch_label_suffix``
+                        # independently.
+                        preview_text = ""
                         branch_header = idx_to_msg.get(branch_idx)
                         if branch_header and isinstance(
                             branch_header.content, SessionHeaderMessage
                         ):
-                            # Extract preview from branch title (e.g. "Branch • preview...")
-                            title = branch_header.content.title
-                            if " • " in title:
-                                preview = title.split(" • ", 1)[1]
-                                # Distinguish real content from UUID fallback
-                                uuid_fragment = branch_sid.split("@")[-1][:8]
-                                if preview != uuid_fragment:
-                                    branch_preview = preview
+                            preview_text = branch_header.content.preview or ""
+                        # The fork-point template prepends
+                        # ``Branch &bull; ...`` itself, so we hand it
+                        # only the suffix — single source of truth for
+                        # the format keeps the index nav, the body
+                        # header and this link aligned even if the
+                        # ``Branch • `` head ever changes.
+                        link_suffix = _branch_label_suffix(branch_sid, preview_text)
                         fork_msg.junction_forward_links.append(
-                            (branch_sid, branch_idx, branch_preview)
+                            (branch_sid, branch_idx, link_suffix)
                         )
-                # Elide fork points without at least 2 non-empty branches
-                non_empty = sum(1 for _, _, p in fork_msg.junction_forward_links if p)
-                if non_empty < 2:
+                # A real fork has ≥ 2 navigable branches. Drop the
+                # indicator when the DAG-level layer left only a
+                # single-branch shell (e.g. a passthrough sibling whose
+                # first message was filtered out — the spurious
+                # parallel-tool_use forks are now collapsed at the DAG
+                # level, but defense-in-depth here covers any residual
+                # cases). When ≥ 2 branches remain, surface the
+                # indicator regardless of whether titles are
+                # human-readable previews or UUID-only fallbacks — the
+                # backlinks are useful navigation either way.
+                if len(fork_msg.junction_forward_links) < 2:
                     fork_msg.junction_forward_links.clear()
                     fork_msg.fork_point_preview = ""
 
@@ -934,6 +959,140 @@ def prepare_session_summaries(messages: list[TranscriptEntry]) -> dict[str, str]
     return session_summaries
 
 
+def _enrich_branch_titles(ctx: RenderingContext) -> None:
+    """Lift each branch's first UserTextMessage as the header preview.
+
+    ``_render_messages`` sets the branch header title from the branch's
+    very first transcript entry. That fails when a branch starts with an
+    assistant turn (a "No response requested." after ``/exit``) or with a
+    tool_result — the user content arrives later. This pass scans the
+    final ``ctx.messages`` list, picks the first ``UserTextMessage``
+    associated with each branch's render_session_id, and re-labels the
+    header (sets both ``content.preview`` and ``content.title``) only
+    when the original pass left no preview behind. We never overwrite a
+    real preview the original pass captured — including short
+    slash-command captures like ``"/exit"`` — because the scanned
+    UserTextMessage may be less informative even when longer.
+
+    Run after ``_pair_skill_tool_uses`` so the message set is stable
+    (skill-folded slash commands removed, indices re-mapped). Idempotent.
+    """
+    branch_headers: dict[str, "TemplateMessage"] = {}
+    for msg in ctx.messages:
+        if isinstance(msg.content, SessionHeaderMessage) and msg.content.is_branch:
+            branch_headers.setdefault(msg.content.session_id, msg)
+
+    if not branch_headers:
+        return
+
+    # First user-text per branch sid (preserves chronological order from ctx.messages).
+    first_user_text: dict[str, str] = {}
+    for msg in ctx.messages:
+        rsid = msg.render_session_id
+        if rsid not in branch_headers or rsid in first_user_text:
+            continue
+        if not isinstance(msg.content, UserTextMessage):
+            continue
+        # Skip sub-agent / sidechain user prompts. ``render_session_id``
+        # for an agent's wrapped messages can be set to the agent's
+        # parent_session_id (i.e. a branch sid), so without this guard
+        # an agent's first inner user prompt could be lifted as the
+        # branch's preview instead of the actual branch-local human
+        # turn. See ``_render_messages`` agent-parent handling.
+        if msg.is_sidechain:
+            continue
+        parts = [
+            item.text for item in msg.content.items if isinstance(item, TextContent)
+        ]
+        text = " ".join(p for p in parts if p).strip()
+        if text:
+            first_user_text[rsid] = create_session_preview(text)
+
+    for sid, header in branch_headers.items():
+        scanned = first_user_text.get(sid, "")
+        if not scanned:
+            continue
+        # Only widen when the existing preview is empty or is the
+        # bare UUID-only fallback (i.e. the original
+        # ``_render_messages`` pass found nothing useful — the branch
+        # started with an assistant or tool_result). A real preview
+        # already on the header — including short slash-command bodies
+        # like ``"/exit"`` (5 chars) — must not be replaced by a longer
+        # but less informative scan result. The earlier
+        # length-comparison heuristic conflated "longer" with "more
+        # informative" and lost slash-command captures in pathological
+        # cases.
+        content = header.content
+        assert isinstance(content, SessionHeaderMessage)  # branch_headers filter
+        if content.preview:
+            continue
+        content.preview = scanned
+        content.title = _branch_label(sid, scanned)
+
+
+def branch_short_uuid(branch_sid: str) -> str:
+    """Return the 8-char prefix of the branch root's UUID.
+
+    Branch session IDs follow the ``{trunk}@{first_uuid_prefix}`` shape; the
+    last segment after ``@`` is the branch root's UUID truncated to 12
+    chars by ``_walk_session_with_forks``. We surface its first 8 chars as
+    the stable identifier in branch labels.
+
+    Cross-module helper — the markdown renderer composes
+    ``branch-<uuid8>`` anchor keys and a defensive heading fallback off
+    the same rule, and centralising them here prevents drift if the
+    suffix length or splitting convention ever changes (e.g. if branch
+    sids ever switch separators).
+    """
+    return branch_sid.split("@")[-1][:8]
+
+
+def _branch_label_suffix(branch_sid: str, preview: str) -> str:
+    """The ``<uuid8>`` or ``<uuid8> • <preview>`` tail of a branch label.
+
+    Single source of truth for the format that follows the literal
+    ``"Branch "`` head in :func:`_branch_label`. The fork-point box's
+    template renders ``Branch &bull; {{ branch_preview }}`` on its own
+    side, so it needs only this suffix — composing the full
+    :func:`_branch_label` and slicing off ``"Branch • "`` would couple
+    the consumer to the head's exact literal, which makes future
+    tweaks (i18n, an icon, separator change) silently breaking.
+
+    Truncates ``preview`` to 80 chars plus a single ``…`` (U+2026)
+    when the source is longer.
+    """
+    short_uuid = branch_short_uuid(branch_sid)
+    if not preview:
+        return short_uuid
+    short = preview[:80]
+    if len(preview) > 80:
+        short += "…"
+    return f"{short_uuid} • {short}"
+
+
+def _branch_label(branch_sid: str, preview: str) -> str:
+    """Compose the consistent ``Branch • <uuid8> • <preview>`` label.
+
+    Used in three places that all need to agree:
+    - the body branch-header title (``SessionHeaderMessage.title``),
+    - the session/graph index nav (``first_user_message``),
+    - the fork-point box's per-branch link (the trailing-text portion,
+      via :func:`_branch_label_suffix`).
+
+    Always includes the 8-char UUID — both as a stable navigation handle
+    when the preview is missing or generic, and to disambiguate two
+    branches whose previews happen to start the same way (two `/exit`
+    branches, two slash-command branches with similar prefixes, …).
+
+    Truncates ``preview`` to 80 chars plus a single ``…`` (U+2026) when
+    the source is longer, keeping the body header on one line. The
+    single-character ellipsis matters: ``"..."`` (3 chars) would push
+    the truncated preview to 83 visible chars and contradict the
+    docstring's "80 + ellipsis" cap.
+    """
+    return f"Branch • {_branch_label_suffix(branch_sid, preview)}"
+
+
 def _fork_point_preview(fork_msg: "TemplateMessage", ctx: RenderingContext) -> str:
     """Get a meaningful preview for a fork point message.
 
@@ -1060,22 +1219,26 @@ def prepare_session_navigation(
 
     # Add branch pseudo-sessions from hierarchy
     if session_hierarchy:
-        # Collect first user message preview for each branch
+        # Lift each branch's raw ``preview`` directly off its
+        # SessionHeaderMessage. The body header path
+        # (``_render_messages``) already extracted text from the
+        # branch's first user entry — handling plain text, slash
+        # commands and other user shapes uniformly via
+        # ``extract_text_content`` — and stored the result; the
+        # ``_enrich_branch_titles`` post-pass widens it when the first
+        # entry was an assistant. We just read what's there.
         branch_previews: dict[str, str] = {}
         for msg in ctx.messages:
-            rsid = msg.render_session_id
-            if rsid in branch_previews or not isinstance(msg.content, UserTextMessage):
+            if not isinstance(msg.content, SessionHeaderMessage):
                 continue
-            hier = session_hierarchy.get(rsid, {})
-            if hier.get("is_branch"):
-                # Extract text from UserTextMessage items
-                preview_parts: list[str] = []
-                for item in msg.content.items:
-                    if isinstance(item, TextContent):
-                        preview_parts.append(item.text)
-                preview = " ".join(preview_parts).strip()
-                if preview:
-                    branch_previews[rsid] = create_session_preview(preview)
+            if not msg.content.is_branch:
+                continue
+            sid = msg.content.session_id
+            if sid in branch_previews:
+                continue
+            preview = msg.content.preview or ""
+            if preview:
+                branch_previews[sid] = preview
 
         # Group branches by their junction point (attachment_uuid)
         junction_branches: dict[str, list[dict[str, Any]]] = {}
@@ -1167,9 +1330,8 @@ def prepare_session_navigation(
                     "first_timestamp": "",
                     "last_timestamp": "",
                     "message_count": 0,
-                    "first_user_message": branch_previews.get(
-                        branch_sid,
-                        f"Branch {branch_sid.split('@')[-1][:8]}",
+                    "first_user_message": _branch_label(
+                        branch_sid, branch_previews.get(branch_sid, "")
                     ),
                     "token_summary": "",
                     "parent_session_id": parent_sid,
@@ -2536,6 +2698,43 @@ def _reindex_filtered_context(
         if (new_idx := index_remap.get(old_idx)) is not None
     }
 
+    # Branch / child session headers cache the fork-point's index in
+    # ``parent_message_index`` (set at register time, drives the
+    # "from ⑂ Fork point" backlink). The reindex must update those
+    # references too — otherwise the backlink jumps to whatever message
+    # ends up at the stale index after the reindex shift, which manifests
+    # as the "Branch • c36e76a6 from #msg-d-510" mismatch when
+    # ``_pair_skill_tool_uses`` drops slash-command bodies.
+    #
+    # Same fix applies to ``junction_forward_links`` cached on fork-point
+    # template messages — populated in ``generate_template_messages``
+    # *before* the optional detail-level filter calls _reindex again, so
+    # the second reindex must remap each tuple's ``branch_idx`` (or drop
+    # the tuple if its target was filtered out) to keep the fork-point
+    # box's per-branch links pointing at the right ``msg-d-{N}`` anchor.
+    for msg in filtered:
+        if isinstance(msg.content, SessionHeaderMessage):
+            old_parent_idx = msg.content.parent_message_index
+            if old_parent_idx is not None:
+                msg.content.parent_message_index = index_remap.get(old_parent_idx)
+        if msg.junction_forward_links:
+            remapped: list[tuple[str, Optional[int], str]] = []
+            for branch_sid, old_branch_idx, link_suffix in msg.junction_forward_links:
+                if old_branch_idx is None:
+                    remapped.append((branch_sid, None, link_suffix))
+                    continue
+                new_branch_idx = index_remap.get(old_branch_idx)
+                if new_branch_idx is None:
+                    # Target message filtered out — drop the link.
+                    continue
+                remapped.append((branch_sid, new_branch_idx, link_suffix))
+            msg.junction_forward_links = remapped
+            # If the fork now has fewer than 2 navigable branches, mirror
+            # the elision the population pass does and drop the indicator.
+            if len(msg.junction_forward_links) < 2:
+                msg.junction_forward_links = []
+                msg.fork_point_preview = ""
+
 
 def _filter_template_by_detail(
     messages: list[TemplateMessage],
@@ -2803,14 +3002,7 @@ def _render_messages(
                     branch_text = extract_text_content(user_entry.message.content)
                     if branch_text:
                         branch_preview = create_session_preview(branch_text)
-                # Truncate for header title (keep full preview for nav)
-                if branch_preview:
-                    short = branch_preview[:80]
-                    if len(branch_preview) > 80:
-                        short += "..."
-                    branch_title = f"Branch • {short}"
-                else:
-                    branch_title = f"Branch • {branch_sid.split('@')[-1][:8]}"
+                branch_title = _branch_label(branch_sid, branch_preview)
 
                 branch_header_meta = MessageMeta(
                     session_id=branch_sid,
@@ -2846,6 +3038,7 @@ def _render_messages(
                     original_session_id=original_sid,
                     first_uuid=message_uuid,
                     team_name=branch_team_name,
+                    preview=branch_preview or None,
                 )
                 branch_header = TemplateMessage(branch_header_content)
                 branch_header.render_session_id = branch_sid

--- a/dev-docs/dag.md
+++ b/dev-docs/dag.md
@@ -389,12 +389,56 @@ Today passthrough entries are always leaves, but if a future passthrough
 type ever carries conversational descendants, it will correctly fall
 through to the normal fork logic instead of masking the content.
 
+#### Variant 3 — Parallel-tool_use chain via passthrough
+
+Real Claude Code teammate transcripts (CC 2.1.32+) thread parallel
+tool_uses through `progress` passthroughs rather than as direct
+`tool_use` siblings. Each parallel turn produces a 2-child fork at the
+spawning assistant: the user(tool_result) for the first parallel call
+sits beside a passthrough that chains into the next assistant tool_use.
+The passthrough subtree carries the live continuation; the
+user(tool_result) carries only structural callbacks (a hook
+acknowledgement leaf), so it dead-ends.
+
+```mermaid
+graph TD
+    A1["A(tool_use₁)"] --> U1["U(tool_result₁)"]
+    A1 --> P1["🗿 progress (passthrough)"]
+    U1 --> H1["🗿 hook callback (leaf)"]
+    P1 --> A2["A(tool_use₂)"]
+    A2 --> U2["U(tool_result₂)"]
+    A2 --> P2["🗿 progress"]
+    P2 --> rest["..."]
+    classDef structural fill:#eef,stroke:#99c
+    class P1,H1,P2 structural
+```
+
+Detection in `_walk_session_with_forks`: exactly one passthrough child
+has a non-structural subtree (live continuation), and every other
+sibling has a structural subtree (no user/assistant descendants). The
+passthrough sibling becomes the chain continuation; the dead-end
+user/assistant siblings are appended to the chain inline and their
+descendants are collected into `skipped`.
+
+Variants 1 and 2 in `_stitch_tool_results` share the same
+"user-tool_result vs assistant-tool_use" framing and don't fire when
+the live continuation is a passthrough; the earlier
+structural-side-branch collapse (which only treats *passthrough* kids
+as structural) doesn't fire when the structural sibling is a
+user(tool_result). Variant 3 fills that gap. Distinct from real user
+rewinds, which never include passthrough children.
+
+The fix also relies on `_is_structural_subtree` being unbounded over
+the subtree (no depth cap): real `progress` chains under a
+parallel-tool_use anchor regularly run >20 entries deep.
+
 #### Summary of detection criteria
 
 | Pattern | Detection | Action |
 |---------|-----------|--------|
 | Variant 1 | `_is_structural_subtree(U)` true for every user child; exactly one assistant continuation | Splice user children ahead of assistant continuation |
 | Variant 2 | `_is_subtree_dead_end(A)` true for every assistant child; exactly one user continuation | Splice assistant children ahead of user continuation |
+| Variant 3 | Exactly one passthrough child with non-structural subtree; every other child has a structural subtree | Append dead-end siblings to chain; continue through the live passthrough |
 | Structural side-branch collapse | At least one structural passthrough child; ≤1 non-structural child | Collapse structural children into chain; continue via the single non-structural (or terminate) |
 | Real rewind | Multiple non-structural children at different timestamps | Real within-session fork → branch pseudo-sessions |
 | Compaction replay | Multiple children sharing the same timestamp | Follow first, skip rest (see next section) |
@@ -439,12 +483,37 @@ graph TB
    by `first_timestamp`.
 3. Classify roots to decide log level:
    - `_EXPECTED_ROOT_SYSTEM_SUBTYPES = {"compact_boundary", "local_command"}`
-   - If every non-primary root is an expected system subtype → `logger.debug`
+     covers system entries; `_EXPECTED_ROOT_PASSTHROUGH_TYPES = {"progress"}`
+     covers passthrough entries. See [Expected Root Types](#expected-root-types)
+     below for the full taxonomy.
+   - If every non-primary root is one of the expected types → `logger.debug`
    - Otherwise (orphan user/assistant hinting at a missing parent) →
      `logger.warning` with unexpected count
 
 This keeps the signal useful: orphan user/assistant entries still surface
-as warnings; routine `/compact` multi-root sessions stay quiet.
+as warnings; routine `/compact` multi-root sessions and async-hook
+remnants stay quiet.
+
+#### Expected Root Types
+
+Six known shapes legitimately appear as parentless (or orphan-promoted)
+roots within a session. Long-running sessions that span multiple
+`/compact` runs accumulate roots from several of these categories.
+
+| Shape | parentUuid in JSONL | Why it lands as a root |
+|---|---|---|
+| **The session's actual first `user` prompt** | `null` | It's the earliest message — no preceding turn exists. |
+| `SystemTranscriptEntry` `subtype="compact_boundary"` | `null` | Each `/compact` run writes a fresh boundary entry with no parent. The pre-compaction context is replaced by a summary. |
+| `SystemTranscriptEntry` `subtype="local_command"` | sometimes `null` | Early `/memory`, `/config` etc. occasionally land before any user prompt has been recorded. |
+| `PassthroughTranscriptEntry` `type="progress"` from a session-start hook (e.g. `SessionStart:clear`) | `null` | Hooks fire **before** the first user turn has a uuid to point at — so the very first entry of a session can be a session-start hook rather than the user prompt. |
+| `PassthroughTranscriptEntry` `type="progress"` from an in-flight tool hook (e.g. `PostToolUse:Read`) | promoted from missing parent | A hook still in flight when `/compact` fires loses its spawning `tool_use` to the discarded pre-compaction context. `build_dag` clears the dangling parent and promotes the entry to a root. Always temporally adjacent to a following `compact_boundary`. |
+| **Subagent root** (first entry of an agent transcript) | `null` (in the agent file), then back-patched | Subagent transcripts live in `<session>/subagents/agent-*.jsonl` with `parentUuid: null` on entry zero. `_integrate_agent_entries` re-points it at the spawning Task/Agent `tool_result` and assigns a synthetic sessionId `{trunk}#agent-{agentId}`, so by the time `extract_session_dag_lines` runs the subagent has a proper parent and a per-agent root in its own DAG-line — not in the trunk's root list. |
+
+The first five all sit in the trunk's session and feed into the
+`extract_session_dag_lines` multi-root warning logic. The subagent shape
+is structurally similar but resolved one layer earlier — the trunk
+never sees these as orphans because `_integrate_agent_entries` runs
+first; see [Agent Transcripts](#agent-transcripts).
 
 **Nav landmarks** (`prepare_session_navigation` in renderer.py): each
 `CompactedSummaryMessage` in a session becomes an `is_compaction_point`

--- a/test/test_dag.py
+++ b/test/test_dag.py
@@ -1441,6 +1441,60 @@ class TestRootClassification:
             f"Expected a multi-root warning; got: {[r.message for r in warnings]}"
         )
 
+    def test_progress_passthrough_roots_are_expected(self, caplog) -> None:
+        """`progress` passthrough roots — both the SessionStart shape
+        (parentUuid:null naturally) and the orphan-promoted shape (a
+        PostToolUse hook whose spawning tool_use was compacted away) —
+        must NOT trigger the multi-root warning. Both are routine
+        async-hook artifacts; treating them as expected matches the
+        reality on long-running real-world sessions."""
+        import logging
+
+        def _passthrough(uuid: str, parent: str | None, ts: str) -> dict:
+            return {
+                "type": "progress",
+                "timestamp": ts,
+                "parentUuid": parent,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "uuid": uuid,
+            }
+
+        data = [
+            # Root 1: SessionStart hook firing before any user turn
+            # (parentUuid:null naturally).
+            _passthrough("p_start", None, "2025-07-01T10:00:00.000Z"),
+            _make_entry("user", "u1", "p_start", "2025-07-01T10:00:01.000Z"),
+            _make_entry("assistant", "a1", "u1", "2025-07-01T10:01:00.000Z"),
+            # Compact in the middle.
+            _make_system_entry(
+                "cb",
+                None,
+                "2025-07-01T11:00:00.000Z",
+                subtype="compact_boundary",
+            ),
+            _make_entry("user", "u2", "cb", "2025-07-01T11:00:01.000Z"),
+            # Root 3: a PostToolUse-shaped passthrough whose parent
+            # uuid points outside the session (compacted-out tool_use).
+            _passthrough("p_orphan", "missing-parent", "2025-07-01T10:59:55.000Z"),
+        ]
+        entries = [create_transcript_entry(d) for d in data]
+        with caplog.at_level(logging.WARNING, logger="claude_code_log.dag"):
+            build_dag_from_entries(entries)
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        # The orphan-promotion warning (one per orphan, fires from
+        # `build_dag` for any missing parent) is fine — it's the
+        # multi-root "X roots found (Y unexpected)" warning that
+        # progress passthroughs must NOT trigger.
+        multi_root_warnings = [r for r in warnings if "roots found" in r.message]
+        assert not multi_root_warnings, (
+            f"Expected no multi-root warning for progress passthroughs; "
+            f"got: {[r.message for r in multi_root_warnings]}"
+        )
+
 
 class TestMixedStructuralCollapse:
     """A structural (passthrough) sibling of a conversational child should
@@ -1533,3 +1587,104 @@ class TestMixedStructuralCollapse:
 
         branches = [s for s in tree.sessions.values() if s.is_branch]
         assert len(branches) == 2
+
+
+class TestParallelToolUseViaPassthrough:
+    """Parallel-tool_use chains threaded through ``progress`` passthroughs.
+
+    Real Claude Code teammate transcripts emit each parallel tool_use under
+    its own assistant message, then chain them together via `progress`
+    passthrough callbacks rather than as direct siblings. The dead-end
+    user(tool_result) for the first parallel tool_use sits beside that
+    passthrough chain, producing a 2-child fork at every parallel turn:
+
+        A(tool_use₁)
+        ├── U(tool_result₁) → progress (structural, dead end)
+        └── progress → A(tool_use₂) → U(tool_result₂) → progress → A(tool_use₃) → ...
+
+    The passthrough subtree carries the live continuation; the
+    user(tool_result) carries only structural callbacks. Without the
+    Variant 3 stitch each turn becomes a spurious 2-branch fork.
+    """
+
+    def _passthrough(self, uuid: str, parent: str, ts: str) -> dict:
+        return {
+            "type": "progress",
+            "timestamp": ts,
+            "parentUuid": parent,
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/tmp",
+            "sessionId": "s1",
+            "version": "1.0.0",
+            "uuid": uuid,
+        }
+
+    def test_passthrough_with_live_subtree_collapses(self) -> None:
+        """user(tool_result) subtree is structural, passthrough chain is live."""
+        data = [
+            _make_entry("user", "u1", None, "2025-07-01T10:00:00.000Z"),
+            # Assistant emits two parallel tool_uses.
+            _make_entry("assistant", "a1", "u1", "2025-07-01T10:01:00.000Z"),
+            # First tool_result + its dead-end progress callback.
+            _make_entry("user", "tr1", "a1", "2025-07-01T10:01:02.000Z"),
+            self._passthrough("p_tr1", "tr1", "2025-07-01T10:01:02.500Z"),
+            # Live progress chain leading to the second parallel tool_use.
+            self._passthrough("p_chain", "a1", "2025-07-01T10:01:01.000Z"),
+            _make_entry("assistant", "a2", "p_chain", "2025-07-01T10:01:03.000Z"),
+            _make_entry("user", "tr2", "a2", "2025-07-01T10:01:04.000Z"),
+            _make_entry("assistant", "a3", "tr2", "2025-07-01T10:01:05.000Z"),
+        ]
+        entries = [create_transcript_entry(d) for d in data]
+        tree = build_dag_from_entries(entries)
+
+        # Spurious fork elided: trunk threads through the passthrough chain.
+        # tr1 is appended to the trunk as a dead-end side entry; its
+        # passthrough descendant is collected into ``skipped`` and absent.
+        uuids = tree.sessions["s1"].uuids
+        assert uuids == ["u1", "a1", "tr1", "p_chain", "a2", "tr2", "a3"]
+        branch_count = sum(1 for s in tree.sessions.values() if s.is_branch)
+        assert branch_count == 0
+
+    def test_deep_passthrough_chain_classified_structural(self) -> None:
+        """Exercises the depth-unboundedness invariant Variant 3 *depends
+        on*, not Variant 3 itself. Live continuation here flows through
+        the user child ``u2`` (the structural-side-branch collapse path —
+        Shape B in dev-docs/dag.md), with a >20-deep ``progress`` chain
+        as the structural sibling.
+
+        ``_is_structural_subtree`` no longer clamps at depth=20 — the
+        ``seen`` set + ``session_uuids`` filter still bound termination,
+        but the depth cap previously misclassified long passthrough
+        chains as live (returning ``False`` for "too deep to tell"),
+        which suppressed both this Shape B collapse and Variant 3.
+        Without the cap removal a parallel-tool_use anchor whose
+        passthrough sibling unfolds into >20 chained ``progress``
+        callbacks would falsely appear "live" — leaving a spurious
+        1-branch fork.
+        """
+        data = [
+            _make_entry("user", "u1", None, "2025-07-01T10:00:00.000Z"),
+            _make_entry("assistant", "a1", "u1", "2025-07-01T10:01:00.000Z"),
+            # Live continuation through the user child.
+            _make_entry("user", "u2", "a1", "2025-07-01T10:02:00.000Z"),
+        ]
+        # Sibling passthrough chain of 25 entries, all structural.
+        prev = "a1"
+        for i in range(25):
+            uuid = f"p{i:02d}"
+            data.append(
+                self._passthrough(uuid, prev, f"2025-07-01T10:01:{30 + i:02d}.000Z")
+            )
+            prev = uuid
+        entries = [create_transcript_entry(d) for d in data]
+        tree = build_dag_from_entries(entries)
+
+        # The deep passthrough chain is structural; the existing
+        # passthrough-collapse path absorbs p00 (and skips its descendants),
+        # the chain follows u2.
+        uuids = tree.sessions["s1"].uuids
+        assert "u1" in uuids and "a1" in uuids and "u2" in uuids
+        assert "p00" in uuids  # stitched in as the structural sibling
+        branch_count = sum(1 for s in tree.sessions.values() if s.is_branch)
+        assert branch_count == 0

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -561,6 +561,148 @@ class TestSkillPairing:
         assert output.content == "Some unrelated payload"
 
 
+class TestReindexBranchBackrefs:
+    """Index-remap regression: ``_reindex_filtered_context`` must update
+    every ``message_index`` reference, including ``parent_message_index``
+    cached on branch / child ``SessionHeaderMessage`` instances.
+
+    Background — ``_pair_skill_tool_uses`` drops slash-command bodies and
+    re-indexes ``ctx.messages``. Branch headers are created earlier, in
+    ``_render_messages``, and resolve the fork-point's ``message_index``
+    at register time. Without remapping the cached
+    ``parent_message_index``, the "from ⑂ Fork point" backlink in the
+    body header jumps to whatever message ends up at the *old* index
+    after the reindex shift — which surfaced as
+    ``Branch • c36e76a6 from #msg-d-510`` in real transcripts where the
+    fork point was actually d-496.
+    """
+
+    def test_parent_message_index_remapped(self) -> None:
+        from claude_code_log.models import (
+            MessageMeta,
+            SessionHeaderMessage,
+            UserSlashCommandMessage,
+        )
+        from claude_code_log.renderer import (
+            RenderingContext,
+            TemplateMessage,
+            _reindex_filtered_context,
+        )
+
+        ctx = RenderingContext()
+
+        def _register_user(uuid_: str, sid: str) -> TemplateMessage:
+            content = UserSlashCommandMessage(
+                MessageMeta(session_id=sid, timestamp="", uuid=uuid_),
+                text="x",
+            )
+            msg = TemplateMessage(content)
+            ctx.register(msg)
+            return msg
+
+        def _register_branch(
+            sid: str, parent_idx: int, attachment_uuid: str
+        ) -> TemplateMessage:
+            content = SessionHeaderMessage(
+                MessageMeta(session_id=sid, timestamp="", uuid=""),
+                title="Branch • test",
+                session_id=sid,
+                parent_session_id="root",
+                parent_message_index=parent_idx,
+                attachment_uuid=attachment_uuid,
+                is_branch=True,
+            )
+            msg = TemplateMessage(content)
+            ctx.register(msg)
+            return msg
+
+        # Build: 5 messages, then a branch header pointing back to
+        # message index 2 (the fork point).
+        m0 = _register_user("u0", "root")  # idx 0
+        m1 = _register_user("u1", "root")  # idx 1
+        fork = _register_user("u2", "root")  # idx 2 — the fork point
+        _register_user("u3", "root")  # idx 3 — to be dropped
+        _register_user("u4", "root")  # idx 4 — to be dropped
+        branch = _register_branch("root@b", parent_idx=2, attachment_uuid="u2")
+        # idx 5
+        assert branch.message_index is not None
+        ctx.session_first_message["root"] = 0
+        ctx.session_first_message["root@b"] = branch.message_index  # 5
+
+        # Drop indices 3 and 4 (mirrors what ``_pair_skill_tool_uses``
+        # does when it removes slash-command bodies + redundant
+        # tool_results), then reindex.
+        kept = [m0, m1, fork, branch]  # consumed1, consumed2 dropped
+        _reindex_filtered_context(ctx, kept)
+
+        # No-shift scenario: only indices 3 and 4 are dropped, so the
+        # fork point at index 2 stays at index 2 — the link integrity
+        # check verifies the remap *call* doesn't corrupt unshifted
+        # references. The shifting case (drop an earlier index, watch
+        # parent_message_index follow the shift) is covered by
+        # ``test_parent_message_index_remapped_when_fork_shifts`` below.
+        assert isinstance(branch.content, SessionHeaderMessage)
+        new_parent_idx = branch.content.parent_message_index
+        assert new_parent_idx is not None
+        assert ctx.messages[new_parent_idx].meta.uuid == "u2", (
+            f"Branch parent_message_index points at "
+            f"{ctx.messages[new_parent_idx].meta.uuid!r}, expected u2"
+        )
+
+    def test_parent_message_index_remapped_when_fork_shifts(self) -> None:
+        """Reindex shifts the fork-point's index when an earlier message
+        is dropped. The branch backlink must follow the shift."""
+        from claude_code_log.models import (
+            MessageMeta,
+            SessionHeaderMessage,
+            UserSlashCommandMessage,
+        )
+        from claude_code_log.renderer import (
+            RenderingContext,
+            TemplateMessage,
+            _reindex_filtered_context,
+        )
+
+        ctx = RenderingContext()
+
+        def _user(uuid_: str) -> TemplateMessage:
+            msg = TemplateMessage(
+                UserSlashCommandMessage(
+                    MessageMeta(session_id="root", timestamp="", uuid=uuid_),
+                    text="x",
+                )
+            )
+            ctx.register(msg)
+            return msg
+
+        m0 = _user("u0")  # idx 0
+        _user("u1")  # idx 1 — to be dropped
+        fork = _user("u2")  # idx 2
+        m3 = _user("u3")  # idx 3
+        branch_msg = TemplateMessage(
+            SessionHeaderMessage(
+                MessageMeta(session_id="root@b", timestamp="", uuid=""),
+                title="Branch",
+                session_id="root@b",
+                parent_session_id="root",
+                parent_message_index=2,  # points at fork
+                attachment_uuid="u2",
+                is_branch=True,
+            )
+        )
+        ctx.register(branch_msg)  # idx 4
+
+        # Drop m1; fork's new index becomes 1, branch becomes 3.
+        _reindex_filtered_context(ctx, [m0, fork, m3, branch_msg])
+
+        assert fork.message_index == 1
+        assert isinstance(branch_msg.content, SessionHeaderMessage)
+        assert branch_msg.content.parent_message_index == 1, (
+            "Branch parent_message_index should follow the fork point "
+            "to its new index after reindex"
+        )
+
+
 # -- Renderer output ---------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Long-running team-spawn / parallel-tool_use sessions surfaced a cascade
of within-session-fork rendering artifacts:

- Spurious `Fork point (1 branches)` ghost entries in the index, deeply
  nested in the parallel-tool_use case where every parallel turn became
  a 2-child DAG fork (one continuation through a `progress` passthrough,
  one dead-end `tool_result`).
- Branches labelled inconsistently across the session index, the body
  branch header, and the in-flow fork-point box — same fork shown three
  different ways (rich preview here, UUID-only there, "Branch <8 hex>"
  in the third spot).
- `from ⑂ Fork point` backlinks pointing at the wrong message after the
  Skill-pair reindex shifted indices: the cached `parent_message_index`
  on `SessionHeaderMessage` instances created earlier in
  `_render_messages` was never remapped, so the link jumped to whatever
  message ended up at the *old* index after the shift.
- Noisy `Session …: 15 roots found (7 unexpected)` warnings on
  every long compacted session, with 6 individual `Orphan node …`
  log lines per `/compact` boundary.

This PR addresses all four under one consistent framing.

## Two commits

1. **DAG: collapse parallel-tool_use forks via passthrough chain**
   - New Variant 3 in `_walk_session_with_forks`: at a fork where exactly
     one passthrough child has a live (non-structural) subtree and every
     other child is structural, follow the passthrough as the chain
     continuation and stitch the user/assistant siblings inline as
     dead-end side entries. Distinct from real user rewinds, which never
     include passthrough children.
   - Drop the `max_depth=20` clamp on `_is_structural_subtree` —
     `progress` passthrough chains under a parallel-tool_use anchor
     regularly exceed the limit, which was misclassifying them as live.
     The `seen` set + `session_uuids` filter still bound termination.
   - Classify `progress` passthroughs as expected roots
     (`_EXPECTED_ROOT_PASSTHROUGH_TYPES = {"progress"}`). Async hooks
     (`SessionStart:*`, `PostToolUse:*`) routinely fire as parentless
     roots — either as a session's first event before any user turn, or
     orphan-promoted when their spawning `tool_use` is in the discarded
     pre-compaction context. Per-orphan log demoted to DEBUG when the
     orphan is a progress passthrough; multi-root warning stays quiet.
   - `dev-docs/dag.md` gets a Variant 3 section (mermaid + detection
     criteria + summary-table row) and a new "Expected Root Types"
     subsection tabulating all six legitimate root shapes (compact
     boundary, local_command, two flavors of progress passthrough,
     session's actual first entry, subagent root).

2. **Renderer: consistent branch labels + fix stale fork-point backlinks**
   - `_reindex_filtered_context` now also remaps `parent_message_index`
     on every branch / child `SessionHeaderMessage`, not just
     `ctx.session_first_message`. Otherwise the `_pair_skill_tool_uses`
     reindex left every branch's "from ⑂ Fork point" link pointing at a
     stale index.
   - New helpers `_branch_short_uuid` and `_branch_label` are the single
     source of truth for the `Branch • <uuid8> • <preview>` (or
     `Branch • <uuid8>` when no preview) shape. Used by:
     - the body branch header title in `_render_messages`,
     - the index nav `first_user_message` in `prepare_session_navigation`,
     - the fork-point box per-branch link composition.
   - New `_enrich_branch_titles` post-pass scans the final `ctx` for
     each branch's first `UserTextMessage` when the branch's literal
     first transcript entry is an assistant (e.g. "No response
     requested." after `/exit`) or a tool_result — so the body header
     surfaces the same rich preview the index already had.
   - Fork-point indicator's "≥ 2 non-empty previews" elision relaxed to
     "≥ 2 navigable branches": the DAG-level Variant 3 already collapses
     spurious single-branch shells, so this layer surfaces the indicator
     reliably for every real fork.

## Test plan

- [x] New `TestParallelToolUseViaPassthrough` (basic shape + the >20-deep
      passthrough chain that exercises the depth-cap removal)
- [x] `TestRootClassification::test_progress_passthrough_roots_are_expected`
      covering both `parentUuid:null` and orphan-promoted shapes
- [x] `TestReindexBranchBackrefs` (`test_skill_pairing.py`) — two cases:
      unshifted (drop later messages) and shifted (drop an earlier
      message moves the fork-point's index, the backlink must follow)
- [x] `just ci` clean: 1206 tests, ruff, pyright, ty all green
- [x] Real-data verification on a 9-`/compact` 14k-node session with
      multiple parallel-tool_use turns: 5 fork points / 10 branches →
      2 fork points / 4 branches (the two remaining are real
      slash-command rewinds), and zero DAG warnings emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch-aware session anchors, richer branch headers, and TOC/navigation linking to correct branch headings; branch preview text preserved for labeling.

* **Bug Fixes**
  * Better structural-subtree detection to avoid spurious forks on long passthrough chains.
  * Expected passthrough roots (progress) no longer reported as unexpected.
  * Backlink/index remapping fixed when context is filtered.

* **Documentation**
  * Expanded stitching-heuristics and expected-root taxonomy.

* **Tests**
  * New regression and robustness tests covering these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->