### PR TITLE
Fix DAG cyclic-children hang and add SIGUSR1 stack dump

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,17 @@ CLAUDE_CODE_LOG_DEBUG_TIMING=1 claude-code-log path/to/file.jsonl
 
 This outputs detailed timing for each rendering phase. The timing module is in `claude_code_log/renderer_timings.py`.
 
+## Diagnosing Hangs
+
+If `claude-code-log` appears stuck (100% CPU, no output), send `SIGUSR1` to print the live Python stack to stderr without killing the process:
+
+```bash
+# In another terminal
+kill -USR1 $(pgrep -f claude-code-log | head -1)
+```
+
+The handler is installed in `cli.py` via `faulthandler.register(SIGUSR1)`. POSIX-only; no-op on Windows. Unlike `py-spy`, it needs no root and no extra install.
+
 ## Architecture
 
 For detailed architecture documentation, see [dev-docs/rendering-architecture.md](dev-docs/rendering-architecture.md).

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """CLI interface for claude-code-log."""
 
+import faulthandler
 import logging
 import os
+import signal
 import sys
 from pathlib import Path
 from typing import Optional
@@ -25,6 +27,25 @@ from .cache import (
     get_cache_db_path,
     get_library_version,
 )
+
+
+def _install_stack_dump_signal() -> None:
+    """Make ``kill -USR1 <pid>`` print the live Python stack to stderr.
+
+    Useful for diagnosing apparent hangs without killing the process —
+    py-spy needs root on macOS, but this only needs the signal. SIGUSR1
+    is POSIX-only; on Windows we silently skip.
+    """
+    sigusr1 = getattr(signal, "SIGUSR1", None)
+    if sigusr1 is None:
+        return
+    try:
+        faulthandler.register(sigusr1, all_threads=True, chain=False)
+    except (RuntimeError, ValueError, OSError):
+        # E.g. signal already taken, no-tty environments, or platforms
+        # where faulthandler.register raises. Diagnostics shouldn't
+        # break the CLI — silently skip.
+        pass
 
 
 def get_default_projects_dir() -> Path:
@@ -568,6 +589,10 @@ def main(
 
     INPUT_PATH: Path to a Claude transcript JSONL file, directory containing JSONL files, or project path to convert. If not provided, defaults to ~/.claude/projects/ and --all-projects is used.
     """
+    # Install signal-based stack dumper before any heavy work, so a hang
+    # can be diagnosed with `kill -USR1 <pid>` without root or restart.
+    _install_stack_dump_signal()
+
     # Configure logging to show warnings and above
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 

--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -157,43 +157,45 @@ def build_dag(
     for node in nodes.values():
         node.children_uuids = []
 
-    # Build parent→children links
+    # Step 1: clear dangling parent_uuids (orphans become roots).
+    # Done before children population so orphan nodes never appear in a
+    # missing parent's nonexistent children list.
     for node in nodes.values():
-        if node.parent_uuid is not None:
-            parent = nodes.get(node.parent_uuid)
-            if parent is not None:
-                parent.children_uuids.append(node.uuid)
-            else:
-                if node.parent_uuid not in _sidechain_uuids:
-                    # Progress passthroughs are async hooks: their parent
-                    # tool_use is routinely lost to ``/compact`` (the
-                    # spawning turn is in the discarded pre-compaction
-                    # context). Log at debug — the multi-root warning
-                    # already classifies them as expected roots; per-node
-                    # warnings here would just multiply the noise on long
-                    # compacted sessions. See ``_is_expected_root_type``.
-                    if (
-                        isinstance(node.entry, PassthroughTranscriptEntry)
-                        and node.entry.type in _EXPECTED_ROOT_PASSTHROUGH_TYPES
-                    ):
-                        logger.debug(
-                            "Orphan progress hook %s: parentUuid %s not "
-                            "found in loaded data (promoting to root)",
-                            node.uuid,
-                            node.parent_uuid,
-                        )
-                    else:
-                        logger.warning(
-                            "Orphan node %s: parentUuid %s not found in "
-                            "loaded data (promoting to root)",
-                            node.uuid,
-                            node.parent_uuid,
-                        )
-                # Clear the dangling parent so this node becomes a root
-                # and can participate in DAG walks
-                node.parent_uuid = None
+        if node.parent_uuid is not None and node.parent_uuid not in nodes:
+            if node.parent_uuid not in _sidechain_uuids:
+                # Progress passthroughs are async hooks: their parent
+                # tool_use is routinely lost to ``/compact`` (the
+                # spawning turn is in the discarded pre-compaction
+                # context). Log at debug — the multi-root warning
+                # already classifies them as expected roots; per-node
+                # warnings here would just multiply the noise on long
+                # compacted sessions. See ``_is_expected_root_type``.
+                if (
+                    isinstance(node.entry, PassthroughTranscriptEntry)
+                    and node.entry.type in _EXPECTED_ROOT_PASSTHROUGH_TYPES
+                ):
+                    logger.debug(
+                        "Orphan progress hook %s: parentUuid %s not "
+                        "found in loaded data (promoting to root)",
+                        node.uuid,
+                        node.parent_uuid,
+                    )
+                else:
+                    logger.warning(
+                        "Orphan node %s: parentUuid %s not found in "
+                        "loaded data (promoting to root)",
+                        node.uuid,
+                        node.parent_uuid,
+                    )
+            # Clear the dangling parent so this node becomes a root
+            # and can participate in DAG walks
+            node.parent_uuid = None
 
-    # Validate: no cycles (walk parent chain for each node)
+    # Step 2: break any parent_uuid cycles BEFORE populating
+    # children_uuids. If we built children first, cyclic edges would
+    # become cyclic child links — and downstream walks via
+    # children_uuids would loop forever. Each cycle is broken by nulling
+    # the parent_uuid of the first revisited node, promoting it to root.
     for node in nodes.values():
         visited: set[str] = set()
         current: Optional[str] = node.uuid
@@ -207,6 +209,21 @@ def build_dag(
             if parent is None:
                 break
             current = parent.parent_uuid
+
+    # Step 3: build parent→children links from the now-acyclic parent
+    # pointers. Defensive guards: skip self-edges and skip duplicates so
+    # a malformed input still produces a tree.
+    for node in nodes.values():
+        if node.parent_uuid is None:
+            continue
+        if node.parent_uuid == node.uuid:
+            # Self-loop survived cycle-breaking only if a node's own
+            # uuid was the only entry on its chain — defensive belt.
+            node.parent_uuid = None
+            continue
+        parent = nodes[node.parent_uuid]
+        if node.uuid not in parent.children_uuids:
+            parent.children_uuids.append(node.uuid)
 
 
 # =============================================================================
@@ -491,6 +508,11 @@ def _walk_session_with_forks(
     queue: list[tuple[str, str, Optional[str]]] = [(root.uuid, session_id, None)]
     result: list[SessionDAGLine] = []
     skipped: set[str] = set()  # Compaction replay UUIDs
+    # Defence-in-depth: even though build_dag breaks parent cycles before
+    # populating children_uuids, a future bug or malformed input could
+    # reintroduce a cyclic edge. Track visited uuids across the whole
+    # walk so we can never enter an unbounded loop here.
+    walk_visited: set[str] = set()
 
     while queue:
         start_uuid, line_id, parent_line_id = queue.pop(0)
@@ -499,6 +521,16 @@ def _walk_session_with_forks(
         is_branch = line_id != session_id
 
         while current is not None:
+            if current.uuid in walk_visited:
+                logger.warning(
+                    "Cycle in children_uuids detected at %s while walking "
+                    "session %s (line %s); truncating chain",
+                    current.uuid,
+                    session_id,
+                    line_id,
+                )
+                break
+            walk_visited.add(current.uuid)
             chain.append(current.uuid)
             # Update session_id for branch nodes (needed for build_session_tree)
             if is_branch:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,6 +12,7 @@ from claude_code_log.cli import (
     _clear_caches,
     _clear_output_files,
     _discover_projects,
+    _install_stack_dump_signal,
     get_default_projects_dir,
     main,
 )
@@ -574,3 +575,63 @@ class TestCLIErrorHandling:
 
         # Should not crash
         assert result.exit_code in (0, 1)
+
+
+class TestStackDumpSignal:
+    """SIGUSR1 must dump a Python traceback to stderr without exiting."""
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("signal"), "SIGUSR1"),
+        reason="SIGUSR1 only available on POSIX systems",
+    )
+    def test_sigusr1_dumps_stack_to_stderr(self) -> None:
+        """Send SIGUSR1 to a child process and assert traceback hits stderr."""
+        import os
+        import subprocess
+        import sys
+        import time
+
+        # Child runs claude_code_log.cli helper, then loops forever so we
+        # can signal it. Stack dump goes to stderr; we read after killing.
+        script = (
+            "from claude_code_log.cli import _install_stack_dump_signal\n"
+            "import time, sys\n"
+            "_install_stack_dump_signal()\n"
+            "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+            "while True:\n"
+            "    time.sleep(0.05)\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert proc.stdout is not None
+            # Wait for the child to install the handler.
+            line = proc.stdout.readline()
+            assert line.strip() == "ready"
+
+            os.kill(proc.pid, __import__("signal").SIGUSR1)
+            # Give faulthandler a moment to flush its dump.
+            time.sleep(0.2)
+        finally:
+            proc.terminate()
+            try:
+                _, stderr = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                _, stderr = proc.communicate()
+
+        # faulthandler.dump_traceback writes lines like
+        # "Current thread 0x...:" followed by Python frames. Look for
+        # something that proves a Python stack dump happened.
+        assert "Thread" in stderr or "File " in stderr, (
+            f"Expected traceback in stderr, got: {stderr!r}"
+        )
+
+    def test_install_is_idempotent(self) -> None:
+        """Calling the installer twice must not raise."""
+        _install_stack_dump_signal()
+        _install_stack_dump_signal()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -587,12 +587,19 @@ class TestStackDumpSignal:
     def test_sigusr1_dumps_stack_to_stderr(self) -> None:
         """Send SIGUSR1 to a child process and assert traceback hits stderr."""
         import os
+        import signal
         import subprocess
         import sys
+        import threading
         import time
 
         # Child runs claude_code_log.cli helper, then loops forever so we
-        # can signal it. Stack dump goes to stderr; we read after killing.
+        # can signal it. The faulthandler signal handler writes the dump
+        # to stderr synchronously, but signal *delivery* is asynchronous
+        # — after os.kill returns, the child may not have run the handler
+        # yet. Polling stderr until the dump appears (rather than a fixed
+        # sleep) avoids both the SIGUSR1/SIGTERM race and CI-runner
+        # timing flake.
         script = (
             "from claude_code_log.cli import _install_stack_dump_signal\n"
             "import time, sys\n"
@@ -601,34 +608,77 @@ class TestStackDumpSignal:
             "while True:\n"
             "    time.sleep(0.05)\n"
         )
+        # Binary mode for stderr: text-mode ``read(n)`` blocks trying to
+        # *fill* its buffer, so a small (~150 byte) faulthandler dump
+        # stays trapped in Python's buffer until EOF. Binary
+        # ``BufferedReader.read1(n)`` returns whatever is available from
+        # one underlying syscall, which is what we want here.
         proc = subprocess.Popen(
             [sys.executable, "-c", script],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
         )
+
+        # Drain stderr in a background thread so the child can never
+        # block on a full pipe and so we can poll for the marker without
+        # racing against proc.communicate() at teardown.
+        captured: list[bytes] = []
+        captured_lock = threading.Lock()
+
+        def drain_stderr() -> None:
+            # typeshed types proc.stderr as IO[bytes]; the actual object
+            # in binary mode is a BufferedReader which exposes read1.
+            from io import BufferedReader
+            from typing import cast
+
+            stderr = cast(BufferedReader, proc.stderr)
+            while True:
+                chunk = stderr.read1(1024)
+                if not chunk:
+                    return
+                with captured_lock:
+                    captured.append(chunk)
+
+        drainer = threading.Thread(target=drain_stderr, daemon=True)
+        drainer.start()
+
+        found = False
         try:
             assert proc.stdout is not None
             # Wait for the child to install the handler.
             line = proc.stdout.readline()
-            assert line.strip() == "ready"
+            assert line.strip() == b"ready"
 
-            os.kill(proc.pid, __import__("signal").SIGUSR1)
-            # Give faulthandler a moment to flush its dump.
-            time.sleep(0.2)
+            os.kill(proc.pid, signal.SIGUSR1)
+
+            # Poll for traceback markers up to a generous deadline. The
+            # handler usually fires within a few ms; we allow much more
+            # so a loaded CI machine never trips the test.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                with captured_lock:
+                    joined = b"".join(captured)
+                if b"Thread" in joined or b"File " in joined:
+                    found = True
+                    break
+                time.sleep(0.05)
         finally:
             proc.terminate()
             try:
-                _, stderr = proc.communicate(timeout=5)
+                proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
-                _, stderr = proc.communicate()
+                proc.wait()
+            # Drain thread exits when the child closes stderr on exit.
+            drainer.join(timeout=5)
 
-        # faulthandler.dump_traceback writes lines like
-        # "Current thread 0x...:" followed by Python frames. Look for
-        # something that proves a Python stack dump happened.
-        assert "Thread" in stderr or "File " in stderr, (
-            f"Expected traceback in stderr, got: {stderr!r}"
+        with captured_lock:
+            stderr_text = b"".join(captured).decode(errors="replace")
+        # faulthandler.dump_traceback writes "Current thread 0x...:"
+        # followed by Python "File ..." frames. Either token proves a
+        # Python stack dump happened.
+        assert found, (
+            f"Expected traceback in stderr within 5s of SIGUSR1, got: {stderr_text!r}"
         )
 
     def test_install_is_idempotent(self) -> None:

--- a/test/test_dag.py
+++ b/test/test_dag.py
@@ -2,10 +2,12 @@
 
 import json
 from pathlib import Path
+from typing import Callable, Optional, TypeVar
 
 import pytest
 
 from claude_code_log.dag import (
+    MessageNode,
     SessionTree,
     build_dag,
     build_dag_from_entries,
@@ -18,6 +20,8 @@ from claude_code_log.models import (
     SummaryTranscriptEntry,
     TranscriptEntry,
 )
+
+T = TypeVar("T")
 
 TEST_DATA = Path(__file__).parent / "test_data"
 REAL_PROJECTS = TEST_DATA / "real_projects"
@@ -630,6 +634,138 @@ class TestExtractSessionDAGLines:
         sessions = extract_session_dag_lines(nodes)
         assert sessions["s1"].uuids == ["a", "b", "c", "d", "e"]
         assert sessions["s2"].uuids == ["f", "g", "h"]
+
+
+# =============================================================================
+# Test: Cyclic parentUuid chains (regression for memory-exhaustion hang)
+# =============================================================================
+
+
+class TestCyclicParentChain:
+    """Regression: cyclic parentUuid must not produce cyclic children_uuids.
+
+    Real-world JSONL files occasionally contain cyclic parentUuid chains
+    (e.g. A claims B as parent, B claims A as parent, or A claims itself).
+    Earlier versions of build_dag detected the cycle in the parent chain
+    and nulled one node's parent_uuid, but children_uuids had already been
+    populated from the cyclic edges. Downstream walks (e.g.
+    _walk_session_with_forks) followed children_uuids without a visited
+    guard and looped forever, accumulating gigabytes of state.
+    """
+
+    @staticmethod
+    def _make_entry(
+        uuid: str, parent_uuid: str | None, sid: str = "s1", i: int = 0
+    ) -> TranscriptEntry:
+        data: dict[str, object] = {
+            "type": "user",
+            "timestamp": f"2025-07-01T10:00:{i:02d}.000Z",
+            "parentUuid": parent_uuid,
+            "isSidechain": False,
+            "userType": "human",
+            "cwd": "/tmp",
+            "sessionId": sid,
+            "version": "1.0.0",
+            "uuid": uuid,
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": f"msg {uuid}"}],
+            },
+        }
+        return create_transcript_entry(data)
+
+    @staticmethod
+    def _assert_no_child_cycle(nodes: dict[str, MessageNode]) -> None:
+        """Walk children_uuids from every node; fail if any node revisits itself."""
+        for start in nodes.values():
+            visited: set[str] = set()
+            stack: list[str] = [start.uuid]
+            while stack:
+                u = stack.pop()
+                if u in visited:
+                    pytest.fail(
+                        f"Cycle in children_uuids reached {u} starting from {start.uuid}"
+                    )
+                visited.add(u)
+                stack.extend(nodes[u].children_uuids)
+
+    @staticmethod
+    def _run_with_timeout(fn: Callable[[], T], seconds: float = 5.0) -> Optional[T]:
+        """Run fn() in a thread; fail the test if it does not terminate in time.
+
+        Without a timeout, a regression of this bug would hang the entire
+        suite (and exhaust memory). The thread is left to die with the
+        process — acceptable for a regression guard.
+        """
+        import threading
+
+        result: list[T] = []
+        error: list[BaseException] = []
+
+        def runner() -> None:
+            try:
+                result.append(fn())
+            except BaseException as e:  # noqa: BLE001
+                error.append(e)
+
+        t = threading.Thread(target=runner, daemon=True)
+        t.start()
+        t.join(timeout=seconds)
+        if t.is_alive():
+            pytest.fail(
+                f"call did not terminate within {seconds}s — likely cyclic walk"
+            )
+        if error:
+            raise error[0]
+        return result[0] if result else None
+
+    def test_self_cycle_does_not_create_self_child(self) -> None:
+        """A node whose parentUuid points to itself must not list itself as a child."""
+        a = self._make_entry("a", parent_uuid=None, i=0)
+        b = self._make_entry("b", parent_uuid="b", i=1)
+        nodes = build_message_index([a, b])
+        build_dag(nodes)
+        assert "b" not in nodes["b"].children_uuids
+        self._assert_no_child_cycle(nodes)
+
+    def test_two_cycle_produces_acyclic_children(self) -> None:
+        """A two-node cycle (A→B→A) must yield acyclic children_uuids."""
+        a = self._make_entry("a", parent_uuid="b", i=0)
+        b = self._make_entry("b", parent_uuid="a", i=1)
+        nodes = build_message_index([a, b])
+        build_dag(nodes)
+        self._assert_no_child_cycle(nodes)
+
+    def test_three_cycle_produces_acyclic_children(self) -> None:
+        """A three-node cycle (A→B→C→A) must yield acyclic children_uuids."""
+        a = self._make_entry("a", parent_uuid="c", i=0)
+        b = self._make_entry("b", parent_uuid="a", i=1)
+        c = self._make_entry("c", parent_uuid="b", i=2)
+        nodes = build_message_index([a, b, c])
+        build_dag(nodes)
+        self._assert_no_child_cycle(nodes)
+
+    def test_extract_session_dag_lines_terminates_on_self_cycle(self) -> None:
+        """End-to-end: cyclic input must not hang extract_session_dag_lines."""
+        a = self._make_entry("a", parent_uuid=None, i=0)
+        b = self._make_entry("b", parent_uuid="b", i=1)
+        nodes = build_message_index([a, b])
+        build_dag(nodes)
+        sessions = self._run_with_timeout(lambda: extract_session_dag_lines(nodes))
+        assert sessions is not None
+        assert "s1" in sessions
+        assert set(sessions["s1"].uuids) == {"a", "b"}
+
+    def test_extract_session_dag_lines_terminates_on_two_cycle(self) -> None:
+        """End-to-end: two-node cycle must not hang extract_session_dag_lines."""
+        a = self._make_entry("a", parent_uuid="b", i=0)
+        b = self._make_entry("b", parent_uuid="a", i=1)
+        nodes = build_message_index([a, b])
+        build_dag(nodes)
+        sessions = self._run_with_timeout(lambda: extract_session_dag_lines(nodes))
+        assert sessions is not None
+        assert "s1" in sessions
+        assert set(sessions["s1"].uuids) == {"a", "b"}
 
 
 # =============================================================================


### PR DESCRIPTION
Real-world transcripts can contain cyclic ``parentUuid`` chains — two entries naming each other as parent, or a self-loop. ``build_dag`` detected the cycle in the parent-walk validation step and nulled the offending ``parent_uuid``, but it had **already** populated ``children_uuids`` from those same cyclic edges. The parent chain ended up acyclic while ``children_uuids`` retained the loop.

``_walk_session_with_forks`` traverses via ``children_uuids`` with no visited-set guard, so on hitting a cyclic child it would chase the loop forever, growing ``chain``, ``queue`` and per-node state without bound. A live ``py-spy`` dump caught the hang in the wild: 50+ minutes at 100% CPU, 256 GB resident, ``chain`` filled with the same UUID thousands of times over, ``same_session_children`` containing the node itself.

## Fix

``build_dag`` is reordered into three explicit phases:

1. Clear dangling parent_uuids (orphans → roots).
2. **Break parent_uuid cycles.** Done before children population, so children can never contain a cyclic edge. Nulling the offending pointer alone is now sufficient.
3. Build parent→children links from the now-acyclic parent pointers, with self-edge and duplicate guards as belt-and-braces.

``_walk_session_with_forks`` gains a ``walk_visited`` set in its inner loop. Defence in depth — even if a future change reintroduces a cyclic child, the walk truncates the chain and warns instead of hanging.

## Regression tests

``test/test_dag.py::TestCyclicParentChain`` — five tests covering self-cycle, two-cycle and three-cycle inputs at both the structural level (``children_uuids`` acyclic) and the end-to-end level (``extract_session_dag_lines`` terminates). The end-to-end checks run under a thread-based 5 s timeout so a regression of this bug fails the test instead of hanging the entire suite. All five fail on main before the fix; all pass after.

## Diagnostic: SIGUSR1 stack dump

``cli.py`` registers ``faulthandler`` against ``SIGUSR1`` so ``kill -USR1 <pid>`` prints the live Python stack to stderr without killing the process. Unlike ``py-spy``, no root or extra install is required — handy on macOS where ``py-spy`` needs ``sudo``. The investigation that found this bug took 50 minutes; with this hook the same diagnosis takes seconds. POSIX-only; silently no-ops on Windows. Documented in CONTRIBUTING.md under "Diagnosing Hangs".

Two tests in ``test/test_cli.py::TestStackDumpSignal`` cover an end-to-end subprocess flow (signal in, traceback out on stderr) and idempotency of the installer.

## Test results

- 1136 unit tests pass, 0 failures.
- Production files clean under ruff and pyright.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stack-trace diagnostics to dump live Python threads for hung processes (POSIX-only signal trigger).

* **Documentation**
  * Added "Diagnosing Hangs" section to the contributing guide with usage instructions.

* **Bug Fixes**
  * Improved DAG construction to handle orphan nodes and break parent-chain cycles, preventing traversal hangs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->