### PR TITLE
Suppress noise in system-info messages (#129)

### DIFF
--- a/claude_code_log/factories/__init__.py
+++ b/claude_code_log/factories/__init__.py
@@ -28,6 +28,8 @@ from .user_factory import (
     create_slash_command_message,
     create_user_memory_message,
     create_user_message,
+    # Command-tag cleanup helper (used by system_factory, utils preview path)
+    simplify_command_tags,
     # Patterns and constants
     COMPACTED_SUMMARY_PREFIX,
     IDE_DIAGNOSTICS_PATTERN,
@@ -108,6 +110,8 @@ __all__ = [
     "create_slash_command_message",
     "create_user_memory_message",
     "create_user_message",
+    # Command-tag cleanup helper
+    "simplify_command_tags",
     # Patterns and constants
     "COMPACTED_SUMMARY_PREFIX",
     "IDE_DIAGNOSTICS_PATTERN",

--- a/claude_code_log/factories/system_factory.py
+++ b/claude_code_log/factories/system_factory.py
@@ -17,6 +17,7 @@ from ..models import (
     SystemTranscriptEntry,
 )
 from .meta_factory import create_meta
+from .user_factory import simplify_command_tags
 
 
 # =============================================================================
@@ -85,6 +86,29 @@ def create_system_message(
     meta = create_meta(transcript)
     level = transcript.level or "info"
 
+    # ``local_command`` system entries carry the harness's
+    # ``<command-name>X</command-name><command-message>X</command-message>
+    # <command-args>Y</command-args>`` triple (for typed slash commands)
+    # or a ``<local-command-stdout>X</local-command-stdout>`` payload
+    # (for dialog-dismissal hints like ``"Status dialog dismissed"``).
+    # Render those as ``"/X"`` / ``"X"`` rather than the raw XML —
+    # closes #129. Other subtypes (``compact_boundary``,
+    # ``stop_hook_summary``, …) carry plain text and pass through
+    # unchanged via the no-match fallback in ``simplify_command_tags``.
+    #
+    # The subtype gate is **intent-documenting, not safety-providing**:
+    # ``simplify_command_tags`` is opportunistic by design (returns its
+    # input unchanged when none of the patterns match), so applying it
+    # unconditionally would also be safe. The gate is here to make
+    # "we only expect this XML soup in ``local_command`` entries"
+    # explicit, and to keep the audit trail tight if the harness ever
+    # starts emitting command tags under a different subtype.
+    text = (
+        simplify_command_tags(transcript.content)
+        if transcript.subtype == "local_command"
+        else transcript.content
+    )
+
     # Surface compact-boundary metadata on the SystemMessage so the nav
     # label on the following CompactedSummaryMessage can read preTokens
     # and trigger without having to crawl back to the transcript entry.
@@ -103,7 +127,7 @@ def create_system_message(
 
     return SystemMessage(
         level=level,
-        text=transcript.content,
+        text=text,
         meta=meta,
         compact_pre_tokens=pre_tokens,
         compact_trigger=compact_trigger,

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -75,6 +75,57 @@ def is_bash_output(text_content: str) -> bool:
 
 
 # =============================================================================
+# Command-tag Cleanup
+# =============================================================================
+
+
+_COMMAND_NAME_RE = re.compile(r"<command-name>([^<]+)</command-name>")
+_COMMAND_ARGS_RE = re.compile(r"<command-args>([^<]*)</command-args>")
+_LOCAL_STDOUT_RE = re.compile(
+    r"<local-command-stdout>(.*?)</local-command-stdout>", re.DOTALL
+)
+_LOCAL_STDERR_RE = re.compile(
+    r"<local-command-stderr>(.*?)</local-command-stderr>", re.DOTALL
+)
+
+
+def simplify_command_tags(text: str) -> str:
+    """Strip Claude Code's command-tag XML soup down to its semantic core.
+
+    Three shapes covered:
+
+    - ``<command-name>/X</command-name><command-message>X</command-message><command-args>Y</command-args>``
+      → ``"/X"`` (or ``"/X Y"`` when args are non-empty). The
+      ``<command-message>`` field is always a redundant restatement of
+      the name without the leading ``/``, never carrying information.
+    - ``<local-command-stdout>X</local-command-stdout>`` → ``"X"`` —
+      the harness's user-facing hint for dialog-style commands
+      (``"Status dialog dismissed"``, ``"Skills dialog dismissed"``,
+      …).
+    - ``<local-command-stderr>X</local-command-stderr>`` → ``"X"``
+      (paired stderr equivalent).
+
+    Returns the text unchanged when none of the patterns match — keeps
+    the helper safe to apply opportunistically as part of a preview
+    pipeline (slash-command branch headers, system-info messages, …)
+    that also receives non-command text.
+    """
+    name_match = _COMMAND_NAME_RE.search(text)
+    if name_match:
+        cmd = name_match.group(1).strip()
+        args_match = _COMMAND_ARGS_RE.search(text)
+        args = args_match.group(1).strip() if args_match else ""
+        return f"{cmd} {args}".strip() if args else cmd
+
+    for regex in (_LOCAL_STDOUT_RE, _LOCAL_STDERR_RE):
+        match = regex.search(text)
+        if match:
+            return match.group(1).strip()
+
+    return text
+
+
+# =============================================================================
 # Slash Command Creation
 # =============================================================================
 

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -80,13 +80,32 @@ def is_bash_output(text_content: str) -> bool:
 
 
 _COMMAND_NAME_RE = re.compile(r"<command-name>([^<]+)</command-name>")
-_COMMAND_ARGS_RE = re.compile(r"<command-args>([^<]*)</command-args>")
+# DOTALL + non-greedy: the harness writes free-form text into
+# ``<command-args>`` and free-form text legitimately contains ``<``
+# (e.g. ``/explain <Component>``). The earlier ``[^<]*`` form silently
+# dropped such args because the closing ``</command-args>`` couldn't
+# match. ``(.*?)`` is robust to ``<`` in payload; the closing tag
+# anchors termination. ``</command-args>`` literal in args remains
+# theoretically unsafe but isn't an emission shape the harness produces.
+_COMMAND_ARGS_RE = re.compile(r"<command-args>(.*?)</command-args>", re.DOTALL)
 _LOCAL_STDOUT_RE = re.compile(
     r"<local-command-stdout>(.*?)</local-command-stdout>", re.DOTALL
 )
 _LOCAL_STDERR_RE = re.compile(
     r"<local-command-stderr>(.*?)</local-command-stderr>", re.DOTALL
 )
+
+
+def _normalize_slash(cmd: str) -> str:
+    """Prefix ``/`` to a command name that doesn't already carry one.
+
+    Modern harness emissions (2025+) write ``<command-name>/exit</command-name>``
+    with the leading slash; legacy / synthetic fixtures occasionally
+    write the bare form (``<command-name>init</command-name>``). Display
+    paths and structured content models want a single shape so mixed
+    transcripts don't render ``/exit`` next to ``test-command``.
+    """
+    return cmd if cmd.startswith("/") else f"/{cmd}"
 
 
 def simplify_command_tags(text: str) -> str:
@@ -98,6 +117,9 @@ def simplify_command_tags(text: str) -> str:
       → ``"/X"`` (or ``"/X Y"`` when args are non-empty). The
       ``<command-message>`` field is always a redundant restatement of
       the name without the leading ``/``, never carrying information.
+      Bare ``<command-name>X</command-name>`` (legacy emission) is
+      normalised to ``"/X"`` for display consistency with modern
+      ``/X``-prefixed emissions.
     - ``<local-command-stdout>X</local-command-stdout>`` → ``"X"`` —
       the harness's user-facing hint for dialog-style commands
       (``"Status dialog dismissed"``, ``"Skills dialog dismissed"``,
@@ -112,7 +134,7 @@ def simplify_command_tags(text: str) -> str:
     """
     name_match = _COMMAND_NAME_RE.search(text)
     if name_match:
-        cmd = name_match.group(1).strip()
+        cmd = _normalize_slash(name_match.group(1).strip())
         args_match = _COMMAND_ARGS_RE.search(text)
         args = args_match.group(1).strip() if args_match else ""
         return f"{cmd} {args}".strip() if args else cmd
@@ -136,6 +158,13 @@ def create_slash_command_message(
 ) -> Optional[SlashCommandMessage]:
     """Create SlashCommandMessage from text containing command tags.
 
+    ``command_name`` is normalised to ``/cmd`` shape — the modern
+    harness emits the leading slash, but legacy ``<command-name>init``
+    fixtures don't, and the typed content model is consumed by display
+    paths that expect a single shape (HTML/Markdown title formatters,
+    JSON output). ``command_args`` is captured verbatim including any
+    ``<`` characters in the payload (see ``_COMMAND_ARGS_RE``).
+
     Args:
         text: Raw text that may contain command-name, command-args, command-contents tags
         meta: Message metadata
@@ -143,13 +172,13 @@ def create_slash_command_message(
     Returns:
         SlashCommandMessage if tags found, None otherwise
     """
-    command_name_match = re.search(r"<command-name>([^<]+)</command-name>", text)
+    command_name_match = _COMMAND_NAME_RE.search(text)
     if not command_name_match:
         return None
 
-    command_name = command_name_match.group(1).strip()
+    command_name = _normalize_slash(command_name_match.group(1).strip())
 
-    command_args_match = re.search(r"<command-args>([^<]*)</command-args>", text)
+    command_args_match = _COMMAND_ARGS_RE.search(text)
     command_args = command_args_match.group(1).strip() if command_args_match else ""
 
     # Parse command contents, handling JSON format

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -569,7 +569,12 @@ class MarkdownRenderer(Renderer):
         parts: list[str] = []
         # Command name is in the title, only include args and contents here
         if content.command_args:
-            parts.append(f"**Args:** `{content.command_args}`")
+            # Use the adaptive inline-code helper: ``command_args`` is
+            # free-form user input that legitimately contains backticks
+            # (``run `date` && ...``). A naïve single-tick span would
+            # close at the first inner tick and emit a mix of plain text
+            # and unmatched ticks downstream.
+            parts.append(f"**Args:** {_inline_code(content.command_args)}")
         if content.command_contents:
             parts.append(self._code_fence(content.command_contents))
         return "\n\n".join(parts)
@@ -578,8 +583,11 @@ class MarkdownRenderer(Renderer):
         self, content: SlashCommandMessage, _message: TemplateMessage
     ) -> str:
         """Title → '🤷 Command `/cmd`'."""
-        # command_name already includes the leading slash
-        return f"🤷 Command `{content.command_name}`"
+        # command_name already includes the leading slash; harness emits
+        # short identifiers (no backticks) but use the adaptive helper
+        # for symmetry with the args site and to stay safe if the
+        # emission shape ever drifts.
+        return f"🤷 Command {_inline_code(content.command_name)}"
 
     def title_UserSlashCommandMessage(
         self, _content: UserSlashCommandMessage, _: TemplateMessage
@@ -597,7 +605,7 @@ class MarkdownRenderer(Renderer):
                 if (partner := self._ctx.get(partner_idx)) and isinstance(
                     partner.content, SlashCommandMessage
                 ):
-                    return f"🤷 Command `{partner.content.command_name}`"
+                    return f"🤷 Command {_inline_code(partner.content.command_name)}"
         # Fallback to base behaviour ("User (slash command)").
         return super().title_UserSlashCommandMessage(_content, _)
 

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -20,6 +20,7 @@ from .factories import (
     is_command_message,
     is_local_command_output,
     is_system_message,
+    simplify_command_tags,
 )
 
 
@@ -168,17 +169,6 @@ def should_skip_message(text_content: str) -> bool:
     return is_system and not is_command and not is_output
 
 
-def extract_init_command_description(text_content: str) -> str:
-    """
-    Extract a meaningful description from init command content.
-
-    Returns a user-friendly description for init commands instead of raw XML.
-    """
-    if "<command-name>init" in text_content and "<command-contents>" in text_content:
-        return "Claude Initializes Codebase Documentation Guide (/init command)"
-    return text_content
-
-
 def should_use_as_session_starter(text_content: str) -> bool:
     """
     Determine if a user message should be used as a session starter preview.
@@ -213,11 +203,22 @@ def create_session_preview(text_content: str) -> str:
 
     Returns:
         A preview string, truncated to FIRST_USER_MESSAGE_PREVIEW_LENGTH with
-        ellipsis if needed, with init commands converted to friendly descriptions,
-        and IDE tags replaced with compact emoji indicators.
+        ellipsis if needed, with command-tag XML stripped to its semantic
+        core (``/X``-style slash commands and ``<local-command-stdout>``
+        dialog hints), and IDE tags replaced with compact emoji
+        indicators.
+
+    The ``simplify_command_tags`` cleanup serves two distinct callers
+    that ended up wanting the same shape: branch headers (whose first
+    user entry is often a ``/exit`` slash command, formerly displayed
+    as the raw ``<command-name>/exit</command-name>...`` soup) and the
+    occasional session preview that does start with a slash command
+    (``init`` historically had a hardcoded English description here;
+    ``simplify_command_tags`` collapses it to ``/init`` instead, more
+    accurate and consistent with every other slash command). #129.
     """
-    # Apply init command transformation first
-    preview_content = extract_init_command_description(text_content)
+    # Strip command-tag XML soup down to ``/cmd`` or inner-text shape.
+    preview_content = simplify_command_tags(text_content)
 
     # Apply compact IDE tag indicators BEFORE truncation
     preview_content = _compact_ide_tags_for_preview(preview_content)

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -214,8 +214,9 @@ def create_session_preview(text_content: str) -> str:
     as the raw ``<command-name>/exit</command-name>...`` soup) and the
     occasional session preview that does start with a slash command
     (``init`` historically had a hardcoded English description here;
-    ``simplify_command_tags`` collapses it to ``/init`` instead, more
-    accurate and consistent with every other slash command). #129.
+    ``simplify_command_tags`` collapses it to ``/init`` instead — bare
+    legacy emissions are normalised to the ``/cmd`` shape so previews
+    stay consistent in mixed transcripts). #129.
     """
     # Strip command-tag XML soup down to ``/cmd`` or inner-text shape.
     preview_content = simplify_command_tags(text_content)

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -29246,7 +29246,7 @@
               </div>
           </div>
           <div class='debug-info'>edge_007</div>
-          <div class='content'><code>test-command</code><br><strong>Args:</strong> --verbose --output /tmp/test.log<br><strong>Content:</strong><pre>This is the actual command content with some JSON structure and escaped characters: &quot;quotes&quot; and 
+          <div class='content'><code>/test-command</code><br><strong>Args:</strong> --verbose --output /tmp/test.log<br><strong>Content:</strong><pre>This is the actual command content with some JSON structure and escaped characters: &quot;quotes&quot; and 
   line breaks
   </pre></div>
           

--- a/test/__snapshots__/test_snapshot_markdown.ambr
+++ b/test/__snapshots__/test_snapshot_markdown.ambr
@@ -434,7 +434,7 @@
   Error: Tool execution failed with error: Command not found
   ```
   
-  ## 🤷 Command `test-command`
+  ## 🤷 Command `/test-command`
   
   **Args:** `--verbose --output /tmp/test.log`
   

--- a/test/test_command_handling.py
+++ b/test/test_command_handling.py
@@ -58,7 +58,12 @@ def test_slash_command_handling():
         else:
             # For short content, should have pre tag with the escaped content
             assert "<pre>" in html, "Should contain pre tag for short content"
-        assert "<code>init</code>" in html, "Should show command name"
+        # Bare ``<command-name>init</command-name>`` (legacy harness emission)
+        # is normalised to ``/init`` by ``create_slash_command_message`` so
+        # display is consistent with modern ``/init``-prefixed emissions.
+        assert "<code>/init</code>" in html, (
+            "Should show normalised command name (/init)"
+        )
         # Check for user slash-command CSS class (not "system")
         # These are user messages with command tags, not system messages
         assert "class='message user slash-command" in html, (

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -301,3 +301,59 @@ class TestMarkdownRender:
         # Both must remain visible after pairing.
         assert "<code>/exit</code>" in html
         assert "See ya!" in html
+
+    def test_args_with_backticks_render_with_widened_fence(self, tmp_path) -> None:
+        """``command_args`` containing backticks must not break the inline span.
+
+        Reachability note: the ``_COMMAND_ARGS_RE`` tightening to ``(.*?)``
+        in this PR widened the class of args that survive parsing — args
+        containing ``<`` (which strongly correlates with shell-ish
+        payloads carrying backticks) used to be silently dropped, now
+        round-trip. The Markdown formatter wraps ``command_args`` in an
+        inline code span; with a single-tick fence, an inner backtick
+        would terminate the span at the first match and the rest of the
+        args would render as a mix of plain text and unmatched ticks.
+        ``_inline_code`` widens the fence past the longest backtick run.
+        """
+        import json
+        from claude_code_log.converter import load_transcript
+        from claude_code_log.markdown.renderer import MarkdownRenderer
+
+        args_payload = "echo `date` && diff a > b"
+        line = {
+            "type": "user",
+            "uuid": "u1",
+            "timestamp": "2026-04-17T01:13:55Z",
+            "sessionId": "s1",
+            "version": "1",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "user",
+            "cwd": "/x",
+            "message": {
+                "role": "user",
+                "content": (
+                    "<command-name>/run</command-name>"
+                    "<command-message>run</command-message>"
+                    f"<command-args>{args_payload}</command-args>"
+                ),
+            },
+        }
+        fn = tmp_path / "t.jsonl"
+        fn.write_text(json.dumps(line))
+        msgs = load_transcript(fn)
+        md = MarkdownRenderer().generate(msgs, "Test")
+
+        # The args payload must appear verbatim somewhere in the output.
+        assert args_payload in md
+        # The whole payload must sit inside one inline-code span — i.e.
+        # delimited by the same fence on both sides. With the widened
+        # fence (``` outside, single ` inside), the line should contain
+        # ``**Args:** ``echo `date` && diff a > b``\n``-style output.
+        # Locate the substring and verify the surrounding fence pair.
+        assert "**Args:** ``" in md, f"Expected widened fence, got: {md!r}"
+        # Sanity: the payload wasn't fragmented across multiple ticks
+        # (which a single-tick span would have produced).
+        assert f"``{args_payload}``" in md, (
+            f"Expected widened fence to wrap args verbatim, got: {md!r}"
+        )

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -262,11 +262,13 @@ class TestMarkdownRender:
     def test_triple_renders_command_name_and_output(self, tmp_path) -> None:
         from claude_code_log.markdown.renderer import MarkdownRenderer
 
+        # Bare ``exit`` exercises the legacy-emission normalisation path —
+        # the rendered command name carries the unified ``/exit`` shape.
         msgs = self._load_triple(tmp_path, cmd="exit")
         md = MarkdownRenderer().generate(msgs, "Test")
 
         # Slash command title borrowed (would otherwise be "User (slash command)").
-        assert "🤷 Command `exit`" in md
+        assert "🤷 Command `/exit`" in md
         assert "User (slash command)" not in md
         # Caveat body kept (delegated from pair_first to itself).
         assert "Caveat: caveat text." in md
@@ -294,7 +296,8 @@ class TestMarkdownRender:
         assert "pair_middle" in classes[1]
         assert "pair_last" in classes[2]
         # Triple still surfaces the three distinct messages — slash-command card
-        # carries the bare command name in its body code tag, command-output
-        # card carries its stdout. Both must remain visible after pairing.
-        assert "<code>exit</code>" in html
+        # carries the normalised command name in its body code tag (bare
+        # ``exit`` → ``/exit``), command-output card carries its stdout.
+        # Both must remain visible after pairing.
+        assert "<code>/exit</code>" in html
         assert "See ya!" in html

--- a/test/test_template_utils.py
+++ b/test/test_template_utils.py
@@ -103,24 +103,32 @@ class TestCommandExtraction:
     """Test command information extraction from system messages."""
 
     def test_create_slash_command_message_complete(self):
-        """Test parsing complete slash command information."""
+        """Test parsing complete slash command information.
+
+        Bare ``test-cmd`` in the input asserts the legacy-emission
+        normalisation path: the typed model carries the unified
+        ``/cmd`` shape.
+        """
         text = '<command-message>Testing...</command-message>\n<command-name>test-cmd</command-name>\n<command-args>--verbose</command-args>\n<command-contents>{"type": "text", "text": "Test content"}</command-contents>'
 
         result = create_slash_command_message(MessageMeta.empty(), text)
 
         assert result is not None
-        assert result.command_name == "test-cmd"
+        assert result.command_name == "/test-cmd"
         assert result.command_args == "--verbose"
         assert result.command_contents == "Test content"
 
     def test_create_slash_command_message_missing_parts(self):
-        """Test parsing slash command with missing parts."""
+        """Test parsing slash command with missing parts.
+
+        Bare ``minimal-cmd`` is normalised to ``/minimal-cmd``.
+        """
         text = "<command-name>minimal-cmd</command-name>"
 
         result = create_slash_command_message(MessageMeta.empty(), text)
 
         assert result is not None
-        assert result.command_name == "minimal-cmd"
+        assert result.command_name == "/minimal-cmd"
         assert result.command_args == ""
         assert result.command_contents == ""
 
@@ -139,7 +147,7 @@ class TestCommandExtraction:
         result = create_slash_command_message(MessageMeta.empty(), text)
 
         assert result is not None
-        assert result.command_name == "bad-json"
+        assert result.command_name == "/bad-json"
         assert (
             result.command_contents == '{"invalid": json'
         )  # Raw text when JSON parsing fails

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -602,6 +602,195 @@ class TestCreateSessionPreview:
         assert "✂️" in preview
         assert "Please review this code for bugs" in preview
 
+    def test_create_session_preview_strips_slash_command_xml(self):
+        """A user-typed slash command at branch-root or session-start should
+        surface as ``/cmd`` rather than the raw ``<command-name>...`` soup.
+
+        Closes #129 — and feeds branch headers (which display
+        ``Branch • <uuid8> • <preview>``) the cleaned form so
+        ``Branch • 8d0ae973 • <command-name>/exit</command-name>...``
+        becomes ``Branch • 8d0ae973 • /exit``.
+        """
+        text = (
+            "<command-name>/exit</command-name>\n"
+            "            <command-message>exit</command-message>\n"
+            "            <command-args></command-args>"
+        )
+        preview = create_session_preview(text)
+        assert preview == "/exit"
+
+    def test_create_session_preview_strips_slash_command_with_args(self):
+        text = (
+            "<command-name>/clmail:list</command-name>"
+            "<command-message>clmail:list</command-message>"
+            "<command-args>/quit</command-args>"
+        )
+        preview = create_session_preview(text)
+        assert preview == "/clmail:list /quit"
+
+    def test_create_session_preview_strips_local_command_stdout(self):
+        """Dialog-dismissal hints render their inner text, not the wrapping tag."""
+        text = "<local-command-stdout>Status dialog dismissed</local-command-stdout>"
+        preview = create_session_preview(text)
+        assert preview == "Status dialog dismissed"
+
+    def test_create_session_preview_init_command_yields_slash_init(self):
+        """Replaces the previous hardcoded English description for ``/init``.
+
+        The old ``extract_init_command_description`` had a special-case
+        string ``"Claude Initializes Codebase Documentation Guide
+        (/init command)"`` that nothing tested or asserted on. The
+        general ``simplify_command_tags`` cleanup now collapses it to
+        the same ``/init`` shape every other slash command gets —
+        consistent and shorter.
+        """
+        text = (
+            "<command-name>init</command-name>"
+            "<command-message>init</command-message>"
+            "<command-args></command-args>"
+            '<command-contents>{"text": "some init prompt"}</command-contents>'
+        )
+        preview = create_session_preview(text)
+        assert preview == "init"
+
+
+class TestSimplifyCommandTags:
+    """Direct unit tests for ``simplify_command_tags``.
+
+    The helper is shared between the SystemMessage factory (turning
+    ``local_command`` system entries into ``ℹ️ /status`` rather than
+    raw XML soup — closes #129) and the branch-preview path through
+    ``create_session_preview`` (so a slash-command branch root surfaces
+    as ``Branch • <uuid8> • /exit`` instead of the
+    ``<command-name>...`` blob).
+    """
+
+    def test_slash_command_no_args(self):
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/status</command-name>"
+            "<command-message>status</command-message>"
+            "<command-args></command-args>"
+        )
+        assert simplify_command_tags(text) == "/status"
+
+    def test_slash_command_with_args(self):
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/clmail:list</command-name>"
+            "<command-message>clmail:list</command-message>"
+            "<command-args>/quit</command-args>"
+        )
+        assert simplify_command_tags(text) == "/clmail:list /quit"
+
+    def test_local_command_stdout(self):
+        from claude_code_log.factories import simplify_command_tags
+
+        text = "<local-command-stdout>Status dialog dismissed</local-command-stdout>"
+        assert simplify_command_tags(text) == "Status dialog dismissed"
+
+    def test_local_command_stderr(self):
+        from claude_code_log.factories import simplify_command_tags
+
+        text = "<local-command-stderr>Error: bad arg</local-command-stderr>"
+        assert simplify_command_tags(text) == "Error: bad arg"
+
+    def test_passthrough_when_no_tags(self):
+        """No-match path — caller must be safe to invoke opportunistically."""
+        from claude_code_log.factories import simplify_command_tags
+
+        assert simplify_command_tags("plain text") == "plain text"
+        assert simplify_command_tags("") == ""
+
+    def test_command_name_wins_over_stdout(self):
+        """When both shapes appear (theoretical), the typed-command form
+        is the more specific signal — surface that and let the
+        ``<local-command-stdout>`` payload be the renderer's concern.
+        """
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/status</command-name>"
+            "<command-message>status</command-message>"
+            "<command-args></command-args>"
+            "<local-command-stdout>Status dialog dismissed</local-command-stdout>"
+        )
+        assert simplify_command_tags(text) == "/status"
+
+
+class TestSystemMessageLocalCommandCleanup:
+    """SystemMessage ``text`` for ``subtype="local_command"`` must come
+    out as the cleaned ``/cmd`` / inner-text shape, not the raw XML
+    blob the harness writes to the JSONL — closes #129. Other system
+    subtypes (``compact_boundary`` etc.) pass through unchanged.
+    """
+
+    def _make_system(
+        self,
+        content: str,
+        *,
+        subtype: str = "local_command",
+        level: str = "info",
+    ):
+        from claude_code_log.factories import create_transcript_entry
+
+        return create_transcript_entry(
+            {
+                "type": "system",
+                "subtype": subtype,
+                "level": level,
+                "content": content,
+                "timestamp": "2026-04-28T10:00:00Z",
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "uuid": "u1",
+            }
+        )
+
+    def test_local_command_slash(self):
+        from claude_code_log.factories import create_system_message
+        from claude_code_log.models import SystemMessage
+
+        entry = self._make_system(
+            "<command-name>/status</command-name>"
+            "<command-message>status</command-message>"
+            "<command-args></command-args>"
+        )
+        msg = create_system_message(entry)
+        assert isinstance(msg, SystemMessage)
+        assert msg.text == "/status"
+
+    def test_local_command_stdout_dialog_dismissed(self):
+        from claude_code_log.factories import create_system_message
+        from claude_code_log.models import SystemMessage
+
+        entry = self._make_system(
+            "<local-command-stdout>Status dialog dismissed</local-command-stdout>"
+        )
+        msg = create_system_message(entry)
+        assert isinstance(msg, SystemMessage)
+        assert msg.text == "Status dialog dismissed"
+
+    def test_other_subtype_passes_through_unchanged(self):
+        """Cleanup is gated on ``subtype == "local_command"`` — the
+        ``compact_boundary`` summary text must not be touched."""
+        from claude_code_log.factories import create_system_message
+        from claude_code_log.models import SystemMessage
+
+        entry = self._make_system(
+            "Conversation compacted (115k tokens)",
+            subtype="compact_boundary",
+        )
+        msg = create_system_message(entry)
+        assert isinstance(msg, SystemMessage)
+        assert msg.text == "Conversation compacted (115k tokens)"
+
 
 class TestGetWarmupSessionIds:
     """Test bulk warmup session ID detection."""

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -642,16 +642,18 @@ class TestCreateSessionPreview:
         (/init command)"`` that nothing tested or asserted on. The
         general ``simplify_command_tags`` cleanup now collapses it to
         the same ``/init`` shape every other slash command gets —
-        consistent and shorter.
+        consistent and shorter. Modern harness emission carries the
+        leading ``/`` directly; bare legacy emissions are covered by
+        ``test_simplify_command_tags_normalises_bare_name``.
         """
         text = (
-            "<command-name>init</command-name>"
+            "<command-name>/init</command-name>"
             "<command-message>init</command-message>"
             "<command-args></command-args>"
             '<command-contents>{"text": "some init prompt"}</command-contents>'
         )
         preview = create_session_preview(text)
-        assert preview == "init"
+        assert preview == "/init"
 
 
 class TestSimplifyCommandTags:
@@ -719,6 +721,152 @@ class TestSimplifyCommandTags:
         )
         assert simplify_command_tags(text) == "/status"
 
+    def test_simplify_command_tags_normalises_bare_name(self):
+        """Bare ``<command-name>X</command-name>`` (legacy emission) →
+        ``/X`` to match modern ``/X``-prefixed emissions; mixed
+        transcripts must not render ``/exit`` next to ``test-command``.
+        """
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>init</command-name>"
+            "<command-message>init</command-message>"
+            "<command-args></command-args>"
+        )
+        assert simplify_command_tags(text) == "/init"
+
+    def test_simplify_command_tags_already_slash_unchanged(self):
+        """Modern emissions carrying ``/`` must not gain a second one."""
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/init</command-name>"
+            "<command-message>init</command-message>"
+            "<command-args></command-args>"
+        )
+        assert simplify_command_tags(text) == "/init"
+
+    def test_simplify_command_tags_real_world_init_with_args(self):
+        """Real-world example: free-form English args after ``/init``.
+
+        The harness writes the user's typed-after-command text into
+        ``<command-args>`` verbatim. A representative real-world input
+        round-trips intact through the helper.
+        """
+        from claude_code_log.factories import simplify_command_tags
+
+        args_payload = "and pay particular attention to dev-docs/, but ignore examples/"
+        text = (
+            "<command-name>/init</command-name>"
+            "<command-message>init</command-message>"
+            f"<command-args>{args_payload}</command-args>"
+        )
+        assert simplify_command_tags(text) == f"/init {args_payload}"
+
+    def test_simplify_command_tags_args_with_less_than_preserved(self):
+        """Args containing ``<`` must not be silently dropped.
+
+        The earlier ``[^<]*`` regex matched up to but not including the
+        first ``<``, then failed to find the closing tag — so any args
+        with ``<`` ended up empty. Tightened to ``(.*?)`` with DOTALL.
+        """
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/explain</command-name>"
+            "<command-message>explain</command-message>"
+            "<command-args>render <Component> here</command-args>"
+        )
+        assert simplify_command_tags(text) == "/explain render <Component> here"
+
+    def test_simplify_command_tags_args_multiline_preserved(self):
+        """Newline-bearing args must survive — confirmed by DOTALL."""
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/note</command-name>"
+            "<command-message>note</command-message>"
+            "<command-args>line one\nline two\nline three</command-args>"
+        )
+        assert simplify_command_tags(text) == "/note line one\nline two\nline three"
+
+    def test_simplify_command_tags_args_with_special_chars(self):
+        """Quotes, backticks, ampersands and ``>`` round-trip verbatim."""
+        from claude_code_log.factories import simplify_command_tags
+
+        text = (
+            "<command-name>/run</command-name>"
+            "<command-message>run</command-message>"
+            '<command-args>echo "hi" && diff a > b `date`</command-args>'
+        )
+        assert simplify_command_tags(text) == '/run echo "hi" && diff a > b `date`'
+
+
+class TestCreateSlashCommandMessage:
+    """``create_slash_command_message`` is the structured-content
+    counterpart to ``simplify_command_tags`` — same harness shape, but
+    extracts ``command_name`` / ``command_args`` / ``command_contents``
+    into a typed model. Same normalisation rules apply so HTML,
+    Markdown and JSON output all see the unified ``/cmd`` shape and
+    args containing ``<`` are not silently dropped.
+    """
+
+    @staticmethod
+    def _meta():
+        from claude_code_log.models import MessageMeta
+
+        return MessageMeta(session_id="s1", timestamp="2026-04-28T10:00:00Z", uuid="u1")
+
+    def test_command_name_normalised_when_bare(self):
+        from claude_code_log.factories import create_slash_command_message
+
+        text = (
+            "<command-name>init</command-name>"
+            "<command-message>init</command-message>"
+            "<command-args></command-args>"
+        )
+        msg = create_slash_command_message(self._meta(), text)
+        assert msg is not None
+        assert msg.command_name == "/init"
+
+    def test_command_name_already_slash_unchanged(self):
+        from claude_code_log.factories import create_slash_command_message
+
+        text = (
+            "<command-name>/exit</command-name>"
+            "<command-message>exit</command-message>"
+            "<command-args></command-args>"
+        )
+        msg = create_slash_command_message(self._meta(), text)
+        assert msg is not None
+        assert msg.command_name == "/exit"
+
+    def test_command_args_with_less_than_preserved(self):
+        from claude_code_log.factories import create_slash_command_message
+
+        text = (
+            "<command-name>/explain</command-name>"
+            "<command-message>explain</command-message>"
+            "<command-args>render <Component> here</command-args>"
+        )
+        msg = create_slash_command_message(self._meta(), text)
+        assert msg is not None
+        assert msg.command_args == "render <Component> here"
+
+    def test_command_args_real_world_init_payload(self):
+        from claude_code_log.factories import create_slash_command_message
+
+        args_payload = "and pay particular attention to dev-docs/, but ignore examples/"
+        text = (
+            "<command-name>/init</command-name>"
+            "<command-message>init</command-message>"
+            f"<command-args>{args_payload}</command-args>"
+        )
+        msg = create_slash_command_message(self._meta(), text)
+        assert msg is not None
+        assert msg.command_name == "/init"
+        assert msg.command_args == args_payload
+
 
 class TestSystemMessageLocalCommandCleanup:
     """SystemMessage ``text`` for ``subtype="local_command"`` must come
@@ -776,6 +924,22 @@ class TestSystemMessageLocalCommandCleanup:
         msg = create_system_message(entry)
         assert isinstance(msg, SystemMessage)
         assert msg.text == "Status dialog dismissed"
+
+    def test_local_command_bare_name_normalised(self):
+        """Legacy bare ``<command-name>X</command-name>`` is normalised
+        to ``/X`` so the SystemMessage text never carries the inconsistent
+        bare shape into HTML/Markdown/JSON output."""
+        from claude_code_log.factories import create_system_message
+        from claude_code_log.models import SystemMessage
+
+        entry = self._make_system(
+            "<command-name>init</command-name>"
+            "<command-message>init</command-message>"
+            "<command-args></command-args>"
+        )
+        msg = create_system_message(entry)
+        assert isinstance(msg, SystemMessage)
+        assert msg.text == "/init"
 
     def test_other_subtype_passes_through_unchanged(self):
         """Cleanup is gated on ``subtype == "local_command"`` — the


### PR DESCRIPTION
Closes #129.

## Summary

Two visible artifacts of raw command-tag XML soup get cleaned up under one shared helper:

1. **System-info cards** for ``subtype="local_command"`` entries. The harness emits typed slash commands as

   ```
   <command-name>/status</command-name>
   <command-message>status</command-message>
   <command-args></command-args>
   ```

   and dialog-dismissal hints as ``<local-command-stdout>Status dialog dismissed</local-command-stdout>``. Both rendered verbatim before — now ``ℹ️ /status`` / ``ℹ️ Status dialog dismissed``.

2. **Branch header previews** when the branch's first user entry is itself a ``/cmd`` slash command. The same XML soup propagated into the body branch header, the session/graph index nav, and the fork-point box's per-branch link via ``SessionHeaderMessage.preview`` (introduced in #131). They surfaced as

   ```
   Branch • 8d0ae973 • <command-name>/exit</command-name> <command-message>exit</command-me…
   ```

   Now: ``Branch • 8d0ae973 • /exit``.

## How

One shared helper + three thin call-sites:

- ``factories/user_factory.py::simplify_command_tags(text)`` — strips the three known shapes (``<command-name>``, ``<local-command-stdout>``, ``<local-command-stderr>``), passthrough on no-match. Co-located with the existing ``create_slash_command_message`` etc. that already parse the same patterns into typed shapes.
- ``factories/system_factory.py::create_system_message`` calls it for ``subtype == "local_command"`` only — gate is **intent-documenting**, not safety-providing (the helper is opportunistic by design).
- ``utils.py::create_session_preview`` calls it on the way to the truncation step. **Replaces the older ``extract_init_command_description``** (a one-shape ``<command-name>init`` + ``<command-contents>``-only helper that returned a hardcoded English string and was asserted by zero tests). The general helper collapses ``/init`` to ``/init`` — same shape every other slash command gets, more consistent and shorter. The init-only helper was effectively dead code.

## Test plan

- [x] ``TestSimplifyCommandTags`` — 6 direct unit tests (the three patterns, args, passthrough, command-name precedence over a coexisting stdout payload).
- [x] ``TestSystemMessageLocalCommandCleanup`` — 3 integration tests on ``create_system_message`` (slash command, dialog stdout, ``compact_boundary`` passthrough).
- [x] 4 new ``TestCreateSessionPreview`` cases for the slash-command / stdout / init paths.
- [x] ``just ci`` clean (1218 tests, ruff, pyright, ty).
- [x] Real-data verification on the BCT/clmail/monk teammates session (d602eb5f): ``Branch • 1addcb81 • /clmail:list /quit``, ``Branch • 7a3bee4e • /exit``, system-info cards now show ``ℹ️ /status`` and ``ℹ️ Status dialog dismissed``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System and local-command outputs are normalized into readable slash-command form (e.g., "/cmd") in messages and previews; inner stdout/stderr is preserved for display.
  * Command titles and arguments render safely when they contain backticks, preventing broken formatting.

* **Tests**
  * Extensive test coverage added for command normalization, previews, local-command rendering, and edge cases to ensure consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->