### PR TITLE
RFC: plugin system (unified message-transformer mechanism)

### DIFF
--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -1,0 +1,393 @@
+# Tool-renderer plugin system
+
+## Status: Design proposal (no implementation yet)
+
+## Problem statement
+
+Today every tool renderer is baked into `claude-code-log`: a new
+tool means a PR against `claude_code_log/factories/tool_factory.py`,
+`claude_code_log/html/tool_formatters.py`, and the
+`format_<ClassName>` methods on the two renderer classes. This is
+fine for the in-tree set (Bash, Read, WebSearch, ...), but it
+prevents third parties — including the ClMail MCP plugin we use
+ourselves — from shipping a *content-aware* renderer alongside
+their tool. The visible symptom: `--detail low` Markdown today
+shows synthetic hook lines like `[clmail] You've got a new mail
+(#3076)` rather than the actual mail subject / body excerpt, because
+no in-tree renderer knows what `mcp__plugin_clmail_clmail__communicate`
+returns.
+
+This document proposes a plugin mechanism that lets external
+packages contribute tool renderers via setuptools entry points,
+with a priority offset so an out-of-tree plugin can either
+**supplement** the in-tree set (positive priority, used only if no
+builtin claims the tool) or **supersede** it (negative priority,
+wins until something more negative arrives). The driving use case
+is the ClMail tools, but the same mechanism unlocks any future
+MCP tool plus a path to pluggable output formatters (see
+[Future](#future-extensions)).
+
+## Current architecture (what we hook into)
+
+Three dispatch points matter:
+
+1. **`TOOL_INPUT_MODELS`** (dict) at
+   `claude_code_log/factories/tool_factory.py:93` — maps tool name
+   string → Pydantic input model class. `create_tool_input()`
+   (line 143) looks the name up; on miss falls back to
+   `ToolUseContent`.
+2. **`TOOL_OUTPUT_PARSERS`** (dict) at
+   `claude_code_log/factories/tool_factory.py:1234` — maps tool
+   name → parser callable producing the output dataclass. Used by
+   `create_tool_output()` (line 1272).
+3. **`_dispatch_format`** at `claude_code_log/renderer.py:4143` —
+   takes a content object, walks `type(obj).__mro__`, and calls
+   `format_<ClassName>` on the renderer instance. The MRO walk
+   gives free polymorphic fallback (`format_BashInput` →
+   `format_ToolUseContent`).
+
+Detail-level filtering lives at `renderer.py:3151–3224`. The
+keep-list at `--detail low` is the hardcoded set
+`_LOW_KEEP_TOOLS = {"WebSearch", "WebFetch", "Task", "Agent"}`.
+
+Icons are scattered as string literals across title methods in
+`html/renderer.py:843–930` (no central registry).
+
+These are the four surfaces a plugin needs to influence. The
+plugin system's whole job is to populate the first two dicts, the
+third's MRO-discoverable methods, the fourth's keep-list, and a
+new icon registry — from out-of-tree packages.
+
+## Discovery + selection: `importlib.metadata.entry_points`
+
+**Recommendation: stdlib entry points, group name
+`claude_code_log.tool_renderers`.**
+
+Compared to `pluggy`:
+
+| | entry_points (stdlib) | pluggy |
+|---|---|---|
+| Dependency | zero | one (`pluggy`) |
+| Declarative pyproject hook | yes | no (needs `pm.register()` calls) |
+| Composition (firstresult, before/after) | no | yes |
+| Mental model | "load a class by name" | "hook spec / hook impl" |
+| Fits our need | yes (one winner per tool) | overkill |
+
+We need *one* renderer per `(tool_name, output_format)` at any
+time, chosen by priority — not multi-hook composition. Pluggy's
+expressiveness pays for itself in pytest, where each hook can fire
+multiple impls; here it would just be ceremony. Entry points stay
+in the boring lane: stdlib, no new dep, mirrors how Click commands
+and pytest plugins themselves are discovered.
+
+A plugin package declares:
+
+```toml
+[project.entry-points."claude_code_log.tool_renderers"]
+clmail_communicate = "claude_code_log_clmail:ClmailCommunicateRenderer"
+clmail_control     = "claude_code_log_clmail:ClmailControlRenderer"
+clmail_actors      = "claude_code_log_clmail:ClmailActorsRenderer"
+clmail_terminal    = "claude_code_log_clmail:ClmailTerminalRenderer"
+```
+
+At startup, `claude_code_log` enumerates this group once, loads
+each entry, validates against the `ToolRenderer` protocol, groups
+by `tool_name`, resolves by priority, and freezes the winners
+into the runtime dispatch tables. No reload at runtime; the cost
+of a CLI restart is acceptable for a tool-renderer change.
+
+## Renderer interface (Protocol sketch)
+
+A plugin is a class implementing `ToolRenderer`. Class attributes
+declare metadata; instance methods do the rendering. Methods
+return `None` to defer (e.g. let Markdown→HTML conversion handle
+the HTML side).
+
+```python
+from typing import ClassVar, Protocol, runtime_checkable
+from claude_code_log.models import (
+    TemplateMessage, ToolUseContent, ToolResultContent,
+)
+
+DetailLevel = Literal["full", "high", "medium", "low"]  # already exists
+
+@runtime_checkable
+class ToolRenderer(Protocol):
+    # --- registration ---
+    tool_name: ClassVar[str]              # e.g. "mcp__plugin_clmail_clmail__communicate"
+    priority: ClassVar[int]               # 0 = builtin; <0 supersedes; >0 fallback
+    min_detail: ClassVar[DetailLevel]     # smallest level at which this tool is rendered
+    icon: ClassVar[str | None]            # optional Unicode glyph for the heading
+
+    # --- parsing (factory side) ---
+    InputModel: ClassVar[type[BaseModel]]              # Pydantic
+    OutputModel: ClassVar[type[Any] | None]            # dataclass; None for unstructured
+
+    @staticmethod
+    def parse_output(raw: dict, message: TemplateMessage) -> Any | None: ...
+        # default: identity (raw dict) or instantiate OutputModel from `toolUseResult`
+
+    # --- rendering (renderer side) ---
+    def render_input_markdown(self, content: ToolUseContent,
+                              message: TemplateMessage) -> str: ...
+
+    def render_output_markdown(self, content: ToolResultContent,
+                               message: TemplateMessage) -> str: ...
+
+    def render_input_html(self, content: ToolUseContent,
+                          message: TemplateMessage) -> str | None: ...
+        # None => fall back to mistune(render_input_markdown(...))
+
+    def render_output_html(self, content: ToolResultContent,
+                           message: TemplateMessage) -> str | None: ...
+
+    def title(self, content: ToolUseContent,
+              message: TemplateMessage) -> str | None: ...
+        # None => default "{icon} {ToolName} <summary>"
+```
+
+The two-way (Markdown required, HTML optional) split is what lets
+the user's stated constraint hold: **Markdown is the minimum
+required output; HTML can be derived from Markdown.** When
+`render_input_html` returns `None`, the system runs the plugin's
+Markdown output through the same `mistune` pipeline already used
+for assistant content.
+
+Notably absent: no `render_input_json`. JSON output (see
+`dev-docs/implementing-a-tool-renderer.md` §JSON) already works
+generically from the dataclass / Pydantic models via
+`dataclasses.asdict`; a plugin that ships the model classes gets
+JSON support for free.
+
+## Priority + detail-level resolution
+
+Pseudocode for the discovery loop:
+
+```python
+def load_plugins() -> dict[str, ToolRenderer]:
+    candidates: dict[str, list[ToolRenderer]] = defaultdict(list)
+    # 1. Discover entry-point plugins.
+    for ep in entry_points(group="claude_code_log.tool_renderers"):
+        try:
+            cls = ep.load()
+        except Exception as e:
+            warn(f"failed to load tool renderer plugin {ep.name!r}: {e}")
+            continue
+        if not isinstance(cls, type) or not isinstance(cls(), ToolRenderer):
+            warn(f"plugin {ep.name!r} does not implement ToolRenderer")
+            continue
+        candidates[cls.tool_name].append(cls())
+    # 2. Also feed in builtins as priority=0 entries.
+    for tool_name, builtin in BUILTIN_RENDERERS.items():
+        candidates[tool_name].append(builtin)
+    # 3. Resolve: lowest priority wins; tie-break alphabetically by class name with a warning.
+    winners: dict[str, ToolRenderer] = {}
+    for tool_name, group in candidates.items():
+        group.sort(key=lambda p: (p.priority, type(p).__name__))
+        if len(group) > 1 and group[0].priority == group[1].priority:
+            warn(f"tie-break for {tool_name!r} at priority {group[0].priority}: "
+                 f"using {type(group[0]).__name__}")
+        winners[tool_name] = group[0]
+    return winners
+```
+
+The winners table is consulted at three places:
+
+- `TOOL_INPUT_MODELS[tool_name]` ← `winner.InputModel`
+- `TOOL_OUTPUT_PARSERS[tool_name]` ← `winner.parse_output`
+- `_dispatch_format` consults `winners[tool_name]` when the
+  content's class doesn't match a `format_<ClassName>` method on
+  the renderer (today's MRO fallback path).
+
+Detail filtering becomes data-driven:
+
+```python
+def is_tool_active_at(detail: DetailLevel, tool_name: str) -> bool:
+    plugin = winners.get(tool_name)
+    if plugin is None:
+        return False           # unknown tool, generic fallback
+    return _detail_ge(detail, plugin.min_detail)
+
+# _detail_ge: "low" satisfies "low" / "medium" / "high" / "full" descending
+```
+
+This replaces the hardcoded `_LOW_KEEP_TOOLS` set. The in-tree
+WebSearch / WebFetch / Task / Agent renderers declare
+`min_detail = "low"`; everyone else defaults to `"high"` or
+`"full"`. The ClMail communicate renderer declares `"low"`.
+
+### Decisions inside the algorithm
+
+- **`min_detail` only, no `max_detail`.** A tool *worth showing
+  at low detail* is also worth showing at full detail — the user
+  asked for more information, not less. A max would invert that.
+  If a corner case ever needs hiding-when-verbose, the renderer
+  can branch on `message.detail` inside its render method.
+- **Tie-break is stable alphabetical by class name with a
+  warning.** Predictable enough to debug, loud enough that an
+  unintended tie surfaces. Plugins that genuinely want to stack
+  should pick distinct priorities.
+- **Priority 0 reserved for builtins.** Plugins should use any
+  non-zero integer; the convention `-5` / `+5` (or further-out
+  values) is documented but not enforced. Builtins themselves do
+  not declare a priority — the loader injects them at 0.
+
+## Worked example: ClMail tools plugin
+
+A separate package, `claude-code-log-clmail-renderer`, ships
+alongside the existing `clmail` Python package (or as a `clmail`
+sub-extra). Layout:
+
+```
+claude_code_log_clmail/
+  __init__.py
+  _base.py                     # shared ClMail mail-format helpers
+  communicate.py               # ClmailCommunicateRenderer
+  control.py                   # ClmailControlRenderer
+  actors.py                    # ClmailActorsRenderer
+  terminal.py                  # ClmailTerminalRenderer
+  templates/
+    communicate.md.j2          # optional Jinja partials
+```
+
+Representative renderer (sketch only):
+
+```python
+class ClmailCommunicateRenderer:
+    tool_name  = "mcp__plugin_clmail_clmail__communicate"
+    priority   = -5                # supersede the generic ToolUseContent fallback
+    min_detail = "low"
+    icon       = "✉"
+
+    class InputModel(BaseModel):
+        action: Literal["send", "list", "read", "thread", "search",
+                        "delete", "clear"]
+        actor: str = ""
+        params: dict | str = {}
+
+    @dataclass
+    class OutputModel:
+        action: str
+        # action-specific shape — discriminated union pattern, one
+        # parser per action.
+
+    @staticmethod
+    def parse_output(raw, message):
+        action = raw.get("action") or _infer_action_from(raw)
+        return _PARSERS_BY_ACTION[action](raw)
+
+    def render_input_markdown(self, content, message):
+        match content.parsed.action:
+            case "send":
+                return f"**Sending to {content.parsed.params['to']}**\n\n"\
+                       f"> {content.parsed.params['subject']}"
+            case "read":
+                return f"Reading message #{content.parsed.params['id']}"
+            ...
+
+    def render_output_markdown(self, content, message):
+        # action == "read" -> render mail body excerpt + frontmatter
+        # action == "list" -> count + 1-line-per-message preview
+        # action == "send" -> "Sent to {to} (id {message_ids[0]})"
+        ...
+
+    # render_*_html return None -> derived from Markdown via mistune.
+```
+
+At `--detail low`, instead of:
+
+```
+[clmail] You've got a new mail (#3076)
+```
+
+the Markdown output would carry, inside the tool block:
+
+```
+✉ clmail communicate · read
+
+Reading message #3076
+
+> Subject: PR #164 status check — user wants you to finish it
+> From: main · 2026-05-21
+> Hi carol — the user said "monitor carol while she finishes #164" …
+```
+
+The synthetic hook line stays in the user-prompt stream (alice's
+parallel work strips it at `--detail low`); the *content* now
+lives in the rendered tool block instead.
+
+## Test strategy
+
+Three layers:
+
+1. **Plugin loader unit tests** (mock entry points via
+   `importlib.metadata.entry_points`'s
+   `select(group=...)` and a fake EntryPoint object): cover
+   priority ordering, tie-break warning, malformed plugin
+   rejection, builtin injection.
+2. **Renderer integration tests**: ship a `dummy_plugin` fixture
+   in `test/test_data/` registering a fake tool. Drive a JSONL
+   transcript through `claude-code-log` with the plugin
+   discoverable, assert Markdown / HTML output picks up the
+   plugin's rendering. Cover all four `(min_detail, current
+   detail)` quadrants.
+3. **ClMail plugin tests** (in the ClMail-renderer package, not
+   here): per-action snapshot tests covering the seven
+   `communicate` actions, the four `control` actions, etc. Lives
+   with that package's own test suite.
+
+Snapshot tests for the in-tree builtin set need no change beyond
+declaring their `min_detail` values explicitly — the existing
+snapshot pins their current output.
+
+## Open questions (decisions deferred to implementation)
+
+- **Plugin caching.** Entry-point discovery costs ~10ms on first
+  call. If that shows in startup profiling, cache the resolved
+  winners table to disk keyed by installed plugin versions. Not
+  needed in v1.
+- **Plugin enable/disable flag.** Should `--no-plugin <name>` or
+  an env var let the user mask a plugin without uninstalling? A
+  case can be made for testing; defer until requested.
+- **Plugin version pinning.** No machine-readable "requires
+  claude-code-log >= X.Y" yet. Use the existing pyproject
+  `requires` field; we'll cross that bridge when a breaking
+  Protocol change happens.
+- **MCP namespace handling.** Should the system offer a sugar
+  like `tool_name = "clmail__communicate"` that auto-resolves
+  any `mcp__*__clmail__communicate`? Decline for v1 — plugins
+  declare the exact verbatim tool name. Revisit once we have
+  two MCP plugin names that collide across servers.
+- **Icon source of truth.** v1 keeps icons declared per-renderer.
+  An optional follow-up could migrate the in-tree scattered
+  icons into a single `_ICONS: dict[str, str]` populated by the
+  loader from each winner's `icon` attribute, retiring the
+  hardcoded literals at `html/renderer.py:843–930`.
+- **Templates.** Plugins MAY ship Jinja partials and load them
+  via `importlib.resources`; we won't standardise a directory
+  convention until a second plugin needs it.
+
+## Future extensions
+
+The same entry-point machinery extends cleanly to two adjacent
+needs without changing the v1 surface:
+
+1. **Pluggable formatters** (the user's named future direction).
+   A new group `claude_code_log.formatters` discovers full
+   format renderers — RTF, JATS, etc. The discovery,
+   priority, and detail-level vocabulary all carry over. A
+   formatter plugin would register both a name (`"rtf"`) and a
+   renderer object that knows how to walk the `TemplateMessage`
+   tree; tool renderers contribute `render_input_<format>` /
+   `render_output_<format>` methods for any format they wish to
+   support, falling back to "derive from Markdown" for the rest.
+2. **Pluggable message-type renderers** (less interesting today,
+   but the same shape). The current factories (`meta_factory`,
+   `user_factory`, etc.) are themselves dispatch tables. The
+   plugin machinery built for tools is reusable for them; the
+   only delta is the dispatch key.
+
+In neither case does v1 need to ship anything for the future —
+the entry-point group `claude_code_log.tool_renderers` is scoped
+narrowly enough that adding a `claude_code_log.formatters` group
+later is purely additive.

--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -1,126 +1,128 @@
-# Plugin system: tool renderers and message transformers
+# Plugin system: unified message-transformer mechanism
 
 ## Status: Design proposal (no implementation yet)
 
+## Design reversal acknowledgement
+
+This RFC went through a substantial restructure during design
+review. Earlier commits proposed two parallel plugin mechanisms
+(`ToolRenderer` + `MessageTransformer`), then narrowed the
+transformer side to "existing core variants only" for v1 surface
+reasons, then — on a pointed question from the user via main
+(clmail #3132) — collapsed both mechanisms into one.
+
+The current direction: **a single `MessageTransformer` Protocol**
+that handles both the hook-demotion case AND the MCP-tool-rendering
+case, by letting plugins rewrite generic content (`UserTextMessage`,
+`ToolUseContent`, `ToolResultContent`, ...) into plugin-defined
+specialized subclasses that carry their own format/title methods.
+
+This is a deliberate expansion of v1 surface area (plugins now
+define `MessageContent` subclasses, register format-method
+contributions, and declare detail-level visibility) chosen for
+architectural symmetry: built-in tools already use specialized
+subclasses dispatched via MRO (`BashInputContent` and friends).
+The two-mechanism split was a workaround for plugins not having
+method-binding; eliminate the workaround and one mechanism
+suffices for both cases.
+
+See [the reversal context](#reversal-context-and-trade-offs) for
+the design considerations the user weighed.
+
 ## Problem statement
 
-Two parallel needs both want the same plugin machinery.
+Two motivating cases:
 
-**Tool renderers.** Today every tool renderer is baked into
-`claude-code-log`: a new tool means a PR against
-`claude_code_log/factories/tool_factory.py`,
-`claude_code_log/html/tool_formatters.py`, and the
-`format_<ClassName>` methods on the two renderer classes. This is
-fine for the in-tree set (Bash, Read, WebSearch, ...), but it
-prevents third parties — including the ClMail MCP plugin we use
-ourselves — from shipping a *content-aware* renderer alongside
-their tool. The visible symptom: `--detail low` Markdown today
-shows synthetic hook lines like `[clmail] You've got a new mail
-(#3076)` rather than the actual mail subject / body excerpt, because
-no in-tree renderer knows what `mcp__plugin_clmail_clmail__communicate`
-returns.
+**Tool rendering.** Today every tool renderer is baked into
+`claude-code-log`. The factory (`tool_factory.py`) maps tool name
+to a specialized `ToolUseContent` subclass (`BashInputContent`,
+`ReadInputContent`, etc.); the renderer dispatches to
+`format_BashInput` via the MRO walk in `_dispatch_format`. This is
+fine for the in-tree set but prevents third parties — including
+the ClMail MCP plugin we use ourselves — from shipping a
+*content-aware* renderer alongside their tool. Visible symptom:
+`--detail low` Markdown today shows synthetic hook lines like
+`[clmail] You've got a new mail (#3076)` rather than the actual
+mail subject / body excerpt.
 
-**Message transformers.** In parallel, PR #167 (alice's
-`dev/filter-hook-turns` branch) introduces
-`detect_hook_notification()` in
-`claude_code_log/factories/user_factory.py:79–99`: a regex over
+**Hook-injected user turns.** PR #167 (alice's
+`dev/filter-hook-turns`) introduces `detect_hook_notification()`
+in `claude_code_log/factories/user_factory.py:79–99`: a regex over
 `(monitor|clmail)`-prefixed user turns that demotes them from
-`UserTextMessage` to a typed `UserHookNotificationMessage` which
-the renderer filters at HIGH/MEDIUM/LOW/MINIMAL. The regex is
-hard-coded for two specific external hook sources — exactly the
-kind of plugin-shaped concern that should live with the plugin that
-*causes* those notifications (the ClMail plugin), not in core.
+`UserTextMessage` to a typed `UserHookNotificationMessage`. The
+regex is hard-coded for two specific external hook sources —
+exactly the kind of plugin-shaped concern that belongs with the
+plugin that *causes* those notifications.
 
-Both problems collapse to: **external code wants to influence
-which Python class wraps a parsed entry, and how that class
-renders.** This document proposes a single plugin mechanism that
-lets external packages contribute either kind of capability via
-setuptools entry points, with a priority offset so an out-of-tree
-plugin can either **supplement** the in-tree set (positive priority,
-used only if no builtin claims the slot) or **supersede** it
-(negative priority, wins until something more negative arrives).
-The driving use cases are the ClMail tools and the clmail/monitor
-hook-demotion, but the same mechanism unlocks any future MCP tool,
-any future hook-injection format, plus a path to pluggable output
-formatters (see [Future](#future-extensions)).
+Both cases share a single shape: **external code wants to rewrite
+a parsed `MessageContent` into a plugin-defined subclass, then
+have that subclass render itself.** This document proposes one
+plugin mechanism — message transformers + plugin-defined
+`MessageContent` subclasses — that handles both.
 
 ## Current architecture (what we hook into)
 
-Six dispatch points matter — three for tool renderers, three more
-that transformers touch.
+The architecture today is more plugin-friendly than the original
+RFC framing suggested. The key observation: **the factory already
+creates specialized subclasses, and `_dispatch_format` already
+finds their format methods via MRO walk.** A plugin extension
+that produces *more* specialized subclasses needs only to (a) hook
+into the factory's classification step and (b) supply format
+methods that the existing MRO walk can find.
 
-**Tool-renderer surfaces:**
+Three surfaces matter:
 
-1. **`TOOL_INPUT_MODELS`** (dict) at
-   `claude_code_log/factories/tool_factory.py:93` — maps tool name
-   string → Pydantic input model class. `create_tool_input()`
-   (line 143) looks the name up; on miss falls back to
-   `ToolUseContent`.
-2. **`TOOL_OUTPUT_PARSERS`** (dict) at
-   `claude_code_log/factories/tool_factory.py:1234` — maps tool
-   name → parser callable producing the output dataclass. Used by
-   `create_tool_output()` (line 1272).
-3. **`_dispatch_format`** at `claude_code_log/renderer.py:4143` —
-   takes a content object, walks `type(obj).__mro__`, and calls
-   `format_<ClassName>` on the renderer instance. The MRO walk
-   gives free polymorphic fallback (`format_BashInput` →
-   `format_ToolUseContent`). Used by both tool renderers (for
-   `ToolUseContent` subclasses) and transformers (for the
-   `MessageContent` subclasses they introduce).
-
-Detail-level filtering lives at `renderer.py:3151–3224`. The
-keep-list at `--detail low` is the hardcoded set
-`_LOW_KEEP_TOOLS = {"WebSearch", "WebFetch", "Task", "Agent"}`.
-
-Icons are scattered as string literals across title methods in
-`html/renderer.py:843–930` (no central registry).
-
-**Transformer surfaces:**
-
-4. **Factory dispatch chain** at
+1. **Factory dispatch chain** at
    `claude_code_log/factories/user_factory.py:539–568` (and the
-   analogous functions for assistant / system / meta entries).
+   analogous functions for assistant / system / meta / tool entries).
    `create_user_message` tries detectors in a fixed sequence:
    `is_command_message` → `is_local_command_output` →
    `is_bash_input / is_bash_output` → `has_teammate_message` →
    `has_task_notification` → `detect_hook_notification` (#167) →
    `is_slash_command` (isMeta) → generic text fallback. Each
-   detector either claims the entry (producing a typed
-   `MessageContent` subclass) or passes through. Transformers
-   plug into this chain at declared priority offsets.
-5. **`extract_text_content(content_list)`** at user_factory — the
+   detector either claims the entry (producing a specialized
+   `MessageContent` subclass) or passes through. The tool factory
+   at `tool_factory.py:93+` does the equivalent for tool entries
+   via `TOOL_INPUT_MODELS[tool_name]` and `TOOL_OUTPUT_PARSERS`.
+   Transformers plug into these chains at declared priority offsets.
+
+2. **`_dispatch_format`** at `claude_code_log/renderer.py:4143` —
+   takes a content object, walks `type(obj).__mro__`, and calls
+   `format_<ClassName>` on the renderer instance. The MRO walk
+   gives free polymorphic fallback (`format_BashInput` →
+   `format_ToolUseContent`). This is the central dispatch point;
+   the plugin mechanism extends it with a second resolution step
+   (class-defined `format_markdown` / `format_html` / `title`
+   methods on the content class itself).
+
+3. **`extract_text_content(content_list)`** at user_factory — the
    joined-with-newlines text string that detectors regex against.
    The plugin contract guarantees that `UserTextMessage.text`
    (and equivalents on other message types) is byte-equivalent
    to this extraction, so transformer regexes behave consistently
    whether called inside the factory or against a parsed
-   `MessageContent`. **Enforcement.** The plugin-system test
-   suite includes a dedicated equivalence test that walks the
-   existing JSONL test corpus and asserts
+   `MessageContent`. **Enforcement.** The plugin-system test suite
+   includes a dedicated equivalence test walking the existing
+   JSONL test corpus and asserting
    `UserTextMessage(content_list=cl).text == extract_text_content(cl)`
    for every user entry. A future factory PR that introduces
-   normalization (markdown cleanup, whitespace folding, etc.)
-   between extraction and assignment fails this test, surfacing
-   the contract break before it silently drifts plugin regex
-   behaviour.
+   normalization between extraction and assignment fails this test.
 
-Detail-level filtering for hook-notification noise lives in
-`_HIGH_EXCLUDE_CLASSES` (renderer.py). This stays as a core
-registry in v1 — see [v1 scope](#v1-scope-existing-variants-only)
-for why transformers rewrite *to* existing core classes rather
-than defining their own.
+Detail-level filtering for hook-noise lives in
+`_HIGH_EXCLUDE_CLASSES` (renderer.py); the keep-list at
+`--detail low` is `_LOW_KEEP_TOOLS = {"WebSearch", "WebFetch",
+"Task", "Agent"}`. The plugin mechanism replaces both with a
+class-level `detail_visibility` attribute; see [detail-visibility
+semantics](#detail_visibility-semantics-and-built-in-bridge).
 
-These are the surfaces a plugin needs to influence. The plugin
-system's whole job is to populate the tool-renderer surfaces
-(1–3 plus keep-list and icon registry) and the transformer
-surfaces (4–5) — from out-of-tree packages, through one shared
-discovery mechanism.
+Icons remain scattered as string literals across title methods
+in `html/renderer.py:843–930`. Plugins can place their own icons
+in the title methods they ship; centralization is a follow-up.
 
 ## Discovery + selection: `importlib.metadata.entry_points`
 
 **Recommendation: stdlib entry points, single group
-`claude_code_log.plugins`, loader type-dispatches each entry on
-Protocol conformance.**
+`claude_code_log.plugins`.**
 
 Compared to `pluggy`:
 
@@ -130,129 +132,35 @@ Compared to `pluggy`:
 | Declarative pyproject hook | yes | no (needs `pm.register()` calls) |
 | Composition (firstresult, before/after) | no | yes |
 | Mental model | "load a class by name" | "hook spec / hook impl" |
-| Fits our need | yes (one winner per slot) | overkill |
+| Fits our need | yes (first non-None wins) | overkill |
 
-We need *one* winner per `(tool_name, output_format)` and one
-winner per `(applies_to-type, priority)` slot, chosen by priority —
-not multi-hook composition. Pluggy's expressiveness pays for
-itself in pytest, where each hook can fire multiple impls; here it
-would just be ceremony. Entry points stay in the boring lane:
-stdlib, no new dep, mirrors how Click commands and pytest plugins
-themselves are discovered.
+We need *one* transformer per `(applies_to-type, priority)` slot,
+chosen by priority — not multi-hook composition. Pluggy's
+expressiveness pays for itself in pytest; here it would just be
+ceremony.
 
-**One group, capability inferred from class.** Both `ToolRenderer`
-and `MessageTransformer` plugins register under the same
-entry-point group; the loader inspects each yielded class for
-Protocol conformance and routes accordingly. This matches the
-pytest11 / mkdocs / mypy stubs pattern, avoids forcing pure-tool
-plugins to ship a `Plugin` aggregator class, and gives a single
-discovery namespace that's easy to audit (one `entry_points`
-call, one place to look). A multi-capability plugin just
-declares N entries.
-
-A plugin package declares:
+One group, one Protocol, idiomatic Python. A plugin package
+declares any number of `MessageTransformer` classes:
 
 ```toml
 [project.entry-points."claude_code_log.plugins"]
-# Tool renderers
-clmail_communicate     = "claude_code_log_clmail.renderers:ClmailCommunicateRenderer"
-clmail_control         = "claude_code_log_clmail.renderers:ClmailControlRenderer"
-clmail_actors          = "claude_code_log_clmail.renderers:ClmailActorsRenderer"
-clmail_terminal        = "claude_code_log_clmail.renderers:ClmailTerminalRenderer"
-# Message transformers
+# Hook-demotion transformers (rewrite UserTextMessage)
 clmail_hook_demotion   = "claude_code_log_clmail.transformers:ClmailHookDemotion"
 monitor_hook_demotion  = "claude_code_log_clmail.transformers:MonitorHookDemotion"
+# Tool-rendering transformers (rewrite ToolUseContent / ToolResultContent)
+clmail_communicate_in  = "claude_code_log_clmail.transformers:ClmailCommunicateInputTransformer"
+clmail_communicate_out = "claude_code_log_clmail.transformers:ClmailCommunicateOutputTransformer"
+clmail_control_in      = "claude_code_log_clmail.transformers:ClmailControlInputTransformer"
+clmail_control_out     = "claude_code_log_clmail.transformers:ClmailControlOutputTransformer"
+# (analogous for actors, terminal)
 ```
 
 At startup, `claude_code_log` enumerates this group once, loads
-each entry, dispatches by Protocol (`isinstance(cls(),
-ToolRenderer)` vs `isinstance(cls(), MessageTransformer)`),
-resolves each capability's winners by priority, and freezes the
-results into the runtime dispatch tables. No reload at runtime;
-the cost of a CLI restart is acceptable for any plugin change.
+each entry, validates against the `MessageTransformer` Protocol,
+sorts globally by priority, and freezes the result. No reload at
+runtime.
 
-## Plugin Protocols (one per capability)
-
-A plugin is a class implementing exactly one of two Protocols:
-`ToolRenderer` (renders a specific tool's input/output) or
-`MessageTransformer` (rewrites a parsed `MessageContent` into a
-different variant during factory dispatch). Both Protocols share
-the same priority + discovery semantics so plugins can mix and
-match.
-
-### `ToolRenderer`
-
-Class attributes
-declare metadata; instance methods do the rendering. Methods
-return `None` to defer (e.g. let Markdown→HTML conversion handle
-the HTML side).
-
-```python
-from typing import ClassVar, Protocol, runtime_checkable
-from claude_code_log.models import (
-    TemplateMessage, ToolUseContent, ToolResultContent,
-)
-
-DetailLevel = Literal["full", "high", "medium", "low"]  # already exists
-
-@runtime_checkable
-class ToolRenderer(Protocol):
-    # --- registration ---
-    tool_name: ClassVar[str]              # e.g. "mcp__plugin_clmail_clmail__communicate"
-    priority: ClassVar[int]               # 0 = builtin; <0 supersedes; >0 fallback
-    min_detail: ClassVar[DetailLevel]     # smallest level at which this tool is rendered
-    icon: ClassVar[str | None]            # optional Unicode glyph for the heading
-
-    # --- parsing (factory side) ---
-    InputModel: ClassVar[type[BaseModel]]              # Pydantic
-    OutputModel: ClassVar[type[Any] | None]            # dataclass; None for unstructured
-
-    @staticmethod
-    def parse_output(raw: dict, message: TemplateMessage) -> Any | None: ...
-        # default: identity (raw dict) or instantiate OutputModel from `toolUseResult`
-
-    # --- rendering (renderer side) ---
-    def render_input_markdown(self, content: ToolUseContent,
-                              message: TemplateMessage) -> str: ...
-
-    def render_output_markdown(self, content: ToolResultContent,
-                               message: TemplateMessage) -> str: ...
-
-    def render_input_html(self, content: ToolUseContent,
-                          message: TemplateMessage) -> str | None: ...
-        # None => fall back to mistune(render_input_markdown(...))
-
-    def render_output_html(self, content: ToolResultContent,
-                           message: TemplateMessage) -> str | None: ...
-
-    def title(self, content: ToolUseContent,
-              message: TemplateMessage) -> str | None: ...
-        # None => default "{icon} {ToolName} <summary>"
-```
-
-The two-way (Markdown required, HTML optional) split is what lets
-the user's stated constraint hold: **Markdown is the minimum
-required output; HTML can be derived from Markdown.** When
-`render_input_html` returns `None`, the system runs the plugin's
-Markdown output through the same `mistune` pipeline already used
-for assistant content.
-
-Notably absent: no `render_input_json`. JSON output (see
-`dev-docs/implementing-a-tool-renderer.md` §JSON) already works
-generically from the dataclass / Pydantic models via
-`dataclasses.asdict`; a plugin that ships the model classes gets
-JSON support for free.
-
-### `MessageTransformer`
-
-A transformer rewrites a parsed `MessageContent` into a different
-`MessageContent` variant during factory dispatch. **v1 scope:
-plugins rewrite *to* existing core `MessageContent` variants
-only.** A plugin does not define new `MessageContent` subclasses,
-does not register format/title methods, and does not touch the
-detail-level filter machinery — visibility comes for free by
-virtue of targeting an existing core class. See
-[v1 scope](#v1-scope-existing-variants-only) for the rationale.
+## The `MessageTransformer` Protocol
 
 ```python
 from typing import ClassVar, Optional, Protocol, runtime_checkable
@@ -262,136 +170,195 @@ from claude_code_log.models import MessageContent, MessageMeta
 class MessageTransformer(Protocol):
     # --- registration ---
     name: ClassVar[str]                                 # e.g. "clmail.hook-demotion"
-    priority: ClassVar[int]                             # see built-in priority table below
+    priority: ClassVar[int]                             # see priority table
     applies_to: ClassVar[tuple[type[MessageContent], ...]]
         # MRO-filtered: only invoked when the factory's *current* candidate
-        # MessageContent matches (subclass check). Most transformers target
-        # (UserTextMessage,) — they only fire for entries that would
-        # otherwise fall through to the generic text variant.
+        # MessageContent matches (subclass check). Examples:
+        #   (UserTextMessage,)       hook-demotion transformers
+        #   (ToolUseContent,)        tool-rendering input transformers
+        #   (ToolResultContent,)     tool-rendering output transformers
 
     # --- transformation ---
     def transform(
         self,
-        text_content: str,
-        content_list: list,
+        content: MessageContent,
         meta: MessageMeta,
     ) -> Optional[MessageContent]:
-        """Return an instance of an EXISTING core MessageContent variant,
-        or None to pass through. Called inside the factory dispatch chain
-        at this transformer's declared priority. text_content is
-        byte-equivalent to what the factory's built-in detectors consume.
-
-        v1 contract: the returned MessageContent MUST be an instance of
-        a class already defined in claude_code_log.models — typically
-        one of the typed user-side variants (UserHookNotificationMessage,
-        UserSlashCommandMessage, etc.). Plugins cannot introduce new
-        MessageContent subclasses in v1.
+        """Return a replacement MessageContent (typically a plugin-defined
+        subclass), or None to pass through. Called inside the factory
+        dispatch chain at this transformer's declared priority.
         """
 ```
 
-### v1 scope: existing-variants-only
+Notable design choices:
 
-A transformer's `transform()` MUST return an instance of a class
-already defined in `claude_code_log.models`. The natural target
-for hook-style transformers is the generic
-`UserHookNotificationMessage(source: str, text: str)` introduced
-by PR #167, which lives in core and is plugin-friendly by design
-(no clmail-specific typing on the class itself; the docstring
-names monitor/clmail as *examples*).
+- **Input is the parsed content**, not raw text or content_list.
+  This works for both `UserTextMessage` (where text-prefix matching
+  reads `content.text`) and `ToolUseContent` (where tool-name
+  matching reads `content.tool_name`). Plugins access whatever
+  fields they need on the typed content.
+- **Output is `Optional[MessageContent]`**, not constrained to any
+  particular base class. v1 accepts any subclass; convention is
+  that transformers produce *more specific* subclasses of their
+  `applies_to` types (e.g. a `ToolUseContent` transformer
+  typically returns a `ClMailCommunicateInput(ToolUseContent)`).
+- **No `OutputClass` field on the transformer.** The output
+  class is whatever the `transform()` method returns; the loader
+  doesn't need to know it ahead of time. The plugin author defines
+  the subclass and instantiates it inside `transform()`.
 
-Why this scope:
+## Plugin-defined `MessageContent` subclasses
 
-- **Filter-bucket inheritance.** Visibility is a property of the
-  target class, owned by core, inherited by every transformer
-  that targets it. No `detail_visibility` class attribute, no
-  per-plugin renderer registration, no migration of built-in
-  classes. The plugin contract reduces to a single method
-  (`transform`) and three metadata fields.
-- **Renderer/timeline/fold-rules surface stays unchanged.** No
-  v1 commitment to a plugin-touchable rendering API; we can
-  iterate on the rendering pipeline freely without breaking
-  out-of-tree code.
-- **v1 → v2 migration is purely additive.** A future v2 that
-  permits plugin-owned `MessageContent` subclasses
-  (`detail_visibility` attribute, plugin-registered format/title
-  methods) extends this contract without breaking it. The
-  reverse direction is not true: shipping plugin-owned classes
-  in v1 commits the rendering surface to a plugin-touchable API
-  forever.
-- **The clmail case doesn't motivate v2.** Alice's PR #167
-  defines `UserHookNotificationMessage` generically; any future
-  hook-source plugin (monitor, other tooling) rewrites *to* it
-  by passing a different `source=` string. No new typed wrapper
-  needed.
-
-Migration of PR #167 to a plugin under v1 is a *deletion-only*
-refactor from core's perspective: remove the
-`_HOOK_NOTIFICATION_SOURCES` tuple, remove the regex, remove the
-call site in `create_user_message`. The class, its renderer/title
-methods, and its `_HIGH_EXCLUDE_CLASSES` membership all stay in
-core unchanged. The clmail plugin ships one
-`MessageTransformer` per source (mechanically: one regex →
-two transformers).
-
-**In-factory-dispatch placement.** Transformers run *inside* the
-factory's existing detector sequence, not as a post-factory pass.
-Concretely, `create_user_message` (and analogues) walks a single
-unified priority-ordered list: built-in detectors interleaved with
-registered transformers, each checked in turn. This preserves the
-existing ordering invariants (`is_slash_command` always wins
-before any text-targeting transformer can fire) and avoids
-re-walking the tree.
-
-**Multi-line guards and other matcher-specific concerns** live in
-the plugin, not the core contract. A transformer that wants to
-reject multi-line bodies (clmail's case) does so inside its own
-`transform()`; a transformer that wants to accept them is free to.
-
-## Priority + detail-level resolution
-
-Pseudocode for the discovery loop:
+Plugins define new `MessageContent` subclasses freely. The class
+declares its rendering and visibility on itself:
 
 ```python
-def load_plugins() -> tuple[dict[str, ToolRenderer], list[MessageTransformer]]:
-    renderer_candidates: dict[str, list[ToolRenderer]] = defaultdict(list)
-    transformers: list[MessageTransformer] = []
-    # 1. Discover entry-point plugins; dispatch on Protocol.
-    for ep in entry_points(group="claude_code_log.plugins"):
-        try:
-            cls = ep.load()
-            instance = cls()
-        except Exception as e:
-            warn(f"failed to load plugin {ep.name!r}: {e}")
-            continue
-        if isinstance(instance, ToolRenderer):
-            renderer_candidates[cls.tool_name].append(instance)
-        elif isinstance(instance, MessageTransformer):
-            transformers.append(instance)
-        else:
-            warn(f"plugin {ep.name!r} does not implement any plugin Protocol")
-    # 2. Feed in builtins as priority=0 entries.
-    for tool_name, builtin in BUILTIN_RENDERERS.items():
-        renderer_candidates[tool_name].append(builtin)
-    # 3. Resolve renderers: lowest priority wins; tie-break alphabetically by class name with a warning.
-    winners: dict[str, ToolRenderer] = {}
-    for tool_name, group in renderer_candidates.items():
-        group.sort(key=lambda p: (p.priority, type(p).__name__))
-        if len(group) > 1 and group[0].priority == group[1].priority:
-            warn(f"tie-break for {tool_name!r} at priority {group[0].priority}: "
-                 f"using {type(group[0]).__name__}")
-        winners[tool_name] = group[0]
-    # 4. Sort transformers globally by priority (no per-slot grouping; factory
-    #    consults them in order alongside built-in detectors).
-    transformers.sort(key=lambda t: (t.priority, type(t).__name__))
-    return winners, transformers
+from typing import ClassVar
+from pydantic import BaseModel
+from claude_code_log.models import DetailLevel, ToolUseContent
+
+
+class ClMailCommunicateModel(BaseModel):
+    action: Literal["send", "list", "read", "thread", "search", "delete", "clear"]
+    actor: str = ""
+    params: dict | str = {}
+
+
+class ClMailCommunicateInput(ToolUseContent):
+    parsed: ClMailCommunicateModel
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
+
+    def format_markdown(self, renderer, message) -> str:
+        match self.parsed.action:
+            case "send":
+                return (f"**Sending to {self.parsed.params['to']}**\n\n"
+                        f"> {self.parsed.params['subject']}")
+            case "read":
+                return f"Reading message #{self.parsed.params['id']}"
+            ...
+
+    def format_html(self, renderer, message) -> str | None:
+        return None    # fall back to mistune(format_markdown)
+
+    def title(self, renderer, message) -> str | None:
+        return f"✉ ClMail communicate · {self.parsed.action}"
 ```
 
-### Built-in detector priority table
+`_dispatch_format` finds these methods at render time via a
+two-step resolution (see below). No global registry, no
+monkey-patching of renderer classes, no descriptor protocol
+gymnastics — the methods live on the class, the dispatcher knows
+where to look.
 
-Transformers position themselves relative to the in-factory
-detector sequence. Built-in detectors get explicit named
-priorities exposed as module constants, with gaps of 100 to leave
-room for plugin insertion without renumbering:
+**This is a deliberate philosophy shift.** Today's `MessageContent`
+subclasses are pure data; renderers are methods on renderer
+classes. Adding `format_*` / `title` as methods on content
+classes themselves means the content class now knows about
+rendering. The trade-off is symmetry (one place to look for "how
+does this class render") and plugin ergonomics (no separate
+binding step). Built-in `MessageContent` subclasses remain
+unaltered in v1; they're rendered by the existing
+`format_<ClassName>` renderer methods. Migration of built-ins to
+the class-method pattern is a follow-up PR and is optional — the
+two patterns coexist cleanly.
+
+## `detail_visibility` semantics and built-in bridge
+
+A `MessageContent` subclass with a `detail_visibility: ClassVar[DetailLevel]`
+attribute is rendered iff
+`current_detail >= cls.detail_visibility` in the canonical
+`DetailLevel` ordering. Pin the ordering once in `renderer.py`:
+
+```
+FULL  > HIGH  > MEDIUM  > LOW  > MINIMAL  > USER_ONLY
+```
+
+(Will verify against the actual enum at implementation time;
+the exact spelling of the levels is whatever `DetailLevel`
+currently defines. The semantics are: higher = more verbose; a
+class with `detail_visibility = LOW` is rendered at `--detail
+low`/`medium`/`high`/`full`, dropped at `--detail minimal`/`user-only`.)
+
+**Default.** A `MessageContent` subclass without a
+`detail_visibility` attribute defaults to `USER_ONLY` (always
+visible). Plugins MUST set the attribute explicitly when they
+want filtering behaviour.
+
+**Built-in bridge.** v1 does not migrate built-in
+`MessageContent` subclasses to the class-attribute form. The
+existing `_HIGH_EXCLUDE_CLASSES` set in `renderer.py` continues
+to govern built-in visibility. Resolution order at the filter
+pass:
+
+```python
+def is_visible(content_cls: type, current_detail: DetailLevel) -> bool:
+    # 1. Class attribute wins if present (plugin classes, future migrated built-ins).
+    if hasattr(content_cls, "detail_visibility"):
+        return current_detail >= content_cls.detail_visibility
+    # 2. _HIGH_EXCLUDE_CLASSES bridge for built-ins not yet migrated.
+    if content_cls in _HIGH_EXCLUDE_CLASSES:
+        return current_detail == DetailLevel.FULL
+    # 3. Default visible.
+    return True
+```
+
+A built-in that's both in `_HIGH_EXCLUDE_CLASSES` *and* later
+gets a `detail_visibility` attribute (during follow-up migration)
+honours the attribute; the registry entry becomes dead code and
+can be removed in the same PR. Plugin classes never appear in
+`_HIGH_EXCLUDE_CLASSES`; they always use the attribute.
+
+## `_dispatch_format` resolution order
+
+When the renderer needs to format a content object, the lookup
+walks the content's MRO and tries two strategies at each class:
+
+```python
+def _dispatch_format(self, content, output_format):
+    method_attr = f"format_{output_format}"     # "format_markdown" / "format_html"
+    for klass in type(content).__mro__:
+        # Strategy 1: renderer-side format_<ClassName> method.
+        # Preserves built-in dispatch unchanged; the renderer class
+        # carries hand-written format_BashInput / format_ReadInput / etc.
+        renderer_method = getattr(self, f"format_{klass.__name__}", None)
+        if renderer_method is not None:
+            return renderer_method(content)
+        # Strategy 2: class-side format_<output> method.
+        # Plugin-defined classes carry format_markdown / format_html on
+        # themselves; the dispatcher invokes them with the renderer as
+        # first arg so they have access to renderer state (mistune, etc.).
+        class_method = klass.__dict__.get(method_attr)
+        if class_method is not None:
+            return class_method(content, self, content.message)
+    raise NotImplementedError(...)
+```
+
+**Four-way matrix** (for a given content class):
+
+| renderer-method present | class-method present | Winner |
+|---|---|---|
+| yes | yes | renderer-method (precedence by MRO position; ties resolved by strategy order at the same level) |
+| yes | no | renderer-method |
+| no | yes | class-method |
+| no | no | continue MRO walk; raise if exhausted |
+
+The "renderer-method wins" rule preserves all existing built-in
+dispatch unchanged — no regression risk. A plugin that subclasses
+a built-in (e.g. `ClMailCommunicateInput(ToolUseContent)`) can
+shadow the built-in `format_ToolUseContent` by defining
+`format_markdown` on the plugin class — the MRO walk visits
+`ClMailCommunicateInput` first, finds class-side `format_markdown`,
+uses it, never reaches `ToolUseContent`'s renderer-side
+`format_ToolUseContent`.
+
+If `format_html` is absent (only `format_markdown` defined), the
+HTML pipeline falls back to `mistune_render(format_markdown(...))`
+— same convention as the original RFC's two-way split.
+
+## Priority + ordering
+
+Built-in detector priorities are exposed as module constants
+with gaps of 100 so plugins position relative without renumbering:
 
 ```python
 # claude_code_log.factories.priorities
@@ -400,187 +367,139 @@ LOCAL_COMMAND_OUTPUT      = 200
 BASH_INPUT_OUTPUT         = 300
 TEAMMATE_MESSAGE          = 400
 TASK_NOTIFICATION         = 500
-HOOK_NOTIFICATION         = 600   # alice's #167 default seat
+HOOK_NOTIFICATION         = 600   # PR #167's seat
 SLASH_COMMAND_ISMETA      = 700
-TEXT_FALLBACK             = 1000  # always last; generic UserTextMessage
+TEXT_FALLBACK             = 1000  # generic UserTextMessage
+# Tool side:
+TOOL_INPUT_GENERIC        = 5000
+TOOL_OUTPUT_GENERIC       = 5100
 ```
 
-A clmail-plugin transformer registered at `priority=600` *replaces*
-the hardcoded hook detector. At `priority=550` it runs *before* it
-(useful only to override built-in behaviour). At `priority=650` it
-runs *after* it (useful as a fallback if the built-in eventually
-narrows its scope). Lower number = higher priority = runs first;
-first non-None wins.
+A clmail tool-rendering transformer at priority `4500` runs
+*before* the generic tool input classification (so the generic
+`ToolUseContent` is never produced for matched tools; the plugin's
+`ClMailCommunicateInput` is). A hook-demotion transformer at
+priority `600` *replaces* the in-core hook detector during the
+migration.
+
+Lower number = higher priority = runs first; first non-None
+return wins. Tie-break is stable alphabetical by class name with
+a startup warning.
 
 ### Subtle ordering note
 
 `applies_to = (UserTextMessage,)` is the natural scope for any
-text-prefix transformer: it only fires on entries that have not
-already been claimed by an earlier detector. A transformer cannot
-accidentally intercept a slash-command, bash-input, or
-teammate-message entry, because those never become `UserTextMessage`
-in the first place. This is a real safety property, not just a
-micro-optimization — the existing factory ordering enforces
-plugin precedence by class assignment.
+text-prefix transformer: the transformer fires only on entries
+that have not already been claimed by an earlier detector. A
+text-prefix transformer cannot accidentally intercept a
+slash-command or bash-input entry, because those never become
+`UserTextMessage` in the first place. This is a real safety
+property: factory ordering enforces plugin precedence by class
+assignment.
 
-The winners table is consulted at three places:
+For tool-rendering transformers, the analogous safety property:
+`applies_to = (ToolUseContent,)` matches only entries the tool
+factory has classified as generic tool input (i.e. not already
+specialized to `BashInputContent`, `ReadInputContent`, etc.). The
+plugin's `transform()` then narrows by `content.tool_name` to
+target a specific tool.
 
-- `TOOL_INPUT_MODELS[tool_name]` ← `winner.InputModel`
-- `TOOL_OUTPUT_PARSERS[tool_name]` ← `winner.parse_output`
-- `_dispatch_format` consults `winners[tool_name]` when the
-  content's class doesn't match a `format_<ClassName>` method on
-  the renderer (today's MRO fallback path).
-
-### `_dispatch_format` invocation pattern
-
-Once `_dispatch_format` resolves a plugin winner for a given
-content object, it picks the renderer method by joining two
-dispatch axes: **content type** (`ToolUseContent` →
-`render_input_*`, `ToolResultContent` → `render_output_*`) and
-**requested output format** (`markdown` / `html`, with HTML
-falling back to mistune-on-Markdown when the plugin returns
-`None`):
+## Loader pseudocode
 
 ```python
-def _dispatch_via_plugin(
-    content: ToolUseContent | ToolResultContent,
-    message: TemplateMessage,
-    output_format: Literal["markdown", "html"],
-) -> str:
-    winner = winners[content.tool_name]
-
-    if isinstance(content, ToolUseContent):
-        if output_format == "markdown":
-            return winner.render_input_markdown(content, message)
-        else:  # html
-            rendered = winner.render_input_html(content, message)
-            if rendered is None:
-                # Derive HTML from the plugin's Markdown via mistune.
-                md = winner.render_input_markdown(content, message)
-                return mistune_render(md)
-            return rendered
-
-    elif isinstance(content, ToolResultContent):
-        if output_format == "markdown":
-            return winner.render_output_markdown(content, message)
-        else:  # html
-            rendered = winner.render_output_html(content, message)
-            if rendered is None:
-                md = winner.render_output_markdown(content, message)
-                return mistune_render(md)
-            return rendered
+def load_plugins() -> list[MessageTransformer]:
+    transformers: list[MessageTransformer] = []
+    for ep in entry_points(group="claude_code_log.plugins"):
+        try:
+            cls = ep.load()
+            instance = cls()
+        except Exception as e:
+            warn(f"failed to load plugin {ep.name!r}: {e}")
+            continue
+        if not isinstance(instance, MessageTransformer):
+            warn(f"plugin {ep.name!r} does not implement MessageTransformer")
+            continue
+        transformers.append(instance)
+    transformers.sort(key=lambda t: (t.priority, type(t).__name__))
+    # Tie-break warning
+    for a, b in zip(transformers, transformers[1:]):
+        if a.priority == b.priority and a.applies_to == b.applies_to:
+            warn(f"priority tie for {a.applies_to!r}: "
+                 f"using {type(a).__name__} before {type(b).__name__}")
+    return transformers
 ```
 
-The MRO-walk that today underlies `_dispatch_format` stays in
-place: the dispatcher *first* tries `format_<ClassName>` on the
-renderer instance (covering both built-ins and in-tree
-subclasses), and *only* falls back to the plugin-winner path
-above when no matching `format_*` method exists. The plugin path
-is itself a `format_*`-equivalent — it answers the same
-question, just via the plugin contract instead of method
-inheritance.
+The factory's dispatch chain consults this list at each detector
+slot: for each transformer whose priority slots into the
+current position and whose `applies_to` matches the current
+candidate's class, call `transform()`; first non-None return wins
+and replaces the candidate.
 
-The same plugin instance fulfils both the input and output
-sides; there is no separate "input renderer" vs "output
-renderer" plugin. This keeps a single source of truth (icons,
-title heuristics, content schemas) per tool.
+## Worked example: ClMail plugin
 
-Detail filtering becomes data-driven:
+A single package, `claude-code-log-clmail`, ships both the
+hook-demotion transformers AND the tool-rendering transformers
+for the four ClMail MCP tools. One mechanism, one Protocol, one
+Plugin folder.
 
-```python
-def is_tool_active_at(detail: DetailLevel, tool_name: str) -> bool:
-    plugin = winners.get(tool_name)
-    if plugin is None:
-        return False           # unknown tool, generic fallback
-    return _detail_ge(detail, plugin.min_detail)
-
-# _detail_ge: "low" satisfies "low" / "medium" / "high" / "full" descending
-```
-
-This replaces the hardcoded `_LOW_KEEP_TOOLS` set. The in-tree
-WebSearch / WebFetch / Task / Agent renderers declare
-`min_detail = "low"`; everyone else defaults to `"high"` or
-`"full"`. The ClMail communicate renderer declares `"low"`.
-
-### Decisions inside the algorithm
-
-- **`min_detail` only, no `max_detail`.** A tool *worth showing
-  at low detail* is also worth showing at full detail — the user
-  asked for more information, not less. A max would invert that.
-  If a corner case ever needs hiding-when-verbose, the renderer
-  can branch on `message.detail` inside its render method.
-- **Tie-break is stable alphabetical by class name with a
-  warning.** Predictable enough to debug, loud enough that an
-  unintended tie surfaces. Plugins that genuinely want to stack
-  should pick distinct priorities.
-- **Priority 0 reserved for builtins.** Plugins should use any
-  non-zero integer; the convention `-5` / `+5` (or further-out
-  values) is documented but not enforced. Builtins themselves do
-  not declare a priority — the loader injects them at 0.
-
-## Worked example: ClMail plugin (renderers + transformers)
-
-A separate package, `claude-code-log-clmail`, ships alongside the
-existing `clmail` Python package (or as a `clmail` sub-extra). One
-package provides both capabilities — content-aware renderers for
-the four ClMail MCP tools *and* the message transformers that
-demote `[clmail]` / `[monitor]` user turns to hook-notification
-noise. Layout:
+Layout:
 
 ```
 claude_code_log_clmail/
   __init__.py
   _base.py                     # shared mail-format helpers
-  renderers/
-    __init__.py
-    communicate.py             # ClmailCommunicateRenderer
-    control.py                 # ClmailControlRenderer
-    actors.py                  # ClmailActorsRenderer
-    terminal.py                # ClmailTerminalRenderer
   transformers/
     __init__.py
     hook_demotion.py           # ClmailHookDemotion, MonitorHookDemotion
-                               # (target UserHookNotificationMessage which
-                               #  lives in core; the plugin only ships matchers)
+                               # (rewrite UserTextMessage → UserHookNotificationMessage)
+    communicate.py             # ClmailCommunicateInput + ...Output + transformers
+    control.py                 # ClmailControlInput + ...Output + transformers
+    actors.py
+    terminal.py
   templates/
     communicate.md.j2          # optional Jinja partials
 ```
 
-### Transformer side (replaces alice's hardcoded regex)
-
-`detect_hook_notification()` from
-`claude_code_log/factories/user_factory.py:79–99` reduces to ~12
-lines of plugin code per source. Under v1 (existing-variants-only),
-`UserHookNotificationMessage` stays in core unchanged — it was
-defined generically by PR #167 (`source: str`, `text: str`, with
-no clmail-specific typing on the class itself). The clmail plugin
-ships only the matcher; core knows nothing about `[monitor]` or
-`[clmail]` prefixes specifically, but the wrapper class it
-produces is core-owned and inherits its detail-visibility from
-the existing `_HIGH_EXCLUDE_CLASSES` registry.
+### Hook-demotion transformer (replaces alice's hardcoded regex)
 
 ```python
 # claude_code_log_clmail/transformers/hook_demotion.py
 import re
+from typing import ClassVar
+from pydantic import BaseModel
 from claude_code_log.models import (
-    MessageContent, MessageMeta, UserTextMessage,
-    UserHookNotificationMessage,            # core-owned, generic
+    DetailLevel, MessageContent, MessageMeta, UserTextMessage, UserMessage,
 )
 from claude_code_log.factories.priorities import HOOK_NOTIFICATION
 
 
-def _make_hook_transformer(source: str, priority_offset: int = 0):
+class UserHookNotificationMessage(UserMessage):
+    source: str    # "monitor", "clmail", ...
+    text: str
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
+    def format_markdown(self, renderer, message) -> str:
+        return f"_[{self.source}] {self.text}_"
+
+    def format_html(self, renderer, message) -> str | None:
+        return None    # mistune fallback
+
+    def title(self, renderer, message) -> str | None:
+        return None    # headless; appears inline
+
+
+def _make_hook_transformer(source: str):
     pattern = re.compile(rf"^\s*\[{source}\]\s*(.*?)\s*\Z", re.DOTALL)
 
     class _HookDemotion:
         name       = f"clmail.{source}-hook-demotion"
-        priority   = HOOK_NOTIFICATION + priority_offset
+        priority   = HOOK_NOTIFICATION
         applies_to = (UserTextMessage,)
 
-        def transform(self, text_content, content_list, meta):
-            m = pattern.match(text_content)
+        def transform(self, content, meta):
+            m = pattern.match(content.text)
             if m is None or "\n" in m.group(1):
-                return None         # multi-line guard: real prompt, not hook
+                return None
             return UserHookNotificationMessage(
                 source=source, text=m.group(1), meta=meta,
             )
@@ -593,63 +512,72 @@ ClmailHookDemotion  = _make_hook_transformer("clmail")
 MonitorHookDemotion = _make_hook_transformer("monitor")
 ```
 
-No `OutputClass` field, no `detail_visibility` attribute, no
-plugin-side `format_X` / `title_X` methods. Those all live in
-core, attached to `UserHookNotificationMessage` by PR #167. The
-core-to-plugin contract is genuinely minimal: a matcher that
-returns an instance of an existing core class.
+When the clmail plugin is installed, PR #167's
+`detect_hook_notification()` + `_HOOK_NOTIFICATION_SOURCES` tuple
++ the call site in `create_user_message` all delete from core.
+`UserHookNotificationMessage` (and its format/title methods and
+CSS) move out with them. Migration is one PR, mechanical.
 
-The migration of #167 to a plugin (if/when the user decides to
-ship the clmail integration as an external package) is a
-*deletion-only* refactor in core: remove `_HOOK_NOTIFICATION_SOURCES`,
-remove the regex, remove the call site in `create_user_message`.
-Class, renderer, title, and `_HIGH_EXCLUDE_CLASSES` membership all
-remain in core unchanged.
-
-### Renderer side
-
-Representative tool renderer (sketch only):
+### Tool-rendering transformer (replaces ClmailCommunicateRenderer)
 
 ```python
-class ClmailCommunicateRenderer:
-    tool_name  = "mcp__plugin_clmail_clmail__communicate"
-    priority   = -5                # supersede the generic ToolUseContent fallback
-    min_detail = "low"
-    icon       = "✉"
+# claude_code_log_clmail/transformers/communicate.py
+from typing import ClassVar, Literal
+from pydantic import BaseModel
+from claude_code_log.models import (
+    DetailLevel, ToolUseContent, ToolResultContent, MessageMeta,
+)
+from claude_code_log.factories.priorities import TOOL_INPUT_GENERIC, TOOL_OUTPUT_GENERIC
 
-    class InputModel(BaseModel):
-        action: Literal["send", "list", "read", "thread", "search",
-                        "delete", "clear"]
-        actor: str = ""
-        params: dict | str = {}
+TOOL_NAME = "mcp__plugin_clmail_clmail__communicate"
 
-    @dataclass
-    class OutputModel:
-        action: str
-        # action-specific shape — discriminated union pattern, one
-        # parser per action.
 
-    @staticmethod
-    def parse_output(raw, message):
-        action = raw.get("action") or _infer_action_from(raw)
-        return _PARSERS_BY_ACTION[action](raw)
+class ClmailCommunicateModel(BaseModel):
+    action: Literal["send", "list", "read", "thread", "search", "delete", "clear"]
+    actor: str = ""
+    params: dict | str = {}
 
-    def render_input_markdown(self, content, message):
-        match content.parsed.action:
+
+class ClmailCommunicateInput(ToolUseContent):
+    parsed: ClmailCommunicateModel
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
+
+    def format_markdown(self, renderer, message) -> str:
+        match self.parsed.action:
             case "send":
-                return f"**Sending to {content.parsed.params['to']}**\n\n"\
-                       f"> {content.parsed.params['subject']}"
+                return (f"**Sending to {self.parsed.params['to']}**\n\n"
+                        f"> {self.parsed.params['subject']}")
             case "read":
-                return f"Reading message #{content.parsed.params['id']}"
+                return f"Reading message #{self.parsed.params['id']}"
+            case "list":
+                return "Listing unread mail"
             ...
 
-    def render_output_markdown(self, content, message):
-        # action == "read" -> render mail body excerpt + frontmatter
-        # action == "list" -> count + 1-line-per-message preview
-        # action == "send" -> "Sent to {to} (id {message_ids[0]})"
-        ...
+    def format_html(self, renderer, message) -> str | None:
+        return None
 
-    # render_*_html return None -> derived from Markdown via mistune.
+    def title(self, renderer, message) -> str | None:
+        return f"✉ ClMail communicate · {self.parsed.action}"
+
+
+class ClmailCommunicateInputTransformer:
+    name       = "clmail.communicate.input"
+    priority   = TOOL_INPUT_GENERIC - 500    # supersede generic tool input
+    applies_to = (ToolUseContent,)
+
+    def transform(self, content, meta):
+        if content.tool_name != TOOL_NAME:
+            return None
+        return ClmailCommunicateInput(
+            tool_name=content.tool_name,
+            tool_use_id=content.tool_use_id,
+            parsed=ClmailCommunicateModel(**content.raw_input),
+            meta=meta,
+            **{k: getattr(content, k) for k in _PRESERVED_TOOLUSE_FIELDS},
+        )
+
+
+# (analogous classes for ClmailCommunicateOutput / ClmailCommunicateOutputTransformer)
 ```
 
 At `--detail low`, instead of:
@@ -658,138 +586,201 @@ At `--detail low`, instead of:
 [clmail] You've got a new mail (#3076)
 ```
 
-the Markdown output would carry, inside the tool block:
+the Markdown output carries, inside the tool block:
 
 ```
-✉ clmail communicate · read
+✉ ClMail communicate · read
 
 Reading message #3076
 
-> Subject: PR #164 status check — user wants you to finish it
+> Subject: PR #164 status check
 > From: main · 2026-05-21
-> Hi carol — the user said "monitor carol while she finishes #164" …
+> ...
 ```
 
-The synthetic hook line stays in the user-prompt stream (alice's
-parallel work strips it at `--detail low`); the *content* now
-lives in the rendered tool block instead.
+The hook-demotion transformer strips the synthetic
+`[clmail] ...` line from the user prompt stream; the
+tool-rendering transformer surfaces the actual content. One
+plugin, both improvements, one mechanism.
+
+### `terminal__look` auto-filtering (illustrates `detail_visibility` reuse)
+
+```python
+class ClmailTerminalLookInput(ToolUseContent):
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+    # ... format methods ...
+```
+
+Setting `detail_visibility = FULL` on a noisy low-value tool's
+specialized subclass auto-filters it at LOW/MEDIUM/HIGH — same
+mechanism the hook-demotion case uses. No separate `_LOW_KEEP_TOOLS`
+list to update.
+
+## Test-embedded reference plugin
+
+A minimal version of `claude-code-log-clmail` lives in
+`test/_plugins/clmail/` (or similar path). Two roles:
+
+1. **Layer-4 test fixture.** Plugin-system tests use this real
+   plugin as their fixture, not mocks. The contract is validated
+   end-to-end: entry-point discovery, Protocol conformance,
+   transformer dispatch, `format_*` method resolution,
+   `detail_visibility` filtering, all exercised against actual
+   plugin code.
+2. **Canonical documentation by example.** Third-party plugin
+   authors copy this directory as a template. Living
+   documentation that can't drift from the implementation.
+
+Layout sketch:
+
+```
+test/_plugins/clmail/
+  pyproject.toml             # entry-point declarations
+  src/claude_code_log_clmail_test/
+    __init__.py
+    transformers/
+      hook_demotion.py       # minimal versions of the four shown above
+      communicate.py
+  README.md                  # one-page plugin author guide
+```
+
+The plugin is installed in editable mode during test setup
+(`uv pip install -e test/_plugins/clmail`) so entry-points
+resolve at test runtime. Production installs of `claude-code-log`
+don't see it; CI does.
 
 ## Test strategy
 
 Four layers:
 
 1. **Plugin loader unit tests** (mock entry points via
-   `importlib.metadata.entry_points`'s
-   `select(group=...)` and a fake EntryPoint object): cover
-   priority ordering, tie-break warning, malformed plugin
-   rejection, builtin injection, Protocol dispatch
-   (`ToolRenderer` vs `MessageTransformer` routing), and
-   format-method binding for transformer-defined classes.
-2. **Renderer integration tests**: ship a `dummy_renderer_plugin`
-   fixture in `test/test_data/` registering a fake tool. Drive a
-   JSONL transcript through `claude-code-log` with the plugin
-   discoverable, assert Markdown / HTML output picks up the
-   plugin's rendering. Cover all four `(min_detail, current
-   detail)` quadrants.
-3. **Transformer integration tests**: ship a
-   `dummy_transformer_plugin` fixture whose matcher returns an
-   instance of a core `MessageContent` variant
-   (`UserHookNotificationMessage` is the natural choice). Drive a
-   JSONL transcript carrying a matching prefix; assert the
-   transformer fires inside the factory chain at its declared
-   priority, the resulting entry uses the core variant (correct
-   class, correct fields), and inherited filter-bucket membership
-   drops it at HIGH/MEDIUM/LOW/MINIMAL. Multi-line guard, source
-   namespace, and priority-collision warnings each get one test.
-4. **ClMail plugin tests** (in the ClMail plugin package, not
-   here): per-action snapshot tests covering the seven
-   `communicate` actions, the four `control` actions, etc., plus
-   transformer tests for `[clmail]` / `[monitor]` demotion
-   (porting over alice's `test_hook_user_notifications.py` cases
-   from the #167 branch). Lives with that package's own test
-   suite.
+   `importlib.metadata.entry_points`'s `select(group=...)` and a
+   fake EntryPoint object): cover priority ordering, tie-break
+   warning, malformed plugin rejection, Protocol-conformance
+   rejection.
+2. **`_dispatch_format` resolution-order tests**: cover all four
+   cells of the resolution matrix (renderer-method only,
+   class-method only, both present, neither present). Use the
+   embedded reference plugin's classes as fixtures.
+3. **Transformer integration tests**: drive a JSONL transcript
+   through `claude-code-log` with the embedded reference plugin
+   discoverable. Assert transformers fire at correct priorities,
+   produced classes flow through `_dispatch_format` to their
+   class-side `format_*` methods, `detail_visibility` filters at
+   each detail level.
+4. **ClMail plugin tests** (in the real `claude-code-log-clmail`
+   plugin package, not here): per-action snapshot tests for
+   communicate/control/actors/terminal; hook-demotion regression
+   tests ported from PR #167's `test_hook_user_notifications.py`.
 
-Snapshot tests for the in-tree builtin set need no change beyond
-declaring their `min_detail` values explicitly — the existing
-snapshot pins their current output.
+Snapshot tests for the in-tree built-in renderers (Bash, Read,
+WebSearch, ...) need no change — they continue to dispatch via
+`format_<ClassName>` on the renderer instance, exactly as today.
+The plugin mechanism is purely additive for built-ins.
 
-## Open questions (decisions deferred to implementation)
+## Reversal context and trade-offs
+
+The user's pointed question in clmail #3132 reframed the design:
+
+> What if we'd solve the primary need (rendering of generic tools)
+> via v2 as well? That is, intercept the generic tool use/result
+> messages emitted for `mcp__plugin_clmail_clmail__communicate`
+> (and al.) and convert those to specific messages
+> (`ClMailToolUse`, `ClMailToolResult`), THEN register parsing
+> methods for them.
+
+This collapses the two parallel plugin mechanisms (tool renderers
++ message transformers) of the earlier RFC drafts into one. The
+architectural insight: `_dispatch_format` already does MRO walk +
+class dispatch, and built-in tools already use specialized
+subclasses (`BashInputContent` and friends). The
+`winners[tool_name]` table in the earlier RFC was a workaround
+for plugins not having method-binding; eliminate the workaround
+and one mechanism suffices for both cases.
+
+The trade-offs accepted in adopting unification:
+
+- **v1 surface grows.** Plugins define `MessageContent`
+  subclasses, contribute `format_*` / `title` methods on those
+  classes, and declare `detail_visibility`. These were all "v2"
+  in the earlier RFC; they're "v1" now.
+- **Rendering philosophy shifts.** `MessageContent` subclasses
+  now know about rendering (via the `format_*` methods they
+  carry). Today's classes are pure data. This is a deliberate
+  expansion of the class's responsibility, justified by
+  symmetry with built-ins and plugin ergonomics.
+- **PR #167's eventual migration is no longer deletion-only.**
+  Under the existing-variants-only design, migrating #167 to
+  a plugin would be a deletion-only refactor in core. Under
+  unified-v1, the `UserHookNotificationMessage` class, its
+  format/title methods, its CSS, and its tests all move to the
+  plugin alongside the matchers. Bigger migration, but
+  tractable and one-shot.
+- **`detail_visibility` semantics must be pinned in v1.** The
+  monotone-down rule (`current_detail >= cls.detail_visibility`)
+  and the `_HIGH_EXCLUDE_CLASSES` bridge are part of the v1
+  contract.
+
+The earlier "v1 = existing-variants only" landing (commit
+`74b5ca6`) was the right answer to a different question (alice
+and main both preferred the smaller v1 surface given the
+two-mechanism split). The user's #3132 question changes the
+shape of the answer: the two-mechanism split was itself the
+problem, and collapsing it pays back the surface-area cost in
+architectural simplicity.
+
+## Open questions (deferred to implementation)
 
 - **Plugin caching.** Entry-point discovery costs ~10ms on first
-  call. If that shows in startup profiling, cache the resolved
-  winners table to disk keyed by installed plugin versions. Not
-  needed in v1.
-- **Plugin enable/disable flag.** Should `--no-plugin <name>` or
-  an env var let the user mask a plugin without uninstalling? A
-  case can be made for testing; defer until requested.
+  call. If startup profiling shows it, cache the resolved
+  transformer list to disk keyed by installed plugin versions.
+  Not needed in v1.
+- **Plugin enable/disable flag.** `--no-plugin <name>` or env
+  var to mask a plugin without uninstalling. Deferred until
+  requested.
 - **Plugin version pinning.** No machine-readable "requires
-  claude-code-log >= X.Y" yet. Use the existing pyproject
-  `requires` field; we'll cross that bridge when a breaking
-  Protocol change happens.
-- **MCP namespace handling.** Should the system offer a sugar
-  like `tool_name = "clmail__communicate"` that auto-resolves
-  any `mcp__*__clmail__communicate`? Decline for v1 — plugins
-  declare the exact verbatim tool name. Revisit once we have
-  two MCP plugin names that collide across servers.
-- **Icon source of truth.** v1 keeps icons declared per-renderer.
-  An optional follow-up could migrate the in-tree scattered
-  icons into a single `_ICONS: dict[str, str]` populated by the
-  loader from each winner's `icon` attribute, retiring the
-  hardcoded literals at `html/renderer.py:843–930`.
-- **Templates.** Plugins MAY ship Jinja partials and load them
-  via `importlib.resources`; we won't standardise a directory
-  convention until a second plugin needs it.
-- **Plugin-owned `MessageContent` subclasses (v2).** v1 restricts
-  transformers to rewriting *to* existing core variants. A future
-  v2 could allow plugins to register new subclasses (with
-  `detail_visibility` class attribute and plugin-registered
-  format/title methods). Purely additive on top of v1; defer
-  until a concrete use case justifies the larger surface
-  (renderer/timeline/fold-rules become plugin-touchable).
-- **Transformer surfacing / namespace collision diagnosis.** No
-  `--list-plugins` CLI in v1. If two plugins claim overlapping
-  prefixes (e.g. two competing `[monitor]` transformers), the
-  priority field resolves who wins, but the user has no easy way
-  to see *that* it happened. Consider startup log + `--list-plugins`
-  in a follow-up once we have evidence of collisions in the wild.
-- **Transformer chaining.** v1 is first-non-None-wins, no
-  chaining. Chaining ("transformer A produces a `FooMessage`;
-  transformer B targets `FooMessage` and rewrites further") is
-  expressively richer but opens "plugin A's transform breaks
-  plugin B's matcher" debug rabbit holes. Revisit only with a
-  concrete use case.
-- **Transformer scope: user-only by default vs all entry types.**
-  v1 lets `applies_to` accept any `MessageContent` subtype (no
-  artificial restriction); the natural worked example is
-  `(UserTextMessage,)` but a transformer targeting
-  `AssistantTextMessage` or a tool-result variant is permitted.
-  Constrained in practice by what core variants exist to rewrite
-  *to*. We'll see what plugins actually do.
+  claude-code-log >= X.Y" yet. Use pyproject `requires`; cross
+  that bridge when a breaking Protocol change happens.
+- **MCP namespace sugar.** Match `clmail__communicate` against
+  any `mcp__*__clmail__communicate`. Decline for v1; plugins
+  declare exact verbatim tool names. Revisit once we have two
+  MCP servers exposing the same tool name.
+- **Icon centralization.** Follow-up could migrate scattered
+  icon literals (`html/renderer.py:843–930`) into a registry
+  populated by plugin classes' icon declarations. v1 keeps
+  icons in title methods.
+- **Built-in migration to class-method pattern.** Mechanical
+  follow-up after v1 lands. Reduces the renderer classes'
+  surface area and unifies dispatch. Not blocking.
+- **Built-in migration from `_HIGH_EXCLUDE_CLASSES` to
+  `detail_visibility`.** Same: mechanical follow-up.
+- **Transformer chaining.** First non-None wins in v1; no
+  chaining. Revisit only with a concrete use case.
+- **Plugin-author docs.** The embedded reference plugin doubles
+  as the spec; a `docs/plugin-authoring.md` page may eventually
+  formalize it. Defer until external plugins exist.
+- **Namespace-collision diagnosis.** No `--list-plugins` CLI in
+  v1. Startup warning logs cover the worst case (two transformers
+  with same priority and `applies_to`). Follow-up if needed.
 
 ## Future extensions
 
-The same entry-point machinery extends cleanly to one adjacent
-need without changing the v1 surface:
+The same entry-point machinery extends cleanly to:
 
-1. **Pluggable formatters** (the user's named future direction).
-   A new group `claude_code_log.formatters` discovers full
-   format renderers — RTF, JATS, etc. The discovery,
-   priority, and detail-level vocabulary all carry over. A
-   formatter plugin would register both a name (`"rtf"`) and a
-   renderer object that knows how to walk the `TemplateMessage`
-   tree; tool renderers contribute `render_input_<format>` /
-   `render_output_<format>` methods for any format they wish to
+1. **Pluggable formatters.** A new group
+   `claude_code_log.formatters` discovers full output formats
+   (RTF, JATS, etc.). Discovery, priority, and detail-level
+   vocabulary all carry over. A formatter plugin walks the
+   `TemplateMessage` tree; classes contribute
+   `format_<output_format>` methods for any format they wish to
    support, falling back to "derive from Markdown" for the rest.
+2. **Pluggable factories.** Plugins introducing entirely new
+   top-level dispatch chains (rather than transforming inside
+   an existing one) — e.g. a new entry type the harness might
+   emit in future. Much larger surface; not on the near-term
+   roadmap.
 
-(An earlier draft of this section listed "pluggable message-type
-renderers" as a second future extension. That's now covered
-directly by `MessageTransformer` for the rewrite-to-another-variant
-case. The remaining gap — plugins introducing entirely new
-top-level *factory* dispatch chains rather than transforming inside
-an existing one — is a much larger surface and not on the
-near-term roadmap.)
-
-In neither case does v1 need to ship anything for the future —
-the entry-point group `claude_code_log.plugins` is scoped
-narrowly enough that adding a `claude_code_log.formatters` group
-later is purely additive.
+v1 ships nothing for either future direction; the
+`claude_code_log.plugins` entry-point group is scoped narrowly
+enough that adding `claude_code_log.formatters` later is purely
+additive.

--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -1,11 +1,14 @@
-# Tool-renderer plugin system
+# Plugin system: tool renderers and message transformers
 
 ## Status: Design proposal (no implementation yet)
 
 ## Problem statement
 
-Today every tool renderer is baked into `claude-code-log`: a new
-tool means a PR against `claude_code_log/factories/tool_factory.py`,
+Two parallel needs both want the same plugin machinery.
+
+**Tool renderers.** Today every tool renderer is baked into
+`claude-code-log`: a new tool means a PR against
+`claude_code_log/factories/tool_factory.py`,
 `claude_code_log/html/tool_formatters.py`, and the
 `format_<ClassName>` methods on the two renderer classes. This is
 fine for the in-tree set (Bash, Read, WebSearch, ...), but it
@@ -17,19 +20,36 @@ shows synthetic hook lines like `[clmail] You've got a new mail
 no in-tree renderer knows what `mcp__plugin_clmail_clmail__communicate`
 returns.
 
-This document proposes a plugin mechanism that lets external
-packages contribute tool renderers via setuptools entry points,
-with a priority offset so an out-of-tree plugin can either
-**supplement** the in-tree set (positive priority, used only if no
-builtin claims the tool) or **supersede** it (negative priority,
-wins until something more negative arrives). The driving use case
-is the ClMail tools, but the same mechanism unlocks any future
-MCP tool plus a path to pluggable output formatters (see
-[Future](#future-extensions)).
+**Message transformers.** In parallel, PR #167 (alice's
+`dev/filter-hook-turns` branch) introduces
+`detect_hook_notification()` in
+`claude_code_log/factories/user_factory.py:79–99`: a regex over
+`(monitor|clmail)`-prefixed user turns that demotes them from
+`UserTextMessage` to a typed `UserHookNotificationMessage` which
+the renderer filters at HIGH/MEDIUM/LOW/MINIMAL. The regex is
+hard-coded for two specific external hook sources — exactly the
+kind of plugin-shaped concern that should live with the plugin that
+*causes* those notifications (the ClMail plugin), not in core.
+
+Both problems collapse to: **external code wants to influence
+which Python class wraps a parsed entry, and how that class
+renders.** This document proposes a single plugin mechanism that
+lets external packages contribute either kind of capability via
+setuptools entry points, with a priority offset so an out-of-tree
+plugin can either **supplement** the in-tree set (positive priority,
+used only if no builtin claims the slot) or **supersede** it
+(negative priority, wins until something more negative arrives).
+The driving use cases are the ClMail tools and the clmail/monitor
+hook-demotion, but the same mechanism unlocks any future MCP tool,
+any future hook-injection format, plus a path to pluggable output
+formatters (see [Future](#future-extensions)).
 
 ## Current architecture (what we hook into)
 
-Three dispatch points matter:
+Six dispatch points matter — three for tool renderers, three more
+that transformers touch.
+
+**Tool-renderer surfaces:**
 
 1. **`TOOL_INPUT_MODELS`** (dict) at
    `claude_code_log/factories/tool_factory.py:93` — maps tool name
@@ -44,7 +64,9 @@ Three dispatch points matter:
    takes a content object, walks `type(obj).__mro__`, and calls
    `format_<ClassName>` on the renderer instance. The MRO walk
    gives free polymorphic fallback (`format_BashInput` →
-   `format_ToolUseContent`).
+   `format_ToolUseContent`). Used by both tool renderers (for
+   `ToolUseContent` subclasses) and transformers (for the
+   `MessageContent` subclasses they introduce).
 
 Detail-level filtering lives at `renderer.py:3151–3224`. The
 keep-list at `--detail low` is the hardcoded set
@@ -53,15 +75,45 @@ keep-list at `--detail low` is the hardcoded set
 Icons are scattered as string literals across title methods in
 `html/renderer.py:843–930` (no central registry).
 
-These are the four surfaces a plugin needs to influence. The
-plugin system's whole job is to populate the first two dicts, the
-third's MRO-discoverable methods, the fourth's keep-list, and a
-new icon registry — from out-of-tree packages.
+**Transformer surfaces:**
+
+4. **Factory dispatch chain** at
+   `claude_code_log/factories/user_factory.py:539–568` (and the
+   analogous functions for assistant / system / meta entries).
+   `create_user_message` tries detectors in a fixed sequence:
+   `is_command_message` → `is_local_command_output` →
+   `is_bash_input / is_bash_output` → `has_teammate_message` →
+   `has_task_notification` → `detect_hook_notification` (#167) →
+   `is_slash_command` (isMeta) → generic text fallback. Each
+   detector either claims the entry (producing a typed
+   `MessageContent` subclass) or passes through. Transformers
+   plug into this chain at declared priority offsets.
+5. **`_HIGH_EXCLUDE_CLASSES`** (set) in `renderer.py` — the
+   filter-bucket registry that drops hook-noise content at
+   HIGH/MEDIUM/LOW/MINIMAL detail. Today this is a hardcoded set
+   of `MessageContent` subclass references; the plugin system
+   replaces it with a `detail_visibility: ClassVar[DetailLevel]`
+   attribute on each `MessageContent` subclass (built-ins migrate
+   in a follow-up PR after #166 lands).
+6. **`extract_text_content(content_list)`** at user_factory — the
+   joined-with-newlines text string that detectors regex against.
+   The plugin contract guarantees that `UserTextMessage.text`
+   (and equivalents on other message types) is byte-equivalent
+   to this extraction, so transformer regexes behave consistently
+   whether called inside the factory or against a parsed
+   `MessageContent`.
+
+These are the surfaces a plugin needs to influence. The plugin
+system's whole job is to populate the tool-renderer surfaces
+(1–3 plus keep-list and icon registry) and the transformer
+surfaces (4–6) — from out-of-tree packages, through one shared
+discovery mechanism.
 
 ## Discovery + selection: `importlib.metadata.entry_points`
 
-**Recommendation: stdlib entry points, group name
-`claude_code_log.tool_renderers`.**
+**Recommendation: stdlib entry points, single group
+`claude_code_log.plugins`, loader type-dispatches each entry on
+Protocol conformance.**
 
 Compared to `pluggy`:
 
@@ -71,34 +123,59 @@ Compared to `pluggy`:
 | Declarative pyproject hook | yes | no (needs `pm.register()` calls) |
 | Composition (firstresult, before/after) | no | yes |
 | Mental model | "load a class by name" | "hook spec / hook impl" |
-| Fits our need | yes (one winner per tool) | overkill |
+| Fits our need | yes (one winner per slot) | overkill |
 
-We need *one* renderer per `(tool_name, output_format)` at any
-time, chosen by priority — not multi-hook composition. Pluggy's
-expressiveness pays for itself in pytest, where each hook can fire
-multiple impls; here it would just be ceremony. Entry points stay
-in the boring lane: stdlib, no new dep, mirrors how Click commands
-and pytest plugins themselves are discovered.
+We need *one* winner per `(tool_name, output_format)` and one
+winner per `(applies_to-type, priority)` slot, chosen by priority —
+not multi-hook composition. Pluggy's expressiveness pays for
+itself in pytest, where each hook can fire multiple impls; here it
+would just be ceremony. Entry points stay in the boring lane:
+stdlib, no new dep, mirrors how Click commands and pytest plugins
+themselves are discovered.
+
+**One group, capability inferred from class.** Both `ToolRenderer`
+and `MessageTransformer` plugins register under the same
+entry-point group; the loader inspects each yielded class for
+Protocol conformance and routes accordingly. This matches the
+pytest11 / mkdocs / mypy stubs pattern, avoids forcing pure-tool
+plugins to ship a `Plugin` aggregator class, and gives a single
+discovery namespace that's easy to audit (one `entry_points`
+call, one place to look). A multi-capability plugin just
+declares N entries.
 
 A plugin package declares:
 
 ```toml
-[project.entry-points."claude_code_log.tool_renderers"]
-clmail_communicate = "claude_code_log_clmail:ClmailCommunicateRenderer"
-clmail_control     = "claude_code_log_clmail:ClmailControlRenderer"
-clmail_actors      = "claude_code_log_clmail:ClmailActorsRenderer"
-clmail_terminal    = "claude_code_log_clmail:ClmailTerminalRenderer"
+[project.entry-points."claude_code_log.plugins"]
+# Tool renderers
+clmail_communicate     = "claude_code_log_clmail.renderers:ClmailCommunicateRenderer"
+clmail_control         = "claude_code_log_clmail.renderers:ClmailControlRenderer"
+clmail_actors          = "claude_code_log_clmail.renderers:ClmailActorsRenderer"
+clmail_terminal        = "claude_code_log_clmail.renderers:ClmailTerminalRenderer"
+# Message transformers
+clmail_hook_demotion   = "claude_code_log_clmail.transformers:ClmailHookDemotion"
+monitor_hook_demotion  = "claude_code_log_clmail.transformers:MonitorHookDemotion"
 ```
 
 At startup, `claude_code_log` enumerates this group once, loads
-each entry, validates against the `ToolRenderer` protocol, groups
-by `tool_name`, resolves by priority, and freezes the winners
-into the runtime dispatch tables. No reload at runtime; the cost
-of a CLI restart is acceptable for a tool-renderer change.
+each entry, dispatches by Protocol (`isinstance(cls(),
+ToolRenderer)` vs `isinstance(cls(), MessageTransformer)`),
+resolves each capability's winners by priority, and freezes the
+results into the runtime dispatch tables. No reload at runtime;
+the cost of a CLI restart is acceptable for any plugin change.
 
-## Renderer interface (Protocol sketch)
+## Plugin Protocols (one per capability)
 
-A plugin is a class implementing `ToolRenderer`. Class attributes
+A plugin is a class implementing exactly one of two Protocols:
+`ToolRenderer` (renders a specific tool's input/output) or
+`MessageTransformer` (rewrites a parsed `MessageContent` into a
+different variant during factory dispatch). Both Protocols share
+the same priority + discovery semantics so plugins can mix and
+match.
+
+### `ToolRenderer`
+
+Class attributes
 declare metadata; instance methods do the rendering. Methods
 return `None` to defer (e.g. let Markdown→HTML conversion handle
 the HTML side).
@@ -159,37 +236,168 @@ generically from the dataclass / Pydantic models via
 `dataclasses.asdict`; a plugin that ships the model classes gets
 JSON support for free.
 
+### `MessageTransformer`
+
+A transformer rewrites a parsed `MessageContent` into a different
+`MessageContent` variant during factory dispatch. The plugin owns
+the target class — it defines the new `MessageContent` subclass,
+declares its detail-level visibility, and registers its
+format/title methods via the same MRO-discoverable dispatch as
+built-ins.
+
+```python
+from typing import ClassVar, Optional, Protocol, runtime_checkable
+from claude_code_log.models import (
+    DetailLevel, MessageContent, MessageMeta,
+)
+
+@runtime_checkable
+class MessageTransformer(Protocol):
+    # --- registration ---
+    name: ClassVar[str]                                 # e.g. "clmail.hook-demotion"
+    priority: ClassVar[int]                             # built-in baseline; see priority table below
+    applies_to: ClassVar[tuple[type[MessageContent], ...]]
+        # MRO-filtered: only invoked when the factory's *current* candidate
+        # MessageContent matches (subclass check). Most transformers target
+        # (UserTextMessage,) — they only fire for entries that would
+        # otherwise fall through to the generic text variant.
+
+    # --- the new MessageContent class this transformer produces ---
+    OutputClass: ClassVar[type[MessageContent]]
+        # Plugin-owned. Declares detail_visibility on itself; carries
+        # format_<ClassName> / title_<ClassName> methods registered
+        # alongside the transformer (see below).
+
+    # --- transformation ---
+    def transform(
+        self,
+        text_content: str,
+        content_list: list,
+        meta: MessageMeta,
+    ) -> Optional[MessageContent]:
+        """Return an OutputClass instance, or None to pass through.
+
+        Called inside the factory dispatch chain at this transformer's
+        declared priority. text_content is byte-equivalent to what the
+        factory's built-in detectors consume.
+        """
+
+    # --- renderer methods (registered alongside the transformer) ---
+    # Plugin defines format_<ClassName> and title_<ClassName> functions
+    # for the OutputClass; the loader binds them onto the renderer
+    # classes the same way built-in formatters work. Signature mirrors
+    # the existing convention in renderer.py / html/renderer.py /
+    # markdown/renderer.py.
+```
+
+The plugin-owned `OutputClass` declares its visibility directly:
+
+```python
+class UserHookNotificationMessage(MessageContent):
+    source: str   # "monitor" or "clmail"
+    text: str
+
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+        # Only visible at --detail full; dropped at HIGH/MEDIUM/LOW/MINIMAL.
+```
+
+This replaces the hardcoded `_HIGH_EXCLUDE_CLASSES` registry: the
+renderer's filter pass reads `cls.detail_visibility` (with a
+default of `DetailLevel.MINIMAL` = always visible) instead of
+consulting a central set. Built-in `MessageContent` subclasses
+migrate to the class-attribute form in a follow-up PR — mechanical
+diff, doesn't block #166.
+
+**In-factory-dispatch placement.** Transformers run *inside* the
+factory's existing detector sequence, not as a post-factory pass.
+Concretely, `create_user_message` (and analogues) walks a single
+unified priority-ordered list: built-in detectors interleaved with
+registered transformers, each checked in turn. This preserves the
+existing ordering invariants (`is_slash_command` always wins
+before any text-targeting transformer can fire) and avoids
+re-walking the tree.
+
+**Multi-line guards and other matcher-specific concerns** live in
+the plugin, not the core contract. A transformer that wants to
+reject multi-line bodies (clmail's case) does so inside its own
+`transform()`; a transformer that wants to accept them is free to.
+
 ## Priority + detail-level resolution
 
 Pseudocode for the discovery loop:
 
 ```python
-def load_plugins() -> dict[str, ToolRenderer]:
-    candidates: dict[str, list[ToolRenderer]] = defaultdict(list)
-    # 1. Discover entry-point plugins.
-    for ep in entry_points(group="claude_code_log.tool_renderers"):
+def load_plugins() -> tuple[dict[str, ToolRenderer], list[MessageTransformer]]:
+    renderer_candidates: dict[str, list[ToolRenderer]] = defaultdict(list)
+    transformers: list[MessageTransformer] = []
+    # 1. Discover entry-point plugins; dispatch on Protocol.
+    for ep in entry_points(group="claude_code_log.plugins"):
         try:
             cls = ep.load()
+            instance = cls()
         except Exception as e:
-            warn(f"failed to load tool renderer plugin {ep.name!r}: {e}")
+            warn(f"failed to load plugin {ep.name!r}: {e}")
             continue
-        if not isinstance(cls, type) or not isinstance(cls(), ToolRenderer):
-            warn(f"plugin {ep.name!r} does not implement ToolRenderer")
-            continue
-        candidates[cls.tool_name].append(cls())
-    # 2. Also feed in builtins as priority=0 entries.
+        if isinstance(instance, ToolRenderer):
+            renderer_candidates[cls.tool_name].append(instance)
+        elif isinstance(instance, MessageTransformer):
+            transformers.append(instance)
+            _register_format_methods(cls.OutputClass)  # binds plugin's format_X/title_X
+        else:
+            warn(f"plugin {ep.name!r} does not implement any plugin Protocol")
+    # 2. Feed in builtins as priority=0 entries.
     for tool_name, builtin in BUILTIN_RENDERERS.items():
-        candidates[tool_name].append(builtin)
-    # 3. Resolve: lowest priority wins; tie-break alphabetically by class name with a warning.
+        renderer_candidates[tool_name].append(builtin)
+    # 3. Resolve renderers: lowest priority wins; tie-break alphabetically by class name with a warning.
     winners: dict[str, ToolRenderer] = {}
-    for tool_name, group in candidates.items():
+    for tool_name, group in renderer_candidates.items():
         group.sort(key=lambda p: (p.priority, type(p).__name__))
         if len(group) > 1 and group[0].priority == group[1].priority:
             warn(f"tie-break for {tool_name!r} at priority {group[0].priority}: "
                  f"using {type(group[0]).__name__}")
         winners[tool_name] = group[0]
-    return winners
+    # 4. Sort transformers globally by priority (no per-slot grouping; factory
+    #    consults them in order alongside built-in detectors).
+    transformers.sort(key=lambda t: (t.priority, type(t).__name__))
+    return winners, transformers
 ```
+
+### Built-in detector priority table
+
+Transformers position themselves relative to the in-factory
+detector sequence. Built-in detectors get explicit named
+priorities exposed as module constants, with gaps of 100 to leave
+room for plugin insertion without renumbering:
+
+```python
+# claude_code_log.factories.priorities
+COMMAND_MESSAGE           = 100
+LOCAL_COMMAND_OUTPUT      = 200
+BASH_INPUT_OUTPUT         = 300
+TEAMMATE_MESSAGE          = 400
+TASK_NOTIFICATION         = 500
+HOOK_NOTIFICATION         = 600   # alice's #167 default seat
+SLASH_COMMAND_ISMETA      = 700
+TEXT_FALLBACK             = 1000  # always last; generic UserTextMessage
+```
+
+A clmail-plugin transformer registered at `priority=600` *replaces*
+the hardcoded hook detector. At `priority=550` it runs *before* it
+(useful only to override built-in behaviour). At `priority=650` it
+runs *after* it (useful as a fallback if the built-in eventually
+narrows its scope). Lower number = higher priority = runs first;
+first non-None wins.
+
+### Subtle ordering note
+
+`applies_to = (UserTextMessage,)` is the natural scope for any
+text-prefix transformer: it only fires on entries that have not
+already been claimed by an earlier detector. A transformer cannot
+accidentally intercept a slash-command, bash-input, or
+teammate-message entry, because those never become `UserTextMessage`
+in the first place. This is a real safety property, not just a
+micro-optimization — the existing factory ordering enforces
+plugin precedence by class assignment.
 
 The winners table is consulted at three places:
 
@@ -232,25 +440,100 @@ WebSearch / WebFetch / Task / Agent renderers declare
   values) is documented but not enforced. Builtins themselves do
   not declare a priority — the loader injects them at 0.
 
-## Worked example: ClMail tools plugin
+## Worked example: ClMail plugin (renderers + transformers)
 
-A separate package, `claude-code-log-clmail-renderer`, ships
-alongside the existing `clmail` Python package (or as a `clmail`
-sub-extra). Layout:
+A separate package, `claude-code-log-clmail`, ships alongside the
+existing `clmail` Python package (or as a `clmail` sub-extra). One
+package provides both capabilities — content-aware renderers for
+the four ClMail MCP tools *and* the message transformers that
+demote `[clmail]` / `[monitor]` user turns to hook-notification
+noise. Layout:
 
 ```
 claude_code_log_clmail/
   __init__.py
-  _base.py                     # shared ClMail mail-format helpers
-  communicate.py               # ClmailCommunicateRenderer
-  control.py                   # ClmailControlRenderer
-  actors.py                    # ClmailActorsRenderer
-  terminal.py                  # ClmailTerminalRenderer
+  _base.py                     # shared mail-format helpers
+  renderers/
+    __init__.py
+    communicate.py             # ClmailCommunicateRenderer
+    control.py                 # ClmailControlRenderer
+    actors.py                  # ClmailActorsRenderer
+    terminal.py                # ClmailTerminalRenderer
+  transformers/
+    __init__.py
+    hook_demotion.py           # ClmailHookDemotion, MonitorHookDemotion
+                               #   + UserHookNotificationMessage (the OutputClass)
   templates/
     communicate.md.j2          # optional Jinja partials
 ```
 
-Representative renderer (sketch only):
+### Transformer side (replaces alice's hardcoded regex)
+
+`detect_hook_notification()` from
+`claude_code_log/factories/user_factory.py:79–99` reduces to a
+~12-line plugin transformer. The plugin owns the
+`UserHookNotificationMessage` class outright; core knows nothing
+about `[monitor]` or `[clmail]` prefixes.
+
+```python
+# claude_code_log_clmail/transformers/hook_demotion.py
+import re
+from typing import ClassVar
+from claude_code_log.models import (
+    DetailLevel, MessageContent, MessageMeta, UserTextMessage,
+)
+from claude_code_log.factories.priorities import HOOK_NOTIFICATION
+
+
+class UserHookNotificationMessage(MessageContent):
+    source: str   # "monitor" | "clmail" | future plugin-defined sources
+    text: str
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
+
+def _make_hook_transformer(source: str, priority_offset: int = 0):
+    pattern = re.compile(rf"^\s*\[{source}\]\s*(.*?)\s*\Z", re.DOTALL)
+
+    class _HookDemotion:
+        name       = f"clmail.{source}-hook-demotion"
+        priority   = HOOK_NOTIFICATION + priority_offset
+        applies_to = (UserTextMessage,)
+        OutputClass = UserHookNotificationMessage
+
+        def transform(self, text_content, content_list, meta):
+            m = pattern.match(text_content)
+            if m is None or "\n" in m.group(1):
+                return None         # multi-line guard: real prompt, not hook
+            return UserHookNotificationMessage(
+                source=source, text=m.group(1), meta=meta,
+            )
+
+    _HookDemotion.__name__ = f"{source.title()}HookDemotion"
+    return _HookDemotion
+
+
+ClmailHookDemotion  = _make_hook_transformer("clmail")
+MonitorHookDemotion = _make_hook_transformer("monitor")
+
+
+# Renderer methods registered alongside the OutputClass.
+def format_UserHookNotificationMessage(self, content, message):
+    return f"_[{content.source}] {content.text}_"
+
+
+def title_UserHookNotificationMessage(self, content, message):
+    return None   # headless — appears inline
+```
+
+The plugin loader, on discovering the transformer, registers
+`format_UserHookNotificationMessage` and
+`title_UserHookNotificationMessage` onto the Markdown and HTML
+renderer classes via the existing MRO-discoverable dispatch. No
+core changes needed beyond the loader itself.
+
+### Renderer side
+
+Representative tool renderer (sketch only):
 
 ```python
 class ClmailCommunicateRenderer:
@@ -318,23 +601,35 @@ lives in the rendered tool block instead.
 
 ## Test strategy
 
-Three layers:
+Four layers:
 
 1. **Plugin loader unit tests** (mock entry points via
    `importlib.metadata.entry_points`'s
    `select(group=...)` and a fake EntryPoint object): cover
    priority ordering, tie-break warning, malformed plugin
-   rejection, builtin injection.
-2. **Renderer integration tests**: ship a `dummy_plugin` fixture
-   in `test/test_data/` registering a fake tool. Drive a JSONL
-   transcript through `claude-code-log` with the plugin
+   rejection, builtin injection, Protocol dispatch
+   (`ToolRenderer` vs `MessageTransformer` routing), and
+   format-method binding for transformer-defined classes.
+2. **Renderer integration tests**: ship a `dummy_renderer_plugin`
+   fixture in `test/test_data/` registering a fake tool. Drive a
+   JSONL transcript through `claude-code-log` with the plugin
    discoverable, assert Markdown / HTML output picks up the
    plugin's rendering. Cover all four `(min_detail, current
    detail)` quadrants.
-3. **ClMail plugin tests** (in the ClMail-renderer package, not
+3. **Transformer integration tests**: ship a
+   `dummy_transformer_plugin` fixture introducing a new
+   `MessageContent` subclass with `detail_visibility = FULL`.
+   Drive a JSONL transcript carrying a matching prefix; assert
+   the transformer fires inside the factory chain, the new class
+   is dispatched to format/title methods, and the entry is
+   filtered out at HIGH/MEDIUM/LOW/MINIMAL.
+4. **ClMail plugin tests** (in the ClMail plugin package, not
    here): per-action snapshot tests covering the seven
-   `communicate` actions, the four `control` actions, etc. Lives
-   with that package's own test suite.
+   `communicate` actions, the four `control` actions, etc., plus
+   transformer tests for `[clmail]` / `[monitor]` demotion
+   (porting over alice's `test_hook_user_notifications.py` cases
+   from the #167 branch). Lives with that package's own test
+   suite.
 
 Snapshot tests for the in-tree builtin set need no change beyond
 declaring their `min_detail` values explicitly — the existing
@@ -366,11 +661,34 @@ snapshot pins their current output.
 - **Templates.** Plugins MAY ship Jinja partials and load them
   via `importlib.resources`; we won't standardise a directory
   convention until a second plugin needs it.
+- **Built-in migration to `detail_visibility`.** Existing
+  built-in `MessageContent` subclasses currently have visibility
+  encoded in `_HIGH_EXCLUDE_CLASSES`. Migration to the
+  class-attribute form is mechanical and lands in a follow-up
+  PR after #166 — doesn't block the plugin API.
+- **Transformer surfacing / namespace collision diagnosis.** No
+  `--list-plugins` CLI in v1. If two plugins claim overlapping
+  prefixes (e.g. two competing `[monitor]` transformers), the
+  priority field resolves who wins, but the user has no easy way
+  to see *that* it happened. Consider startup log + `--list-plugins`
+  in a follow-up once we have evidence of collisions in the wild.
+- **Transformer chaining.** v1 is first-non-None-wins, no
+  chaining. Chaining ("transformer A produces a `FooMessage`;
+  transformer B targets `FooMessage` and rewrites further") is
+  expressively richer but opens "plugin A's transform breaks
+  plugin B's matcher" debug rabbit holes. Revisit only with a
+  concrete use case.
+- **Transformer scope: user-only by default vs all entry types.**
+  v1 lets `applies_to` accept any `MessageContent` subtype (no
+  artificial restriction); the natural worked example is
+  `(UserTextMessage,)` but a transformer targeting
+  `AssistantTextMessage` or a tool-result variant is permitted.
+  We'll see what plugins actually do.
 
 ## Future extensions
 
-The same entry-point machinery extends cleanly to two adjacent
-needs without changing the v1 surface:
+The same entry-point machinery extends cleanly to one adjacent
+need without changing the v1 surface:
 
 1. **Pluggable formatters** (the user's named future direction).
    A new group `claude_code_log.formatters` discovers full
@@ -381,13 +699,16 @@ needs without changing the v1 surface:
    tree; tool renderers contribute `render_input_<format>` /
    `render_output_<format>` methods for any format they wish to
    support, falling back to "derive from Markdown" for the rest.
-2. **Pluggable message-type renderers** (less interesting today,
-   but the same shape). The current factories (`meta_factory`,
-   `user_factory`, etc.) are themselves dispatch tables. The
-   plugin machinery built for tools is reusable for them; the
-   only delta is the dispatch key.
+
+(An earlier draft of this section listed "pluggable message-type
+renderers" as a second future extension. That's now covered
+directly by `MessageTransformer` for the rewrite-to-another-variant
+case. The remaining gap — plugins introducing entirely new
+top-level *factory* dispatch chains rather than transforming inside
+an existing one — is a much larger surface and not on the
+near-term roadmap.)
 
 In neither case does v1 need to ship anything for the future —
-the entry-point group `claude_code_log.tool_renderers` is scoped
+the entry-point group `claude_code_log.plugins` is scoped
 narrowly enough that adding a `claude_code_log.formatters` group
 later is purely additive.

--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -88,14 +88,7 @@ Icons are scattered as string literals across title methods in
    detector either claims the entry (producing a typed
    `MessageContent` subclass) or passes through. Transformers
    plug into this chain at declared priority offsets.
-5. **`_HIGH_EXCLUDE_CLASSES`** (set) in `renderer.py` — the
-   filter-bucket registry that drops hook-noise content at
-   HIGH/MEDIUM/LOW/MINIMAL detail. Today this is a hardcoded set
-   of `MessageContent` subclass references; the plugin system
-   replaces it with a `detail_visibility: ClassVar[DetailLevel]`
-   attribute on each `MessageContent` subclass (built-ins migrate
-   in a follow-up PR after #166 lands).
-6. **`extract_text_content(content_list)`** at user_factory — the
+5. **`extract_text_content(content_list)`** at user_factory — the
    joined-with-newlines text string that detectors regex against.
    The plugin contract guarantees that `UserTextMessage.text`
    (and equivalents on other message types) is byte-equivalent
@@ -103,10 +96,16 @@ Icons are scattered as string literals across title methods in
    whether called inside the factory or against a parsed
    `MessageContent`.
 
+Detail-level filtering for hook-notification noise lives in
+`_HIGH_EXCLUDE_CLASSES` (renderer.py). This stays as a core
+registry in v1 — see [v1 scope](#v1-scope-existing-variants-only)
+for why transformers rewrite *to* existing core classes rather
+than defining their own.
+
 These are the surfaces a plugin needs to influence. The plugin
 system's whole job is to populate the tool-renderer surfaces
 (1–3 plus keep-list and icon registry) and the transformer
-surfaces (4–6) — from out-of-tree packages, through one shared
+surfaces (4–5) — from out-of-tree packages, through one shared
 discovery mechanism.
 
 ## Discovery + selection: `importlib.metadata.entry_points`
@@ -239,34 +238,28 @@ JSON support for free.
 ### `MessageTransformer`
 
 A transformer rewrites a parsed `MessageContent` into a different
-`MessageContent` variant during factory dispatch. The plugin owns
-the target class — it defines the new `MessageContent` subclass,
-declares its detail-level visibility, and registers its
-format/title methods via the same MRO-discoverable dispatch as
-built-ins.
+`MessageContent` variant during factory dispatch. **v1 scope:
+plugins rewrite *to* existing core `MessageContent` variants
+only.** A plugin does not define new `MessageContent` subclasses,
+does not register format/title methods, and does not touch the
+detail-level filter machinery — visibility comes for free by
+virtue of targeting an existing core class. See
+[v1 scope](#v1-scope-existing-variants-only) for the rationale.
 
 ```python
 from typing import ClassVar, Optional, Protocol, runtime_checkable
-from claude_code_log.models import (
-    DetailLevel, MessageContent, MessageMeta,
-)
+from claude_code_log.models import MessageContent, MessageMeta
 
 @runtime_checkable
 class MessageTransformer(Protocol):
     # --- registration ---
     name: ClassVar[str]                                 # e.g. "clmail.hook-demotion"
-    priority: ClassVar[int]                             # built-in baseline; see priority table below
+    priority: ClassVar[int]                             # see built-in priority table below
     applies_to: ClassVar[tuple[type[MessageContent], ...]]
         # MRO-filtered: only invoked when the factory's *current* candidate
         # MessageContent matches (subclass check). Most transformers target
         # (UserTextMessage,) — they only fire for entries that would
         # otherwise fall through to the generic text variant.
-
-    # --- the new MessageContent class this transformer produces ---
-    OutputClass: ClassVar[type[MessageContent]]
-        # Plugin-owned. Declares detail_visibility on itself; carries
-        # format_<ClassName> / title_<ClassName> methods registered
-        # alongside the transformer (see below).
 
     # --- transformation ---
     def transform(
@@ -275,38 +268,62 @@ class MessageTransformer(Protocol):
         content_list: list,
         meta: MessageMeta,
     ) -> Optional[MessageContent]:
-        """Return an OutputClass instance, or None to pass through.
+        """Return an instance of an EXISTING core MessageContent variant,
+        or None to pass through. Called inside the factory dispatch chain
+        at this transformer's declared priority. text_content is
+        byte-equivalent to what the factory's built-in detectors consume.
 
-        Called inside the factory dispatch chain at this transformer's
-        declared priority. text_content is byte-equivalent to what the
-        factory's built-in detectors consume.
+        v1 contract: the returned MessageContent MUST be an instance of
+        a class already defined in claude_code_log.models — typically
+        one of the typed user-side variants (UserHookNotificationMessage,
+        UserSlashCommandMessage, etc.). Plugins cannot introduce new
+        MessageContent subclasses in v1.
         """
-
-    # --- renderer methods (registered alongside the transformer) ---
-    # Plugin defines format_<ClassName> and title_<ClassName> functions
-    # for the OutputClass; the loader binds them onto the renderer
-    # classes the same way built-in formatters work. Signature mirrors
-    # the existing convention in renderer.py / html/renderer.py /
-    # markdown/renderer.py.
 ```
 
-The plugin-owned `OutputClass` declares its visibility directly:
+### v1 scope: existing-variants-only
 
-```python
-class UserHookNotificationMessage(MessageContent):
-    source: str   # "monitor" or "clmail"
-    text: str
+A transformer's `transform()` MUST return an instance of a class
+already defined in `claude_code_log.models`. The natural target
+for hook-style transformers is the generic
+`UserHookNotificationMessage(source: str, text: str)` introduced
+by PR #167, which lives in core and is plugin-friendly by design
+(no clmail-specific typing on the class itself; the docstring
+names monitor/clmail as *examples*).
 
-    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
-        # Only visible at --detail full; dropped at HIGH/MEDIUM/LOW/MINIMAL.
-```
+Why this scope:
 
-This replaces the hardcoded `_HIGH_EXCLUDE_CLASSES` registry: the
-renderer's filter pass reads `cls.detail_visibility` (with a
-default of `DetailLevel.MINIMAL` = always visible) instead of
-consulting a central set. Built-in `MessageContent` subclasses
-migrate to the class-attribute form in a follow-up PR — mechanical
-diff, doesn't block #166.
+- **Filter-bucket inheritance.** Visibility is a property of the
+  target class, owned by core, inherited by every transformer
+  that targets it. No `detail_visibility` class attribute, no
+  per-plugin renderer registration, no migration of built-in
+  classes. The plugin contract reduces to a single method
+  (`transform`) and three metadata fields.
+- **Renderer/timeline/fold-rules surface stays unchanged.** No
+  v1 commitment to a plugin-touchable rendering API; we can
+  iterate on the rendering pipeline freely without breaking
+  out-of-tree code.
+- **v1 → v2 migration is purely additive.** A future v2 that
+  permits plugin-owned `MessageContent` subclasses
+  (`detail_visibility` attribute, plugin-registered format/title
+  methods) extends this contract without breaking it. The
+  reverse direction is not true: shipping plugin-owned classes
+  in v1 commits the rendering surface to a plugin-touchable API
+  forever.
+- **The clmail case doesn't motivate v2.** Alice's PR #167
+  defines `UserHookNotificationMessage` generically; any future
+  hook-source plugin (monitor, other tooling) rewrites *to* it
+  by passing a different `source=` string. No new typed wrapper
+  needed.
+
+Migration of PR #167 to a plugin under v1 is a *deletion-only*
+refactor from core's perspective: remove the
+`_HOOK_NOTIFICATION_SOURCES` tuple, remove the regex, remove the
+call site in `create_user_message`. The class, its renderer/title
+methods, and its `_HIGH_EXCLUDE_CLASSES` membership all stay in
+core unchanged. The clmail plugin ships one
+`MessageTransformer` per source (mechanically: one regex →
+two transformers).
 
 **In-factory-dispatch placement.** Transformers run *inside* the
 factory's existing detector sequence, not as a post-factory pass.
@@ -342,7 +359,6 @@ def load_plugins() -> tuple[dict[str, ToolRenderer], list[MessageTransformer]]:
             renderer_candidates[cls.tool_name].append(instance)
         elif isinstance(instance, MessageTransformer):
             transformers.append(instance)
-            _register_format_methods(cls.OutputClass)  # binds plugin's format_X/title_X
         else:
             warn(f"plugin {ep.name!r} does not implement any plugin Protocol")
     # 2. Feed in builtins as priority=0 entries.
@@ -407,6 +423,60 @@ The winners table is consulted at three places:
   content's class doesn't match a `format_<ClassName>` method on
   the renderer (today's MRO fallback path).
 
+### `_dispatch_format` invocation pattern
+
+Once `_dispatch_format` resolves a plugin winner for a given
+content object, it picks the renderer method by joining two
+dispatch axes: **content type** (`ToolUseContent` →
+`render_input_*`, `ToolResultContent` → `render_output_*`) and
+**requested output format** (`markdown` / `html`, with HTML
+falling back to mistune-on-Markdown when the plugin returns
+`None`):
+
+```python
+def _dispatch_via_plugin(
+    content: ToolUseContent | ToolResultContent,
+    message: TemplateMessage,
+    output_format: Literal["markdown", "html"],
+) -> str:
+    winner = winners[content.tool_name]
+
+    if isinstance(content, ToolUseContent):
+        if output_format == "markdown":
+            return winner.render_input_markdown(content, message)
+        else:  # html
+            rendered = winner.render_input_html(content, message)
+            if rendered is None:
+                # Derive HTML from the plugin's Markdown via mistune.
+                md = winner.render_input_markdown(content, message)
+                return mistune_render(md)
+            return rendered
+
+    elif isinstance(content, ToolResultContent):
+        if output_format == "markdown":
+            return winner.render_output_markdown(content, message)
+        else:  # html
+            rendered = winner.render_output_html(content, message)
+            if rendered is None:
+                md = winner.render_output_markdown(content, message)
+                return mistune_render(md)
+            return rendered
+```
+
+The MRO-walk that today underlies `_dispatch_format` stays in
+place: the dispatcher *first* tries `format_<ClassName>` on the
+renderer instance (covering both built-ins and in-tree
+subclasses), and *only* falls back to the plugin-winner path
+above when no matching `format_*` method exists. The plugin path
+is itself a `format_*`-equivalent — it answers the same
+question, just via the plugin contract instead of method
+inheritance.
+
+The same plugin instance fulfils both the input and output
+sides; there is no separate "input renderer" vs "output
+renderer" plugin. This keeps a single source of truth (icons,
+title heuristics, content schemas) per tool.
+
 Detail filtering becomes data-driven:
 
 ```python
@@ -462,7 +532,8 @@ claude_code_log_clmail/
   transformers/
     __init__.py
     hook_demotion.py           # ClmailHookDemotion, MonitorHookDemotion
-                               #   + UserHookNotificationMessage (the OutputClass)
+                               # (target UserHookNotificationMessage which
+                               #  lives in core; the plugin only ships matchers)
   templates/
     communicate.md.j2          # optional Jinja partials
 ```
@@ -470,25 +541,24 @@ claude_code_log_clmail/
 ### Transformer side (replaces alice's hardcoded regex)
 
 `detect_hook_notification()` from
-`claude_code_log/factories/user_factory.py:79–99` reduces to a
-~12-line plugin transformer. The plugin owns the
-`UserHookNotificationMessage` class outright; core knows nothing
-about `[monitor]` or `[clmail]` prefixes.
+`claude_code_log/factories/user_factory.py:79–99` reduces to ~12
+lines of plugin code per source. Under v1 (existing-variants-only),
+`UserHookNotificationMessage` stays in core unchanged — it was
+defined generically by PR #167 (`source: str`, `text: str`, with
+no clmail-specific typing on the class itself). The clmail plugin
+ships only the matcher; core knows nothing about `[monitor]` or
+`[clmail]` prefixes specifically, but the wrapper class it
+produces is core-owned and inherits its detail-visibility from
+the existing `_HIGH_EXCLUDE_CLASSES` registry.
 
 ```python
 # claude_code_log_clmail/transformers/hook_demotion.py
 import re
-from typing import ClassVar
 from claude_code_log.models import (
-    DetailLevel, MessageContent, MessageMeta, UserTextMessage,
+    MessageContent, MessageMeta, UserTextMessage,
+    UserHookNotificationMessage,            # core-owned, generic
 )
 from claude_code_log.factories.priorities import HOOK_NOTIFICATION
-
-
-class UserHookNotificationMessage(MessageContent):
-    source: str   # "monitor" | "clmail" | future plugin-defined sources
-    text: str
-    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
 
 
 def _make_hook_transformer(source: str, priority_offset: int = 0):
@@ -498,7 +568,6 @@ def _make_hook_transformer(source: str, priority_offset: int = 0):
         name       = f"clmail.{source}-hook-demotion"
         priority   = HOOK_NOTIFICATION + priority_offset
         applies_to = (UserTextMessage,)
-        OutputClass = UserHookNotificationMessage
 
         def transform(self, text_content, content_list, meta):
             m = pattern.match(text_content)
@@ -514,22 +583,20 @@ def _make_hook_transformer(source: str, priority_offset: int = 0):
 
 ClmailHookDemotion  = _make_hook_transformer("clmail")
 MonitorHookDemotion = _make_hook_transformer("monitor")
-
-
-# Renderer methods registered alongside the OutputClass.
-def format_UserHookNotificationMessage(self, content, message):
-    return f"_[{content.source}] {content.text}_"
-
-
-def title_UserHookNotificationMessage(self, content, message):
-    return None   # headless — appears inline
 ```
 
-The plugin loader, on discovering the transformer, registers
-`format_UserHookNotificationMessage` and
-`title_UserHookNotificationMessage` onto the Markdown and HTML
-renderer classes via the existing MRO-discoverable dispatch. No
-core changes needed beyond the loader itself.
+No `OutputClass` field, no `detail_visibility` attribute, no
+plugin-side `format_X` / `title_X` methods. Those all live in
+core, attached to `UserHookNotificationMessage` by PR #167. The
+core-to-plugin contract is genuinely minimal: a matcher that
+returns an instance of an existing core class.
+
+The migration of #167 to a plugin (if/when the user decides to
+ship the clmail integration as an external package) is a
+*deletion-only* refactor in core: remove `_HOOK_NOTIFICATION_SOURCES`,
+remove the regex, remove the call site in `create_user_message`.
+Class, renderer, title, and `_HIGH_EXCLUDE_CLASSES` membership all
+remain in core unchanged.
 
 ### Renderer side
 
@@ -617,12 +684,15 @@ Four layers:
    plugin's rendering. Cover all four `(min_detail, current
    detail)` quadrants.
 3. **Transformer integration tests**: ship a
-   `dummy_transformer_plugin` fixture introducing a new
-   `MessageContent` subclass with `detail_visibility = FULL`.
-   Drive a JSONL transcript carrying a matching prefix; assert
-   the transformer fires inside the factory chain, the new class
-   is dispatched to format/title methods, and the entry is
-   filtered out at HIGH/MEDIUM/LOW/MINIMAL.
+   `dummy_transformer_plugin` fixture whose matcher returns an
+   instance of a core `MessageContent` variant
+   (`UserHookNotificationMessage` is the natural choice). Drive a
+   JSONL transcript carrying a matching prefix; assert the
+   transformer fires inside the factory chain at its declared
+   priority, the resulting entry uses the core variant (correct
+   class, correct fields), and inherited filter-bucket membership
+   drops it at HIGH/MEDIUM/LOW/MINIMAL. Multi-line guard, source
+   namespace, and priority-collision warnings each get one test.
 4. **ClMail plugin tests** (in the ClMail plugin package, not
    here): per-action snapshot tests covering the seven
    `communicate` actions, the four `control` actions, etc., plus
@@ -661,11 +731,13 @@ snapshot pins their current output.
 - **Templates.** Plugins MAY ship Jinja partials and load them
   via `importlib.resources`; we won't standardise a directory
   convention until a second plugin needs it.
-- **Built-in migration to `detail_visibility`.** Existing
-  built-in `MessageContent` subclasses currently have visibility
-  encoded in `_HIGH_EXCLUDE_CLASSES`. Migration to the
-  class-attribute form is mechanical and lands in a follow-up
-  PR after #166 — doesn't block the plugin API.
+- **Plugin-owned `MessageContent` subclasses (v2).** v1 restricts
+  transformers to rewriting *to* existing core variants. A future
+  v2 could allow plugins to register new subclasses (with
+  `detail_visibility` class attribute and plugin-registered
+  format/title methods). Purely additive on top of v1; defer
+  until a concrete use case justifies the larger surface
+  (renderer/timeline/fold-rules become plugin-touchable).
 - **Transformer surfacing / namespace collision diagnosis.** No
   `--list-plugins` CLI in v1. If two plugins claim overlapping
   prefixes (e.g. two competing `[monitor]` transformers), the
@@ -683,7 +755,8 @@ snapshot pins their current output.
   artificial restriction); the natural worked example is
   `(UserTextMessage,)` but a transformer targeting
   `AssistantTextMessage` or a tool-result variant is permitted.
-  We'll see what plugins actually do.
+  Constrained in practice by what core variants exist to rewrite
+  *to*. We'll see what plugins actually do.
 
 ## Future extensions
 

--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -314,7 +314,7 @@ When the renderer needs to format a content object, the lookup
 walks the content's MRO and tries two strategies at each class:
 
 ```python
-def _dispatch_format(self, content, output_format):
+def _dispatch_format(self, content, message, output_format):
     method_attr = f"format_{output_format}"     # "format_markdown" / "format_html"
     for klass in type(content).__mro__:
         # Strategy 1: renderer-side format_<ClassName> method.
@@ -322,16 +322,26 @@ def _dispatch_format(self, content, output_format):
         # carries hand-written format_BashInput / format_ReadInput / etc.
         renderer_method = getattr(self, f"format_{klass.__name__}", None)
         if renderer_method is not None:
-            return renderer_method(content)
+            return renderer_method(content, message)
         # Strategy 2: class-side format_<output> method.
         # Plugin-defined classes carry format_markdown / format_html on
         # themselves; the dispatcher invokes them with the renderer as
         # first arg so they have access to renderer state (mistune, etc.).
         class_method = klass.__dict__.get(method_attr)
         if class_method is not None:
-            return class_method(content, self, content.message)
+            return class_method(content, self, message)
     raise NotImplementedError(...)
 ```
+
+The `message: TemplateMessage` argument is part of the renderer's
+call contract everywhere else (`format_<ClassName>` methods on the
+renderer classes take `(self, content, message)`). The dispatcher
+passes it through to both strategies; class-side `format_*`
+methods on plugin-defined `MessageContent` subclasses have the
+signature `(self, renderer, message) -> str`. The
+`MessageContent` base class itself does NOT carry a back-pointer
+to its `TemplateMessage`; only the renderer's caller knows
+the binding, and the dispatcher is responsible for threading it.
 
 **Four-way matrix** (for a given content class):
 
@@ -420,12 +430,15 @@ def load_plugins() -> list[MessageTransformer]:
             warn(f"plugin {ep.name!r} does not implement MessageTransformer")
             continue
         transformers.append(instance)
-    transformers.sort(key=lambda t: (t.priority, type(t).__name__))
+    transformers.sort(
+        key=lambda t: (t.priority, type(t).__module__, type(t).__qualname__)
+    )
     # Tie-break warning
     for a, b in zip(transformers, transformers[1:]):
         if a.priority == b.priority and a.applies_to == b.applies_to:
             warn(f"priority tie for {a.applies_to!r}: "
-                 f"using {type(a).__name__} before {type(b).__name__}")
+                 f"using {type(a).__module__}.{type(a).__qualname__} before "
+                 f"{type(b).__module__}.{type(b).__qualname__}")
     return transformers
 ```
 

--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -94,7 +94,15 @@ Icons are scattered as string literals across title methods in
    (and equivalents on other message types) is byte-equivalent
    to this extraction, so transformer regexes behave consistently
    whether called inside the factory or against a parsed
-   `MessageContent`.
+   `MessageContent`. **Enforcement.** The plugin-system test
+   suite includes a dedicated equivalence test that walks the
+   existing JSONL test corpus and asserts
+   `UserTextMessage(content_list=cl).text == extract_text_content(cl)`
+   for every user entry. A future factory PR that introduces
+   normalization (markdown cleanup, whitespace folding, etc.)
+   between extraction and assignment fails this test, surfacing
+   the contract break before it silently drifts plugin regex
+   behaviour.
 
 Detail-level filtering for hook-notification noise lives in
 `_HIGH_EXCLUDE_CLASSES` (renderer.py). This stays as a core


### PR DESCRIPTION
## Summary

Design proposal for a tool-renderer plugin system. **Doc only, no implementation** — open for review and inline comment before any code lands.

The full proposal lives in `work/tool-renderer-plugins.md` (393 lines, ~10–15 min read). Key shape:

- **Discovery via `importlib.metadata.entry_points`** (stdlib, group `claude_code_log.tool_renderers`); pluggy considered and rejected as overkill for "one winner per tool name".
- **`ToolRenderer` Protocol** bundling `InputModel` / `OutputModel` / `render_*_markdown` (required) / `render_*_html` (optional — returns `None` to fall back to Markdown → `mistune`).
- **Priority offset semantics:** `0` reserved for builtins; `<0` supersedes; `>0` fallback; tie-break = stable alphabetical with a startup warning.
- **`min_detail` only** (no `max_detail`) — rationale in the doc.
- **Worked example:** `clmail-communicate` plugin that replaces the synthetic `[clmail] You've got a new mail (#3076)` hook line with the actual mail content at `--detail low`. This is the driving use case.
- **Future formatters** section: the same entry-point machinery extends to a `claude_code_log.formatters` group without changing the v1 surface.

The doc grounds itself in current architecture by file:line — `TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` / `_dispatch_format` / `_LOW_KEEP_TOOLS` / scattered icons. Those four surfaces become data-driven from the plugin loader's winners table.

## Test plan

- [ ] Read the doc end-to-end and check the proposed Protocol against the requirements list in the task brief.
- [ ] Sanity-check the priority resolution pseudocode against the "+5 fallback / -5 supersede" example.
- [ ] Confirm the `min_detail` decision (vs adding `max_detail`) matches the desired UX.
- [ ] Inspect the worked clmail-communicate example for whether the discriminated-union pattern (`action` field driving per-action rendering) is the right shape.
- [ ] Open questions section: do any of them want pushing into v1 vs deferring?

Once the design is acked, a follow-up PR will land the loader + Protocol + one in-tree builtin example refactored to the plugin shape (proof of concept). The clmail plugin ships as a separate package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design proposal introducing a unified plugin model centered on a single message-transformer protocol, discovered at startup, prioritized, and applied during message dispatch.
  * Specifies class-owned rendering (markdown/html/title), standardized detail-visibility filtering, deterministic winner resolution, and loader/dispatch behavior.
  * Includes a worked ClMail example, test strategy, open questions, and future extension ideas for pluggable formatters. Status: design proposal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->