### PR TITLE
Support non-GitHub forges via static map + `--git-link` fallback (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ claude-code-log /path/to/project --detail low --format md --compact
 
 `--compact` merges consecutive same-type sections in Markdown so runs of assistant responses share one heading instead of repeating `### 🤖 Assistant:` for each.
 
+### Linking Commit SHAs
+
+Plain `7c2e6f6`-shaped tokens in transcript prose get turned into clickable commit links when the SHA is reachable from a local remote-tracking branch. **github.com**, **gitlab.com**, and **bitbucket.org** work out of the box. For self-hosted forges (in-house GitLab, Gitea, Forgejo, …), supply a URL template via `--git-link`:
+
+```bash
+# Self-hosted GitLab
+claude-code-log /path/to/transcript --git-link 'https://{host}/{path}/-/commit/{sha}'
+
+# Same thing via env var (useful for TUI / repeated invocations)
+export CLAUDE_CODE_LOG_GIT_LINK='https://{host}/{path}/-/commit/{sha}'
+claude-code-log --tui
+```
+
+Placeholders: `{host}`, `{path}`, `{sha}`. The template fires only when the static map doesn't already know the host, so a mix of GitHub repos + self-hosted GitLab gets correct links from both. SHAs not reachable from any local remote-tracking ref render as plain text — local-only work-in-progress commits never produce broken links.
+
 ## Project Hierarchy Output
 
 When processing all projects, the tool generates:

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -468,6 +468,51 @@ def _clear_output_files(
         click.echo(f"Warning: Failed to clear {ext_upper} files: {e}")
 
 
+# Placeholders accepted by ``--git-link`` templates. Mirrors
+# ``resolve_sha`` in claude_code_log.git_remote — keep in sync.
+_GIT_LINK_ALLOWED_PLACEHOLDERS = frozenset({"host", "path", "sha"})
+
+
+def _validate_git_link_template(template: str) -> None:
+    """Validate a ``--git-link`` template eagerly; raise ``click.UsageError`` on issues.
+
+    Two checks:
+
+    1. ``{sha}`` must be present (it's the only mandatory field —
+       the resolver's whole job is to substitute the commit SHA).
+    2. All placeholders must be in ``_GIT_LINK_ALLOWED_PLACEHOLDERS``.
+       Catches typos like ``{hsot}`` before they reach
+       ``template.format()`` (which would raise ``KeyError`` at
+       render time). The resolver has a try/except guarding the
+       env-var-only path; this validator is the loud-error path for
+       CLI users.
+
+    Uses ``string.Formatter().parse()`` rather than regex so the
+    same parser Python uses for ``str.format`` decides what counts
+    as a placeholder.
+    """
+    import string
+
+    fields = {
+        field
+        for _, field, _, _ in string.Formatter().parse(template)
+        if field is not None and field != ""
+    }
+    unknown = fields - _GIT_LINK_ALLOWED_PLACEHOLDERS
+    if unknown:
+        raise click.UsageError(
+            f"--git-link template uses unknown placeholder(s): "
+            f"{', '.join('{' + f + '}' for f in sorted(unknown))}. "
+            f"Allowed: {{host}}, {{path}}, {{sha}}."
+        )
+    if "sha" not in fields:
+        raise click.UsageError(
+            "--git-link template must contain a {sha} placeholder "
+            f"(got: {template!r}). Example: "
+            "'https://{host}/{path}/-/commit/{sha}'."
+        )
+
+
 @click.command()
 @click.argument("input_path", type=click.Path(path_type=Path), required=False)
 @click.option(
@@ -634,12 +679,7 @@ def main(
     # resolver decoupled from Click; the env var is the underlying
     # contract, the CLI flag is a convenience that sets it.
     if git_link is not None:
-        if "{sha}" not in git_link:
-            raise click.UsageError(
-                "--git-link template must contain a {sha} placeholder "
-                f"(got: {git_link!r}). Example: "
-                "'https://{host}/{path}/-/commit/{sha}'."
-            )
+        _validate_git_link_template(git_link)
         os.environ["CLAUDE_CODE_LOG_GIT_LINK"] = git_link
 
     # Configure logging to show warnings and above

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -579,6 +579,20 @@ def _clear_output_files(
     ),
 )
 @click.option(
+    "--git-link",
+    "git_link",
+    default=None,
+    envvar="CLAUDE_CODE_LOG_GIT_LINK",
+    metavar="TEMPLATE",
+    help=(
+        "URL template for resolving commit SHAs on forges not in the built-in "
+        "map (github.com, gitlab.com, bitbucket.org). Placeholders: {host}, "
+        "{path}, {sha}. Example for self-hosted GitLab: "
+        "--git-link 'https://{host}/{path}/-/commit/{sha}'. Can also be set "
+        "via the CLAUDE_CODE_LOG_GIT_LINK env var."
+    ),
+)
+@click.option(
     "--debug",
     is_flag=True,
     default=False,
@@ -603,6 +617,7 @@ def main(
     session_id: Optional[str],
     detail: str,
     compact: bool,
+    git_link: Optional[str],
     debug: bool,
 ) -> None:
     """Convert Claude transcript JSONL files to HTML or Markdown.
@@ -612,6 +627,20 @@ def main(
     # Install signal-based stack dumper before any heavy work, so a hang
     # can be diagnosed with `kill -USR1 <pid>` without root or restart.
     _install_stack_dump_signal()
+
+    # Custom-forge URL template: validate eagerly with a loud error,
+    # then pin to the env var so the resolver (which reads the env at
+    # render time) picks it up. Doing this at env-var level keeps the
+    # resolver decoupled from Click; the env var is the underlying
+    # contract, the CLI flag is a convenience that sets it.
+    if git_link is not None:
+        if "{sha}" not in git_link:
+            raise click.UsageError(
+                "--git-link template must contain a {sha} placeholder "
+                f"(got: {git_link!r}). Example: "
+                "'https://{host}/{path}/-/commit/{sha}'."
+            )
+        os.environ["CLAUDE_CODE_LOG_GIT_LINK"] = git_link
 
     # Configure logging to show warnings and above
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -493,11 +493,18 @@ def _validate_git_link_template(template: str) -> None:
     """
     import string
 
-    fields = {
+    parsed_fields = [
         field
         for _, field, _, _ in string.Formatter().parse(template)
-        if field is not None and field != ""
-    }
+        if field is not None
+    ]
+    if "" in parsed_fields:
+        raise click.UsageError(
+            "--git-link template uses an anonymous positional placeholder ({}). "
+            "Use a named placeholder ({host}, {path}, or {sha}) instead "
+            f"(got: {template!r})."
+        )
+    fields = set(parsed_fields)
     unknown = fields - _GIT_LINK_ALLOWED_PLACEHOLDERS
     if unknown:
         raise click.UsageError(

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -38,10 +38,17 @@ text; that's a correct-but-slightly-conservative fallback.
 
 ## Adding new hosts
 
-``_HOST_URL_PATTERNS`` is the dispatch table. Add ``"gitlab.com":
-"https://gitlab.com/{path}/-/commit/{sha}"`` and the resolver picks
-it up. The URL parser in ``_parse_git_url`` handles SSH and HTTPS
-shapes uniformly.
+``_HOST_URL_PATTERNS`` is the dispatch table. The URL parser in
+``_parse_git_url`` handles SSH and HTTPS shapes uniformly, so adding
+a new public forge is a one-line entry. For self-hosted instances
+(in-house GitLab, Gitea, etc.) we can't enumerate every host name
+the world might use, so there's also a fallback-template mechanism
+read from the ``CLAUDE_CODE_LOG_GIT_LINK`` environment variable
+(set directly, or via the ``--git-link`` CLI flag). The fallback
+template uses ``{host}``, ``{path}``, and ``{sha}`` placeholders
+and is consulted only when the static map misses, so a user with a
+mix of public-forge and self-hosted repos still gets correct links
+from both.
 """
 
 from __future__ import annotations
@@ -49,6 +56,7 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import functools
+import os
 import re
 import subprocess
 from typing import Any, Iterator, Optional
@@ -59,7 +67,18 @@ from typing import Any, Iterator, Optional
 # uniformly, so a new entry is the only change typically needed.
 _HOST_URL_PATTERNS: dict[str, str] = {
     "github.com": "https://github.com/{path}/commit/{sha}",
+    "gitlab.com": "https://gitlab.com/{path}/-/commit/{sha}",
+    "bitbucket.org": "https://bitbucket.org/{path}/commits/{sha}",
 }
+
+
+# Environment variable consulted as a fallback when the static host
+# map misses. Lets users wire up self-hosted GitLab / Gitea / Forgejo
+# / SourceHut etc. with a single template. Placeholders: ``{host}``
+# (parsed from the remote URL), ``{path}`` (owner/repo or
+# group/subgroup/repo), ``{sha}`` (full 40-char SHA). The CLI
+# ``--git-link`` flag is a UX convenience that sets this env var.
+_FALLBACK_TEMPLATE_ENV = "CLAUDE_CODE_LOG_GIT_LINK"
 
 
 # SSH form ``git@host:path`` or HTTPS ``https://host/path``. The trailing
@@ -183,6 +202,26 @@ def _expand_to_full_sha(cwd: str, sha: str) -> Optional[str]:
     return full if len(full) == 40 else None
 
 
+def _fallback_template() -> Optional[str]:
+    """Read the user-supplied fallback URL template, or ``None``.
+
+    Checks ``CLAUDE_CODE_LOG_GIT_LINK`` at each call (cheap) so a
+    test or long-running process can flip it dynamically. Returns
+    ``None`` for empty / unset, or for templates missing the
+    required ``{sha}`` placeholder — the missing-``{sha}`` case is
+    a silent skip rather than a crash so a misconfigured environment
+    degrades to "no link" instead of breaking rendering. The CLI
+    handler validates ``{sha}`` eagerly with a loud error; this
+    function is the defence-in-depth.
+    """
+    template = os.environ.get(_FALLBACK_TEMPLATE_ENV, "").strip()
+    if not template:
+        return None
+    if "{sha}" not in template:
+        return None
+    return template
+
+
 @functools.lru_cache(maxsize=4096)
 def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
     """Resolve a candidate SHA to a commit URL on a known remote.
@@ -191,13 +230,16 @@ def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
 
     - No render-time cwd (e.g. plugin invoked outside a render pass).
     - cwd isn't inside a git repo, or has no ``origin`` remote.
-    - Remote URL doesn't match any host in ``_HOST_URL_PATTERNS``.
+    - Remote URL doesn't match any host in ``_HOST_URL_PATTERNS``
+      *and* no usable fallback template is set in the environment.
     - SHA isn't reachable from any local remote-tracking branch.
     - SHA can't be expanded to a full commit (e.g. it was actually a
       tag, or shadows a non-commit ref).
 
-    All steps are cached, so repeated SHAs in one transcript pay
-    cost only on first encounter.
+    The static host map is consulted first; the fallback template
+    fills in for self-hosted forges (in-house GitLab etc.). All
+    steps are cached, so repeated SHAs in one transcript pay cost
+    only on first encounter.
     """
     if not cwd:
         return None
@@ -207,13 +249,19 @@ def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
     host, path = remote
     template = _HOST_URL_PATTERNS.get(host)
     if template is None:
-        return None
+        # Static map missed: try the user-supplied fallback before
+        # giving up. Keeps the static map small and predictable while
+        # still letting users opt in to self-hosted forges.
+        fallback = _fallback_template()
+        if fallback is None:
+            return None
+        template = fallback
     if not _commit_reachable_from_remote(cwd, sha):
         return None
     full = _expand_to_full_sha(cwd, sha)
     if full is None:
         return None
-    return template.format(path=path, sha=full)
+    return template.format(host=host, path=path, sha=full)
 
 
 def resolve_sha_for_current_render(sha: str) -> Optional[str]:

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -205,14 +205,18 @@ def _expand_to_full_sha(cwd: str, sha: str) -> Optional[str]:
 def _fallback_template() -> Optional[str]:
     """Read the user-supplied fallback URL template, or ``None``.
 
-    Checks ``CLAUDE_CODE_LOG_GIT_LINK`` at each call (cheap) so a
-    test or long-running process can flip it dynamically. Returns
-    ``None`` for empty / unset, or for templates missing the
+    Returns ``None`` for empty / unset, or for templates missing the
     required ``{sha}`` placeholder — the missing-``{sha}`` case is
     a silent skip rather than a crash so a misconfigured environment
     degrades to "no link" instead of breaking rendering. The CLI
-    handler validates ``{sha}`` eagerly with a loud error; this
-    function is the defence-in-depth.
+    handler validates ``{sha}`` (and whitelists placeholders)
+    eagerly with a loud error; this function is the defence-in-depth
+    for the env-var-only path.
+
+    Note: ``resolve_sha`` is ``@lru_cache``-d, so flipping
+    ``CLAUDE_CODE_LOG_GIT_LINK`` mid-process won't re-resolve
+    already-cached SHAs. Call ``clear_resolver_caches()`` after
+    mutating the env var (the test fixtures already do).
     """
     template = os.environ.get(_FALLBACK_TEMPLATE_ENV, "").strip()
     if not template:
@@ -261,7 +265,16 @@ def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
     full = _expand_to_full_sha(cwd, sha)
     if full is None:
         return None
-    return template.format(host=host, path=path, sha=full)
+    try:
+        return template.format(host=host, path=path, sha=full)
+    except (KeyError, IndexError, ValueError):
+        # Template has an unknown placeholder (``{foo}``), a positional
+        # ``{0}``, or unbalanced braces. The CLI handler whitelists
+        # ``{host, path, sha}`` up-front and rejects loudly, so the
+        # only way we reach here is a malformed env-var-only template
+        # — silent skip matches the resolver's other degradation
+        # paths (no link is better than a crash mid-render).
+        return None
 
 
 def resolve_sha_for_current_render(sha: str) -> Optional[str]:

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -618,15 +618,89 @@ class TestFallbackTemplate:
         url = resolve_sha("/fake/cwd", "999abcd")
         assert url == "https://example.test/commit/" + "9" * 40
 
+    def test_fallback_unknown_placeholder_is_silent_skip(self, monkeypatch):
+        # Regression for monk's blocking finding on this PR. A user
+        # who typos ``{hsot}`` (instead of ``{host}``) passes the
+        # ``{sha}``-presence check in ``_fallback_template()`` but
+        # would crash ``template.format()`` with KeyError. The
+        # resolver wraps that in try/except and degrades to None.
+        # The CLI path catches this loudly via the placeholder
+        # whitelist (see TestGitLinkTemplateValidation below); this
+        # test guards the env-var-only path.
+        monkeypatch.setenv(
+            "CLAUDE_CODE_LOG_GIT_LINK", "https://{hsot}/{path}/-/commit/{sha}"
+        )
+        _StubResolverEnv(monkeypatch, "git.internal.example", "team/repo", "8" * 40)
+        assert resolve_sha("/fake/cwd", "888abcd") is None
+
+    def test_fallback_positional_placeholder_is_silent_skip(self, monkeypatch):
+        # ``{0}`` would raise IndexError at format time — same
+        # silent-skip degradation as the KeyError case.
+        monkeypatch.setenv("CLAUDE_CODE_LOG_GIT_LINK", "https://{0}/{sha}")
+        _StubResolverEnv(monkeypatch, "git.internal.example", "team/repo", "7" * 40)
+        assert resolve_sha("/fake/cwd", "777abcd") is None
+
+
+class TestGitLinkTemplateValidation:
+    """Unit tests for the CLI-side ``_validate_git_link_template`` helper.
+
+    Loud-error path for users who pass ``--git-link`` directly. The
+    env-var-only path (no CLI) instead silently degrades via the
+    resolver's try/except — see ``TestFallbackTemplate`` above.
+    """
+
+    def test_missing_sha_raises_usage_error(self):
+        import click
+        from claude_code_log.cli import _validate_git_link_template
+
+        with pytest.raises(click.UsageError, match=r"must contain a \{sha\}"):
+            _validate_git_link_template("https://example.test/no-placeholders")
+
+    def test_unknown_placeholder_raises_usage_error(self):
+        # The typo-catching case monk flagged. ``{hsot}`` ≠ ``{host}``.
+        import click
+        from claude_code_log.cli import _validate_git_link_template
+
+        with pytest.raises(click.UsageError, match=r"unknown placeholder.*hsot"):
+            _validate_git_link_template("https://{hsot}/{path}/-/commit/{sha}")
+
+    def test_positional_placeholder_raises_usage_error(self):
+        # ``{0}`` parses as a placeholder named ``"0"`` — not in the
+        # whitelist, so it's flagged as unknown.
+        import click
+        from claude_code_log.cli import _validate_git_link_template
+
+        with pytest.raises(click.UsageError, match=r"unknown placeholder"):
+            _validate_git_link_template("https://{0}/{sha}")
+
+    def test_all_three_placeholders_passes(self):
+        from claude_code_log.cli import _validate_git_link_template
+
+        _validate_git_link_template("https://{host}/{path}/-/commit/{sha}")
+        # No exception → pass.
+
+    def test_only_sha_passes(self):
+        from claude_code_log.cli import _validate_git_link_template
+
+        _validate_git_link_template("https://example.test/commit/{sha}")
+
+    def test_host_and_sha_no_path_passes(self):
+        from claude_code_log.cli import _validate_git_link_template
+
+        _validate_git_link_template("https://{host}/commit/{sha}")
+
 
 class TestGitLinkCliOption:
-    """``--git-link`` flag wiring: validation, env-var sync."""
+    """``--git-link`` flag end-to-end wiring: validation surfaces, env-var sync."""
 
     def teardown_method(self):
         # Don't leak the env var across tests.
         os.environ.pop("CLAUDE_CODE_LOG_GIT_LINK", None)
 
     def test_missing_sha_placeholder_raises_usage_error(self):
+        # End-to-end: confirms the CLI hooks the validator in. The
+        # validator unit tests above cover the validation logic
+        # itself; this is the integration smoke.
         from click.testing import CliRunner
         from claude_code_log.cli import main
 
@@ -642,35 +716,6 @@ class TestGitLinkCliOption:
         # Click usage errors exit with 2.
         assert result.exit_code == 2
         assert "must contain a {sha} placeholder" in result.output
-
-    def test_valid_template_propagates_to_env(self, tmp_path):
-        # Smoke: a valid template hits the env-var setter. We can't
-        # easily exercise full rendering here (would need a real
-        # transcript), so we just confirm the env var is set after
-        # the CLI passes validation. The fallback-template tests
-        # above cover the resolver's reaction.
-        from click.testing import CliRunner
-        from claude_code_log.cli import main
-
-        os.environ.pop("CLAUDE_CODE_LOG_GIT_LINK", None)
-        runner = CliRunner()
-        # An empty input directory: the CLI completes the early
-        # validation work then bails on "nothing to process". The
-        # env var is set before that point.
-        empty = tmp_path / "empty"
-        empty.mkdir()
-        runner.invoke(
-            main,
-            [
-                "--git-link",
-                "https://{host}/{path}/-/commit/{sha}",
-                str(empty),
-            ],
-        )
-        assert (
-            os.environ.get("CLAUDE_CODE_LOG_GIT_LINK")
-            == "https://{host}/{path}/-/commit/{sha}"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -673,6 +673,17 @@ class TestGitLinkTemplateValidation:
         with pytest.raises(click.UsageError, match=r"unknown placeholder"):
             _validate_git_link_template("https://{0}/{sha}")
 
+    def test_anonymous_positional_placeholder_raises_usage_error(self):
+        # CR-flagged contract hole: ``{}`` parses as a placeholder with
+        # field == "" and would crash at ``.format()`` time. Catch it
+        # at CLI validation so users get a precise error instead of a
+        # silent skip (env-var path) or a delayed crash (resolver).
+        import click
+        from claude_code_log.cli import _validate_git_link_template
+
+        with pytest.raises(click.UsageError, match=r"anonymous positional"):
+            _validate_git_link_template("https://example.test/{}/commit/{sha}")
+
     def test_all_three_placeholders_passes(self):
         from claude_code_log.cli import _validate_git_link_template
 

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -13,6 +13,7 @@ Covers two modules and their integration:
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -396,6 +397,37 @@ class TestParseGitUrl:
     def test_rejects_no_owner(self):
         assert _parse_git_url("git@github.com:repo.git") is None
 
+    # -- Multi-forge URL shapes the parser must handle uniformly --
+
+    def test_gitlab_https(self):
+        assert _parse_git_url("https://gitlab.com/group/project.git") == (
+            "gitlab.com",
+            "group/project",
+        )
+
+    def test_gitlab_ssh_with_subgroup(self):
+        # GitLab supports arbitrary subgroup nesting; the path captures
+        # everything between the host and the optional .git suffix.
+        assert _parse_git_url("git@gitlab.com:group/sub/project.git") == (
+            "gitlab.com",
+            "group/sub/project",
+        )
+
+    def test_self_hosted_gitlab(self):
+        # Self-hosted GitLab: host name is arbitrary (e.g.
+        # git.bct-technology.com). Parser doesn't classify hosts —
+        # just splits. Classification happens in resolve_sha against
+        # the static map + env fallback.
+        assert _parse_git_url(
+            "git@git.bct-technology.com:BCT/claudecode/repoindexer.git"
+        ) == ("git.bct-technology.com", "BCT/claudecode/repoindexer")
+
+    def test_bitbucket_https(self):
+        assert _parse_git_url("https://bitbucket.org/workspace/repo.git") == (
+            "bitbucket.org",
+            "workspace/repo",
+        )
+
 
 # ---------------------------------------------------------------------------
 # canonical_cwd_from_messages
@@ -446,6 +478,199 @@ class TestRenderRepoContext:
         with render_with_repo_context("/some/repo"):
             pass
         assert resolve_sha_for_current_render("abc1234") is None
+
+
+# ---------------------------------------------------------------------------
+# Forge templates: static map + env-var fallback
+#
+# The resolver's URL-shape logic is unit-tested here by stubbing the
+# three subprocess-backed helpers (``_git_remote_for``,
+# ``_commit_reachable_from_remote``, ``_expand_to_full_sha``). This
+# isolates the host-classification + template-substitution logic
+# from the actual git plumbing — the integration class below covers
+# end-to-end resolution against this repo's real origin/main.
+
+
+class _StubResolverEnv:
+    """Monkeypatch fixture: pin the subprocess-backed helpers to known
+    answers so resolve_sha tests just exercise the URL-shape logic.
+
+    The three patched functions correspond to the three subprocess
+    boundaries inside resolve_sha:
+    - ``_git_remote_for`` → (host, path) parsing
+    - ``_commit_reachable_from_remote`` → reachability check
+    - ``_expand_to_full_sha`` → short → full SHA peel
+    """
+
+    def __init__(self, monkeypatch, host: str, path: str, full_sha: str):
+        import claude_code_log.git_remote as gr
+
+        clear_resolver_caches()
+        monkeypatch.setattr(gr, "_git_remote_for", lambda _cwd: (host, path))
+        monkeypatch.setattr(
+            gr, "_commit_reachable_from_remote", lambda _cwd, _sha: True
+        )
+        monkeypatch.setattr(gr, "_expand_to_full_sha", lambda _cwd, _sha: full_sha)
+
+
+class TestStaticForgeMap:
+    """``_HOST_URL_PATTERNS`` covers github / gitlab / bitbucket out of the box."""
+
+    def teardown_method(self):
+        clear_resolver_caches()
+
+    def test_github_url(self, monkeypatch):
+        _StubResolverEnv(monkeypatch, "github.com", "owner/repo", "0" * 40)
+        url = resolve_sha("/fake/cwd", "abc1234")
+        assert url == "https://github.com/owner/repo/commit/" + "0" * 40
+
+    def test_gitlab_url_uses_dash_commit_segment(self):
+        # GitLab's URL shape is ``host/path/-/commit/sha`` (the
+        # ``/-/`` is the namespace separator). Pinning here so a
+        # well-meaning refactor of the static map doesn't silently
+        # collapse it back to ``/commit/``.
+        # No subprocess needed since we go direct via the template.
+        from claude_code_log.git_remote import _HOST_URL_PATTERNS
+
+        assert (
+            _HOST_URL_PATTERNS["gitlab.com"]
+            == "https://gitlab.com/{path}/-/commit/{sha}"
+        )
+
+    def test_gitlab_url_end_to_end(self, monkeypatch):
+        _StubResolverEnv(monkeypatch, "gitlab.com", "group/sub/repo", "f" * 40)
+        url = resolve_sha("/fake/cwd", "fff1234")
+        assert url == "https://gitlab.com/group/sub/repo/-/commit/" + "f" * 40
+
+    def test_bitbucket_url_uses_commits_plural(self):
+        # Bitbucket's URL shape is ``host/path/commits/sha`` (plural).
+        # Same pinning rationale as the GitLab case above.
+        from claude_code_log.git_remote import _HOST_URL_PATTERNS
+
+        assert (
+            _HOST_URL_PATTERNS["bitbucket.org"]
+            == "https://bitbucket.org/{path}/commits/{sha}"
+        )
+
+    def test_bitbucket_url_end_to_end(self, monkeypatch):
+        _StubResolverEnv(monkeypatch, "bitbucket.org", "ws/repo", "1" * 40)
+        url = resolve_sha("/fake/cwd", "1111111")
+        assert url == "https://bitbucket.org/ws/repo/commits/" + "1" * 40
+
+    def test_unknown_host_no_fallback_returns_none(self, monkeypatch):
+        # Self-hosted forge with no env-var fallback → None.
+        monkeypatch.delenv("CLAUDE_CODE_LOG_GIT_LINK", raising=False)
+        _StubResolverEnv(monkeypatch, "git.internal.example", "team/repo", "a" * 40)
+        assert resolve_sha("/fake/cwd", "aaa1234") is None
+
+
+class TestFallbackTemplate:
+    """``CLAUDE_CODE_LOG_GIT_LINK`` covers self-hosted forges."""
+
+    def teardown_method(self):
+        clear_resolver_caches()
+
+    def test_fallback_substitutes_host_path_sha(self, monkeypatch):
+        monkeypatch.setenv(
+            "CLAUDE_CODE_LOG_GIT_LINK",
+            "https://{host}/{path}/-/commit/{sha}",
+        )
+        _StubResolverEnv(monkeypatch, "git.bct-technology.com", "BCT/x/repo", "b" * 40)
+        url = resolve_sha("/fake/cwd", "bbb1234")
+        assert url == "https://git.bct-technology.com/BCT/x/repo/-/commit/" + "b" * 40
+
+    def test_static_map_wins_over_fallback(self, monkeypatch):
+        # Even with a "broken" fallback set, the static map's
+        # github.com entry takes precedence — guard against a
+        # refactor accidentally reversing the lookup order.
+        monkeypatch.setenv(
+            "CLAUDE_CODE_LOG_GIT_LINK",
+            "https://WRONG/{host}/{path}/{sha}",
+        )
+        _StubResolverEnv(monkeypatch, "github.com", "owner/repo", "c" * 40)
+        url = resolve_sha("/fake/cwd", "ccc1234")
+        assert url == "https://github.com/owner/repo/commit/" + "c" * 40
+        assert "WRONG" not in url
+
+    def test_fallback_missing_sha_placeholder_is_silent_skip(self, monkeypatch):
+        # Defence-in-depth: the CLI handler errors loudly on a
+        # template without {sha}, but if the env var is set directly
+        # with a broken template, the resolver degrades to "no link"
+        # rather than crashing rendering.
+        monkeypatch.setenv("CLAUDE_CODE_LOG_GIT_LINK", "https://nope/{path}")
+        _StubResolverEnv(monkeypatch, "git.internal.example", "team/repo", "d" * 40)
+        assert resolve_sha("/fake/cwd", "ddd1234") is None
+
+    def test_empty_fallback_is_silent_skip(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_LOG_GIT_LINK", "")
+        _StubResolverEnv(monkeypatch, "git.internal.example", "team/repo", "e" * 40)
+        assert resolve_sha("/fake/cwd", "eee1234") is None
+
+    def test_fallback_with_only_sha_placeholder(self, monkeypatch):
+        # Minimal valid template: only ``{sha}``. Documents that
+        # ``{host}`` / ``{path}`` are optional from the resolver's
+        # standpoint — a user could supply a fully-qualified URL
+        # stub if they had reason to.
+        monkeypatch.setenv(
+            "CLAUDE_CODE_LOG_GIT_LINK", "https://example.test/commit/{sha}"
+        )
+        _StubResolverEnv(monkeypatch, "git.internal.example", "team/repo", "9" * 40)
+        url = resolve_sha("/fake/cwd", "999abcd")
+        assert url == "https://example.test/commit/" + "9" * 40
+
+
+class TestGitLinkCliOption:
+    """``--git-link`` flag wiring: validation, env-var sync."""
+
+    def teardown_method(self):
+        # Don't leak the env var across tests.
+        os.environ.pop("CLAUDE_CODE_LOG_GIT_LINK", None)
+
+    def test_missing_sha_placeholder_raises_usage_error(self):
+        from click.testing import CliRunner
+        from claude_code_log.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--git-link",
+                "https://example.test/commit/no-placeholder",
+                "/dev/null",
+            ],
+        )
+        # Click usage errors exit with 2.
+        assert result.exit_code == 2
+        assert "must contain a {sha} placeholder" in result.output
+
+    def test_valid_template_propagates_to_env(self, tmp_path):
+        # Smoke: a valid template hits the env-var setter. We can't
+        # easily exercise full rendering here (would need a real
+        # transcript), so we just confirm the env var is set after
+        # the CLI passes validation. The fallback-template tests
+        # above cover the resolver's reaction.
+        from click.testing import CliRunner
+        from claude_code_log.cli import main
+
+        os.environ.pop("CLAUDE_CODE_LOG_GIT_LINK", None)
+        runner = CliRunner()
+        # An empty input directory: the CLI completes the early
+        # validation work then bails on "nothing to process". The
+        # env var is set before that point.
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        runner.invoke(
+            main,
+            [
+                "--git-link",
+                "https://{host}/{path}/-/commit/{sha}",
+                str(empty),
+            ],
+        )
+        assert (
+            os.environ.get("CLAUDE_CODE_LOG_GIT_LINK")
+            == "https://{host}/{path}/-/commit/{sha}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #156 follow-up. PR #161 shipped only `github.com`, so transcripts referencing commits on `gitlab.com`, `bitbucket.org`, or self-hosted forges rendered SHAs as plain text. This PR adds two pieces:

1. **Static map expansion** — `gitlab.com` (`/-/commit/`) and `bitbucket.org` (`/commits/` plural) added to `_HOST_URL_PATTERNS`. Both URL shapes are pinned by template-equality tests so a refactor can't silently collapse them back to the GitHub shape.

2. **Fallback URL template** — read from `CLAUDE_CODE_LOG_GIT_LINK` (set directly or via the new `--git-link` CLI flag). Three placeholders: `{host}`, `{path}`, `{sha}`. Consulted *only* when the static map misses, so a user with a mix of public-forge repos and self-hosted GitLab still gets correct links from both with one flag.

```bash
# Self-hosted GitLab
claude-code-log /path/to/transcript --git-link 'https://{host}/{path}/-/commit/{sha}'

# Or via env var (handy for TUI / repeated invocations)
export CLAUDE_CODE_LOG_GIT_LINK='https://{host}/{path}/-/commit/{sha}'
claude-code-log --tui
```

## Smoke test — user's real scenario

User confirmed the gap against `git.bct-technology.com` (self-hosted GitLab). With the template above:

```
19458d7 → https://git.bct-technology.com/BCT/claudecode/repoindexer/-/commit/19458d78…
05ef53e → https://git.bct-technology.com/BCT/claudecode/repoindexer/-/commit/05ef53e4…
```

Both rendered as plain text on `main`.

## Commits

1. **`faaf021`** — initial implementation: static-map expansion, fallback template via env var, CLI flag with `{sha}`-presence validation, 17 new tests.
2. **`744ae3b`** — review fixup: wrap `template.format()` in `try/except (KeyError, IndexError, ValueError)` for malformed user templates; extract `_validate_git_link_template` helper with whitelist of allowed placeholders (so typos like `{hsot}` surface loudly to CLI users); tighten docstring on `_fallback_template` to reflect the `@lru_cache` reality.

## Design notes

- **Env var is the underlying contract**, CLI flag is a UX convenience that sets it. Keeps the resolver decoupled from Click. Library users who set the env var directly get the silent-skip degradation on malformed templates; CLI users get loud `click.UsageError` via the placeholder whitelist.
- **`str.format` semantics**: extra kwargs are ignored, so the static templates (which don't reference `{host}`) and the fallback template (which can) share one `template.format(host=, path=, sha=)` call. Unknown placeholders raise; the resolver guards that with `try/except` returning `None`.
- **`string.Formatter().parse()`** is used for validation rather than regex — same parser Python uses for `str.format`, so the whitelist accepts everything `str.format` accepts (including format specs like `{sha:>40}`, though that's unusual for URL templates).

## Out of scope

- Exotic forges (Azure DevOps, AWS CodeCommit, Gerrit) have URL shapes that don't fit the `{host}/{path}/{sha}` template. Users could still add bespoke entries to the static map locally.
- The mid-process cache-invalidation question (flipping `CLAUDE_CODE_LOG_GIT_LINK` after rendering has started) is documented but not solved — `clear_resolver_caches()` is the workaround.
- Issue #162's sandbox-fixture refactor would benefit `git_remote.py`'s subprocess-coverage gap too, but is intentionally a separate piece of work.

## Test plan

- [x] `just ci` clean: 1805 unit + 78 integration + 1 benchmark passed, 7 skipped
- [x] 8 snapshots no drift
- [x] `ruff format` / `ruff check` / `pyright` / `ty` — all 0 errors
- [x] `test_commit_linkifier.py` alone: 87/87 passed (was 63 on `main`; +24 new for the multi-forge work)
- [x] Manual smoke test against user's real self-hosted GitLab repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commit-link support for GitLab and Bitbucket and a CLI option to supply custom link templates for self-hosted/unsupported forges.
* **Documentation**
  * Added docs describing commit-SHA linking behavior, provider defaults, custom template format, and fallback behavior when SHAs are unresolved.
* **Tests**
  * Expanded tests covering URL parsing, template validation, fallback behaviors, and the new CLI flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->