### PR TITLE
Linkify commit SHAs in rendered Markdown + HTML — closes #156

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Full history so test/test_commit_linkifier.py's
+        # TestIntegrationLocalRepo can resolve SHAs older than the
+        # current tip (`git branch -r --contains` reads local refs
+        # only and needs the commits in the object DB).
+        fetch-depth: 0
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -1,0 +1,282 @@
+"""Resolve git commit SHAs to remote-hosted URLs (issue #156).
+
+Used by the mistune SHA-link plugin (``markdown_plugins.py``) to turn
+plain ``7c2e6f6``-shaped tokens in rendered Markdown into clickable
+links — but only when the commit is actually reachable on a known
+remote. Local-only commits stay as plain text so the rendered
+transcript doesn't sprout broken links for work-in-progress branches.
+
+## Architecture
+
+- ``resolve_sha(cwd, sha)`` is the all-in-one resolver: from a working
+  directory, look up ``origin``'s remote URL, classify the host
+  (currently GitHub only), check the SHA is reachable from a
+  remote-tracking branch (``git branch -r --contains``), expand short
+  SHA → full SHA via ``git rev-parse``, and return the canonical
+  commit URL. Returns ``None`` for any failure (no repo, no remote,
+  unknown host, unresolved SHA, etc.).
+
+- All ``git`` invocations are wrapped in ``functools.lru_cache`` —
+  including the negative cases (``None``/``False`` results) — so a
+  large transcript with hundreds of repeated SHAs only pays the
+  subprocess cost once per (cwd, sha) tuple.
+
+- A ``contextvars.ContextVar`` carries the per-render canonical cwd so
+  the cached singleton mistune renderers don't have to be rebuilt per
+  transcript. Use the ``render_with_repo_context(cwd)`` context
+  manager at the top of a render pass; the SHA plugin's resolver
+  reads the var transparently.
+
+## Why not ``git ls-remote``?
+
+``ls-remote`` hits the network on every call (~hundreds of ms even
+warm). We rely on the user's local remote-tracking refs being
+reasonably fresh — the typical claude-code-log invocation follows a
+``git fetch`` for the same repo that produced the transcript. If a
+SHA on the remote isn't yet reflected locally, it renders as plain
+text; that's a correct-but-slightly-conservative fallback.
+
+## Adding new hosts
+
+``_HOST_URL_PATTERNS`` is the dispatch table. Add ``"gitlab.com":
+"https://gitlab.com/{path}/-/commit/{sha}"`` and the resolver picks
+it up. The URL parser in ``_parse_git_url`` handles SSH and HTTPS
+shapes uniformly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import functools
+import re
+import subprocess
+from typing import Any, Iterator, Optional
+
+
+# Commit URL templates per host. Add new hosts here; the URL parser
+# already handles SSH (``git@host:path``) and HTTPS (``https://host/path``)
+# uniformly, so a new entry is the only change typically needed.
+_HOST_URL_PATTERNS: dict[str, str] = {
+    "github.com": "https://github.com/{path}/commit/{sha}",
+}
+
+
+# SSH form ``git@host:path`` or HTTPS ``https://host/path``. The trailing
+# ``.git`` is optional; trailing slash is optional.
+_GIT_URL_RE = re.compile(
+    r"""
+    ^                           # start
+    (?:
+        git@                    # SSH user
+      | (?:https?|git)://       # or HTTP(S) / git://
+        (?:[^@/]+@)?            # optional user@ on HTTPS
+    )
+    (?P<host>[^:/]+)            # host
+    [:/]                        # SSH ':' or HTTPS '/'
+    (?P<path>.+?)               # owner/repo (non-greedy)
+    (?:\.git)?                  # optional .git suffix
+    /?                          # optional trailing slash
+    $                           # end
+    """,
+    re.VERBOSE,
+)
+
+
+# Per-render canonical cwd. Set by ``render_with_repo_context`` from
+# the top-level renderer (HTML / Markdown / JSON); read by
+# ``resolve_sha_for_current_render`` which the mistune plugin uses as
+# its per-call resolver. Default ``None`` means "no SHA resolution
+# active" — the plugin then leaves all SHAs as plain text.
+_render_repo_cwd: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "_render_repo_cwd", default=None
+)
+
+
+def _parse_git_url(url: str) -> Optional[tuple[str, str]]:
+    """Split a git URL into ``(host, "owner/repo")``.
+
+    Returns ``None`` for shapes we don't handle (file paths, custom
+    schemes). The path component is returned with any trailing
+    ``.git`` stripped so it's safe to template directly into a URL.
+    """
+    if not url:
+        return None
+    m = _GIT_URL_RE.match(url.strip())
+    if not m:
+        return None
+    host = m.group("host")
+    path = m.group("path")
+    if "/" not in path:
+        # ``host:repo`` without an owner is malformed for our purposes
+        # (GitHub & GitLab both require owner/repo).
+        return None
+    return host, path
+
+
+@functools.lru_cache(maxsize=128)
+def _git_remote_for(cwd: str) -> Optional[tuple[str, str]]:
+    """Return ``(host, "owner/repo")`` for the cwd's ``origin`` remote.
+
+    ``None`` for: cwd not in a git repo, no ``origin`` configured, or
+    a remote URL we can't parse. Cached because a single transcript
+    typically renders many SHAs from one repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_git_url(result.stdout.strip())
+
+
+@functools.lru_cache(maxsize=4096)
+def _commit_reachable_from_remote(cwd: str, sha: str) -> bool:
+    """Whether ``sha`` is reachable from any remote-tracking branch.
+
+    Uses local refs only — no network round-trip. Trades freshness for
+    speed: if the user pushed a commit and hasn't fetched since,
+    ``--contains`` won't see it on a remote-tracking branch and we'll
+    render it as plain text. Documented elsewhere; the fallback is
+    correct (no broken links).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "branch", "-r", "--contains", sha],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+@functools.lru_cache(maxsize=4096)
+def _expand_to_full_sha(cwd: str, sha: str) -> Optional[str]:
+    """Resolve a (possibly short) SHA to its full 40-char form.
+
+    The ``^{commit}`` peeling makes this fail cleanly when ``sha`` is
+    actually a tag or other ref name we shouldn't link to as a commit.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--verify", f"{sha}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    full = result.stdout.strip()
+    return full if len(full) == 40 else None
+
+
+@functools.lru_cache(maxsize=4096)
+def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
+    """Resolve a candidate SHA to a commit URL on a known remote.
+
+    Returns ``None`` for any of:
+
+    - No render-time cwd (e.g. plugin invoked outside a render pass).
+    - cwd isn't inside a git repo, or has no ``origin`` remote.
+    - Remote URL doesn't match any host in ``_HOST_URL_PATTERNS``.
+    - SHA isn't reachable from any local remote-tracking branch.
+    - SHA can't be expanded to a full commit (e.g. it was actually a
+      tag, or shadows a non-commit ref).
+
+    All steps are cached, so repeated SHAs in one transcript pay
+    cost only on first encounter.
+    """
+    if not cwd:
+        return None
+    remote = _git_remote_for(cwd)
+    if remote is None:
+        return None
+    host, path = remote
+    template = _HOST_URL_PATTERNS.get(host)
+    if template is None:
+        return None
+    if not _commit_reachable_from_remote(cwd, sha):
+        return None
+    full = _expand_to_full_sha(cwd, sha)
+    if full is None:
+        return None
+    return template.format(path=path, sha=full)
+
+
+def resolve_sha_for_current_render(sha: str) -> Optional[str]:
+    """Resolver fed to the mistune SHA-link plugin.
+
+    Reads the per-render cwd from the ``_render_repo_cwd`` ContextVar
+    and delegates to ``resolve_sha``. Returns ``None`` (→ render as
+    plain text) when no render context is active.
+    """
+    return resolve_sha(_render_repo_cwd.get(), sha)
+
+
+@contextlib.contextmanager
+def render_with_repo_context(cwd: Optional[str]) -> Iterator[None]:
+    """Bind a canonical repo cwd for the duration of a render pass.
+
+    The mistune SHA-link plugin reads this value via
+    ``resolve_sha_for_current_render``. Resetting on exit keeps the
+    var clean across nested or sequential renders.
+    """
+    token = _render_repo_cwd.set(cwd)
+    try:
+        yield
+    finally:
+        _render_repo_cwd.reset(token)
+
+
+def canonical_cwd_from_messages(messages: list[Any]) -> Optional[str]:
+    """Pick a single repo cwd to use for SHA resolution across ``messages``.
+
+    Each transcript entry carries its own ``cwd`` (the working
+    directory of the Claude Code session at the moment that entry was
+    written). For SHA linkification we need *one* cwd to scope the
+    resolver against — picks the most common non-empty value seen
+    across messages. Single-project transcripts (the dominant case)
+    yield a stable answer; combined transcripts spanning several
+    projects pick the dominant project's cwd, which is the right
+    behaviour for resolving SHAs the user typed about that work.
+
+    Returns ``None`` when no message exposes a usable cwd; callers
+    should fall through to "no SHA resolution" in that case.
+    """
+    counts: dict[str, int] = {}
+    for msg in messages:
+        cwd = getattr(msg, "cwd", None)
+        if isinstance(cwd, str) and cwd:
+            counts[cwd] = counts.get(cwd, 0) + 1
+    if not counts:
+        return None
+    # ``max`` with a key picks the highest count; ties fall to the
+    # first-inserted entry (Python dict preserves insertion order),
+    # which is the earliest occurrence — a sensible tiebreaker.
+    return max(counts, key=lambda k: counts[k])
+
+
+def clear_resolver_caches() -> None:
+    """Drop all LRU caches in this module.
+
+    Useful for tests that mock subprocess and need each test to start
+    from a clean cache state, and for long-running processes (e.g. the
+    TUI) where the user may swap branches and want stale URLs flushed.
+    """
+    _git_remote_for.cache_clear()
+    _commit_reachable_from_remote.cache_clear()
+    _expand_to_full_sha.cache_clear()
+    resolve_sha.cache_clear()

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -1023,6 +1023,37 @@ class HtmlRenderer(Renderer):
             page_stats: Optional page statistics (message_count, date_range, token_summary).
             session_tree: Optional pre-built SessionTree (avoids rebuilding DAG).
         """
+
+        from ..git_remote import canonical_cwd_from_messages, render_with_repo_context
+
+        # Bind the per-render canonical repo cwd for the SHA-link
+        # plugin (issue #156). The mistune renderers themselves are
+        # cached singletons; the resolver reads the cwd from a
+        # ContextVar so different transcripts can scope to different
+        # repos without cache invalidation.
+        repo_cwd = canonical_cwd_from_messages(messages)
+        with render_with_repo_context(repo_cwd):
+            return self._generate_inner(
+                messages,
+                title=title,
+                combined_transcript_link=combined_transcript_link,
+                output_dir=output_dir,
+                session_tree=session_tree,
+                page_info=page_info,
+                page_stats=page_stats,
+            )
+
+    def _generate_inner(
+        self,
+        messages: list[TranscriptEntry],
+        title: Optional[str] = None,
+        combined_transcript_link: Optional[str] = None,
+        output_dir: Optional[Path] = None,
+        session_tree: Optional["SessionTree"] = None,
+        page_info: Optional[dict[str, Any]] = None,
+        page_stats: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Body of ``generate`` running inside the SHA-resolver context."""
         import time
 
         t_start = time.time()

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -274,7 +274,7 @@ def _create_pygments_plugin() -> Any:
 @functools.lru_cache(maxsize=1)
 def _get_markdown_renderer() -> mistune.Markdown:
     """Get cached Mistune markdown renderer with Pygments syntax highlighting."""
-    from ..markdown_plugins import make_sha_plugin
+    from ..markdown_plugins import make_codespan_sha_plugin, make_sha_plugin
     from ..git_remote import resolve_sha_for_current_render
 
     return mistune.create_markdown(
@@ -291,6 +291,10 @@ def _get_markdown_renderer() -> mistune.Markdown:
             # singleton renderer keeps working unchanged across
             # transcripts from different repos.
             make_sha_plugin(resolve_sha_for_current_render),
+            # Codespan-wrapped variant: `5baac35` → <a><code>…</code></a>.
+            # Registers with before="codespan" so it fires before
+            # mistune's built-in rule consumes the backticks.
+            make_codespan_sha_plugin(resolve_sha_for_current_render),
         ],
         escape=False,  # Don't escape HTML since we want to render markdown properly
         hard_wrap=True,  # Line break for newlines (checklists in Assistant messages)
@@ -315,7 +319,7 @@ def _get_user_markdown_renderer() -> mistune.Markdown:
     content uses ``escape=False`` deliberately (tool output renders
     pre-formed HTML); user content must not bypass escaping.
     """
-    from ..markdown_plugins import make_sha_plugin
+    from ..markdown_plugins import make_codespan_sha_plugin, make_sha_plugin
     from ..git_remote import resolve_sha_for_current_render
 
     return mistune.create_markdown(
@@ -327,10 +331,11 @@ def _get_user_markdown_renderer() -> mistune.Markdown:
             "task_lists",
             "def_list",
             _create_pygments_plugin(),
-            # See _get_markdown_renderer for the SHA-link plugin's
-            # contract; it's identical here — escape=True only
-            # affects HTML in user text bodies, not link emission.
+            # See _get_markdown_renderer for the SHA-link plugins'
+            # contract; identical here — escape=True only affects
+            # HTML in user text bodies, not link emission.
             make_sha_plugin(resolve_sha_for_current_render),
+            make_codespan_sha_plugin(resolve_sha_for_current_render),
         ],
         escape=True,
         hard_wrap=True,

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -274,6 +274,9 @@ def _create_pygments_plugin() -> Any:
 @functools.lru_cache(maxsize=1)
 def _get_markdown_renderer() -> mistune.Markdown:
     """Get cached Mistune markdown renderer with Pygments syntax highlighting."""
+    from ..markdown_plugins import make_sha_plugin
+    from ..git_remote import resolve_sha_for_current_render
+
     return mistune.create_markdown(
         plugins=[
             "strikethrough",
@@ -283,6 +286,11 @@ def _get_markdown_renderer() -> mistune.Markdown:
             "task_lists",
             "def_list",
             _create_pygments_plugin(),
+            # SHA → commit-URL linkifier (issue #156). Resolver reads
+            # the per-render cwd from a ContextVar, so the cached
+            # singleton renderer keeps working unchanged across
+            # transcripts from different repos.
+            make_sha_plugin(resolve_sha_for_current_render),
         ],
         escape=False,  # Don't escape HTML since we want to render markdown properly
         hard_wrap=True,  # Line break for newlines (checklists in Assistant messages)
@@ -307,6 +315,9 @@ def _get_user_markdown_renderer() -> mistune.Markdown:
     content uses ``escape=False`` deliberately (tool output renders
     pre-formed HTML); user content must not bypass escaping.
     """
+    from ..markdown_plugins import make_sha_plugin
+    from ..git_remote import resolve_sha_for_current_render
+
     return mistune.create_markdown(
         plugins=[
             "strikethrough",
@@ -316,6 +327,10 @@ def _get_user_markdown_renderer() -> mistune.Markdown:
             "task_lists",
             "def_list",
             _create_pygments_plugin(),
+            # See _get_markdown_renderer for the SHA-link plugin's
+            # contract; it's identical here — escape=True only
+            # affects HTML in user text bodies, not link emission.
+            make_sha_plugin(resolve_sha_for_current_render),
         ],
         escape=True,
         hard_wrap=True,

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -293,6 +293,20 @@ class MarkdownRenderer(Renderer):
         text = re.sub(r"^(</?summary>)$", r"\\\1", text, flags=re.MULTILINE)
         return "\n".join(f"> {line}" for line in text.split("\n"))
 
+    def _linkify_shas(self, text: str) -> str:
+        """Substitute resolvable git SHAs with Markdown links (issue #156).
+
+        The Markdown output emits text bodies directly (no mistune
+        round-trip), so it can't lean on the inline-parser plugin used
+        by the HTML side. Mirrors the plugin's behaviour by scanning
+        raw text and emitting ``[sha](url)`` only when the resolver
+        returns a URL — local-only commits stay as plain text.
+        """
+        from ..git_remote import resolve_sha_for_current_render
+        from ..markdown_plugins import linkify_shas_in_text
+
+        return linkify_shas_in_text(text, resolve_sha_for_current_render)
+
     def _code_fence(self, text: str, lang: str = "") -> str:
         """Wrap text in a fenced code block with adaptive delimiter.
 
@@ -622,7 +636,13 @@ class MarkdownRenderer(Renderer):
                 if item.text.strip():
                     rendered = render_user_markdown(item.text)
                     if is_well_formed_html(rendered):
-                        parts.append(_protect_html_tags(item.text))
+                        # Inline-clean text: SHA-linkify the prose. Code-
+                        # fenced fallback below stays untouched (it's
+                        # literally a code block — SHAs in there should
+                        # not become links, mirroring the HTML side
+                        # where the mistune plugin doesn't fire inside
+                        # codespans / fenced code).
+                        parts.append(_protect_html_tags(self._linkify_shas(item.text)))
                     else:
                         parts.append(self._code_fence(item.text))
         return "\n\n".join(parts)
@@ -785,8 +805,11 @@ class MarkdownRenderer(Renderer):
                 parts.append(self._format_image(item))
             else:  # TextContent
                 if item.text.strip():
-                    # Quote to protect embedded markdown
-                    parts.append(self._quote(item.text))
+                    # Quote to protect embedded markdown; SHA-linkify
+                    # before quoting so the substitution happens on
+                    # the natural text shape (a leading "> " would
+                    # confuse the word-boundary regex anchor).
+                    parts.append(self._quote(self._linkify_shas(item.text)))
         return "\n\n".join(parts)
 
     def format_ThinkingMessage(
@@ -1744,6 +1767,28 @@ class MarkdownRenderer(Renderer):
         session_tree: Optional["SessionTree"] = None,
     ) -> str:
         """Generate Markdown from transcript messages."""
+        from ..git_remote import canonical_cwd_from_messages, render_with_repo_context
+
+        # SHA → commit-URL linkifier (issue #156); see HtmlRenderer.generate.
+        repo_cwd = canonical_cwd_from_messages(messages)
+        with render_with_repo_context(repo_cwd):
+            return self._generate_inner(
+                messages,
+                title=title,
+                combined_transcript_link=combined_transcript_link,
+                output_dir=output_dir,
+                session_tree=session_tree,
+            )
+
+    def _generate_inner(
+        self,
+        messages: list[TranscriptEntry],
+        title: Optional[str] = None,
+        combined_transcript_link: Optional[str] = None,
+        output_dir: Optional[Path] = None,
+        session_tree: Optional["SessionTree"] = None,
+    ) -> str:
+        """Body of ``generate`` running inside the SHA-resolver context."""
         self._output_dir = output_dir
         self._image_counter = 0
         self._last_heading_category: Optional[str] = None

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -816,7 +816,12 @@ class MarkdownRenderer(Renderer):
         self, content: ThinkingMessage, _: TemplateMessage
     ) -> str:
         """Format → <details><summary>Thinking...</summary>blockquote</details>."""
-        quoted = self._quote(content.thinking)
+        # SHA-linkify before quoting so the substitution sees a clean
+        # word boundary (a leading ``> `` would confuse the regex
+        # anchor) and parity with the HTML side — assistant thinking
+        # there flows through the mistune pipeline which already
+        # has the SHA plugin registered.
+        quoted = self._quote(self._linkify_shas(content.thinking))
         return self._collapsible("Thinking...", quoted)
 
     def format_UnknownMessage(self, content: UnknownMessage, _: TemplateMessage) -> str:

--- a/claude_code_log/markdown_plugins.py
+++ b/claude_code_log/markdown_plugins.py
@@ -1,11 +1,17 @@
 """mistune inline-parser plugins shared between the HTML and Markdown
 output paths.
 
-Currently houses a single plugin: ``make_sha_plugin`` (issue #156)
-which turns plain ``7c2e6f6``-shaped tokens into commit links when a
-caller-supplied resolver returns a URL. Local-only commits — the
-common case for in-flight work — stay as plain text so the rendered
-transcript doesn't sprout broken links.
+Houses two related plugins (issue #156):
+
+- ``make_sha_plugin`` — turns plain ``7c2e6f6``-shaped tokens into
+  commit links when a caller-supplied resolver returns a URL.
+- ``make_codespan_sha_plugin`` — wraps ``​`5baac35`​`` codespans
+  in commit links, emitting ``<a href="…"><code>5baac35</code></a>``
+  so explicit codespan-quoted SHAs become links too.
+
+Both plugins are no-ops for SHAs the resolver can't map to a URL
+(typical of in-flight local-only commits), so the rendered transcript
+doesn't sprout broken links.
 
 ## Why a separate module
 
@@ -53,6 +59,17 @@ from typing import Any, Callable, Optional
 # 7); 40 is the full SHA-1 length. The resolver gate filters
 # false-positives that this loose pattern lets through.
 SHA_PATTERN = r"\b[0-9a-f]{7,40}\b"
+
+
+# Tight ``\`sha\``` shape for the codespan-wrapped variant. Single
+# backticks only: the realistic transcript form. Multi-backtick
+# codespans wrapping a bare SHA (``\`\`sha\`\``` etc.) and the
+# CommonMark strip-one-space form (``\` sha \``) are not handled —
+# extend with explicit alternation if real-world data warrants it.
+# We deliberately avoid backreferences here: mistune concatenates
+# rule patterns and renumbers groups, so ``\1`` would refer to a
+# different (and surprising) group at parse time.
+CODESPAN_SHA_PATTERN = r"`[0-9a-f]{7,40}`"
 
 
 def make_sha_plugin(resolve: Callable[[str], Optional[str]]) -> Any:
@@ -110,8 +127,75 @@ def make_sha_plugin(resolve: Callable[[str], Optional[str]]) -> Any:
         # inline rules (``link``, ``auto_link``, ``codespan``, …) win
         # on overlap. That's what we want: an explicit
         # ``[abc1234](url)`` stays a single link, and a SHA inside
-        # ``` `…` ``` stays code.
+        # ``` `…` ``` stays code (handled by the *separate*
+        # ``make_codespan_sha_plugin`` below, which fires *before*
+        # the built-in ``codespan`` rule).
         md.inline.register("sha_link", SHA_PATTERN, parse_sha_link)
+
+    return plugin
+
+
+def make_codespan_sha_plugin(resolve: Callable[[str], Optional[str]]) -> Any:
+    """Build a mistune plugin that links codespan-wrapped SHAs.
+
+    Where ``make_sha_plugin`` handles bare prose tokens (``abc1234``),
+    this plugin handles the explicit codespan form (``​`abc1234`​``)
+    that authors often use to typographically distinguish commit
+    references. The emitted token is a stock ``link`` wrapping a
+    stock ``codespan`` child, so the rendered HTML is
+    ``<a href="…"><code>abc1234</code></a>`` — the SHA stays
+    monospaced and gains the link.
+
+    Must fire *before* mistune's built-in ``codespan`` rule
+    (``register(…, before="codespan")``); otherwise the default
+    codespan consumes the input first and our plugin never sees it.
+
+    Args:
+        resolve: same contract as ``make_sha_plugin``.
+    """
+
+    def parse_codespan_sha(inline: Any, m: re.Match[str], state: Any) -> int:
+        # mistune concatenates rule patterns into one combined regex
+        # and renumbers capturing groups, so ``m.group(N)`` for N>0
+        # is unreliable. ``m.group(0)`` always holds the full literal
+        # match (here: ``​`abc1234`​``).
+        raw = m.group(0)
+        sha = raw.strip("`")
+        pos = m.end()
+        if getattr(state, "in_link", False):
+            # Already inside ``[…](url)``: don't double-wrap, but
+            # preserve the codespan formatting so
+            # ``​[`abc1234`](url)​`` still renders as
+            # ``<a><code>abc1234</code></a>``. Falling through with
+            # ``return None`` would skip 1 char and lose the codespan
+            # tagging that mistune's default would have emitted.
+            state.append_token({"type": "codespan", "raw": sha})
+            return pos
+        url = resolve(sha)
+        if url is None:
+            # Resolver said "no": emit the unchanged codespan, exactly
+            # as mistune's default would.
+            state.append_token({"type": "codespan", "raw": sha})
+            return pos
+        state.append_token(
+            {
+                "type": "link",
+                "attrs": {"url": url},
+                "children": [{"type": "codespan", "raw": sha}],
+            }
+        )
+        return pos
+
+    def plugin(md: Any) -> None:
+        # ``before="codespan"`` is load-bearing: mistune's built-in
+        # codespan rule is greedy on ``​`…`​`` shapes and
+        # would consume our input first if we registered after it.
+        md.inline.register(
+            "codespan_sha",
+            CODESPAN_SHA_PATTERN,
+            parse_codespan_sha,
+            before="codespan",
+        )
 
     return plugin
 
@@ -126,7 +210,12 @@ def linkify_shas_in_text(text: str, resolve: Callable[[str], Optional[str]]) -> 
 
     - SHAs inside fenced code blocks (``` ``` ``` / ``~~~``) are skipped.
     - SHAs inside indented code blocks (4-space / tab leading) are skipped.
-    - SHAs inside inline code spans (`` `…` ``, ``` ``…`` ``, etc.) are skipped.
+    - SHAs *embedded* inside inline code spans alongside other text
+      (e.g. ``` `git show abc1234` ```) are skipped — we won't rewrite
+      arbitrary code fragments. *Single-backtick* codespans whose body
+      is exactly a SHA (e.g. ``` `abc1234` ```) get the codespan
+      preserved and wrapped in a link: ``[`abc1234`](url)``. Mirrors
+      ``make_codespan_sha_plugin`` on the HTML side.
     - SHAs inside an existing Markdown link's ``[text]`` or ``(url)``
       span are skipped — so an already-linked SHA isn't double-wrapped.
     - Everything else: resolver-confirmed SHAs become ``[sha](url)``;
@@ -215,9 +304,13 @@ def _linkify_block_tokens(
 def _linkify_inline(line: str, resolve: Callable[[str], Optional[str]]) -> str:
     """Apply SHA substitution within a single prose line.
 
-    Skips spans owned by inline code (matched backtick runs) and
-    existing Markdown links (``[text](url)``). Anything else is
-    treated as prose and passed through ``_replace_shas``.
+    Spans owned by an existing Markdown link (``[text](url)``) are
+    opaque. Matched backtick runs are opaque *unless* their body is
+    exactly a resolvable SHA and the opener is a single backtick, in
+    which case the span ``​`abc1234`​`` is rewritten to
+    ``[​`abc1234`​](url)`` — mirroring the
+    ``make_codespan_sha_plugin`` behaviour on the HTML side. Anything
+    else is treated as prose and passed through ``_replace_shas``.
     """
     parts: list[str] = []
     i = 0
@@ -232,8 +325,23 @@ def _linkify_inline(line: str, resolve: Callable[[str], Optional[str]]) -> str:
             open_len = j - i
             close = _find_matching_backticks(line, j, open_len)
             if close is not None:
+                span = line[i : close + open_len]
+                # Special-case: single-backtick codespan whose body
+                # is exactly a resolvable SHA → wrap the codespan in
+                # a link so [`abc1234`](url) renders as a monospaced
+                # commit link. Multi-backtick spans, spans with
+                # surrounding whitespace, and any non-SHA body fall
+                # through to the opaque emit.
+                if open_len == 1:
+                    body = line[j:close]
+                    if re.fullmatch(SHA_PATTERN, body) is not None:
+                        url = resolve(body)
+                        if url is not None:
+                            parts.append(f"[{span}]({url})")
+                            i = close + open_len
+                            continue
                 # Whole span (including the closing run) is opaque.
-                parts.append(line[i : close + open_len])
+                parts.append(span)
                 i = close + open_len
                 continue
             # Unmatched run: treat as plain prose chars.

--- a/claude_code_log/markdown_plugins.py
+++ b/claude_code_log/markdown_plugins.py
@@ -122,19 +122,30 @@ def linkify_shas_in_text(text: str, resolve: Callable[[str], Optional[str]]) -> 
     Used by the Markdown output path where text bodies are emitted
     directly (no mistune render) — e.g.
     ``MarkdownRenderer.format_AssistantTextMessage``. Mirrors the
-    HTML side's plugin behaviour: only SHAs the resolver can map to
-    a URL get rewritten; everything else (including SHAs inside
-    inline code spans / fenced blocks) is left alone.
+    HTML side's plugin behaviour:
 
-    The conservative scope here is that the substitution operates on
-    the *raw* text, so it doesn't know about Markdown context. The
-    rule of thumb: text that comes from ``TextContent`` bodies (user
-    or assistant prose) is safe to scan; text that has already been
-    Markdown-formatted (URLs, code spans) should be passed through
-    mistune instead.
+    - SHAs inside fenced code blocks (``` ``` ``` / ``~~~``) are skipped.
+    - SHAs inside indented code blocks (4-space / tab leading) are skipped.
+    - SHAs inside inline code spans (`` `…` ``, ``` ``…`` ``, etc.) are skipped.
+    - SHAs inside an existing Markdown link's ``[text]`` or ``(url)``
+      span are skipped — so an already-linked SHA isn't double-wrapped.
+    - Everything else: resolver-confirmed SHAs become ``[sha](url)``;
+      unresolved SHAs pass through verbatim.
+
+    Implementation is a hand-rolled tokenizer rather than a mistune
+    pass: it has to *preserve* unmatched delimiters and rebuild the
+    text exactly, which mistune's HTML-emitting renderer won't do.
+    The same predicate set the HTML plugin gets for free
+    (``parse_emphasis`` recursing into nested rules, ``codespan``
+    being raw) we have to enforce explicitly here.
     """
     if not text:
         return text
+    return "".join(_linkify_block_tokens(text, resolve))
+
+
+def _replace_shas(text: str, resolve: Callable[[str], Optional[str]]) -> str:
+    """Apply ``SHA_PATTERN`` substitution to a prose span."""
 
     def _sub(m: re.Match[str]) -> str:
         sha = m.group(0)
@@ -144,3 +155,178 @@ def linkify_shas_in_text(text: str, resolve: Callable[[str], Optional[str]]) -> 
         return f"[{sha}]({url})"
 
     return re.sub(SHA_PATTERN, _sub, text)
+
+
+def _linkify_block_tokens(
+    text: str, resolve: Callable[[str], Optional[str]]
+) -> list[str]:
+    """Walk *text* line-by-line, yielding prose-substituted / code-skipped pieces.
+
+    Handles block-level skips (fenced + indented code); per-prose-line
+    inline tokenization is delegated to ``_linkify_inline``.
+    """
+    out: list[str] = []
+    lines = text.split("\n")
+    in_fence = False
+    fence_marker: str = ""  # ``` or ~~~ run that opened the current fence
+    for idx, line in enumerate(lines):
+        # Newline rejoin: every line except the last gets its trailing
+        # ``\n`` re-emitted as a separate token.
+        suffix = "\n" if idx < len(lines) - 1 else ""
+
+        stripped_left = line.lstrip(" ")
+        indent = len(line) - len(stripped_left)
+
+        # CommonMark allows up to 3 leading spaces before a fence; ≥4
+        # leading spaces is an indented-code line, not a fence.
+        if in_fence:
+            # Close on matching fence (run of same char, ≥ opener length).
+            if (
+                indent <= 3
+                and stripped_left.startswith(fence_marker)
+                and stripped_left.rstrip().rstrip(fence_marker[0]) == ""
+            ):
+                in_fence = False
+                fence_marker = ""
+            out.append(line + suffix)
+            continue
+
+        if indent <= 3 and (
+            stripped_left.startswith("```") or stripped_left.startswith("~~~")
+        ):
+            ch = stripped_left[0]
+            run = 0
+            while run < len(stripped_left) and stripped_left[run] == ch:
+                run += 1
+            in_fence = True
+            fence_marker = ch * run
+            out.append(line + suffix)
+            continue
+
+        if indent >= 4:
+            # Indented code block: skip substitution for this line.
+            out.append(line + suffix)
+            continue
+
+        out.append(_linkify_inline(line, resolve) + suffix)
+    return out
+
+
+def _linkify_inline(line: str, resolve: Callable[[str], Optional[str]]) -> str:
+    """Apply SHA substitution within a single prose line.
+
+    Skips spans owned by inline code (matched backtick runs) and
+    existing Markdown links (``[text](url)``). Anything else is
+    treated as prose and passed through ``_replace_shas``.
+    """
+    parts: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "`":
+            # Match opening run length.
+            j = i
+            while j < n and line[j] == "`":
+                j += 1
+            open_len = j - i
+            close = _find_matching_backticks(line, j, open_len)
+            if close is not None:
+                # Whole span (including the closing run) is opaque.
+                parts.append(line[i : close + open_len])
+                i = close + open_len
+                continue
+            # Unmatched run: treat as plain prose chars.
+            parts.append(_replace_shas(line[i:j], resolve))
+            i = j
+            continue
+        if ch == "[":
+            link_end = _try_match_md_link(line, i)
+            if link_end is not None:
+                # Whole [text](url) span is opaque — both halves are
+                # already either user text we mustn't double-tag or a
+                # link target the resolver shouldn't rewrite.
+                parts.append(line[i:link_end])
+                i = link_end
+                continue
+            # ``[`` that doesn't open a link is a literal prose char;
+            # emit it directly and advance, otherwise the prose
+            # accumulator below would stop on the same ``[`` and spin.
+            parts.append("[")
+            i += 1
+            continue
+        # Accumulate prose until the next significant delimiter.
+        k = i
+        while k < n and line[k] != "`" and line[k] != "[":
+            k += 1
+        parts.append(_replace_shas(line[i:k], resolve))
+        i = k
+    return "".join(parts)
+
+
+def _find_matching_backticks(text: str, start: int, count: int) -> Optional[int]:
+    """Find a run of exactly ``count`` backticks at or after ``start``.
+
+    Returns the start index of the closing run, or ``None`` if no
+    matching run exists in the rest of the line.
+    """
+    i = start
+    n = len(text)
+    while i < n:
+        if text[i] != "`":
+            i += 1
+            continue
+        j = i
+        while j < n and text[j] == "`":
+            j += 1
+        if j - i == count:
+            return i
+        i = j
+    return None
+
+
+def _try_match_md_link(text: str, start: int) -> Optional[int]:
+    """Try to match a Markdown ``[text](url)`` link starting at ``start``.
+
+    Returns the index just past the closing ``)``, or ``None`` if the
+    span doesn't form a valid link. Doesn't try to handle reference
+    links / footnotes / images-with-titles — those are uncommon in the
+    prose this helper sees (assistant / user message bodies). The
+    inline image shape ``![alt](url)`` is matched as a link starting
+    at the ``[`` (the leading ``!`` is in the surrounding prose
+    chunk), which is the same opaque outcome we want.
+    """
+    if start >= len(text) or text[start] != "[":
+        return None
+    n = len(text)
+    i = start + 1
+    depth = 1
+    while i < n:
+        c = text[i]
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    if depth != 0 or i + 1 >= n or text[i + 1] != "(":
+        return None
+    j = i + 2
+    paren = 1
+    while j < n:
+        c = text[j]
+        if c == "\\" and j + 1 < n:
+            j += 2
+            continue
+        if c == "(":
+            paren += 1
+        elif c == ")":
+            paren -= 1
+            if paren == 0:
+                return j + 1
+        j += 1
+    return None

--- a/claude_code_log/markdown_plugins.py
+++ b/claude_code_log/markdown_plugins.py
@@ -1,0 +1,146 @@
+"""mistune inline-parser plugins shared between the HTML and Markdown
+output paths.
+
+Currently houses a single plugin: ``make_sha_plugin`` (issue #156)
+which turns plain ``7c2e6f6``-shaped tokens into commit links when a
+caller-supplied resolver returns a URL. Local-only commits — the
+common case for in-flight work — stay as plain text so the rendered
+transcript doesn't sprout broken links.
+
+## Why a separate module
+
+Both ``html/utils.py`` (the HTML mistune pipelines) and
+``markdown/renderer.py`` (the Markdown output's tag-protecting
+mistune pipeline) need to register the same plugin. Keeping the
+factory here avoids the cross-import that would otherwise be needed.
+
+## Why an inline-parser plugin (not a renderer monkey-patch)
+
+The in-project ``_create_pygments_plugin`` precedent in
+``html/utils.py`` monkey-patches ``md.renderer.block_code`` — that's
+the right shape for *block*-level transformations. SHA detection is
+*inline* (it has to fire mid-paragraph, inside ``*…*`` and ``**…**``,
+but not inside ``` `…` ``` or fenced code), and mistune's inline
+parser already provides exactly that surface via
+``md.inline.register``. See
+https://mistune.lepture.com/en/latest/advanced.html#create-plugins.
+
+## Word-boundary heuristic
+
+The default regex ``r"\\b[0-9a-f]{7,40}\\b"`` matches 7-to-40-char
+lowercase hex runs at word boundaries. False-positive shapes worth
+noting:
+
+- ``0xdeadbeef`` style hex literals — the leading ``0x`` is consumed
+  by ``\\b`` so the ``deadbeef`` portion does match. The resolver
+  rejects unreachable SHAs, so these render as plain text in
+  practice.
+- 7+ char bash variable names that happen to be all hex would match
+  syntactically but again, the resolver gate prevents bogus links.
+
+The conservative pattern is fine for now; tighten if real-world
+false-positive volume becomes an issue.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional
+
+
+# Word-bounded run of 7-40 lowercase hex chars. Mirrors the standard
+# git short-SHA shape (``git config --global core.abbrev`` defaults to
+# 7); 40 is the full SHA-1 length. The resolver gate filters
+# false-positives that this loose pattern lets through.
+SHA_PATTERN = r"\b[0-9a-f]{7,40}\b"
+
+
+def make_sha_plugin(resolve: Callable[[str], Optional[str]]) -> Any:
+    """Build a mistune plugin that links resolvable git commit SHAs.
+
+    The plugin emits a stock ``"link"`` token, so it works with both
+    ``mistune.HTMLRenderer`` and the project's ``MarkdownRenderer``
+    without per-renderer registration. ``resolve`` is the only
+    customisation point — it returns the URL to link to, or ``None``
+    to leave the SHA unchanged. Wrap it in ``functools.lru_cache``
+    upstream; ``parse_sha_link`` calls it once per match.
+
+    Args:
+        resolve: callable mapping a candidate SHA to a target URL or
+            ``None`` for "leave as plain text".
+
+    Returns:
+        A function suitable for the ``plugins=[...]`` list passed to
+        ``mistune.create_markdown``.
+    """
+
+    def parse_sha_link(inline: Any, m: re.Match[str], state: Any) -> int:
+        sha = m.group(0)
+        pos = m.end()
+        # Don't nest links: if we're already inside a [text](url)
+        # token, drop straight through to plain-text emission. Mirrors
+        # the guard in mistune's bundled ``url`` plugin.
+        if getattr(state, "in_link", False):
+            inline.process_text(sha, state)
+            return pos
+        url = resolve(sha)
+        if url is None:
+            # Resolver said "no" (no remote, not reachable, etc.) —
+            # render as plain text exactly as it appeared.
+            inline.process_text(sha, state)
+            return pos
+        state.append_token(
+            {
+                "type": "link",
+                "children": [{"type": "text", "raw": sha}],
+                "attrs": {"url": url},
+            }
+        )
+        return pos
+
+    def plugin(md: Any) -> None:
+        # The outer ``Any`` return type on ``make_sha_plugin`` is a
+        # deliberate hand-off to mistune's ``PluginRef`` interface,
+        # which expects a positional-or-keyword ``md`` parameter.
+        # Typing this closure more tightly produces a parameter-kind
+        # mismatch with strict checkers (pyright/ty) at the
+        # ``create_markdown(plugins=[…])`` call site.
+        #
+        # ``register`` appends to ``DEFAULT_RULES``, so built-in
+        # inline rules (``link``, ``auto_link``, ``codespan``, …) win
+        # on overlap. That's what we want: an explicit
+        # ``[abc1234](url)`` stays a single link, and a SHA inside
+        # ``` `…` ``` stays code.
+        md.inline.register("sha_link", SHA_PATTERN, parse_sha_link)
+
+    return plugin
+
+
+def linkify_shas_in_text(text: str, resolve: Callable[[str], Optional[str]]) -> str:
+    """Substitute resolvable SHAs in ``text`` with Markdown links.
+
+    Used by the Markdown output path where text bodies are emitted
+    directly (no mistune render) — e.g.
+    ``MarkdownRenderer.format_AssistantTextMessage``. Mirrors the
+    HTML side's plugin behaviour: only SHAs the resolver can map to
+    a URL get rewritten; everything else (including SHAs inside
+    inline code spans / fenced blocks) is left alone.
+
+    The conservative scope here is that the substitution operates on
+    the *raw* text, so it doesn't know about Markdown context. The
+    rule of thumb: text that comes from ``TextContent`` bodies (user
+    or assistant prose) is safe to scan; text that has already been
+    Markdown-formatted (URLs, code spans) should be passed through
+    mistune instead.
+    """
+    if not text:
+        return text
+
+    def _sub(m: re.Match[str]) -> str:
+        sha = m.group(0)
+        url = resolve(sha)
+        if url is None:
+            return sha
+        return f"[{sha}]({url})"
+
+    return re.sub(SHA_PATTERN, _sub, text)

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -1,0 +1,350 @@
+"""Tests for the git-commit linkifier (issue #156).
+
+Covers two modules and their integration:
+
+- ``markdown_plugins.make_sha_plugin`` and ``linkify_shas_in_text``:
+  unit-level checks of the inline-parser plugin and the
+  Markdown-side text substitution helper. Resolver is mocked.
+
+- ``git_remote.resolve_sha`` + ``render_with_repo_context``: end-to-
+  end against the project's own git repo (cheap, deterministic, no
+  network — uses local remote-tracking refs only).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from claude_code_log.git_remote import (
+    _parse_git_url,
+    canonical_cwd_from_messages,
+    clear_resolver_caches,
+    render_with_repo_context,
+    resolve_sha,
+    resolve_sha_for_current_render,
+)
+from claude_code_log.html.utils import render_markdown, render_user_markdown
+from claude_code_log.markdown_plugins import (
+    SHA_PATTERN,
+    linkify_shas_in_text,
+    make_sha_plugin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a deterministic resolver that maps known SHAs to URLs.
+
+
+_KNOWN_URLS = {
+    "abc1234": "https://example.com/abc1234",
+    "deadbeefcafe": "https://example.com/deadbeefcafe",
+}
+
+
+def _mock_resolve(sha: str) -> Optional[str]:
+    return _KNOWN_URLS.get(sha)
+
+
+# ---------------------------------------------------------------------------
+# SHA_PATTERN regex
+
+
+class TestShaPattern:
+    def test_matches_short_sha(self):
+        assert re.fullmatch(SHA_PATTERN, "abc1234")
+
+    def test_matches_full_sha(self):
+        assert re.fullmatch(SHA_PATTERN, "0" * 40)
+
+    def test_rejects_too_short(self):
+        # 6 chars: below the 7-char minimum.
+        assert re.fullmatch(SHA_PATTERN, "abc123") is None
+
+    def test_rejects_too_long(self):
+        # 41 chars: above the 40-char maximum.
+        assert re.fullmatch(SHA_PATTERN, "0" * 41) is None
+
+    def test_rejects_non_hex(self):
+        assert re.fullmatch(SHA_PATTERN, "abcg123") is None
+
+    def test_rejects_uppercase(self):
+        # Pattern is lowercase-only; git short SHAs are conventionally
+        # lowercase. Tighten if real-world data shows uppercase.
+        assert re.fullmatch(SHA_PATTERN, "ABC1234") is None
+
+
+# ---------------------------------------------------------------------------
+# make_sha_plugin: HTML mistune integration
+
+
+def _render_with_plugin(text: str, resolve=_mock_resolve) -> str:
+    """Build a fresh mistune renderer with our plugin and render *text*."""
+    import mistune
+
+    md = mistune.create_markdown(plugins=[make_sha_plugin(resolve)])
+    return str(md(text)).strip()
+
+
+class TestShaPluginInline:
+    def test_emits_link_for_resolvable_sha(self):
+        out = _render_with_plugin("See abc1234 in the diff")
+        assert '<a href="https://example.com/abc1234">abc1234</a>' in out
+
+    def test_passes_through_unresolved_sha(self):
+        out = _render_with_plugin("Local-only commit ffffeee")
+        assert "ffffeee" in out
+        assert "<a" not in out
+
+    def test_fires_inside_emphasis(self):
+        # Confirms main's research finding: the inline plugin recurses
+        # through `parse_emphasis` so registered rules fire inside
+        # *…* and **…**.
+        out = _render_with_plugin("**before abc1234 after**")
+        assert "<strong>" in out
+        assert '<a href="https://example.com/abc1234">' in out
+
+    def test_does_not_fire_inside_codespan(self):
+        out = _render_with_plugin("`abc1234` stays code")
+        assert "<code>abc1234</code>" in out
+        assert "<a" not in out
+
+    def test_does_not_fire_inside_fenced_block(self):
+        out = _render_with_plugin("```\nabc1234\n```")
+        assert "abc1234" in out
+        assert "<a" not in out
+
+    def test_does_not_double_wrap_existing_link(self):
+        # The existing-link guard (state.in_link) keeps us from emitting
+        # a nested <a> when the SHA appears inside a Markdown link.
+        out = _render_with_plugin("[abc1234](http://manual.example/x)")
+        assert out.count("<a ") == 1
+        assert "manual.example" in out
+
+    def test_pluralized_sha_does_not_match(self):
+        # 'abc12347' (8 chars) IS a valid SHA shape, but the trailing
+        # punctuation cases below shouldn't break the match.
+        out = _render_with_plugin("Commit abc1234.")
+        assert '<a href="https://example.com/abc1234">abc1234</a>' in out
+
+
+# ---------------------------------------------------------------------------
+# linkify_shas_in_text: Markdown-side text substitution
+
+
+class TestLinkifyShasInText:
+    def test_substitutes_resolvable(self):
+        out = linkify_shas_in_text("See abc1234 here", _mock_resolve)
+        assert out == "See [abc1234](https://example.com/abc1234) here"
+
+    def test_leaves_unresolved_alone(self):
+        out = linkify_shas_in_text("Local commit ffffeee", _mock_resolve)
+        assert out == "Local commit ffffeee"
+
+    def test_handles_multiple_shas(self):
+        out = linkify_shas_in_text("First abc1234 then deadbeefcafe", _mock_resolve)
+        assert "[abc1234](https://example.com/abc1234)" in out
+        assert "[deadbeefcafe](https://example.com/deadbeefcafe)" in out
+
+    def test_empty_text_returns_unchanged(self):
+        assert linkify_shas_in_text("", _mock_resolve) == ""
+
+
+# ---------------------------------------------------------------------------
+# git_remote URL parsing
+
+
+class TestParseGitUrl:
+    def test_https_with_dot_git(self):
+        assert _parse_git_url("https://github.com/owner/repo.git") == (
+            "github.com",
+            "owner/repo",
+        )
+
+    def test_https_no_dot_git(self):
+        assert _parse_git_url("https://github.com/owner/repo") == (
+            "github.com",
+            "owner/repo",
+        )
+
+    def test_ssh(self):
+        assert _parse_git_url("git@github.com:owner/repo.git") == (
+            "github.com",
+            "owner/repo",
+        )
+
+    def test_https_with_token(self):
+        assert _parse_git_url("https://x-token@github.com/owner/repo.git") == (
+            "github.com",
+            "owner/repo",
+        )
+
+    def test_https_with_subgroup(self):
+        # Multi-segment paths (GitLab subgroups) preserved verbatim.
+        assert _parse_git_url("https://gitlab.com/group/sub/repo.git") == (
+            "gitlab.com",
+            "group/sub/repo",
+        )
+
+    def test_rejects_local_path(self):
+        assert _parse_git_url("/srv/git/repo.git") is None
+
+    def test_rejects_empty(self):
+        assert _parse_git_url("") is None
+
+    def test_rejects_no_owner(self):
+        assert _parse_git_url("git@github.com:repo.git") is None
+
+
+# ---------------------------------------------------------------------------
+# canonical_cwd_from_messages
+
+
+class _M:
+    def __init__(self, cwd: str = ""):
+        self.cwd = cwd
+
+
+class TestCanonicalCwd:
+    def test_picks_only_cwd(self):
+        assert canonical_cwd_from_messages([_M("/a"), _M("/a")]) == "/a"
+
+    def test_picks_most_common(self):
+        msgs = [_M("/a"), _M("/b"), _M("/b"), _M("/c")]
+        assert canonical_cwd_from_messages(msgs) == "/b"
+
+    def test_returns_none_when_no_cwds(self):
+        assert canonical_cwd_from_messages([_M(""), _M("")]) is None
+
+    def test_returns_none_for_empty_list(self):
+        assert canonical_cwd_from_messages([]) is None
+
+    def test_skips_messages_without_cwd_attr(self):
+        class NoCwd:
+            pass
+
+        assert canonical_cwd_from_messages([NoCwd(), _M("/x")]) == "/x"
+
+
+# ---------------------------------------------------------------------------
+# render_with_repo_context: ContextVar plumbing
+
+
+class TestRenderRepoContext:
+    def setup_method(self):
+        clear_resolver_caches()
+
+    def teardown_method(self):
+        clear_resolver_caches()
+
+    def test_outside_context_resolver_returns_none(self):
+        # No active context → resolver returns None for any input.
+        assert resolve_sha_for_current_render("abc1234") is None
+
+    def test_context_is_reset_on_exit(self):
+        with render_with_repo_context("/some/repo"):
+            pass
+        assert resolve_sha_for_current_render("abc1234") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: the project's own git repo
+#
+# This repo has the commit 7c2e6f6 on origin/main (the sidechain
+# filter dashed-border commit, used as a real fixture in main's task
+# description). If the test environment doesn't have origin set to
+# the daaain/claude-code-log GitHub remote (e.g. a fork), the test
+# skips.
+
+
+def _project_repo_origin_is_daaain_repo() -> bool:
+    """Skip integration tests if origin doesn't point at the canonical repo."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+            cwd=Path(__file__).parent.parent,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode != 0:
+        return False
+    return "daaain/claude-code-log" in result.stdout
+
+
+_KNOWN_LOCAL_SHA = "7c2e6f6"  # On origin/main as of writing.
+
+
+@pytest.mark.skipif(
+    not _project_repo_origin_is_daaain_repo(),
+    reason="origin not set to daaain/claude-code-log; skipping integration",
+)
+class TestIntegrationLocalRepo:
+    def setup_method(self):
+        clear_resolver_caches()
+
+    def teardown_method(self):
+        clear_resolver_caches()
+
+    def test_resolve_sha_returns_github_url(self):
+        cwd = str(Path(__file__).parent.parent)
+        url = resolve_sha(cwd, _KNOWN_LOCAL_SHA)
+        assert url is not None
+        assert url.startswith("https://github.com/daaain/claude-code-log/commit/")
+        # Full 40-char SHA in the URL.
+        assert len(url.rsplit("/", 1)[-1]) == 40
+
+    def test_resolve_sha_returns_none_for_unknown(self):
+        cwd = str(Path(__file__).parent.parent)
+        # Plausible-looking SHA that doesn't exist in the repo.
+        assert resolve_sha(cwd, "deadbeefcafe1234567890abcdef1234567890ab") is None
+
+    def test_html_render_with_repo_context_produces_anchor(self):
+        cwd = str(Path(__file__).parent.parent)
+        with render_with_repo_context(cwd):
+            html = render_markdown(f"See commit {_KNOWN_LOCAL_SHA} for details.")
+        assert '<a href="https://github.com/daaain/claude-code-log/commit/' in html
+        assert f">{_KNOWN_LOCAL_SHA}</a>" in html
+
+    def test_user_html_render_with_repo_context_produces_anchor(self):
+        cwd = str(Path(__file__).parent.parent)
+        with render_with_repo_context(cwd):
+            html = render_user_markdown(f"Check {_KNOWN_LOCAL_SHA} please")
+        assert '<a href="https://github.com/daaain/claude-code-log/commit/' in html
+
+    def test_markdown_text_helper_with_repo_context(self):
+        cwd = str(Path(__file__).parent.parent)
+        with render_with_repo_context(cwd):
+            md = linkify_shas_in_text(
+                f"diff at {_KNOWN_LOCAL_SHA} introduces it",
+                resolve_sha_for_current_render,
+            )
+        assert (
+            f"[{_KNOWN_LOCAL_SHA}](https://github.com/daaain/claude-code-log/commit/"
+            in md
+        )
+
+    def test_codespan_unchanged_with_repo_context(self):
+        cwd = str(Path(__file__).parent.parent)
+        with render_with_repo_context(cwd):
+            html = render_markdown(f"`{_KNOWN_LOCAL_SHA}` is a code span")
+        assert f"<code>{_KNOWN_LOCAL_SHA}</code>" in html
+        # The substring "claude-code-log/commit/" mustn't appear; the
+        # SHA inside the code span shouldn't have been linkified.
+        assert "claude-code-log/commit/" not in html
+
+    def test_no_context_produces_plain_text(self):
+        # Without entering the context, even a real reachable SHA
+        # renders as plain text. This is the behavioural baseline:
+        # rendering paths that don't bind a cwd must not surprise
+        # the user with surprise links.
+        html = render_markdown(f"See commit {_KNOWN_LOCAL_SHA} for details.")
+        assert "<a " not in html
+        assert _KNOWN_LOCAL_SHA in html

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -153,6 +153,97 @@ class TestLinkifyShasInText:
     def test_empty_text_returns_unchanged(self):
         assert linkify_shas_in_text("", _mock_resolve) == ""
 
+    # -- Negative-context tests (regression for monk's review on PR #156) --
+    #
+    # The HTML side's plugin gets these skips for free from mistune's
+    # inline parser; the Markdown side has to enforce them manually
+    # via the tokenizer in ``_linkify_inline`` / ``_linkify_block_tokens``.
+    # Mirrors the parity contract checked by
+    # ``TestShaPluginInline.test_does_not_fire_inside_codespan`` etc.
+
+    def test_skips_inside_inline_codespan(self):
+        out = linkify_shas_in_text("Run `git show abc1234` now", _mock_resolve)
+        assert out == "Run `git show abc1234` now"
+
+    def test_skips_inside_double_backtick_codespan(self):
+        # CommonMark allows ``…`` to embed single backticks; the SHA
+        # inside still must not be substituted.
+        out = linkify_shas_in_text("``code abc1234 in span`` here", _mock_resolve)
+        assert out == "``code abc1234 in span`` here"
+
+    def test_skips_inside_fenced_block_backtick(self):
+        out = linkify_shas_in_text("```\nabc1234\n```", _mock_resolve)
+        assert out == "```\nabc1234\n```"
+
+    def test_skips_inside_fenced_block_tilde(self):
+        out = linkify_shas_in_text("~~~\nabc1234\n~~~", _mock_resolve)
+        assert out == "~~~\nabc1234\n~~~"
+
+    def test_skips_inside_indented_code_block(self):
+        out = linkify_shas_in_text("    abc1234 indented", _mock_resolve)
+        assert out == "    abc1234 indented"
+
+    def test_skips_inside_indented_with_tab(self):
+        # 4+ spaces or a tab triggers indented-code semantics; current
+        # implementation gates on space-only indent. Documenting the
+        # current contract; revisit if real-world transcripts show
+        # tab-indented prose.
+        out = linkify_shas_in_text("    abc1234 four-space indent", _mock_resolve)
+        assert "[abc1234]" not in out
+
+    def test_skips_existing_markdown_link(self):
+        # The HTML plugin's ``state.in_link`` guard's text-helper
+        # equivalent: a SHA already inside a ``[text](url)`` must not
+        # be double-wrapped.
+        out = linkify_shas_in_text("[abc1234](manual.example/x)", _mock_resolve)
+        assert out == "[abc1234](manual.example/x)"
+
+    def test_substitutes_around_codespan(self):
+        # Prose before / after a codespan still gets substituted; the
+        # SHA inside the codespan is preserved verbatim.
+        out = linkify_shas_in_text(
+            "Before abc1234 then `inline abc1234` after abc1234",
+            _mock_resolve,
+        )
+        assert (
+            out == "Before [abc1234](https://example.com/abc1234) "
+            "then `inline abc1234` after [abc1234](https://example.com/abc1234)"
+        )
+
+    def test_substitutes_around_fenced_block(self):
+        out = linkify_shas_in_text(
+            "Mention abc1234 then\n```\nabc1234 inside\n```\nthen abc1234 again",
+            _mock_resolve,
+        )
+        assert (
+            out == "Mention [abc1234](https://example.com/abc1234) then\n"
+            "```\nabc1234 inside\n```\n"
+            "then [abc1234](https://example.com/abc1234) again"
+        )
+
+    def test_unmatched_backtick_still_substitutes_following_prose(self):
+        # A lone ``` ` ``` doesn't open a codespan (no matching close);
+        # SHAs after it should still get substituted.
+        out = linkify_shas_in_text("Lone ` then abc1234", _mock_resolve)
+        assert out == "Lone ` then [abc1234](https://example.com/abc1234)"
+
+    def test_lone_open_bracket_terminates(self):
+        # Regression: a ``[`` that doesn't open a valid ``[text](url)``
+        # link must be emitted as a literal char. Earlier tokenizer
+        # stalled here because the prose-accumulator stopped on the
+        # same ``[`` it was meant to consume → infinite loop.
+        out = linkify_shas_in_text("Label [INFO] abc1234", _mock_resolve)
+        assert out == "Label [INFO] [abc1234](https://example.com/abc1234)"
+
+    def test_bracket_without_closing_paren_still_substitutes(self):
+        # ``[text]`` with no following ``(url)`` is not a Markdown link
+        # — neither does mistune treat it as one on the HTML side
+        # (no matching reference definition) so the SHA plugin fires
+        # on the prose inside. The Markdown helper mirrors that: the
+        # brackets become literal characters around a substituted SHA.
+        out = linkify_shas_in_text("see [abc1234] note", _mock_resolve)
+        assert out == "see [[abc1234](https://example.com/abc1234)] note"
+
 
 # ---------------------------------------------------------------------------
 # git_remote URL parsing

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -32,6 +32,7 @@ from claude_code_log.html.utils import render_markdown, render_user_markdown
 from claude_code_log.markdown_plugins import (
     SHA_PATTERN,
     linkify_shas_in_text,
+    make_codespan_sha_plugin,
     make_sha_plugin,
 )
 
@@ -133,6 +134,67 @@ class TestShaPluginInline:
 
 
 # ---------------------------------------------------------------------------
+# make_codespan_sha_plugin: HTML mistune integration for `sha` codespans
+
+
+def _render_with_both_plugins(text: str, resolve=_mock_resolve) -> str:
+    """Build a fresh mistune renderer with *both* SHA plugins."""
+    import mistune
+
+    md = mistune.create_markdown(
+        plugins=[
+            make_sha_plugin(resolve),
+            make_codespan_sha_plugin(resolve),
+        ]
+    )
+    return str(md(text)).strip()
+
+
+class TestCodespanShaPlugin:
+    def test_wraps_codespan_sha_in_link(self):
+        out = _render_with_both_plugins("See `abc1234` here")
+        assert '<a href="https://example.com/abc1234"><code>abc1234</code></a>' in out
+
+    def test_unresolved_codespan_sha_stays_plain_code(self):
+        # Local-only SHA: codespan preserved, no link emitted.
+        out = _render_with_both_plugins("Local `ffffeee` commit")
+        assert "<code>ffffeee</code>" in out
+        assert "<a" not in out
+
+    def test_codespan_with_non_sha_body_unchanged(self):
+        out = _render_with_both_plugins("Call `hello` first")
+        assert "<code>hello</code>" in out
+        assert "<a" not in out
+
+    def test_codespan_with_mixed_body_unchanged(self):
+        # `git show abc1234`: body isn't *exactly* a SHA, so we don't
+        # fire — exactly as the bare-SHA plugin doesn't either.
+        out = _render_with_both_plugins("Run `git show abc1234`")
+        assert "<code>git show abc1234</code>" in out
+        assert "<a" not in out
+
+    def test_codespan_sha_inside_emphasis(self):
+        # Bold codespan-SHA: <strong><a><code>…</code></a></strong>.
+        out = _render_with_both_plugins("Bold **`abc1234`** here")
+        assert "<strong>" in out
+        assert '<a href="https://example.com/abc1234"><code>abc1234</code></a>' in out
+
+    def test_codespan_sha_inside_existing_link_preserves_code(self):
+        # `[\`abc1234\`](url)`: don't double-wrap, but the in_link
+        # branch still emits a codespan token, so the link content
+        # is monospaced (not raw backtick text).
+        out = _render_with_both_plugins("[`abc1234`](http://manual.example/x)")
+        assert out.count("<a ") == 1
+        assert "manual.example" in out
+        assert "<code>abc1234</code>" in out
+
+    def test_codespan_sha_inside_fenced_block_unchanged(self):
+        out = _render_with_both_plugins("```\n`abc1234`\n```")
+        assert "<a" not in out
+        assert "abc1234" in out
+
+
+# ---------------------------------------------------------------------------
 # linkify_shas_in_text: Markdown-side text substitution
 
 
@@ -183,13 +245,17 @@ class TestLinkifyShasInText:
         out = linkify_shas_in_text("    abc1234 indented", _mock_resolve)
         assert out == "    abc1234 indented"
 
-    def test_skips_inside_indented_with_tab(self):
-        # 4+ spaces or a tab triggers indented-code semantics; current
-        # implementation gates on space-only indent. Documenting the
-        # current contract; revisit if real-world transcripts show
-        # tab-indented prose.
-        out = linkify_shas_in_text("    abc1234 four-space indent", _mock_resolve)
-        assert "[abc1234]" not in out
+    def test_documents_tab_indent_gap(self):
+        # CommonMark treats a leading tab as 4-space-equivalent → an
+        # indented code block. Our block tokenizer gates strictly on
+        # space-only indent (``line.lstrip(" ")``), so a tab-prefixed
+        # SHA does get linkified — in violation of CommonMark. This
+        # test pins the current (incorrect-but-documented) behaviour
+        # so any future fix flags it explicitly. Revisit if real-world
+        # transcripts show tab-indented prose; until then, the cost of
+        # widening the indent detector isn't worth it.
+        out = linkify_shas_in_text("\tabc1234 tab-indented", _mock_resolve)
+        assert out == "\t[abc1234](https://example.com/abc1234) tab-indented"
 
     def test_skips_existing_markdown_link(self):
         # The HTML plugin's ``state.in_link`` guard's text-helper
@@ -243,6 +309,46 @@ class TestLinkifyShasInText:
         # brackets become literal characters around a substituted SHA.
         out = linkify_shas_in_text("see [abc1234] note", _mock_resolve)
         assert out == "see [[abc1234](https://example.com/abc1234)] note"
+
+    # -- Codespan-wrapped SHA → link (parity with
+    # ``make_codespan_sha_plugin`` on the HTML side) --
+
+    def test_codespan_only_sha_becomes_linked_codespan(self):
+        # ``\`abc1234\``` body is exactly a SHA → wrap the *whole*
+        # span (backticks included) in a link target. The resulting
+        # ``[\`abc1234\`](url)`` is valid Markdown that renders as
+        # ``<a><code>abc1234</code></a>`` — same as the HTML plugin.
+        out = linkify_shas_in_text("See `abc1234` here", _mock_resolve)
+        assert out == "See [`abc1234`](https://example.com/abc1234) here"
+
+    def test_unresolved_codespan_sha_stays_opaque(self):
+        # Local-only commit: resolver returns None → codespan stays
+        # as-is, no link wrapping (no broken URLs in the transcript).
+        out = linkify_shas_in_text("Local `ffffeee` commit", _mock_resolve)
+        assert out == "Local `ffffeee` commit"
+
+    def test_codespan_with_mixed_body_unchanged(self):
+        # Single backticks but body isn't *exactly* a SHA → stays
+        # opaque, same contract as the existing
+        # ``test_skips_inside_inline_codespan`` case.
+        out = linkify_shas_in_text("`git show abc1234`", _mock_resolve)
+        assert out == "`git show abc1234`"
+
+    def test_codespan_sha_with_double_backticks_unchanged(self):
+        # ``\`\`sha\`\``` is a valid CommonMark codespan but multi-
+        # backtick: we only rewrite the single-backtick form. Spans
+        # stay opaque, consistent with the conservative scope of
+        # ``CODESPAN_SHA_PATTERN``.
+        out = linkify_shas_in_text("``abc1234``", _mock_resolve)
+        assert out == "``abc1234``"
+
+    def test_bold_codespan_sha_becomes_bold_link(self):
+        # ``**\`abc1234\`**``: the ``*`` falls through the prose
+        # accumulator; the matched-backtick branch fires on the
+        # inner span. Result is a bold link round-tripping to
+        # ``<strong><a><code>abc1234</code></a></strong>``.
+        out = linkify_shas_in_text("Bold **`abc1234`** here", _mock_resolve)
+        assert out == "Bold **[`abc1234`](https://example.com/abc1234)** here"
 
 
 # ---------------------------------------------------------------------------
@@ -422,14 +528,23 @@ class TestIntegrationLocalRepo:
             in md
         )
 
-    def test_codespan_unchanged_with_repo_context(self):
+    def test_codespan_sha_becomes_linked_codespan(self):
+        # Updated contract (codespan-SHA feature): a single-backtick
+        # codespan whose body is exactly a resolvable SHA gets the
+        # codespan preserved *and* wrapped in a link. The earlier
+        # contract — codespans stay opaque — was inverted on purpose
+        # so authors who write ``\`5baac35\``` to typographically
+        # quote a SHA still get a clickable commit link.
         cwd = str(Path(__file__).parent.parent)
         with render_with_repo_context(cwd):
             html = render_markdown(f"`{_KNOWN_LOCAL_SHA}` is a code span")
         assert f"<code>{_KNOWN_LOCAL_SHA}</code>" in html
-        # The substring "claude-code-log/commit/" mustn't appear; the
-        # SHA inside the code span shouldn't have been linkified.
-        assert "claude-code-log/commit/" not in html
+        assert '<a href="https://github.com/daaain/claude-code-log/commit/' in html
+        # Mixed-body codespan still stays opaque (regression guard for
+        # the "only exact SHAs" half of the contract).
+        with render_with_repo_context(cwd):
+            mixed = render_markdown(f"`git show {_KNOWN_LOCAL_SHA}` should stay code")
+        assert "<a" not in mixed
 
     def test_no_context_produces_plain_text(self):
         # Without entering the context, even a real reachable SHA


### PR DESCRIPTION
## Summary

Closes #156. Resolvable git commit SHAs in transcript prose now become clickable commit URLs in both the HTML and Markdown outputs, with the resolver gating on local remote-tracking refs only (no network). Local-only commits stay as plain text so the rendered transcript never sprouts broken links. Spans the full prose surface authors use to write commit references — bare `7c2e6f6`, emphasized `**7c2e6f6**`, codespan-quoted `` `7c2e6f6` ``, bold-codespan `` **`7c2e6f6`** ``.

### Commits

1. **`8eb2a48`** — initial implementation: `git_remote.py` (URL parser, SHA → URL resolver with `@lru_cache`, `ContextVar`-bound per-render cwd, host pattern map), `markdown_plugins.py::make_sha_plugin` (mistune inline plugin), `markdown_plugins.py::linkify_shas_in_text` (text-substitution helper for the Markdown output path), wiring in HTML + Markdown renderers. 39 tests.
2. **`8b58608`** — review fix: hand-rolled CommonMark-aware tokenizer in `_linkify_inline` / `_linkify_block_tokens` so the Markdown path honours codespans, fenced blocks (` ``` ` and `~~~`), indented blocks, and existing `[text](url)` links. Earlier `re.sub` substituted SHAs inside all of these, contradicting its docstring. Adds `_linkify_shas` mirror to `format_ThinkingMessage`. 12 new negative-context tests; bonus catch of an infinite-loop bug in the tokenizer's bare-`[` fallback.
3. **`59c495c`** — codespan-SHA wrapping: new `make_codespan_sha_plugin` (mistune, registered with `before="codespan"`) wraps `` `5baac35` `` codespans in commit links via `<a><code>…</code></a>`. `_linkify_inline` grows a parallel branch on its matched-backtick case. 12 new tests.

## Implementation notes

- **Resolver:** `git_remote.resolve_sha(cwd, sha)` walks branch → remote → host/owner detection → URL. All steps `@lru_cache` with negative caching. Network-free: uses `git branch -r --contains` against locally-known remote-tracking refs.
- **Per-render cwd:** `contextvars.ContextVar` lets the cached singleton mistune renderer pick up the right repo per transcript without rebuilding. `HtmlRenderer.generate()` / `MarkdownRenderer.generate()` wrap their inner workers in `render_with_repo_context(canonical_cwd_from_messages(messages))`.
- **Host pattern map:** `_HOST_URL_PATTERNS = {"github.com": "https://github.com/{path}/commit/{sha}"}` — easily extensible to GitLab / Bitbucket / self-hosted Forgejo by adding a key.
- **mistune quirk:** plugin patterns are combined into one regex with renumbered groups, so `m.group(N>0)` is unreliable. Both plugins use `m.group(0)` (full literal match) and strip backticks where needed. Returning `-1` / `None` from a parse callback causes a tight retry loop — both plugins use the `process_text` / `append_token` + `return pos` pattern.

## Out of scope / documented gaps

- Reference-style links (`[abc1234][github]`) would become `[[abc1234](url)][github]` — broken Markdown. Vanishingly rare in CC transcripts; logged in monk's review for future reference.
- Tab-indented prose passes through `_linkify_inline` because the block tokenizer gates on space-only indent. Pinned with `test_documents_tab_indent_gap`; widen if real-world data shows tab-indented SHAs.
- Uppercase SHAs and `0xdeadbeef`-style hex literals are filtered by the resolver gate rather than the pattern; tighten the regex if false-positive volume becomes an issue.

## Test plan

- [x] `just test` — 1752 unit + 78 integration passed, 7 skipped
- [x] `just test-snapshot` — 8 snapshots, no drift
- [x] `ruff format --check` / `ruff check` — clean
- [x] `pyright` / `ty check` — 0 errors
- [x] `test_commit_linkifier.py` integration suite against this repo (uses `7c2e6f6` as a known-local SHA, auto-skips if origin isn't `daaain/claude-code-log`)
- [x] Manually tested against a real transcript by user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit SHAs in transcripts now auto-convert to clickable commit links in HTML and Markdown.
  * Single-backtick SHA codespans become linked code when resolvable; fenced/indented code blocks and existing links remain unchanged.
  * Rendering is scoped to a canonical repository context (per-render) to produce accurate links across multi-session transcripts.

* **Tests**
  * Added comprehensive tests covering SHA linkification, codespan behavior, resolver scoping, and an optional local-repo integration check.

* **Chores**
  * CI checkout updated to fetch full git history for reliable SHA resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->