### PR TITLE
Per-message timestamps in Markdown output (#160)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -696,6 +696,15 @@ def _validate_git_link_template(template: str) -> None:
     ),
 )
 @click.option(
+    "--no-timestamps",
+    is_flag=True,
+    help=(
+        "Suppress per-message timestamp lines in Markdown output "
+        "(#160). Markdown-only — a warning is emitted (but not an "
+        "error) if combined with --format html / --format json."
+    ),
+)
+@click.option(
     "--debug",
     is_flag=True,
     default=False,
@@ -724,6 +733,7 @@ def main(
     detail: str,
     compact: bool,
     git_link: Optional[str],
+    no_timestamps: bool,
     debug: bool,
 ) -> None:
     """Convert Claude transcript JSONL files to HTML or Markdown.
@@ -816,6 +826,16 @@ def main(
         click.echo(
             "Warning: --expand-paths / --filter-path require --output to be a "
             "directory (no recognised file suffix); ignoring.",
+            err=True,
+        )
+
+    # `--no-timestamps` is Markdown-only (#160). Warn (not error) when
+    # paired with HTML/JSON so the flag is benignly ignored rather than
+    # silently misapplied.
+    if no_timestamps and output_format not in ("md", "markdown"):
+        click.echo(
+            f"Warning: --no-timestamps is Markdown-only; ignoring under "
+            f"--format {output_format}.",
             err=True,
         )
 
@@ -982,6 +1002,7 @@ def main(
                 image_export_mode,
                 detail=detail_level,
                 compact=compact,
+                no_timestamps=no_timestamps,
             )
             click.echo(f"Successfully exported session to {output_path}")
             if open_browser:
@@ -1041,6 +1062,7 @@ def main(
                 expand_paths=expand_paths,
                 filter_path=filter_path,
                 write_combined=write_combined,
+                no_timestamps=no_timestamps,
             )
 
             # Count processed projects
@@ -1099,6 +1121,7 @@ def main(
             # don't occupy a cache slot keyed by an arbitrary destination.
             update_cache=output is None,
             write_combined=write_combined,
+            no_timestamps=no_timestamps,
         )
         if input_path.is_file():
             click.echo(f"Successfully converted {input_path} to {output_path}")

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1568,7 +1568,7 @@ def convert_jsonl_to(
 
     from .utils import variant_suffix as _variant_suffix
 
-    suffix = _variant_suffix(detail, compact, format)
+    suffix = _variant_suffix(detail, compact, format, no_timestamps)
 
     # Output destination decoupled from `input_path` (#151). Both
     # branches below assign to `effective_output_dir`; declare it
@@ -2187,7 +2187,7 @@ def _generate_individual_session_files(
     from .utils import variant_suffix as _variant_suffix
 
     ext = get_file_extension(format)
-    suffix = _variant_suffix(detail, compact, format)
+    suffix = _variant_suffix(detail, compact, format, no_timestamps)
     # Pre-compute warmup sessions to exclude them
     warmup_session_ids = get_warmup_session_ids(messages)
 
@@ -2432,7 +2432,7 @@ def generate_single_session_file(
     from .utils import variant_suffix as _variant_suffix
 
     ext = get_file_extension(format)
-    suffix = _variant_suffix(detail, compact, format)
+    suffix = _variant_suffix(detail, compact, format, no_timestamps)
     output_dir = input_path
     if output is not None:
         # User's explicit path wins; no suffix appended.
@@ -2597,7 +2597,7 @@ def process_projects_hierarchy(
     # all need to use the same name. Hard-coding "combined_transcripts.html"
     # would make non-default --format / --detail / --compact
     # combinations cache-miss forever and link to the wrong file.
-    variant = _variant_suffix(detail, compact, output_format)
+    variant = _variant_suffix(detail, compact, output_format, no_timestamps)
     combined_ext = get_file_extension(output_format)
     combined_name = f"combined_transcripts{variant}.{combined_ext}"
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1527,6 +1527,7 @@ def convert_jsonl_to(
     update_cache: bool = True,
     output_root: Optional[Path] = None,
     write_combined: bool = True,
+    no_timestamps: bool = False,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -1658,7 +1659,13 @@ def convert_jsonl_to(
 
     # Generate combined output file (check if regeneration needed)
     assert output_path is not None
-    renderer = get_renderer(format, image_export_mode, detail=detail, compact=compact)
+    renderer = get_renderer(
+        format,
+        image_export_mode,
+        detail=detail,
+        compact=compact,
+        no_timestamps=no_timestamps,
+    )
 
     # Decide whether to use pagination (HTML only, directory mode, no date filter)
     use_pagination = False
@@ -1782,6 +1789,7 @@ def convert_jsonl_to(
             detail=detail,
             compact=compact,
             write_combined=write_combined,
+            no_timestamps=no_timestamps,
         )
 
     return output_path
@@ -2169,6 +2177,7 @@ def _generate_individual_session_files(
     detail: DetailLevel = DetailLevel.FULL,
     compact: bool = False,
     write_combined: bool = True,
+    no_timestamps: bool = False,
 ) -> int:
     """Generate individual files for each session in the specified format.
 
@@ -2211,7 +2220,13 @@ def _generate_individual_session_files(
     project_title = get_project_display_name(output_dir.name, working_directories)
 
     # Get renderer once outside the loop
-    renderer = get_renderer(format, image_export_mode, detail=detail, compact=compact)
+    renderer = get_renderer(
+        format,
+        image_export_mode,
+        detail=detail,
+        compact=compact,
+        no_timestamps=no_timestamps,
+    )
     regenerated_count = 0
 
     # Generate HTML file for each session
@@ -2314,6 +2329,7 @@ def generate_single_session_file(
     image_export_mode: Optional[str] = None,
     detail: DetailLevel = DetailLevel.FULL,
     compact: bool = False,
+    no_timestamps: bool = False,
 ) -> Path:
     """Generate a single session output file for the given session ID.
 
@@ -2426,7 +2442,13 @@ def generate_single_session_file(
         output_file = input_path / f"session-{matched_id}{suffix}.{ext}"
 
     # Generate content and write
-    renderer = get_renderer(format, image_export_mode, detail=detail, compact=compact)
+    renderer = get_renderer(
+        format,
+        image_export_mode,
+        detail=detail,
+        compact=compact,
+        no_timestamps=no_timestamps,
+    )
     session_content = renderer.generate_session(
         session_messages, matched_id, session_title, cache_manager, output_dir
     )
@@ -2496,6 +2518,7 @@ def process_projects_hierarchy(
     expand_paths: bool = False,
     filter_path: Optional[str] = None,
     write_combined: bool = True,
+    no_timestamps: bool = False,
 ) -> Path:
     """Process the entire ~/.claude/projects/ hierarchy and create linked output files.
 
@@ -2746,6 +2769,7 @@ def process_projects_hierarchy(
                     compact=compact,
                     output_root=(dest_dir if dest_dir != project_dir else None),
                     write_combined=write_combined,
+                    no_timestamps=no_timestamps,
                 )
 
                 # Track timing

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -2065,7 +2065,9 @@ class MarkdownRenderer(Renderer):
         if cache_manager is not None and not suppress_combined_link:
             from ..utils import variant_suffix as _variant_suffix
 
-            suffix = _variant_suffix(self.detail, self.compact, "md")
+            suffix = _variant_suffix(
+                self.detail, self.compact, "md", self.no_timestamps
+            )
             combined_link = f"combined_transcripts{suffix}.md"
         else:
             combined_link = None

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -14,7 +14,7 @@ from mistune.renderers.markdown import MarkdownRenderer as _MistuneMarkdownRende
 
 from ..cache import get_library_version
 from ..html.utils import is_well_formed_html, render_user_markdown
-from ..utils import generate_unified_diff, strip_error_tags
+from ..utils import format_timestamp, generate_unified_diff, strip_error_tags
 from ..models import (
     AssistantTextMessage,
     AwaySummaryMessage,
@@ -356,6 +356,14 @@ class MarkdownRenderer(Renderer):
         # start. Scoped to avoid cross-session contamination in
         # combined transcripts (see RenderingContext.teammate_colors).
         self._teammate_colors_by_session: dict[str, dict[str, str]] = {}
+        # Per-message timestamp emission (issue #160): emit a line
+        # immediately after each heading using a date-on-change rule.
+        # Suppressed entirely under `--no-timestamps` (set via
+        # ``get_renderer``). Last-date-seen state lives here so the
+        # rule observes the actual rendered order, including any
+        # `compact`-mode heading suppression.
+        self.no_timestamps: bool = False
+        self._last_date_seen: Optional[str] = None
 
     # -------------------------------------------------------------------------
     # Private Utility Methods
@@ -1834,6 +1842,31 @@ class MarkdownRenderer(Renderer):
         lines.append("")
         return "\n".join(lines)
 
+    def _format_message_timestamp(self, msg: TemplateMessage) -> str:
+        """Render the per-message timestamp line for *msg* (issue #160).
+
+        Date-on-change rule: when *msg*'s date differs from
+        ``self._last_date_seen`` (which is reset to ``None`` at the
+        start of each ``generate()`` and on every ``SessionHeaderMessage``)
+        the line carries the full ``**`YYYY-MM-DD`** `HH:MM:SS``` form;
+        otherwise just the `` `HH:MM:SS` `` time component. Returns ``""``
+        when the source timestamp is missing or unparseable, so the
+        caller can append unconditionally.
+        """
+        raw = getattr(msg.meta, "timestamp", "") if msg.meta else ""
+        if not raw:
+            return ""
+        formatted = format_timestamp(raw)
+        # ``format_timestamp`` returns ``"YYYY-MM-DD HH:MM:SS"`` on
+        # success, the raw string on parse failure, or "" for None.
+        if " " not in formatted:
+            return ""
+        date_part, _, time_part = formatted.partition(" ")
+        if date_part != self._last_date_seen:
+            self._last_date_seen = date_part
+            return f"**`{date_part}`** `{time_part}`"
+        return f"`{time_part}`"
+
     def _render_message(self, msg: TemplateMessage, level: int) -> str:
         """Render a message and its children recursively."""
         # Skip pair_middle and pair_last — both render under pair_first
@@ -1863,9 +1896,13 @@ class MarkdownRenderer(Renderer):
             heading_category = title.split(":", 1)[0].strip()
 
             # Compact mode: suppress heading for consecutive same-category
-            # messages. Reset tracking on session boundaries.
+            # messages. Reset tracking on session boundaries — and also
+            # reset the per-message timestamp `last_date_seen` so the
+            # first message of every session re-emits its full date
+            # (issue #160).
             if is_session_header:
                 self._last_heading_category = None
+                self._last_date_seen = None
             suppress_heading = (
                 self.compact
                 and not is_session_header
@@ -1876,6 +1913,14 @@ class MarkdownRenderer(Renderer):
             if not suppress_heading:
                 heading_level = min(level, 6)  # Markdown max is h6
                 parts.append(f"{'#' * heading_level} {title}")
+                # Per-message timestamp line (issue #160). Skip for
+                # session headers (they have no meaningful per-msg time)
+                # and when the heading was suppressed by `compact` mode
+                # (the body would dangle behind a stray timestamp).
+                if not self.no_timestamps and not is_session_header:
+                    ts_line = self._format_message_timestamp(msg)
+                    if ts_line:
+                        parts.append(ts_line)
 
             # Format content (if not already output above)
             if content:
@@ -1939,6 +1984,10 @@ class MarkdownRenderer(Renderer):
         self._output_dir = output_dir
         self._image_counter = 0
         self._last_heading_category: Optional[str] = None
+        # Per-message timestamp date-on-change state (issue #160).
+        # Reset each generate() so reusing a renderer across pages /
+        # files doesn't leak the previous run's date.
+        self._last_date_seen = None
 
         if not title:
             title = "Claude Transcript"

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -128,6 +128,13 @@ _COLOR_CIRCLE: dict[str, str] = {
 }
 
 
+# Matches the display form ``format_timestamp`` returns on success
+# (``YYYY-MM-DD HH:MM:SS``). The function falls back to its raw input
+# on parse failure, so we validate the rendered shape rather than
+# presence-of-space — see ``_format_message_timestamp``.
+_TIMESTAMP_DISPLAY_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
+
+
 def _inline_code(value: str) -> str:
     """Wrap *value* in a CommonMark inline code span that survives backticks.
 
@@ -341,11 +348,18 @@ def _render_expand_paths_tree(template_projects: list[Any]) -> list[str]:
 class MarkdownRenderer(Renderer):
     """Markdown renderer for Claude Code transcripts."""
 
-    def __init__(self, image_export_mode: str = "referenced"):
+    def __init__(
+        self,
+        image_export_mode: str = "referenced",
+        *,
+        no_timestamps: bool = False,
+    ):
         """Initialize the Markdown renderer.
 
         Args:
             image_export_mode: Image export mode - "placeholder", "embedded", or "referenced"
+            no_timestamps: When True, suppress the per-message timestamp
+                line emitted after each heading (issue #160).
         """
         super().__init__()
         self.image_export_mode = image_export_mode
@@ -358,11 +372,10 @@ class MarkdownRenderer(Renderer):
         self._teammate_colors_by_session: dict[str, dict[str, str]] = {}
         # Per-message timestamp emission (issue #160): emit a line
         # immediately after each heading using a date-on-change rule.
-        # Suppressed entirely under `--no-timestamps` (set via
-        # ``get_renderer``). Last-date-seen state lives here so the
-        # rule observes the actual rendered order, including any
-        # `compact`-mode heading suppression.
-        self.no_timestamps: bool = False
+        # Last-date-seen state lives here so the rule observes the
+        # actual rendered order, including any `compact`-mode heading
+        # suppression.
+        self.no_timestamps: bool = no_timestamps
         self._last_date_seen: Optional[str] = None
 
     # -------------------------------------------------------------------------
@@ -1858,8 +1871,12 @@ class MarkdownRenderer(Renderer):
             return ""
         formatted = format_timestamp(raw)
         # ``format_timestamp`` returns ``"YYYY-MM-DD HH:MM:SS"`` on
-        # success, the raw string on parse failure, or "" for None.
-        if " " not in formatted:
+        # success and (per its contract) the raw input unchanged on
+        # parse failure. A raw string with an embedded space would
+        # otherwise pass a naive presence-of-space check and produce
+        # garbage like ``**`not`** `a timestamp` ``; validate the
+        # rendered shape instead.
+        if not _TIMESTAMP_DISPLAY_RE.match(formatted):
             return ""
         date_part, _, time_part = formatted.partition(" ")
         if date_part != self._last_date_seen:

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4440,6 +4440,7 @@ def get_renderer(
     image_export_mode: Optional[str] = None,
     detail: DetailLevel = DetailLevel.FULL,
     compact: bool = False,
+    no_timestamps: bool = False,
 ) -> Renderer:
     """Get a renderer instance for the specified format.
 
@@ -4449,6 +4450,9 @@ def get_renderer(
             If None, defaults to "embedded" for HTML and "referenced" for Markdown.
         detail: Output detail level controlling which message types are included.
         compact: If True, merge consecutive same-type headings (Markdown only).
+        no_timestamps: If True, suppress per-message timestamp lines
+            in Markdown output (issue #160). Ignored for HTML/JSON
+            since they don't emit those lines.
 
     Returns:
         A Renderer instance for the specified format.
@@ -4467,7 +4471,9 @@ def get_renderer(
 
         # For Markdown, default to referenced mode
         mode = image_export_mode or "referenced"
-        renderer = MarkdownRenderer(image_export_mode=mode)
+        md_renderer = MarkdownRenderer(image_export_mode=mode)
+        md_renderer.no_timestamps = no_timestamps
+        renderer = md_renderer
     elif format == "json":
         from .json.renderer import JsonRenderer
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4471,9 +4471,7 @@ def get_renderer(
 
         # For Markdown, default to referenced mode
         mode = image_export_mode or "referenced"
-        md_renderer = MarkdownRenderer(image_export_mode=mode)
-        md_renderer.no_timestamps = no_timestamps
-        renderer = md_renderer
+        renderer = MarkdownRenderer(image_export_mode=mode, no_timestamps=no_timestamps)
     elif format == "json":
         from .json.renderer import JsonRenderer
 

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -49,6 +49,7 @@ def variant_suffix(
     detail: DetailLevel | str = DetailLevel.FULL,
     compact: bool = False,
     format: str = "html",
+    no_timestamps: bool = False,
 ) -> str:
     """Compute the filename infix for a given render variant.
 
@@ -64,10 +65,18 @@ def variant_suffix(
     parts: list[str] = []
     if detail != DetailLevel.FULL:
         parts.append(detail.value)
-    # `--compact` is Markdown-only (merges consecutive same-category
-    # headings in the Markdown renderer). For HTML it's a no-op.
-    if compact and format in ("md", "markdown"):
+    # `--compact` and `--no-timestamps` are Markdown-only (merges of
+    # same-category headings / suppression of per-message timestamp
+    # lines). They are silent no-ops for HTML, so they don't earn a
+    # suffix slot under non-markdown output.
+    is_markdown = format in ("md", "markdown")
+    if compact and is_markdown:
         parts.append("compact")
+    # `no_timestamps` participates in the suffix so toggling the flag
+    # produces a distinct filename and the cache/path-existence check
+    # doesn't treat the prior export as up-to-date (CR finding on #165).
+    if no_timestamps and is_markdown:
+        parts.append("no-timestamps")
     return "".join(f".{p}" for p in parts)
 
 

--- a/test/__snapshots__/test_snapshot_markdown.ambr
+++ b/test/__snapshots__/test_snapshot_markdown.ambr
@@ -17,9 +17,13 @@
   
   ## 🤷 User: *Spawn a coverage analysis agent in the background…*
   
+  **`2026-04-19`** `10:01:00`
+  
   Spawn a coverage analysis agent in the background and wait for the result.
   
   ### 🤖 Task (Explore): *Coverage analysis* *[async `#cccc333`]*
+  
+  `10:02:00`
   
   <details>
   <summary>Instructions</summary>
@@ -48,9 +52,13 @@
   
   #### 🔗 Sub-assistant: *Reading the source files now...*
   
+  `10:04:00`
+  
   > Reading the source files now...
   
   ### 🔍 TaskOutput `#cccc333`
+  
+  `10:04:00`
   
   `#cccc333` · **block:** `true` · **timeout:** `60000 ms`
   
@@ -59,6 +67,8 @@
   **Transcript:** `/tmp/claude-1000/synthetic/tasks/cccc333.output`
   
   ### 🔄 Async result · *Agent "Coverage analysis" completed*
+  
+  `10:06:00`
   
   - **Task ID:** `cccc333`
   - **Status:** `completed`
@@ -69,6 +79,8 @@
   - **Spawn:** ↱ Task `#d-2`
   
   ### 🤖 Assistant: *Coverage report received.*
+  
+  `10:07:00`
   
   > Coverage report received. Done.
 # ---
@@ -106,9 +118,13 @@
   
   ## 🤷 User: *Hello Claude!*
   
+  **`2025-07-03`** `15:50:07`
+  
   Hello Claude! Can you help me understand how Python decorators work?
   
   ### 🤖 Assistant: *I'd be happy to help you understand Python…*
+  
+  `15:52:07`
   
   > I'd be happy to help you understand Python decorators! A decorator is a design pattern that allows you to modify or extend the behavior of functions or classes without permanently modifying their code.
   > 
@@ -138,9 +154,13 @@
   
   ## 🤷 User: *Great! Can you also show me how to create…*
   
+  `15:54:07`
+  
   Great! Can you also show me how to create a decorator that takes parameters?
   
   ### ✏️  Edit `decorator_example.py`
+  
+  `15:56:07`
   
   ```diff
   @@ -0,0 +1,14 @@+def repeat(times):
@@ -165,6 +185,8 @@
   
   ### 🤖 Assistant: *Perfect! I've created an example of a parameterized…*
   
+  `16:00:07`
+  
   > Perfect! I've created an example of a parameterized decorator. Here's how it works:
   > 
   > 1. **`repeat(times)`** - This is the decorator factory that takes parameters
@@ -180,9 +202,13 @@
   
   ## 🤷 User: *Can you run that example to show the output…*
   
+  `16:02:07`
+  
   Can you run that example to show the output?
   
   ### 💻 Bash: *Run the decorator example to show output*
+  
+  `16:04:07`
   
   ```bash
   $ python /tmp/decorator_example.py
@@ -196,6 +222,8 @@
   
   ### 🤖 Assistant: *Perfect! As you can see, the `@repeat(3)…*
   
+  `16:08:07`
+  
   > Perfect! As you can see, the `@repeat(3)` decorator successfully made the `greet` function execute three times, printing "Hello, Alice!" three times.
   > 
   > This demonstrates the power of parameterized decorators - you can customize their behavior by passing arguments to the decorator factory. Some common use cases include:
@@ -208,6 +236,8 @@
   > The pattern is always the same: decorator factory → decorator → wrapper function.
   
   ## 🤷 User: *This is really helpful!*
+  
+  `16:10:07`
   
   This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?
 # ---
@@ -229,9 +259,13 @@
   
   ## 🤷 User: *Start a test-coverage team and dispatch two…*
   
+  **`2026-04-19`** `10:01:00`
+  
   Start a test-coverage team and dispatch two teammates.
   
   ### TeamCreate
+  
+  `10:02:00`
   
   - **Team:** `test-coverage`
   - **Agent type:** `team-lead`
@@ -243,6 +277,8 @@
   
   ### TaskCreate
   
+  `10:04:00`
+  
   - **Subject:** Add relay tests
   - **Active form:** alice adds relay tests
   - **Description:** Raise relay.py coverage.
@@ -250,6 +286,8 @@
   `#1` — Add relay tests
   
   ### TaskCreate
+  
+  `10:06:00`
   
   - **Subject:** Add server tests
   - **Active form:** bob adds server tests
@@ -259,11 +297,15 @@
   
   ### TaskUpdate
   
+  `10:08:00`
+  
   `#1` · **status:** `in_progress` · **owner:** 🔵 `alice`
   
   ✓ Updated `#1` — `owner`, `status`
   
   ### 🤖 Task (general-purpose): *Run alice's test work*
+  
+  `10:10:00`
   
   <details>
   <summary>Instructions</summary>
@@ -279,13 +321,19 @@
   
   #### 🔗 Sub-assistant: *Starting relay coverage work.*
   
+  `10:02:00`
+  
   > Starting relay coverage work.
   
   #### 🔗 Sub-assistant: *Relay module coverage is now 96%.*
   
+  `10:03:00`
+  
   > Relay module coverage is now 96%.
   
   ### 🤖 Task (general-purpose): *Run bob's test work*
+  
+  `10:12:00`
   
   <details>
   <summary>Instructions</summary>
@@ -301,19 +349,27 @@
   
   #### Teammate
   
+  `10:01:00`
+  
   🟦 **team-lead** · *task spawn*
   
   > You are **bob**, a teammate in the test-coverage team. Add unit tests for the server module and report back.
   
   #### 🔗 Sub-assistant: *Starting server coverage work.*
   
+  `10:02:00`
+  
   > Starting server coverage work.
   
   #### 🔗 Sub-assistant: *Server module coverage is now 88%.*
   
+  `10:03:00`
+  
   > Server module coverage is now 88%.
   
   ## Teammate
+  
+  `10:14:00`
   
   🔵 **alice** · *relay tests complete*
   
@@ -323,6 +379,8 @@
   > - 4 tests for `calculate_next_retry`
   
   ## Teammate
+  
+  `10:15:00`
   
   🔵 **alice**
   
@@ -338,12 +396,16 @@
   
   ### TaskList
   
+  `10:16:00`
+  
   | # | Status | Subject | Owner |
   |---|---|---|---|
   | #1 | completed | Add relay tests | 🔵 `alice` |
   | #2 | completed | Add server tests | 🟢 `bob` |
   
   ### SendMessage
+  
+  `10:18:00`
   
   **To:** 🔵 `alice`
   
@@ -361,6 +423,8 @@
   
   ### TeamDelete
   
+  `10:20:00`
+  
   ✗ Refused
   
   **Team:** `test-coverage`
@@ -370,6 +434,8 @@
   **Active members:** 🟢 `bob`
   
   ### 🤖 Assistant: *Team test-coverage has one member still active…*
+  
+  `10:22:00`
   
   > Team test-coverage has one member still active. Shut down bob before retrying.
 # ---
@@ -391,9 +457,13 @@
   
   ## 🤷 User: *Here's a message with some \*\*markdown\*\* formatting…*
   
+  **`2025-06-14`** `11:00:00`
+  
   Here's a message with some **markdown** formatting, `inline code`, and even a [link](https://example.com). Let's see how it renders!
   
   ### 🤖 Assistant: *Great example!*
+  
+  `11:00:30`
   
   > Great example! Markdown formatting is indeed supported. Here are some more examples:
   > 
@@ -424,9 +494,13 @@
   
   ## 🤷 User: *Let's test a very long message to see how…*
   
+  `11:01:00`
+  
   Let's test a very long message to see how it handles text wrapping and layout. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.
   
   ### FailingTool
+  
+  `11:01:30`
   
   **test_param:** `This tool will fail to demonstrate error handling`
   
@@ -435,6 +509,8 @@
   ```
   
   ## 🤷 Command `/test-command`
+  
+  `11:02:10`
   
   **Args:** `--verbose --output /tmp/test.log`
   
@@ -455,9 +531,13 @@
   
   ### 🤖 Assistant: *I see the long Lorem ipsum text wraps nicely…*
   
+  `11:03:00`
+  
   > I see the long Lorem ipsum text wraps nicely! Long text handling is important for readability. The CSS should handle word wrapping automatically.
   
   #### ✏️  MultiEdit `complex_example.py`
+  
+  `11:03:00`
   
   **Edit 1:**
   
@@ -493,9 +573,13 @@
   
   ## 🤷 User: *Testing special characters: café, naïve,…*
   
+  `11:03:30`
+  
   Testing special characters: café, naïve, résumé, 中文, العربية, русский, 🎉 emojis 🚀 and symbols ∑∆√π∞
   
   ## 🤷 User: *wow error*
+  
+  `11:03:01`
   
   wow error
   
@@ -504,6 +588,8 @@
   # 📋 Session `todowrit`
   
   ## TodoWrite
+  
+  **`2025-06-14`** `10:02:00`
   
   **todos:**
   
@@ -556,13 +642,19 @@
   
   ## 🤷 User: *This is from a different session file to…*
   
+  **`2025-07-03`** `15:50:07`
+  
   This is from a different session file to test multi-session handling.
   
   ### 🤖 Assistant: *Indeed! This message is from a different…*
   
+  `15:52:07`
+  
   > Indeed! This message is from a different JSONL file, which should help test the session divider logic. Only the first session should show a divider.
   
   ## 🤷 User: *Perfect! This should appear without any session…*
+  
+  `15:54:07`
   
   Perfect! This should appear without any session divider above it.
   
@@ -572,9 +664,13 @@
   
   ## 🤷 User: *Hello Claude!*
   
+  **`2025-07-03`** `15:50:07`
+  
   Hello Claude! Can you help me understand how Python decorators work?
   
   ### 🤖 Assistant: *I'd be happy to help you understand Python…*
+  
+  `15:52:07`
   
   > I'd be happy to help you understand Python decorators! A decorator is a design pattern that allows you to modify or extend the behavior of functions or classes without permanently modifying their code.
   > 
@@ -604,9 +700,13 @@
   
   ## 🤷 User: *Great! Can you also show me how to create…*
   
+  `15:54:07`
+  
   Great! Can you also show me how to create a decorator that takes parameters?
   
   ### ✏️  Edit `decorator_example.py`
+  
+  `15:56:07`
   
   ```diff
   @@ -0,0 +1,14 @@+def repeat(times):
@@ -631,6 +731,8 @@
   
   ### 🤖 Assistant: *Perfect! I've created an example of a parameterized…*
   
+  `16:00:07`
+  
   > Perfect! I've created an example of a parameterized decorator. Here's how it works:
   > 
   > 1. **`repeat(times)`** - This is the decorator factory that takes parameters
@@ -646,9 +748,13 @@
   
   ## 🤷 User: *Can you run that example to show the output…*
   
+  `16:02:07`
+  
   Can you run that example to show the output?
   
   ### 💻 Bash: *Run the decorator example to show output*
+  
+  `16:04:07`
   
   ```bash
   $ python /tmp/decorator_example.py
@@ -662,6 +768,8 @@
   
   ### 🤖 Assistant: *Perfect! As you can see, the `@repeat(3)…*
   
+  `16:08:07`
+  
   > Perfect! As you can see, the `@repeat(3)` decorator successfully made the `greet` function execute three times, printing "Hello, Alice!" three times.
   > 
   > This demonstrates the power of parameterized decorators - you can customize their behavior by passing arguments to the decorator factory. Some common use cases include:
@@ -674,6 +782,8 @@
   > The pattern is always the same: decorator factory → decorator → wrapper function.
   
   ## 🤷 User: *This is really helpful!*
+  
+  `16:10:07`
   
   This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?
 # ---
@@ -695,9 +805,13 @@
   
   ## 🤷 User: *Hello Claude!*
   
+  **`2025-07-03`** `15:50:07`
+  
   Hello Claude! Can you help me understand how Python decorators work?
   
   ### 🤖 Assistant: *I'd be happy to help you understand Python…*
+  
+  `15:52:07`
   
   > I'd be happy to help you understand Python decorators! A decorator is a design pattern that allows you to modify or extend the behavior of functions or classes without permanently modifying their code.
   > 
@@ -727,9 +841,13 @@
   
   ## 🤷 User: *Great! Can you also show me how to create…*
   
+  `15:54:07`
+  
   Great! Can you also show me how to create a decorator that takes parameters?
   
   ### ✏️  Edit `decorator_example.py`
+  
+  `15:56:07`
   
   ```diff
   @@ -0,0 +1,14 @@+def repeat(times):
@@ -754,6 +872,8 @@
   
   ### 🤖 Assistant: *Perfect! I've created an example of a parameterized…*
   
+  `16:00:07`
+  
   > Perfect! I've created an example of a parameterized decorator. Here's how it works:
   > 
   > 1. **`repeat(times)`** - This is the decorator factory that takes parameters
@@ -769,9 +889,13 @@
   
   ## 🤷 User: *Can you run that example to show the output…*
   
+  `16:02:07`
+  
   Can you run that example to show the output?
   
   ### 💻 Bash: *Run the decorator example to show output*
+  
+  `16:04:07`
   
   ```bash
   $ python /tmp/decorator_example.py
@@ -785,6 +909,8 @@
   
   ### 🤖 Assistant: *Perfect! As you can see, the `@repeat(3)…*
   
+  `16:08:07`
+  
   > Perfect! As you can see, the `@repeat(3)` decorator successfully made the `greet` function execute three times, printing "Hello, Alice!" three times.
   > 
   > This demonstrates the power of parameterized decorators - you can customize their behavior by passing arguments to the decorator factory. Some common use cases include:
@@ -797,6 +923,8 @@
   > The pattern is always the same: decorator factory → decorator → wrapper function.
   
   ## 🤷 User: *This is really helpful!*
+  
+  `16:10:07`
   
   This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?
 # ---

--- a/test/test_markdown_timestamps.py
+++ b/test/test_markdown_timestamps.py
@@ -1,0 +1,224 @@
+"""Tests for per-message timestamps in Markdown output (issue #160).
+
+Exercises the date-on-change state machine in
+``claude_code_log.markdown.renderer.MarkdownRenderer._format_message_timestamp``
+and the `--no-timestamps` CLI flag.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.markdown.renderer import MarkdownRenderer
+
+
+def _user_msg(uuid: str, session_id: str, timestamp: str, text: str) -> dict:
+    """Build a minimal user-message transcript entry."""
+    return {
+        "type": "user",
+        "timestamp": timestamp,
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": session_id,
+        "version": "2.1.0",
+        "uuid": uuid,
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _assistant_msg(uuid: str, session_id: str, timestamp: str, text: str) -> dict:
+    """Build a minimal assistant-message transcript entry."""
+    return {
+        "type": "assistant",
+        "timestamp": timestamp,
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "assistant",
+        "cwd": "/tmp",
+        "sessionId": session_id,
+        "version": "2.1.0",
+        "uuid": uuid,
+        "requestId": f"req-{uuid}",
+        "message": {
+            "id": f"msg-{uuid}",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-7",
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+        },
+    }
+
+
+def _render(entries: list[dict], no_timestamps: bool = False) -> str:
+    """Write ``entries`` to a temp JSONL, load, render to Markdown."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+        path = Path(f.name)
+    try:
+        messages = load_transcript(path)
+        renderer = MarkdownRenderer()
+        renderer.no_timestamps = no_timestamps
+        return renderer.generate(messages, title="t")
+    finally:
+        path.unlink()
+
+
+def test_first_message_emits_full_date_and_time():
+    """First message of a session re-emits its full date in bold backticks."""
+    out = _render([_user_msg("u1", "s1", "2026-02-03T21:21:20.000Z", "hi")])
+    assert "**`2026-02-03`** `21:21:20`" in out
+
+
+def test_same_day_subsequent_messages_emit_time_only():
+    """Subsequent same-day messages emit just the time component."""
+    out = _render(
+        [
+            _user_msg("u1", "s1", "2026-02-03T21:21:20.000Z", "first"),
+            _assistant_msg("u2", "s1", "2026-02-03T21:22:18.000Z", "second"),
+            _user_msg("u3", "s1", "2026-02-03T21:30:00.000Z", "third"),
+        ]
+    )
+    # Full date+time appears once (the first message).
+    assert out.count("**`2026-02-03`**") == 1
+    # Subsequent same-day timestamps appear as time-only lines.
+    assert "`21:22:18`" in out
+    assert "`21:30:00`" in out
+    # And those time-only lines must NOT be paired with the date.
+    assert "**`2026-02-03`** `21:22:18`" not in out
+    assert "**`2026-02-03`** `21:30:00`" not in out
+
+
+def test_day_rollover_re_emits_full_date():
+    """When the calendar date advances, the next message carries the new date."""
+    out = _render(
+        [
+            _user_msg("u1", "s1", "2026-02-03T23:59:50.000Z", "late"),
+            _assistant_msg("u2", "s1", "2026-02-04T00:01:45.000Z", "rolled"),
+        ]
+    )
+    assert "**`2026-02-03`** `23:59:50`" in out
+    assert "**`2026-02-04`** `00:01:45`" in out
+
+
+def test_no_timestamps_suppresses_all_lines():
+    """``--no-timestamps`` skips emission entirely."""
+    out = _render(
+        [
+            _user_msg("u1", "s1", "2026-02-03T21:21:20.000Z", "first"),
+            _assistant_msg("u2", "s1", "2026-02-03T21:22:18.000Z", "second"),
+        ],
+        no_timestamps=True,
+    )
+    assert "**`2026-02-03`**" not in out
+    # No bare-time backtick lines either.
+    assert "\n`21:" not in out
+
+
+def test_format_message_timestamp_helper_state_machine():
+    """Direct unit-test of the date-on-change helper, including the
+    multi-session reset path (``_last_date_seen = None`` on
+    ``SessionHeaderMessage``)."""
+    from types import SimpleNamespace
+    from typing import cast
+
+    from claude_code_log.renderer import TemplateMessage
+
+    r = MarkdownRenderer()
+    r._last_date_seen = None
+
+    def msg(ts: str) -> TemplateMessage:
+        # Duck-typed minimal stand-in: the helper only touches
+        # ``msg.meta.timestamp``.
+        return cast(
+            TemplateMessage, SimpleNamespace(meta=SimpleNamespace(timestamp=ts))
+        )
+
+    # First message → full date.
+    line = r._format_message_timestamp(msg("2026-02-03T10:00:00.000Z"))
+    assert line == "**`2026-02-03`** `10:00:00`"
+
+    # Same-day → time only.
+    line = r._format_message_timestamp(msg("2026-02-03T10:05:00.000Z"))
+    assert line == "`10:05:00`"
+
+    # Day rollover → full date.
+    line = r._format_message_timestamp(msg("2026-02-04T00:01:00.000Z"))
+    assert line == "**`2026-02-04`** `00:01:00`"
+
+    # Simulate session-header reset: even though the date is identical
+    # to what we just emitted, the first message of the new session
+    # must re-emit it.
+    r._last_date_seen = None
+    line = r._format_message_timestamp(msg("2026-02-04T00:02:00.000Z"))
+    assert line == "**`2026-02-04`** `00:02:00`"
+
+
+def test_format_message_timestamp_returns_empty_on_missing_or_unparseable():
+    """Empty / unparseable timestamps yield ``""`` so the caller can
+    append unconditionally."""
+    from types import SimpleNamespace
+    from typing import cast
+
+    from claude_code_log.renderer import TemplateMessage
+
+    def stub(ts: str) -> TemplateMessage:
+        return cast(
+            TemplateMessage, SimpleNamespace(meta=SimpleNamespace(timestamp=ts))
+        )
+
+    r = MarkdownRenderer()
+    r._last_date_seen = None
+    assert r._format_message_timestamp(stub("")) == ""
+    # ``format_timestamp`` returns the raw string on parse failure;
+    # without a space, the helper must bail out instead of producing
+    # malformed output.
+    assert r._format_message_timestamp(stub("not-a-timestamp")) == ""
+
+
+@pytest.mark.parametrize("fmt", ["html", "json"])
+def test_no_timestamps_with_non_markdown_format_warns_not_errors(
+    fmt: str, tmp_path: Path
+):
+    """`--no-timestamps` paired with --format html|json should warn
+    (stderr) but not error (exit 0). Matches the existing
+    `--expand-paths` / `--filter-path` warning contract."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    # Minimal valid JSONL project (1 user message).
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "session.jsonl").write_text(
+        json.dumps(_user_msg("u1", "s1", "2026-02-03T21:21:20.000Z", "hi")) + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            str(project),
+            "--no-cache",
+            "--no-timestamps",
+            "--format",
+            fmt,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Warning lands on stderr in production but the test runner mixes
+    # streams by default; assert on the combined output.
+    assert "--no-timestamps is Markdown-only" in result.output

--- a/test/test_markdown_timestamps.py
+++ b/test/test_markdown_timestamps.py
@@ -278,6 +278,35 @@ def test_format_message_timestamp_returns_empty_on_missing_or_unparseable():
     assert r._format_message_timestamp(stub("not a timestamp")) == ""
 
 
+def test_variant_suffix_no_timestamps_markdown_only():
+    """`--no-timestamps` participates in the filename infix only for
+    Markdown output, so toggling it produces a distinct
+    `combined_transcripts.no-timestamps.md` and per-session file. HTML
+    / JSON don't honour the flag (a warning is emitted), so the
+    suffix stays empty for them and we avoid orphaned variant files.
+
+    Regression for CodeRabbit's finding on PR #165: previously the
+    flag was not part of the variant key, so the path-existence /
+    cache lookup treated the prior export as up-to-date and skipped
+    regeneration when the user toggled the flag.
+    """
+    from claude_code_log.utils import variant_suffix
+
+    # Default → empty.
+    assert variant_suffix() == ""
+    # Markdown + no_timestamps → distinct suffix.
+    assert variant_suffix(format="md", no_timestamps=True) == ".no-timestamps"
+    assert variant_suffix(format="markdown", no_timestamps=True) == ".no-timestamps"
+    # Composable with `--compact` (markdown only).
+    assert (
+        variant_suffix(format="md", compact=True, no_timestamps=True)
+        == ".compact.no-timestamps"
+    )
+    # HTML / JSON ignore the flag (no orphaned `.no-timestamps.html`).
+    assert variant_suffix(format="html", no_timestamps=True) == ""
+    assert variant_suffix(format="json", no_timestamps=True) == ""
+
+
 @pytest.mark.parametrize("fmt", ["html", "json"])
 def test_no_timestamps_with_non_markdown_format_warns_not_errors(
     fmt: str, tmp_path: Path

--- a/test/test_markdown_timestamps.py
+++ b/test/test_markdown_timestamps.py
@@ -8,6 +8,7 @@ and the `--no-timestamps` CLI flag.
 from __future__ import annotations
 
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -61,7 +62,11 @@ def _assistant_msg(uuid: str, session_id: str, timestamp: str, text: str) -> dic
     }
 
 
-def _render(entries: list[dict], no_timestamps: bool = False) -> str:
+def _render(
+    entries: list[dict],
+    no_timestamps: bool = False,
+    compact: bool = False,
+) -> str:
     """Write ``entries`` to a temp JSONL, load, render to Markdown."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         for e in entries:
@@ -69,8 +74,8 @@ def _render(entries: list[dict], no_timestamps: bool = False) -> str:
         path = Path(f.name)
     try:
         messages = load_transcript(path)
-        renderer = MarkdownRenderer()
-        renderer.no_timestamps = no_timestamps
+        renderer = MarkdownRenderer(no_timestamps=no_timestamps)
+        renderer.compact = compact
         return renderer.generate(messages, title="t")
     finally:
         path.unlink()
@@ -111,6 +116,85 @@ def test_day_rollover_re_emits_full_date():
     )
     assert "**`2026-02-03`** `23:59:50`" in out
     assert "**`2026-02-04`** `00:01:45`" in out
+
+
+def test_compact_suppresses_timestamp_along_with_heading():
+    """When `--compact` collapses a same-category heading, the
+    timestamp line under it must collapse too — otherwise a body
+    dangles behind a stray timestamp.
+
+    Renders three same-category user messages; expects exactly one
+    heading and exactly one timestamp (the first message's).
+    """
+    out = _render(
+        [
+            _user_msg("u1", "s1", "2026-02-03T10:00:00.000Z", "first"),
+            _user_msg("u2", "s1", "2026-02-03T10:05:00.000Z", "second"),
+            _user_msg("u3", "s1", "2026-02-03T10:10:00.000Z", "third"),
+        ],
+        compact=True,
+    )
+    # Exactly one user-heading line.
+    user_heading_re = re.compile(r"^## .*User:", re.MULTILINE)
+    assert len(user_heading_re.findall(out)) == 1
+    # Exactly one per-message timestamp line — the first message's.
+    # Bold-date line.
+    assert out.count("**`2026-02-03`** `10:00:00`") == 1
+    # No bare-time lines for the suppressed messages.
+    assert "`10:05:00`" not in out
+    assert "`10:10:00`" not in out
+
+
+def test_compact_date_rollover_across_suppressed_messages():
+    """When `--compact` suppresses several headings and the calendar
+    date rolls over in the meantime, the next *unsuppressed* heading
+    must carry the new date (not the stale one from before the
+    rollover)."""
+    out = _render(
+        [
+            _user_msg("u1", "s1", "2026-02-03T23:55:00.000Z", "pre-midnight"),
+            # Same-category, suppressed; date rolls over here.
+            _user_msg("u2", "s1", "2026-02-04T00:00:30.000Z", "rollover-suppressed"),
+            _user_msg("u3", "s1", "2026-02-04T00:05:00.000Z", "rollover-suppressed-2"),
+            # Different category breaks the compact run, so this
+            # heading is emitted.
+            _assistant_msg("u4", "s1", "2026-02-04T00:10:00.000Z", "next-day reply"),
+        ],
+        compact=True,
+    )
+    # First message keeps its pre-midnight date.
+    assert "**`2026-02-03`** `23:55:00`" in out
+    # The assistant heading after the rollover must carry the new
+    # date — `_last_date_seen` should still reflect the *last
+    # rendered* date (2026-02-03), so the rollover IS detected.
+    assert "**`2026-02-04`** `00:10:00`" in out
+    # Suppressed messages emit nothing.
+    assert "`00:00:30`" not in out
+    assert "`00:05:00`" not in out
+
+
+def test_session_header_resets_last_date_seen_end_to_end():
+    """A new session inside the same generate() must re-emit its
+    first message's full date even when the calendar date is
+    unchanged. Exercises the ``_render_message`` reset path that the
+    helper unit test simulates with a manual ``_last_date_seen = None``.
+    """
+    out = _render(
+        [
+            _user_msg("u1", "s1", "2026-02-03T10:00:00.000Z", "s1-first"),
+            _assistant_msg("u2", "s1", "2026-02-03T10:01:00.000Z", "s1-reply"),
+            # New session, same calendar day — the first message of
+            # session 2 must re-emit the date.
+            _user_msg("u3", "s2", "2026-02-03T10:02:00.000Z", "s2-first"),
+            _assistant_msg("u4", "s2", "2026-02-03T10:03:00.000Z", "s2-reply"),
+        ]
+    )
+    # The same date appears twice in bold-backtick form — once per
+    # session — even though both sessions are on the same calendar day.
+    assert out.count("**`2026-02-03`**") == 2
+    # And the in-session continuations are time-only.
+    assert "`10:01:00`" in out
+    assert "`10:03:00`" in out
 
 
 def test_no_timestamps_suppresses_all_lines():
@@ -186,6 +270,12 @@ def test_format_message_timestamp_returns_empty_on_missing_or_unparseable():
     # without a space, the helper must bail out instead of producing
     # malformed output.
     assert r._format_message_timestamp(stub("not-a-timestamp")) == ""
+    # Regression for monk's review on #165: a raw fallback string
+    # that happens to contain a space (e.g. ``"not a timestamp"``)
+    # used to slip past the presence-of-space check and produce
+    # garbage like ``**`not`** `a timestamp` ``. The shape-validating
+    # regex rejects it.
+    assert r._format_message_timestamp(stub("not a timestamp")) == ""
 
 
 @pytest.mark.parametrize("fmt", ["html", "json"])


### PR DESCRIPTION
Closes #160.

## Summary

- Markdown renderer now emits a per-message timestamp line immediately after every message heading, using a **date-on-change** rule: full bold-backtick date + plain-backtick time on the first message of each session and across day rollovers; just the time component on subsequent same-day messages.
- New `--no-timestamps` CLI flag suppresses the feature; Markdown-only with a warning (not error) when paired with `--format html` or `--format json`, matching the `--expand-paths` / `--filter-path` contract.
- State (`_last_date_seen`) is reset at the top of every `generate()` and on every `SessionHeaderMessage` so the first message of each session re-emits its full date.
- The timestamp line is also skipped when the heading itself is suppressed by `--compact` so the body doesn't dangle behind a stray timestamp.

## Example output

```markdown
## 🤷 User: *except there's no need to fetch...*
**`2026-02-03`** `21:21:20`

except there's no need to fetch...

### 🤖 Assistant: *Right, in a git worktree setup all branches…*
`21:22:18`

> Right, in a git worktree setup all branches are already available locally.

### 🤖 Assistant: *next-day continuation*
**`2026-02-04`** `00:01:45`
```

## Implementation

- `markdown/renderer.py::_format_message_timestamp` does the date-on-change decision.
- `markdown/renderer.py::_render_message` invokes it right after the heading append, gated on `not self.no_timestamps and not is_session_header and not suppress_heading`.
- Renderer init / `generate()` set `self._last_date_seen = None`; `_render_message` also resets it on session-header entry alongside the existing `_last_heading_category` reset.
- `get_renderer(..., no_timestamps=False)` accepts and stamps the flag onto the Markdown renderer. HTML / JSON ignore it.
- `cli.py` adds the flag, threads it through `convert_jsonl_to`, `generate_single_session_file`, `process_projects_hierarchy`. Wrong-format combo emits a stderr warning and continues with exit 0.

## Tests

`test/test_markdown_timestamps.py` (new, 8 cases):

- First message of session emits full date+time.
- Same-day subsequent messages emit time only (and explicitly NOT date+time).
- Day rollover re-emits the full date.
- Multi-session reset: simulated `_last_date_seen = None` on session boundary re-emits the date even when it matches.
- Empty / unparseable timestamp returns `""` (safe bail).
- `--no-timestamps` suppresses every emission.
- `--no-timestamps --format html` (and `json`) warns on stderr but exits 0.

Markdown snapshot tests (`test_snapshot_markdown.py`) refreshed — diff is purely additive (the new line per heading).

## Test plan

- [x] `just ci` green (`uv run pytest`, `ruff check --fix`, `pyright`, `ty check`)
- [x] New tests pass (8/8)
- [x] Markdown snapshot diff inspected: purely additive timestamp lines
- [x] Manual smoke against `test/test_data/real_projects` with `--expand-paths --format md --detail low`: 30 session files all carry the expected pattern, `--no-timestamps` produces zero timestamp lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown exports: per-message timestamps (full date+time at session start or on date change; time-only for same-day messages). Compact mode suppresses timestamps alongside collapsed headings; session boundaries reset date tracking.
  * Added --no-timestamps CLI flag to suppress timestamp lines in Markdown; using it with HTML/JSON shows a non-fatal Markdown-only warning.
  * Markdown output filenames now include a no-timestamps variant marker.

* **Tests**
  * Added unit and snapshot tests covering timestamp rendering, compact behavior, session resets, filename variants, helper logic, and the CLI flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->