### PR TITLE
System info cosmetic improvements + chain-pairing fix (#137)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,16 +116,26 @@ just test-cov
 Snapshot tests detect unintended HTML output changes using [syrupy](https://github.com/syrupy-project/syrupy):
 
 ```bash
-# Run snapshot tests
+# Run snapshot tests (parallel mode is fine for read-only runs)
 uv run pytest -n auto test/test_snapshot_html.py -v
 
 # Update snapshots after intentional HTML changes
-uv run pytest -n auto test/test_snapshot_html.py --snapshot-update
+# IMPORTANT: run --snapshot-update WITHOUT -n auto (see warning below)
+uv run pytest test/test_snapshot_html.py --snapshot-update
 ```
+
+> **Warning — don't combine `--snapshot-update` with `-n auto`.** Syrupy
+> and pytest-xdist race when writing snapshot files in parallel: the
+> `.ambr` file ends up truncated (observed: ~6000 lines silently
+> deleted on a single run, leaving the file structurally broken but
+> still passing on next read). Run `--snapshot-update` serially. This
+> is also why pytest is **not** configured with a default `-n auto`
+> in `pyproject.toml`; the `just test` recipes opt in for read-only
+> runs where the race doesn't apply.
 
 When snapshot tests fail:
 1. Review the diff to verify changes are intentional
-2. If intentional, run `--snapshot-update` to accept new output
+2. If intentional, run `--snapshot-update` (serially) to accept new output
 3. If unintentional, fix your code and re-run tests
 
 ### Test Prerequisites

--- a/claude_code_log/html/system_formatters.py
+++ b/claude_code_log/html/system_formatters.py
@@ -21,6 +21,14 @@ from ..models import (
 def format_system_content(content: SystemMessage) -> str:
     """Format a system message with level-specific icon.
 
+    Multi-line content (ASCII visualisations from ``/context``,
+    ``/cost``, etc., or any system entry whose cleaned text spans more
+    than one line) renders inside a ``<pre>`` block so whitespace and
+    grid alignment are preserved. Single-line system messages
+    (``/status`` dialog hints, ``/init`` cleaned-name forms, …) keep
+    the existing inline rendering — adding a block-level ``<pre>`` to a
+    one-liner would cost vertical space without benefit.
+
     Args:
         content: SystemMessage with level and text
 
@@ -29,6 +37,11 @@ def format_system_content(content: SystemMessage) -> str:
     """
     level_icon = {"warning": "⚠️", "error": "❌", "info": "ℹ️"}.get(content.level, "ℹ️")
     html_content = convert_ansi_to_html(content.text)
+    if "\n" in content.text:
+        return (
+            f"<strong>{level_icon}</strong>"
+            f"<pre class='system-content'>{html_content}</pre>"
+        )
     return f"<strong>{level_icon}</strong> {html_content}"
 
 

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -407,6 +407,25 @@
     overflow-x: auto;
 }
 
+/* Multi-line system content — ASCII visualisations from /context, /cost
+ * etc. preserve their grid alignment via white-space: pre (no wrapping)
+ * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+ * combo used for command-output is wrong here: even a single overlong
+ * line in a grid breaks the visualisation when it wraps mid-row. */
+.system-content {
+    background-color: #1e1e1e08;
+    padding: 12px;
+    border-radius: 4px;
+    border: 1px solid #00000011;
+    margin-top: 8px;
+    font-family: var(--font-monospace);
+    font-size: 0.9em;
+    line-height: 1.4;
+    white-space: pre;
+    color: var(--text-primary);
+    overflow-x: auto;
+}
+
 .command-output-content td {
     border-left: 1px dotted #bbb;
     padding: 0 1em;

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -411,8 +411,13 @@
  * etc. preserve their grid alignment via white-space: pre (no wrapping)
  * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
  * combo used for command-output is wrong here: even a single overlong
- * line in a grid breaks the visualisation when it wraps mid-row. */
-.system-content {
+ * line in a grid breaks the visualisation when it wraps mid-row.
+ *
+ * Selector tightened to ``.content pre.system-content`` to win over
+ * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+ * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+ * pattern as the sibling ``.content pre.command-output-content``. */
+.content pre.system-content {
     background-color: #1e1e1e08;
     padding: 12px;
     border-radius: 4px;

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -437,10 +437,23 @@ class MarkdownRenderer(Renderer):
     # -------------------------------------------------------------------------
 
     def format_SystemMessage(self, content: SystemMessage, _: TemplateMessage) -> str:
-        """Format → 'ℹ️ message text'."""
+        """Format → ``ℹ️ message text`` for one-liners; for multi-line
+        content (e.g. ``/context`` ASCII grid), wrap the body in an
+        adaptive fenced code block so CommonMark preserves whitespace
+        and grid alignment.
+
+        Mirrors the HTML side's ``<pre class='system-content'>`` shape.
+        Without the fence, CommonMark collapses internal newlines into
+        spaces unless every line ends with two trailing spaces — wrong
+        for grid content. ``_code_fence`` widens the fence past any
+        backtick run in the body (defensive — unlikely in `/context`
+        grids but free given the helper).
+        """
         level_prefix = {"info": "ℹ️", "warning": "⚠️", "error": "❌"}.get(
             content.level, ""
         )
+        if "\n" in content.text:
+            return f"{level_prefix}\n{self._code_fence(content.text)}"
         return f"{level_prefix} {content.text}"
 
     def format_HookSummaryMessage(

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -1680,10 +1680,25 @@ def _try_pair_by_index(
         if key in indices.tool_result:
             _mark_pair(current, indices.tool_result[key])
 
-    # System child message finding its parent (by parent_uuid)
+    # System child message finding its parent (by parent_uuid).
+    # The uuid index only contains system messages, so this is a
+    # system→system pairing path. Skip when the candidate parent is
+    # itself already a child in some other pair (``pair_first`` set):
+    # chained system entries (each one's ``parentUuid`` = the previous
+    # system entry's ``uuid`` — common with ``/context`` / ``/cost``
+    # multi-step output) would otherwise call ``_mark_pair`` on every
+    # link, leaving each interior node with both ``pair_first`` and
+    # ``pair_last`` set, which ``is_middle_in_pair`` reads as a
+    # triple-middle. The result was a fake N-tuple rendering as
+    # ``pair_first → pair_middle × (N-2) → pair_last`` instead of
+    # N/2 discrete pairs (#137). Skipping pre-paired parents breaks
+    # chains into pairs of two from the leading edge — the natural
+    # shape for command/result rhythms like ``/color`` invoked +
+    # confirmation, ``/context`` invoked + grid.
     if current.type == "system" and current.parent_uuid:
-        if current.parent_uuid in indices.uuid:
-            _mark_pair(indices.uuid[current.parent_uuid], current)
+        parent = indices.uuid.get(current.parent_uuid)
+        if parent is not None and parent.pair_first is None:
+            _mark_pair(parent, current)
 
 
 def _identify_message_pairs(messages: list[TemplateMessage]) -> None:

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -1560,7 +1560,24 @@ def _build_pairing_indices(messages: list[TemplateMessage]) -> PairingIndices:
 
 
 def _mark_pair(first: TemplateMessage, last: TemplateMessage) -> None:
-    """Mark two messages as a pair by setting their pair indices."""
+    """Mark two messages as a pair by setting their pair indices.
+
+    Each member stores a pointer to the *other* end of the pair, not its
+    own role:
+
+    - ``first.pair_last`` is the **forward** link from the first member
+      to its partner (the last member).
+    - ``last.pair_first`` is the **back** link from the last member to
+      its partner (the first member).
+
+    So this function does NOT set ``first.pair_first`` — that field
+    stays ``None`` on a first-role member, and is read by
+    ``is_first_in_pair`` to detect the role. Likewise it does not set
+    ``last.pair_last``. Mistaking the asymmetry has caused two bugs
+    (#137 chain pairing; CodeRabbit-flagged sibling-overwrite); guard
+    logic at call sites must check both fields when deciding whether a
+    parent is already involved in any pair.
+    """
     first_index = first.message_index
     last_index = last.message_index
     if first_index is not None and last_index is not None:
@@ -1683,21 +1700,37 @@ def _try_pair_by_index(
     # System child message finding its parent (by parent_uuid).
     # The uuid index only contains system messages, so this is a
     # system→system pairing path. Skip when the candidate parent is
-    # itself already a child in some other pair (``pair_first`` set):
-    # chained system entries (each one's ``parentUuid`` = the previous
-    # system entry's ``uuid`` — common with ``/context`` / ``/cost``
-    # multi-step output) would otherwise call ``_mark_pair`` on every
-    # link, leaving each interior node with both ``pair_first`` and
-    # ``pair_last`` set, which ``is_middle_in_pair`` reads as a
-    # triple-middle. The result was a fake N-tuple rendering as
-    # ``pair_first → pair_middle × (N-2) → pair_last`` instead of
-    # N/2 discrete pairs (#137). Skipping pre-paired parents breaks
-    # chains into pairs of two from the leading edge — the natural
-    # shape for command/result rhythms like ``/color`` invoked +
-    # confirmation, ``/context`` invoked + grid.
+    # **already involved in any pair** — both ``pair_first`` and
+    # ``pair_last`` must be ``None`` for the call to fire. Two distinct
+    # failure modes this guard covers (#137):
+    #
+    # 1. **Chain.** Each system entry's ``parentUuid`` = the previous
+    #    system entry's ``uuid`` (common with ``/context`` / ``/cost``
+    #    multi-step output). Without a guard, ``_mark_pair`` fires on
+    #    every link, leaving each interior node with both ``pair_first``
+    #    AND ``pair_last`` set, which ``is_middle_in_pair`` reads as a
+    #    triple-middle. The chain-bug guard alone (``pair_first is
+    #    None``) catches this — the second link sees the parent has
+    #    already been paired AS A CHILD (``pair_first`` set).
+    #
+    # 2. **Siblings sharing a parent.** Two system entries with the
+    #    same ``parentUuid``. The chain-bug guard alone misses this:
+    #    ``_mark_pair`` only sets ``parent.pair_last``, never
+    #    ``parent.pair_first``, so a parent that's already someone's
+    #    *first* still passes the ``pair_first is None`` check. The
+    #    second sibling's call would overwrite ``parent.pair_last`` and
+    #    leave the first sibling's ``pair_first`` pointing at a parent
+    #    whose ``pair_last`` no longer points back. The full guard
+    #    (``pair_first is None and pair_last is None``) only pairs
+    #    virgin parents, so siblings beyond the first render as
+    #    standalone cards rather than half-pairs.
     if current.type == "system" and current.parent_uuid:
         parent = indices.uuid.get(current.parent_uuid)
-        if parent is not None and parent.pair_first is None:
+        if (
+            parent is not None
+            and parent.pair_first is None
+            and parent.pair_last is None
+        ):
             _mark_pair(parent, current)
 
 

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -762,6 +762,25 @@
       overflow-x: auto;
   }
   
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
   .command-output-content td {
       border-left: 1px dotted #bbb;
       padding: 0 1em;
@@ -6441,6 +6460,25 @@
       line-height: 1.4;
       white-space: pre-wrap;
       word-wrap: break-word;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
       color: var(--text-primary);
       overflow-x: auto;
   }
@@ -14175,6 +14213,25 @@
       overflow-x: auto;
   }
   
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
   .command-output-content td {
       border-left: 1px dotted #bbb;
       padding: 0 1em;
@@ -19959,6 +20016,25 @@
       line-height: 1.4;
       white-space: pre-wrap;
       word-wrap: break-word;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
       color: var(--text-primary);
       overflow-x: auto;
   }
@@ -25982,6 +26058,25 @@
       overflow-x: auto;
   }
   
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
   .command-output-content td {
       border-left: 1px dotted #bbb;
       padding: 0 1em;
@@ -31865,6 +31960,25 @@
       line-height: 1.4;
       white-space: pre-wrap;
       word-wrap: break-word;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
       color: var(--text-primary);
       overflow-x: auto;
   }
@@ -37811,6 +37925,25 @@
       line-height: 1.4;
       white-space: pre-wrap;
       word-wrap: break-word;
+      color: var(--text-primary);
+      overflow-x: auto;
+  }
+  
+  /* Multi-line system content — ASCII visualisations from /context, /cost
+   * etc. preserve their grid alignment via white-space: pre (no wrapping)
+   * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
+   * combo used for command-output is wrong here: even a single overlong
+   * line in a grid breaks the visualisation when it wraps mid-row. */
+  .system-content {
+      background-color: #1e1e1e08;
+      padding: 12px;
+      border-radius: 4px;
+      border: 1px solid #00000011;
+      margin-top: 8px;
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      line-height: 1.4;
+      white-space: pre;
       color: var(--text-primary);
       overflow-x: auto;
   }

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -766,8 +766,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;
@@ -6468,8 +6473,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;
@@ -14217,8 +14227,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;
@@ -20024,8 +20039,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;
@@ -26062,8 +26082,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;
@@ -31968,8 +31993,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;
@@ -37933,8 +37963,13 @@
    * etc. preserve their grid alignment via white-space: pre (no wrapping)
    * and horizontal-scroll on narrow viewports. The pre-wrap + break-word
    * combo used for command-output is wrong here: even a single overlong
-   * line in a grid breaks the visualisation when it wraps mid-row. */
-  .system-content {
+   * line in a grid breaks the visualisation when it wraps mid-row.
+   *
+   * Selector tightened to ``.content pre.system-content`` to win over
+   * the existing ``.content pre`` rule above (specificity 0,1,1 — would
+   * otherwise force ``white-space: pre-wrap`` and undo the fix). Same
+   * pattern as the sibling ``.content pre.command-output-content``. */
+  .content pre.system-content {
       background-color: #1e1e1e08;
       padding: 12px;
       border-radius: 4px;

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -357,3 +357,130 @@ class TestMarkdownRender:
         assert f"``{args_payload}``" in md, (
             f"Expected widened fence to wrap args verbatim, got: {md!r}"
         )
+
+
+class TestSystemMessageChainPairing:
+    """Regression: chained system messages must not produce N-tuples (#137).
+
+    A chain of N system messages (each one's ``parentUuid`` equal to
+    the previous system message's ``uuid`` — common with ``/context`` /
+    ``/cost`` multi-step output) used to render as
+    ``pair_first → pair_middle × (N-2) → pair_last``: a fake N-tuple.
+    Mechanism: the parent-child indexed pairing called ``_mark_pair``
+    on every link in the chain, leaving every interior node with both
+    ``pair_first`` and ``pair_last`` set, which ``is_middle_in_pair``
+    reads as a triple-middle. The fix skips ``_mark_pair`` when the
+    candidate parent is itself already paired as a child, breaking
+    chains into pairs of two from the leading edge.
+    """
+
+    @staticmethod
+    def _build_chain(tmp_path, n: int):
+        """Write a JSONL with one user root + ``n`` chained system entries.
+
+        Each system entry's ``parentUuid`` equals the previous one's
+        ``uuid``; the first system entry parents the user root. This is
+        the exact shape produced by real-world ``/context``-style output
+        when the harness writes multi-step status into chained system
+        entries.
+        """
+        import json
+        from claude_code_log.converter import load_transcript
+
+        ts = "2026-05-06T10:00:00Z"
+        lines: list[dict[str, object]] = [
+            {
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "2.0.0",
+                "type": "user",
+                "message": {"role": "user", "content": "hello"},
+                "uuid": "root",
+                "timestamp": ts,
+            },
+        ]
+        prev_uuid = "root"
+        for i in range(n):
+            uuid = f"sys{i}"
+            lines.append(
+                {
+                    "parentUuid": prev_uuid,
+                    "isSidechain": False,
+                    "userType": "external",
+                    "cwd": "/tmp",
+                    "sessionId": "s1",
+                    "version": "2.0.0",
+                    "type": "system",
+                    "level": "info",
+                    "subtype": "local_command",
+                    "content": f"system entry {i}",
+                    "uuid": uuid,
+                    "timestamp": ts,
+                }
+            )
+            prev_uuid = uuid
+        fn = tmp_path / "chain.jsonl"
+        fn.write_text("\n".join(json.dumps(line) for line in lines))
+        return load_transcript(fn)
+
+    @staticmethod
+    def _system_pair_classes(html: str) -> list[str]:
+        """Extract pair-role keywords from each system message div."""
+        import re
+
+        roles: list[str] = []
+        for m in re.finditer(r"<div class='message system [^']*'", html):
+            cls = m.group(0)
+            for role in ("pair_first", "pair_middle", "pair_last"):
+                if role in cls:
+                    roles.append(role)
+                    break
+            else:
+                roles.append("none")
+        return roles
+
+    def test_chain_of_four_pairs_into_two_doubles(self, tmp_path) -> None:
+        """4-system chain → ``[pair_first, pair_last, pair_first, pair_last]``.
+
+        Pre-fix shape was ``[pair_first, pair_middle, pair_middle, pair_last]``.
+        """
+        from claude_code_log.html.renderer import HtmlRenderer
+
+        msgs = self._build_chain(tmp_path, n=4)
+        html = HtmlRenderer().generate(msgs, "Test")
+        assert self._system_pair_classes(html) == [
+            "pair_first",
+            "pair_last",
+            "pair_first",
+            "pair_last",
+        ]
+
+    def test_chain_of_three_pairs_first_two_only(self, tmp_path) -> None:
+        """3-system chain → ``[pair_first, pair_last, none]``: the third
+        system stands alone because its parent is already paired."""
+        from claude_code_log.html.renderer import HtmlRenderer
+
+        msgs = self._build_chain(tmp_path, n=3)
+        html = HtmlRenderer().generate(msgs, "Test")
+        assert self._system_pair_classes(html) == [
+            "pair_first",
+            "pair_last",
+            "none",
+        ]
+
+    def test_no_middle_role_in_chain(self, tmp_path) -> None:
+        """Even longer chains never produce a ``pair_middle`` role —
+        the only legitimate source of ``pair_middle`` is the
+        ``UserSlash → Slash → CommandOutput`` triple, which is a
+        different code path."""
+        from claude_code_log.html.renderer import HtmlRenderer
+
+        msgs = self._build_chain(tmp_path, n=8)
+        html = HtmlRenderer().generate(msgs, "Test")
+        roles = self._system_pair_classes(html)
+        assert "pair_middle" not in roles, (
+            f"Chains must not produce pair_middle, got: {roles}"
+        )

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -428,11 +428,23 @@ class TestSystemMessageChainPairing:
 
     @staticmethod
     def _system_pair_classes(html: str) -> list[str]:
-        """Extract pair-role keywords from each system message div."""
+        """Extract pair-role keywords from each system message div.
+
+        The Jinja template currently emits single-quoted class
+        attributes, but accept either quote style so the helper does
+        not silently miss future template changes (and so the test
+        fails loudly if the template starts emitting nothing at all,
+        rather than fails noisily several layers downstream).
+        """
         import re
 
+        # Match either ``class='message system ...'`` or
+        # ``class="message system ..."`` — the quote at the start of
+        # the class attribute is captured and required to match at the
+        # close (back-reference).
+        pattern = re.compile(r"""<div class=(['"])message system [^'"]*\1""")
         roles: list[str] = []
-        for m in re.finditer(r"<div class='message system [^']*'", html):
+        for m in pattern.finditer(html):
             cls = m.group(0)
             for role in ("pair_first", "pair_middle", "pair_last"):
                 if role in cls:
@@ -440,6 +452,11 @@ class TestSystemMessageChainPairing:
                     break
             else:
                 roles.append("none")
+        # Defensive: every test in this class drives a fixture with at
+        # least one system message; an empty list almost certainly means
+        # the template stopped emitting the expected shape, not that
+        # the renderer's behaviour changed.
+        assert roles, "expected at least one system message div in rendered HTML"
         return roles
 
     def test_chain_of_four_pairs_into_two_doubles(self, tmp_path) -> None:

--- a/test/test_slash_command_pairing.py
+++ b/test/test_slash_command_pairing.py
@@ -484,3 +484,91 @@ class TestSystemMessageChainPairing:
         assert "pair_middle" not in roles, (
             f"Chains must not produce pair_middle, got: {roles}"
         )
+
+    @staticmethod
+    def _build_siblings(tmp_path):
+        """Two system entries with the SAME ``parentUuid`` (siblings).
+
+        Distinct from the chain shape above: chains are A→B→C→…; here
+        both system entries point at the same parent. ``_mark_pair``
+        sets only ``parent.pair_last`` (forward-link), never
+        ``parent.pair_first``, so a guard that only checks the back-
+        link silently fires twice and the second sibling overwrites
+        the first's pairing — the bug CodeRabbit flagged on PR #140.
+        """
+        import json
+        from claude_code_log.converter import load_transcript
+
+        ts = "2026-05-07T10:00:00Z"
+        lines: list[dict[str, object]] = [
+            {
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "2.0.0",
+                "type": "user",
+                "message": {"role": "user", "content": "hello"},
+                "uuid": "root",
+                "timestamp": ts,
+            },
+            {
+                "parentUuid": "root",
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "2.0.0",
+                "type": "system",
+                "level": "info",
+                "subtype": "local_command",
+                "content": "parent system entry",
+                "uuid": "parent",
+                "timestamp": ts,
+            },
+        ]
+        # Two siblings, both pointing at "parent".
+        for i in range(2):
+            lines.append(
+                {
+                    "parentUuid": "parent",
+                    "isSidechain": False,
+                    "userType": "external",
+                    "cwd": "/tmp",
+                    "sessionId": "s1",
+                    "version": "2.0.0",
+                    "type": "system",
+                    "level": "info",
+                    "subtype": "local_command",
+                    "content": f"sibling {i}",
+                    "uuid": f"sib{i}",
+                    "timestamp": ts,
+                }
+            )
+        fn = tmp_path / "siblings.jsonl"
+        fn.write_text("\n".join(json.dumps(line) for line in lines))
+        return load_transcript(fn)
+
+    def test_siblings_share_parent_only_first_pairs(self, tmp_path) -> None:
+        """Two system messages with the same parent: only the first
+        pairs with the parent; the second renders standalone.
+
+        Pre-fix shape (chain-bug guard alone, ``pair_first is None``):
+        ``[pair_first (parent, pointing at sib1), pair_last (sib0,
+        stale-pointing at parent), pair_last (sib1)]`` — sib0's
+        ``pair_first`` no longer matches ``parent.pair_last`` after
+        sib1 overwrites it.
+
+        Post-fix shape (full guard, ``pair_first AND pair_last is
+        None``): ``[pair_first (parent ↔ sib0), pair_last (sib0 ↔
+        parent), none (sib1 standalone)]``.
+        """
+        from claude_code_log.html.renderer import HtmlRenderer
+
+        msgs = self._build_siblings(tmp_path)
+        html = HtmlRenderer().generate(msgs, "Test")
+        roles = self._system_pair_classes(html)
+        assert roles == ["pair_first", "pair_last", "none"], (
+            f"Expected siblings-pair shape, got: {roles}"
+        )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -956,6 +956,62 @@ class TestSystemMessageLocalCommandCleanup:
         assert msg.text == "Conversation compacted (115k tokens)"
 
 
+class TestFormatSystemContent:
+    """``format_system_content`` adapts to single-line vs multi-line text.
+
+    Multi-line system content (ASCII visualisations from ``/context``,
+    ``/cost``, etc.) renders inside ``<pre class='system-content'>`` so
+    grid alignment is preserved (#137). Single-line content keeps the
+    existing inline rendering — wrapping a one-liner in a block-level
+    ``<pre>`` is needless vertical noise.
+    """
+
+    @staticmethod
+    def _make_system_message(text: str, level: str = "info"):
+        from claude_code_log.models import MessageMeta, SystemMessage
+
+        return SystemMessage(
+            level=level,
+            text=text,
+            meta=MessageMeta(
+                session_id="s", timestamp="2026-04-28T10:00:00Z", uuid="u"
+            ),
+        )
+
+    def test_single_line_renders_inline(self):
+        from claude_code_log.html.system_formatters import format_system_content
+
+        out = format_system_content(self._make_system_message("/status"))
+        # Inline shape: icon followed by space then text — no block wrapper.
+        assert "<pre" not in out
+        assert out == "<strong>ℹ️</strong> /status"
+
+    def test_multiline_renders_in_pre_block(self):
+        """Real-world: ``/context`` output is multi-line ANSI grid."""
+        from claude_code_log.html.system_formatters import format_system_content
+
+        # Use plain newline content (no ANSI) to keep the assertion stable.
+        text = "Context Usage\nline 1\nline 2\nline 3"
+        out = format_system_content(self._make_system_message(text))
+        assert "<pre class='system-content'>" in out
+        assert "</pre>" in out
+        # Lines preserved verbatim inside the <pre>.
+        assert "line 1" in out
+        assert "line 2" in out
+        assert "line 3" in out
+        # The level icon precedes the <pre> block (visible header).
+        assert out.startswith("<strong>ℹ️</strong>")
+
+    def test_multiline_warning_uses_warning_icon(self):
+        from claude_code_log.html.system_formatters import format_system_content
+
+        out = format_system_content(
+            self._make_system_message("warn: line 1\nwarn: line 2", level="warning")
+        )
+        assert "<pre class='system-content'>" in out
+        assert out.startswith("<strong>⚠️</strong>")
+
+
 class TestGetWarmupSessionIds:
     """Test bulk warmup session ID detection."""
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1012,6 +1012,78 @@ class TestFormatSystemContent:
         assert out.startswith("<strong>⚠️</strong>")
 
 
+class TestMarkdownFormatSystemMessage:
+    """Markdown mirror of the HTML ``format_system_content`` test.
+
+    Multi-line system content (``/context`` ASCII grid, etc.) wraps in
+    a fenced code block so CommonMark preserves whitespace and grid
+    alignment. Single-line content keeps inline rendering. The fence
+    widens adaptively past any backtick run in the body via the
+    existing ``_code_fence`` helper.
+    """
+
+    @staticmethod
+    def _render(text: str, level: str = "info") -> str:
+        from claude_code_log.markdown.renderer import MarkdownRenderer
+        from claude_code_log.models import MessageMeta, SystemMessage
+        from claude_code_log.renderer import TemplateMessage
+
+        msg = TemplateMessage(
+            SystemMessage(
+                level=level,
+                text=text,
+                meta=MessageMeta(
+                    session_id="s", timestamp="2026-04-28T10:00:00Z", uuid="u"
+                ),
+            )
+        )
+        renderer = MarkdownRenderer()
+        return renderer.format_SystemMessage(msg.content, msg)  # type: ignore[arg-type]
+
+    def test_single_line_renders_inline(self):
+        out = self._render("/status")
+        # Inline shape: icon + space + text. No fence, no newline at start.
+        assert "```" not in out
+        assert out == "ℹ️ /status"
+
+    def test_multiline_wraps_in_fenced_block(self):
+        text = "Context Usage\nline 1\nline 2\nline 3"
+        out = self._render(text)
+        # Default fence is 3 ticks (no backticks in payload).
+        assert "```\nContext Usage\nline 1\nline 2\nline 3\n```" in out
+        # Icon precedes the fence on its own line so CommonMark renders
+        # the icon as a paragraph above the code block.
+        assert out.startswith("ℹ️\n")
+
+    def test_multiline_warning_uses_warning_icon(self):
+        out = self._render("warn: line 1\nwarn: line 2", level="warning")
+        assert "```" in out
+        assert out.startswith("⚠️\n")
+
+    def test_multiline_with_backticks_widens_fence(self):
+        """Defensive: backticks in the body must not break the fence.
+
+        Unlikely for `/context` ASCII grids, but `_code_fence` widens
+        past any backtick run — pin the contract via a regression test.
+        """
+        text = "header\nuse `code` like ``this``\nfooter"
+        out = self._render(text)
+        # Longest tick run is 2; fence must be >= 3 (which is also the
+        # default minimum). Use 4 to robustly exceed the longest run.
+        # Either way, a literal ``\n```\n`` (3-tick) inside the payload
+        # would be ambiguous, but the body has no triple-tick run, so
+        # the default 3-tick fence is sufficient. Verify the body
+        # round-trips inside *some* fence pair.
+        assert text in out
+        # Sanity: the payload doesn't fragment — the body is bounded by
+        # matching opening and closing fences with the same width.
+        import re
+
+        m = re.search(r"(`{3,})\n(.*?)\n\1", out, re.DOTALL)
+        assert m is not None, f"Expected fenced block in: {out!r}"
+        assert m.group(2) == text
+
+
 class TestGetWarmupSessionIds:
     """Test bulk warmup session ID detection."""
 


### PR DESCRIPTION
## Summary

Closes #137. Two related bugs in system-info rendering, surfaced by the same user transcript and fixed together because they fix the same user-facing problem (`/context` ASCII grid rendered unusably).

- **Cosmetic** (`html/system_formatters.py` + new `.system-content` CSS): multi-line system content (e.g. `/context` token-usage grid) wraps in `<pre class='system-content'>` so whitespace is preserved. CSS uses `white-space: pre` (not `pre-wrap`) so grid rows don't wrap mid-row on narrow viewports — `overflow-x: auto` provides scroll instead. Single-line system messages keep inline rendering.
- **Pairing chain** (`renderer.py::_try_pair_by_index`): chains of system messages (each `parentUuid` = previous system's `uuid`, common with `/context` / `/cost` multi-step output) used to render as `pair_first → pair_middle × (N-2) → pair_last` — fake N-tuple. Skip `_mark_pair` when the candidate parent is already paired as a child; chains break into pairs of two from the leading edge.
- **Markdown mirror** (`markdown/renderer.py::format_SystemMessage`): the same multi-line bug existed on the Markdown side (raw newlines in inline-paragraph context get collapsed). Routed through the existing `_code_fence` helper so the fence widens adaptively past any backticks in the body.

Two commits are kept self-contained rather than squashed:

- `7edf13e` — HTML `<pre>` wrap + chain-pairing fix + 6 dedicated regression tests + the snapshot updates for the new CSS rule.
- `12bf131` — Markdown mirror + 4 dedicated regression tests; no snapshot churn.

## Test plan

- [x] `just test` — 1576 pass, 7 skipped (was 1566 on `main`; +10 new tests across the two commits)
- [x] `just test-tui` — 66 pass
- [x] `just test-browser` — 39 pass, 1 skipped
- [x] `just ci` (full quality gate) — green
- [x] `ruff check` — clean
- [x] `pyright` on touched production files — clean
- [x] Snapshot updates in `test_snapshot_html.ambr` reviewed: exactly the new `.system-content` CSS rule × 7 snapshots, no content drift
- [x] New regression tests verified to fail pre-fix and pass post-fix:
  - `TestSystemMessageChainPairing` (3 tests) — 4-chain produces `[pair_first, pair_last, pair_first, pair_last]` (was `[pair_first, pair_middle, pair_middle, pair_last]`); 3-chain produces `[pair_first, pair_last, none]`; 8-chain never produces `pair_middle` (only legitimate source remains the `UserSlash → Slash → CommandOutput` triple, different code path)
  - `TestFormatSystemContent` (3 tests) — single-line stays inline, multi-line wraps in `<pre class='system-content'>`, level icon present in both
  - `TestMarkdownFormatSystemMessage` (4 tests) — mirror coverage on the Markdown side, including a backtick-adversarial test that pins the adaptive-fence contract via a regex backreference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System-message pairing corrected to avoid incorrect chain/sibling groupings.

* **New Features**
  * Multi-line system messages render in a monospace preformatted block with the level icon and horizontal scrolling; single-line remains inline.

* **Tests**
  * Added unit and regression tests for system-message rendering and pairing in HTML and Markdown.

* **Documentation**
  * Updated snapshot testing guidance to avoid concurrent update races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->