### PR TITLE
fix: add errors='replace' to read_text/write_text for Unicode safety (#139)

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -125,13 +125,15 @@ class ProjectCache(BaseModel):
 # ========== Helper Functions ==========
 
 
-def _scrub_surrogates(s: Optional[str]) -> Optional[str]:
+def scrub_surrogates(s: Optional[str]) -> Optional[str]:
     """Replace lone surrogates (U+DC80…U+DCFF) with U+FFFD.
 
-    Lone surrogates that leak in via ``surrogateescape``-decoded JSONL
-    data crash sqlite3's text-binding path with ``UnicodeEncodeError``
-    the moment we try to persist them. Same root-cause family as #139's
-    HTML write-side fix; this is the cache-DB-side companion.
+    Public helper used wherever ``surrogateescape``-decoded JSONL data
+    might cross a strict-UTF-8 boundary (issue #139). Examples:
+    sqlite3's text-binding path (``cache.update_session_cache``) and
+    TUI export (``tui.SessionBrowser._ensure_session_file``) — both
+    raise ``UnicodeEncodeError`` on lone surrogates the moment we try
+    to persist them.
 
     Encoding via ``surrogateescape`` (which round-trips lone surrogates
     back to their raw bytes — ``\\udcb2`` → ``b"\\xb2"``) followed by
@@ -644,17 +646,17 @@ class CacheManager:
                         # sqlite3 raises UnicodeEncodeError on lone
                         # surrogates that surrogateescape-decoded JSONL
                         # may have leaked into these text fields. (#139)
-                        _scrub_surrogates(data.summary),
+                        scrub_surrogates(data.summary),
                         data.first_timestamp,
                         data.last_timestamp,
                         data.message_count,
-                        _scrub_surrogates(data.first_user_message),
-                        _scrub_surrogates(data.cwd),
+                        scrub_surrogates(data.first_user_message),
+                        scrub_surrogates(data.cwd),
                         data.total_input_tokens,
                         data.total_output_tokens,
                         data.total_cache_creation_tokens,
                         data.total_cache_read_tokens,
-                        _scrub_surrogates(data.team_name),
+                        scrub_surrogates(data.team_name),
                     ),
                 )
 

--- a/claude_code_log/tui.py
+++ b/claude_code_log/tui.py
@@ -23,7 +23,12 @@ from textual.widgets import (
 from textual.reactive import reactive
 from rich.markup import escape as escape_markup
 
-from .cache import CacheManager, SessionCacheData, get_library_version
+from .cache import (
+    CacheManager,
+    SessionCacheData,
+    get_library_version,
+    scrub_surrogates,
+)
 from .converter import (
     build_session_title,
     ensure_fresh_cache,
@@ -1864,7 +1869,14 @@ class SessionBrowser(App[Optional[str]]):
                 self.project_path,
             )
             if session_content:
-                session_file.write_text(session_content, encoding="utf-8", errors="replace")
+                # Scrub lone surrogates to U+FFFD before strict-UTF-8 write
+                # (#139). `errors="replace"` is defense-in-depth — the
+                # broader `try/except` below silently swallows any residual
+                # encode error, and "Failed to generate" with no traceback
+                # is the worst outcome (worse than the CLI's loud crash,
+                # which is how #139 surfaced in the first place).
+                scrubbed = scrub_surrogates(session_content) or session_content
+                session_file.write_text(scrubbed, encoding="utf-8", errors="replace")
                 return session_file
         except Exception:
             return None

--- a/claude_code_log/tui.py
+++ b/claude_code_log/tui.py
@@ -1675,7 +1675,7 @@ class SessionBrowser(App[Optional[str]]):
                 self.notify("Failed to generate Markdown file", severity="error")
                 return
 
-            content = session_file.read_text(encoding="utf-8")
+            content = session_file.read_text(encoding="utf-8", errors="replace")
             title = f"Session: {self.selected_session_id[:8]}..."
             self.push_screen(MarkdownViewerScreen(content, title))
             if force:
@@ -1864,7 +1864,7 @@ class SessionBrowser(App[Optional[str]]):
                 self.project_path,
             )
             if session_content:
-                session_file.write_text(session_content, encoding="utf-8")
+                session_file.write_text(session_content, encoding="utf-8", errors="replace")
                 return session_file
         except Exception:
             return None

--- a/test/test_tui_surrogate.py
+++ b/test/test_tui_surrogate.py
@@ -1,0 +1,116 @@
+"""TUI export-path regression tests for issue #139.
+
+Counterpart to ``test_surrogate_encoding.py`` — that file exercises the
+CLI path through ``convert_jsonl_to_html``; this one exercises
+``SessionBrowser._ensure_session_file``, which the TUI calls when the
+user opens a session export. Pre-fix, a lone surrogate flowing from the
+in-memory renderer into ``Path.write_text(encoding="utf-8")`` would
+crash, but the TUI's wrapping ``try/except Exception: return None``
+silently swallows the traceback — the user sees only "Failed to
+generate".
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from claude_code_log.tui import SessionBrowser
+
+
+# Lone low surrogate U+DCB2 — what surrogateescape uses for byte 0xB2.
+LONE_SURROGATE = "\udcb2"
+REPLACEMENT_CHAR = "�"
+
+
+def _seed_project_with_session(project_dir: Path, session_id: str) -> None:
+    """Write a minimal JSONL session file the TUI can pick up. Content
+    doesn't matter for this test — `generate_session` is mocked — but
+    the file must exist so cache discovery sees something."""
+    entry = {
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": session_id,
+        "version": "2.1.0",
+        "type": "user",
+        "uuid": "55555555-5555-5555-5555-555555555555",
+        "timestamp": "2026-05-08T10:00:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "doesn't matter — mocked"}],
+        },
+    }
+    (project_dir / f"{session_id}.jsonl").write_text(
+        json.dumps(entry) + "\n", encoding="utf-8"
+    )
+
+
+@pytest.mark.tui
+class TestTUIExportSurrogateHandling:
+    """The TUI export path must scrub lone surrogates so the on-disk file
+    is valid UTF-8. The wrapping ``try/except`` at the call site means a
+    crash here would silently surface as 'Failed to generate' rather than
+    a loud exception — bug-class worth a regression test."""
+
+    def test_session_export_scrubs_lone_surrogate(self, tmp_path: Path):
+        """The renderer is mocked to return surrogate-bearing HTML; the
+        on-disk file must be strict-UTF-8 decodable, the surrogate must
+        be gone, and U+FFFD must be in its place (the canonical Unicode
+        replacement char that ``scrub_surrogates`` produces)."""
+        session_id = "11111111-1111-1111-1111-111111111111"
+        _seed_project_with_session(tmp_path, session_id)
+
+        # Surrogate-bearing content the renderer "would" emit. Pre-fix,
+        # `Path.write_text(encoding="utf-8")` of this would crash.
+        surrogate_html = (
+            f"<html><body><p>marker {LONE_SURROGATE} (issue #139 TUI)</p></body></html>"
+        )
+
+        browser = SessionBrowser(tmp_path)
+        # Populate sessions dict so build_session_title gets useful data.
+        browser.sessions = {}
+
+        # Mock the renderer's generate_session to inject surrogate-bearing
+        # content directly. Also short-circuit `is_outdated` so we always
+        # write, and `load_directory_transcripts` to skip JSONL parsing.
+        mock_renderer = MagicMock()
+        mock_renderer.is_outdated.return_value = True
+        mock_renderer.generate_session.return_value = surrogate_html
+
+        with (
+            patch("claude_code_log.tui.get_renderer", return_value=mock_renderer),
+            patch(
+                "claude_code_log.tui.load_directory_transcripts",
+                return_value=([{"placeholder": True}], None),
+            ),
+            patch.object(browser.cache_manager, "get_cached_project_data") as mock_pd,
+            patch(
+                "claude_code_log.tui.build_session_title", return_value="Test Session"
+            ),
+        ):
+            mock_pd.return_value = MagicMock(working_directories=[str(tmp_path)])
+            session_file = browser._ensure_session_file(session_id, "html", force=True)
+
+        # Method must return a Path (not None — None would mean the
+        # try/except silently swallowed the original surrogate crash).
+        assert session_file is not None, (
+            "TUI export silently failed — the broader try/except likely "
+            "swallowed an UnicodeEncodeError that scrubbing should have "
+            "prevented."
+        )
+        assert session_file.exists()
+
+        # Strict UTF-8 decode of the bytes — would raise pre-fix if the
+        # crash had happened or if the surrogate had been written through
+        # somehow.
+        on_disk = session_file.read_bytes().decode("utf-8")
+        assert "issue #139 TUI" in on_disk
+        assert LONE_SURROGATE not in on_disk
+        # The surrogate should land as U+FFFD (canonical Unicode
+        # replacement character), not ASCII '?' — we use the
+        # `scrub_surrogates` helper which uses surrogateescape →
+        # decode-replace specifically to emit U+FFFD.
+        assert REPLACEMENT_CHAR in on_disk


### PR DESCRIPTION
## Summary

Fixes #139 — UnicodeDecodeError / UnicodeEncodeError on JSONL files containing JSON-escaped lone surrogates.

### Problem

Claude Code can produce `.jsonl` files containing JSON-escaped lone surrogates like `\udcb2` when it reads and logs file content with raw non-UTF-8 bytes (e.g. Latin-1 `0xB2`). While the JSONL file itself is valid UTF-8 on disk, `json.loads()` converts `\udcb2` into a Python lone surrogate character `'\udcb2'`, which then crashes strict UTF-8 encoding in `write_text()`.

**Crash site** (line 1038):
```
content = page_path.read_text(encoding="utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb2 in position 3760886
```

### Solution

Add `errors="replace"` to all `read_text()` and `write_text()` calls in `converter.py` (7 instances) and `tui.py` (2 instances).

This matches the pattern already used in `open()` calls for reading JSONL files (lines 122, 170, 334, 609).

### Changes

| File | Lines | Change |
|------|-------|--------|
| `converter.py` | 1038, 1048, 1379, 1643, 2135, 2289, 2807 | Add `errors="replace"` to read/write calls |
| `tui.py` | 1678, 1867 | Add `errors="replace"` to read/write calls |

### Behavior

- **Before**: Crash on lone surrogates with `UnicodeDecodeError` / `UnicodeEncodeError`
- **After**: Lone surrogates are replaced with `U+FFFD` (replacement character), allowing processing to continue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of session file handling with invalid UTF-8 characters in viewing and export operations
  * Session exports now gracefully replace malformed character sequences instead of failing during generation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->