### PR TITLE
Fix UnicodeEncodeError on JSONL with lone surrogates (#139)

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -125,6 +125,20 @@ class ProjectCache(BaseModel):
 # ========== Helper Functions ==========
 
 
+def _scrub_surrogates(s: Optional[str]) -> Optional[str]:
+    """Round-trip a string through UTF-8 with ``errors="replace"``.
+
+    Strips lone surrogates (U+DC80…U+DCFF) that may have leaked in via
+    ``surrogateescape``-decoded JSONL data — sqlite3's text-binding path
+    raises ``UnicodeEncodeError`` on these the moment we try to persist
+    them. Same root cause as #139's HTML write-side fix; this is the
+    cache-DB-side companion.
+    """
+    if s is None:
+        return None
+    return s.encode("utf-8", errors="replace").decode("utf-8")
+
+
 def get_library_version() -> str:
     """Get the current library version from package metadata or pyproject.toml."""
     # First try to get version from installed package metadata
@@ -619,17 +633,21 @@ class CacheManager:
                     (
                         self._project_id,
                         session_id,
-                        data.summary,
+                        # Scrub surrogate-bearing strings before binding —
+                        # sqlite3 raises UnicodeEncodeError on lone
+                        # surrogates that surrogateescape-decoded JSONL
+                        # may have leaked into these text fields. (#139)
+                        _scrub_surrogates(data.summary),
                         data.first_timestamp,
                         data.last_timestamp,
                         data.message_count,
-                        data.first_user_message,
-                        data.cwd,
+                        _scrub_surrogates(data.first_user_message),
+                        _scrub_surrogates(data.cwd),
                         data.total_input_tokens,
                         data.total_output_tokens,
                         data.total_cache_creation_tokens,
                         data.total_cache_read_tokens,
-                        data.team_name,
+                        _scrub_surrogates(data.team_name),
                     ),
                 )
 

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -126,17 +126,24 @@ class ProjectCache(BaseModel):
 
 
 def _scrub_surrogates(s: Optional[str]) -> Optional[str]:
-    """Round-trip a string through UTF-8 with ``errors="replace"``.
+    """Replace lone surrogates (U+DC80…U+DCFF) with U+FFFD.
 
-    Strips lone surrogates (U+DC80…U+DCFF) that may have leaked in via
-    ``surrogateescape``-decoded JSONL data — sqlite3's text-binding path
-    raises ``UnicodeEncodeError`` on these the moment we try to persist
-    them. Same root cause as #139's HTML write-side fix; this is the
-    cache-DB-side companion.
+    Lone surrogates that leak in via ``surrogateescape``-decoded JSONL
+    data crash sqlite3's text-binding path with ``UnicodeEncodeError``
+    the moment we try to persist them. Same root-cause family as #139's
+    HTML write-side fix; this is the cache-DB-side companion.
+
+    Encoding via ``surrogateescape`` (which round-trips lone surrogates
+    back to their raw bytes — ``\\udcb2`` → ``b"\\xb2"``) followed by
+    decoding with ``errors="replace"`` substitutes the invalid byte
+    sequences with the canonical Unicode replacement character U+FFFD
+    (``\\ufffd``). The simpler ``encode(..., errors="replace")``
+    round-trip would emit ASCII ``?`` (U+003F) instead — also valid
+    UTF-8, but a less informative sentinel.
     """
     if s is None:
         return None
-    return s.encode("utf-8", errors="replace").decode("utf-8")
+    return s.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
 
 
 def get_library_version() -> str:

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -983,7 +983,12 @@ def _enable_next_link_on_previous_page(
     if not page_path.exists():
         return False
 
-    content = page_path.read_text(encoding="utf-8")
+    # ``errors="replace"`` guards against lone surrogates that may have
+    # been written here previously (issue #139): pre-fix runs encoded
+    # JSON-decoded surrogates straight into the HTML, and a strict
+    # read-back would crash on revisit. Replacing them here lets older
+    # corrupt pages still rewrite cleanly.
+    content = page_path.read_text(encoding="utf-8", errors="replace")
 
     # Check if there's a last-page class to remove
     if "last-page" not in content:
@@ -993,7 +998,7 @@ def _enable_next_link_on_previous_page(
     new_content, count = _NEXT_LINK_PATTERN.subn(r"\1\2", content)
 
     if count > 0:
-        page_path.write_text(new_content, encoding="utf-8")
+        page_path.write_text(new_content, encoding="utf-8", errors="replace")
         return True
 
     return False
@@ -1324,7 +1329,11 @@ def _generate_paginated_html(
             page_stats=page_stats,
             session_tree=session_tree,
         )
-        page_file.write_text(html_content, encoding="utf-8")
+        # errors="replace": surrogateescape-decoded bytes from upstream
+        # JSONL may carry lone surrogates (issue #139); strict UTF-8
+        # encoding crashes here. Replace with U+FFFD so output stays
+        # valid UTF-8.
+        page_file.write_text(html_content, encoding="utf-8", errors="replace")
 
         # Update cache
         cache_manager.update_page_cache(
@@ -1588,7 +1597,8 @@ def convert_jsonl_to(
                 messages, title, output_dir=output_dir, session_tree=session_tree
             )
             assert content is not None
-            output_path.write_text(content, encoding="utf-8")
+            # See issue #139: errors="replace" for lone-surrogate safety.
+            output_path.write_text(content, encoding="utf-8", errors="replace")
 
             # Update html_cache for combined transcript (HTML only).
             # Skip when the caller explicitly disabled cache writes — the
@@ -2080,7 +2090,10 @@ def _generate_individual_session_files(
             )
             assert session_content is not None
             # Write session file
-            session_file_path.write_text(session_content, encoding="utf-8")
+            # See issue #139: errors="replace" for lone-surrogate safety.
+            session_file_path.write_text(
+                session_content, encoding="utf-8", errors="replace"
+            )
             regenerated_count += 1
 
             # Update html_cache to track this generation (HTML only)
@@ -2234,7 +2247,8 @@ def generate_single_session_file(
         session_messages, matched_id, session_title, cache_manager, output_dir
     )
     assert session_content is not None
-    output_file.write_text(session_content, encoding="utf-8")
+    # See issue #139: errors="replace" for lone-surrogate safety.
+    output_file.write_text(session_content, encoding="utf-8", errors="replace")
 
     return output_file
 
@@ -2752,7 +2766,8 @@ def process_projects_hierarchy(
             project_summaries, from_date, to_date
         )
         assert index_content is not None
-        index_path.write_text(index_content, encoding="utf-8")
+        # See issue #139: errors="replace" for lone-surrogate safety.
+        index_path.write_text(index_content, encoding="utf-8", errors="replace")
         index_regenerated = True
     elif not silent:
         print(f"Index {ext.upper()} is current, skipping regeneration")

--- a/test/test_surrogate_encoding.py
+++ b/test/test_surrogate_encoding.py
@@ -1,0 +1,133 @@
+"""Regression tests for issue #139: lone-surrogate UnicodeEncodeError.
+
+Background
+----------
+Claude Code logs file contents using `surrogateescape`, which encodes
+non-UTF-8 bytes (e.g. Latin-1 ``0xB2``) as lone surrogate code points
+like ``U+DCB2``. JSONL on disk represents these as the literal escape
+``\\udcb2``. ``json.loads`` rebuilds the lone surrogate; strict
+UTF-8 encoding (the default for ``Path.write_text``) crashes with
+``UnicodeEncodeError`` when one of these flows into the rendered HTML.
+
+The fix adds ``errors="replace"`` to the converter's ``write_text``
+(and one paired ``read_text``) call sites so lone surrogates collapse
+to ``U+FFFD`` rather than crashing the whole run.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import convert_jsonl_to_html
+
+
+# Lone low surrogate U+DCB2 — what surrogateescape uses for byte 0xB2.
+LONE_SURROGATE = "\udcb2"
+
+
+def _make_jsonl_with_surrogate(jsonl_path: Path) -> None:
+    """Write a minimal JSONL transcript whose user-text content carries a
+    lone surrogate. The shape mirrors what Claude Code emits when a tool
+    returns binary file content via ``surrogateescape`` decoding."""
+    user_entry = {
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": "11111111-1111-1111-1111-111111111111",
+        "version": "2.1.0",
+        "type": "user",
+        "uuid": "22222222-2222-2222-2222-222222222222",
+        "timestamp": "2026-05-07T10:00:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    # Embed the lone surrogate inside otherwise-valid text.
+                    "text": f"non-utf8 byte placeholder: {LONE_SURROGATE} (issue #139)",
+                }
+            ],
+        },
+    }
+    # ``ensure_ascii=False`` keeps the literal surrogate in memory; the
+    # final on-disk JSONL escapes it as ``\udcb2`` either way (Python's
+    # JSON encoder permits unpaired surrogates by default).
+    jsonl_path.write_text(json.dumps(user_entry) + "\n", encoding="utf-8")
+
+
+class TestSurrogateEncoding:
+    def test_convert_does_not_crash_on_lone_surrogate(self, tmp_path: Path):
+        """Issue #139's minimum bar: end-to-end conversion of a transcript
+        carrying a lone surrogate must not raise UnicodeEncodeError."""
+        jsonl_path = tmp_path / "session.jsonl"
+        _make_jsonl_with_surrogate(jsonl_path)
+
+        # Should complete without raising.
+        output = convert_jsonl_to_html(jsonl_path, silent=True)
+        assert output.exists(), "converter returned a path that wasn't written"
+
+    def test_output_html_is_valid_utf8(self, tmp_path: Path):
+        """Stronger guarantee: the bytes on disk decode as strict UTF-8.
+        ``errors="replace"`` collapses any surviving lone surrogate to
+        ``U+FFFD``, which is itself valid UTF-8, so a strict re-read must
+        succeed regardless of which intermediate layer (mistune,
+        html.escape, …) replaced it."""
+        jsonl_path = tmp_path / "session.jsonl"
+        _make_jsonl_with_surrogate(jsonl_path)
+
+        output = convert_jsonl_to_html(jsonl_path, silent=True)
+
+        # Strict decode — would raise UnicodeDecodeError if the file still
+        # held a lone surrogate written via the buggy strict path.
+        html = output.read_bytes().decode("utf-8")
+        assert "issue #139" in html, "marker text from the fixture missing"
+        # The lone surrogate must not survive into the output bytes; the
+        # specific replacement character ("?", U+FFFD, or HTML entity)
+        # depends on which layer caught it first, but the surrogate
+        # itself is the canary.
+        assert LONE_SURROGATE not in html
+
+    def test_paginated_re_read_does_not_crash(self, tmp_path: Path):
+        """The paginated `_enable_next_link_on_previous_page` path reads
+        a previously-written page and rewrites it. Pre-fix corrupt pages
+        (with lone surrogates baked in) crashed on the read; the read site
+        also gained ``errors="replace"`` so older corrupt outputs can still
+        be rewritten cleanly. We exercise the read-rewrite cycle by running
+        the converter twice on a multi-page input."""
+        jsonl_path = tmp_path / "session.jsonl"
+        _make_jsonl_with_surrogate(jsonl_path)
+
+        # First run produces the HTML; second run is a cache-hit path
+        # that may exercise the read-rewrite seam.
+        first = convert_jsonl_to_html(jsonl_path, silent=True)
+        assert first.exists()
+        second = convert_jsonl_to_html(jsonl_path, silent=True)
+        assert second.exists()
+
+
+@pytest.mark.parametrize("surrogate", ["\udcb2", "\udc80", "\udcff"])
+def test_various_low_surrogates_handled(tmp_path: Path, surrogate: str):
+    """Spot-check across the surrogateescape range (U+DC80 … U+DCFF) that
+    every byte-mapped lone surrogate encodes safely."""
+    jsonl_path = tmp_path / "session.jsonl"
+    user_entry = {
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": "11111111-1111-1111-1111-111111111111",
+        "version": "2.1.0",
+        "type": "user",
+        "uuid": "22222222-2222-2222-2222-222222222222",
+        "timestamp": "2026-05-07T10:00:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": f"x{surrogate}y"}],
+        },
+    }
+    jsonl_path.write_text(json.dumps(user_entry) + "\n", encoding="utf-8")
+    output = convert_jsonl_to_html(jsonl_path, silent=True)
+    html = output.read_bytes().decode("utf-8")
+    assert surrogate not in html

--- a/test/test_surrogate_encoding.py
+++ b/test/test_surrogate_encoding.py
@@ -89,22 +89,106 @@ class TestSurrogateEncoding:
         # itself is the canary.
         assert LONE_SURROGATE not in html
 
-    def test_paginated_re_read_does_not_crash(self, tmp_path: Path):
-        """The paginated `_enable_next_link_on_previous_page` path reads
-        a previously-written page and rewrites it. Pre-fix corrupt pages
-        (with lone surrogates baked in) crashed on the read; the read site
-        also gained ``errors="replace"`` so older corrupt outputs can still
-        be rewritten cleanly. We exercise the read-rewrite cycle by running
-        the converter twice on a multi-page input."""
-        jsonl_path = tmp_path / "session.jsonl"
-        _make_jsonl_with_surrogate(jsonl_path)
+    def test_paginated_read_rewrite_does_not_crash(self, tmp_path: Path):
+        """Exercise `_enable_next_link_on_previous_page`'s read+write seam.
 
-        # First run produces the HTML; second run is a cache-hit path
-        # that may exercise the read-rewrite seam.
-        first = convert_jsonl_to_html(jsonl_path, silent=True)
-        assert first.exists()
-        second = convert_jsonl_to_html(jsonl_path, silent=True)
-        assert second.exists()
+        Pagination only fires when the input is a *directory*, the format
+        is HTML, no date filter is set, and `total_message_count >
+        page_size`. We force it by passing `page_size=1` against a
+        directory-mode input with two messages, so page 2 generation
+        triggers a read of page 1 (`read_text(errors="replace")`) and a
+        rewrite of it (`write_text(errors="replace")`).
+
+        Pre-fix, that read would raise `UnicodeDecodeError` on a page
+        whose previous run had baked in a lone surrogate; the read-side
+        fix lets older corrupt pages still rewrite cleanly."""
+        # Pagination splits by *session*, never within a session
+        # (`_assign_sessions_to_pages`). Two distinct sessions with
+        # `page_size=1` → page 1 holds the surrogate-bearing session,
+        # page 2 holds the plain one, and page-2 generation invokes
+        # `_enable_next_link_on_previous_page(output_dir, 1, …)`.
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        def _entry(session_id: str, uuid: str, timestamp: str, text: str) -> dict:
+            return {
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": session_id,
+                "version": "2.1.0",
+                "type": "user",
+                "uuid": uuid,
+                "timestamp": timestamp,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+
+        # `_assign_sessions_to_pages` closes a page only when the running
+        # message count *strictly exceeds* `page_size`, so session-A needs
+        # ≥2 messages to push the count past the threshold and force
+        # session-B onto a fresh page (1+1 with page_size=1 still fits in
+        # a single page).
+        session_a_id = "11111111-1111-1111-1111-111111111111"
+        session_b_id = "22222222-2222-2222-2222-222222222222"
+        (project_dir / "session-a.jsonl").write_text(
+            "\n".join(
+                json.dumps(e)
+                for e in [
+                    _entry(
+                        session_a_id,
+                        "33333333-3333-3333-3333-333333333333",
+                        "2026-05-07T10:00:00.000Z",
+                        f"page-1 first msg with {LONE_SURROGATE} (issue #139)",
+                    ),
+                    _entry(
+                        session_a_id,
+                        "33333333-3333-3333-3333-333333333334",
+                        "2026-05-07T10:00:00.500Z",
+                        "page-1 second msg",
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (project_dir / "session-b.jsonl").write_text(
+            json.dumps(
+                _entry(
+                    session_b_id,
+                    "44444444-4444-4444-4444-444444444444",
+                    "2026-05-07T10:00:01.000Z",
+                    "page-2 plain content",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # Directory mode + page_size=1 forces ≥2 pages; page-2 generation
+        # invokes `_enable_next_link_on_previous_page(output_dir, 1, …)`.
+        output = convert_jsonl_to_html(project_dir, page_size=1, silent=True)
+        assert output.exists()
+
+        # Confirm pagination actually fired (page 2 was created — otherwise
+        # the read-rewrite seam wouldn't have been exercised).
+        page_1 = project_dir / "combined_transcripts.html"
+        page_2 = project_dir / "combined_transcripts_2.html"
+        assert page_1.exists() and page_2.exists(), (
+            "expected two paginated HTML files; only one was generated"
+        )
+
+        # Both pages must be strict-UTF-8 decodable (would raise pre-fix
+        # if the surrogate had been written through `write_text` strictly,
+        # and the page-1 read in `_enable_next_link_on_previous_page`
+        # would also have crashed pre-fix on the same payload).
+        page_1_html = page_1.read_bytes().decode("utf-8")
+        page_2_html = page_2.read_bytes().decode("utf-8")
+        assert LONE_SURROGATE not in page_1_html
+        assert LONE_SURROGATE not in page_2_html
 
 
 @pytest.mark.parametrize("surrogate", ["\udcb2", "\udc80", "\udcff"])


### PR DESCRIPTION
## Summary

Claude Code uses `surrogateescape` to log non-UTF-8 file bytes (e.g. Latin-1 `0xB2` → `U+DCB2`). These lone surrogates survive `json.loads` in memory but crash strict UTF-8 encoding the moment the rendered HTML hits `Path.write_text(..., encoding="utf-8")`. This PR adds `errors="replace"` to all converter-side `read_text` / `write_text` call sites that touch rendered HTML so lone surrogates collapse to `U+FFFD` rather than aborting the run.

Closes #139.

## Changed sites in `claude_code_log/converter.py`

The issue originally cited line numbers 828 / 1424 / 1910 / 2064. Code has shifted; the conceptual fix applies to all 7 currently-extant HTML I/O seams:

| Line | Function | Direction |
|------|----------|-----------|
| 991 | `_enable_next_link_on_previous_page` | read |
| 1001 | `_enable_next_link_on_previous_page` | write (paired with 991) |
| 1336 | `_generate_paginated_html` | per-page write |
| 1601 | `convert_jsonl_to` | combined-transcript write |
| 2095 | `_generate_individual_session_files` | per-session write (regenerate) |
| 2251 | `convert_single_session` | single-session output |
| 2770 | `generate_projects_index` | index write |

Input-side reads at lines 98 / 146 / 310 / 585 already used `errors="replace"`; this PR makes the output side symmetric.

## Deliberately untouched

- `~/.claude/settings.json` read at line 2271 — strict-UTF-8 by design (Claude Code's own config), and the surrounding `except (json.JSONDecodeError, OSError)` already provides the safety net. Not on the surrogate-escaped data path.
- `claude_code_log/migrations/runner.py` — reads bundled SQL migrations only, immune.

## Out of scope

The same defect class lives in `claude_code_log/tui.py:1867` (write) and probably `tui.py:1678` (read). The blast radius is *worse* there because a wrapping `try/except Exception: return None` at the TUI export boundary silently turns the same crash into a confusing "Failed to generate" notification with no traceback. Recommend filing as a follow-up issue (e.g. "Apply #139 surrogate fix to TUI export path") and tracking separately.

## Tests

`test/test_surrogate_encoding.py` (new):

- 3 method tests in `TestSurrogateEncoding`:
  - `test_convert_does_not_crash_on_lone_surrogate` — minimum bar from #139.
  - `test_output_html_is_valid_utf8` — strict re-decode of the on-disk bytes succeeds, original surrogate gone.
  - `test_paginated_re_read_does_not_crash` — exercises the read-rewrite seam in `_enable_next_link_on_previous_page`.
- 1 parametrised test across `U+DC80`, `U+DCB2`, `U+DCFF` (the surrogateescape byte-range).

Assertion shape: tests verify that the lone surrogate doesn't survive into output bytes and the file decodes as strict UTF-8. The specific replacement character (`?`, `U+FFFD`, or HTML entity) varies by which intermediate layer caught it first (mistune sometimes pre-replaces with `?` before reaching `write_text`); pinning a particular replacement char would be a fragile cross-layer assertion. The invariant that matters — and that this PR establishes — is "no lone surrogate in output bytes, no crash."

## Test plan

- [x] `just test` — all surrogate tests green.
- [x] `just ci` end-to-end clean — TUI 78p / 7s, benchmark, ruff + pyright + ty all green.
- [x] Manual review of all 7 converter.py I/O sites, verified each handles rendered HTML output (not bundled assets / config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when converting content containing lone-surrogate or other malformed encoding sequences.
  * All generated HTML and related output are now safe UTF-8 and can be regenerated without encoding errors.
  * Improved robustness of metadata caching so oddly-encoded fields no longer cause failures.

* **Tests**
  * Added regression tests to ensure conversion completes, outputs strict UTF-8, and safely handles multiple surrogate cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->