### PR TITLE
Implement unified plugin system from RFC #166

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ with pointers to the deep-dive docs:
 - [dev-docs/teammates.md](dev-docs/teammates.md) - Teammates feature deep-dive
 - [dev-docs/message-hierarchy.md](dev-docs/message-hierarchy.md) - Fold/unfold state machine
 - [dev-docs/implementing-a-tool-renderer.md](dev-docs/implementing-a-tool-renderer.md) - How-to: add a new tool
+- [dev-docs/plugins.md](dev-docs/plugins.md) - Plugin system reference + author guide
 
 User-facing docs live in [docs/](docs/); plans and TODOs live in [work/](work/).
 

--- a/claude_code_log/factories/priorities.py
+++ b/claude_code_log/factories/priorities.py
@@ -1,0 +1,46 @@
+"""Priority constants for plugin transformer ordering.
+
+Built-in factory detectors run in a fixed sequence; these constants
+expose their notional positions on a numeric priority scale so plugin
+transformers can declare where they sit relative to the built-ins
+without renumbering on every core change. Gaps of 100 leave room for
+plugin insertion.
+
+Convention (lower number = higher priority = runs first):
+
+- ``0`` through ``999``  — user/system entry classification
+- ``1000``               — generic text fallback (UserTextMessage)
+- ``5000`` through ``9999`` — tool input / output classification
+- ``10000`` and up       — never used by built-ins; reserved for plugin fallbacks
+
+See ``work/tool-renderer-plugins.md`` §Priority + ordering for the
+RFC discussion and worked examples.
+"""
+
+# User-entry detector chain (see factories/user_factory.py::create_user_message)
+COMMAND_MESSAGE: int = 100
+LOCAL_COMMAND_OUTPUT: int = 200
+BASH_INPUT_OUTPUT: int = 300
+TEAMMATE_MESSAGE: int = 400
+TASK_NOTIFICATION: int = 500
+HOOK_NOTIFICATION: int = 600  # PR #167's seat
+SLASH_COMMAND_ISMETA: int = 700
+TEXT_FALLBACK: int = 1000  # generic UserTextMessage
+
+# Tool-entry classification
+TOOL_INPUT_GENERIC: int = 5000
+TOOL_OUTPUT_GENERIC: int = 5100
+
+
+__all__ = [
+    "BASH_INPUT_OUTPUT",
+    "COMMAND_MESSAGE",
+    "HOOK_NOTIFICATION",
+    "LOCAL_COMMAND_OUTPUT",
+    "SLASH_COMMAND_ISMETA",
+    "TASK_NOTIFICATION",
+    "TEAMMATE_MESSAGE",
+    "TEXT_FALLBACK",
+    "TOOL_INPUT_GENERIC",
+    "TOOL_OUTPUT_GENERIC",
+]

--- a/claude_code_log/factories/tool_factory.py
+++ b/claude_code_log/factories/tool_factory.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional, cast
 from pydantic import BaseModel
 
 from .agent_metadata_factory import parse_agent_result_metadata
+from ..plugins import apply_transformers
 from ..models import (
     # Tool input models
     AskUserQuestionInput,
@@ -1349,12 +1350,17 @@ def create_tool_use_message(
 
     # Create ToolUseMessage wrapper with parsed input for specialized formatting
     # Use ToolUseContent as fallback when no specialized parser exists
-    tool_use_message = ToolUseMessage(
+    tool_use_message: MessageContent = ToolUseMessage(
         meta,
         input=parsed if parsed is not None else tool_use,
         tool_use_id=tool_use.id,
         tool_name=tool_use.name,
     )
+
+    # Plugin transformer pass: lets a plugin rewrite the ToolUseMessage
+    # into a specialized subclass (e.g. ClmailCommunicateInputMessage)
+    # carrying its own format/title methods. No-op when no plugin matches.
+    tool_use_message = apply_transformers(tool_use_message, meta)
 
     return ToolItemResult(
         message_type="tool_use",
@@ -1401,7 +1407,7 @@ def create_tool_result_message(
     )
 
     # Create content model with rendering context
-    content_model = ToolResultMessage(
+    content_model: MessageContent = ToolResultMessage(
         meta,
         tool_use_id=tool_result.tool_use_id,
         output=parsed_output,
@@ -1409,6 +1415,10 @@ def create_tool_result_message(
         tool_name=result_tool_name,
         file_path=result_file_path,
     )
+
+    # Plugin transformer pass: lets a plugin rewrite the ToolResultMessage
+    # into a specialized subclass with its own format/title methods.
+    content_model = apply_transformers(content_model, meta)
 
     return ToolItemResult(
         message_type="tool_result",

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -42,6 +42,7 @@ from ..models import (
     UserSlashCommandMessage,
     UserTextMessage,
 )
+from ..plugins import apply_transformers
 from .task_notification_factory import (
     create_task_notification_message,
     has_task_notification,
@@ -463,6 +464,30 @@ UserMessageContent = Union[
 
 
 def create_user_message(
+    meta: MessageMeta,
+    content_list: list[ContentItem],
+    text_content: str,
+    is_slash_command: bool = False,
+) -> Optional[UserMessageContent]:
+    """Wrapper: build the candidate, then run plugin transformers.
+
+    The body lives in :func:`_classify_user_message`; this wrapper
+    applies the plugin transformer pass to the result so every
+    classification path (slash-command, bash, teammate, ...) becomes
+    rewriteable by a plugin, not just the generic-text fallback.
+    Transformers whose ``applies_to`` doesn't subclass-match the
+    candidate's type pass through with no-op cost.
+    """
+    candidate = _classify_user_message(
+        meta, content_list, text_content, is_slash_command
+    )
+    if candidate is None:
+        return None
+    transformed = apply_transformers(candidate, meta)
+    return cast("UserMessageContent", transformed)
+
+
+def _classify_user_message(
     meta: MessageMeta,
     content_list: list[ContentItem],
     text_content: str,

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -264,6 +264,14 @@ def _build_html_project_tree(template_projects: list[Any]) -> dict[str, Any]:
 class HtmlRenderer(Renderer):
     """HTML renderer for Claude Code transcripts."""
 
+    # Consulted by Renderer._dispatch_format Strategy 2: plugin-defined
+    # content classes contributing a ``format_html`` method get picked up
+    # here. See work/tool-renderer-plugins.md §`_dispatch_format`
+    # resolution order. Class-side ``format_html`` may return None to
+    # opt for mistune-derived HTML; that fallback is handled by callers
+    # of format_content, not by the dispatcher itself.
+    _class_dispatch_format: str = "html"
+
     def __init__(self, image_export_mode: str = "embedded"):
         """Initialize the HTML renderer.
 

--- a/claude_code_log/plugins.py
+++ b/claude_code_log/plugins.py
@@ -193,18 +193,28 @@ def _sort_and_warn(transformers: list[MessageTransformer]) -> list[MessageTransf
         transformers,
         key=lambda t: (t.priority, type(t).__module__, type(t).__qualname__),
     )
-    for a, b in zip(transformers, transformers[1:]):
-        if a.priority == b.priority and a.applies_to == b.applies_to:
+    # Group by (priority, applies_to) rather than walking adjacent pairs:
+    # the sort key is (priority, module, qualname), so two transformers with
+    # the same priority but different applies_to can sit between two
+    # genuine collision partners. The adjacent-pair check would miss that
+    # case. Group-by gives us every collision regardless of sort position.
+    seen: dict[tuple[int, tuple[type[MessageContent], ...]], MessageTransformer] = {}
+    for t in transformers:
+        key = (t.priority, t.applies_to)
+        first = seen.get(key)
+        if first is not None:
             logger.warning(
                 "priority tie for applies_to=%r at priority=%d: "
                 "using %s.%s before %s.%s",
-                a.applies_to,
-                a.priority,
-                type(a).__module__,
-                type(a).__qualname__,
-                type(b).__module__,
-                type(b).__qualname__,
+                t.applies_to,
+                t.priority,
+                type(first).__module__,
+                type(first).__qualname__,
+                type(t).__module__,
+                type(t).__qualname__,
             )
+        else:
+            seen[key] = t
     return transformers
 
 
@@ -249,9 +259,19 @@ def apply_transformers(
     candidate's class (subclass check). First non-None return wins;
     candidate passes through unchanged if no transformer matches.
 
-    Transformer exceptions are caught and logged at WARNING so a buggy
-    plugin doesn't crash the whole conversion; the candidate falls
-    through to the next transformer (or out unchanged).
+    Two defensive surfaces protect downstream code from misbehaving plugins:
+
+    1. **Exception capture.** Transformer exceptions are caught and
+       logged at WARNING so a buggy plugin doesn't crash the whole
+       conversion; the candidate falls through to the next transformer.
+    2. **Return-type enforcement.** The replacement must be a
+       ``MessageContent`` instance AND match the transformer's
+       ``applies_to`` MRO filter (typically a subclass of one of the
+       declared types). A wholly-unrelated MessageContent — e.g. a
+       UserTextMessage-targeting transformer returning a SystemMessage
+       — is rejected with a warning; the candidate continues to the
+       next transformer. This enforces the contract documented on the
+       :class:`MessageTransformer` Protocol.
     """
     for transformer in load_transformers():
         if not isinstance(candidate, transformer.applies_to):
@@ -266,8 +286,30 @@ def apply_transformers(
                 type(candidate).__name__,
             )
             continue
-        if replacement is not None:
-            return replacement
+        if replacement is None:
+            continue
+        # Static type-checkers see the Protocol's Optional[MessageContent]
+        # return annotation and consider this isinstance() unnecessary
+        # — but plugin authors aren't bound by static typing at runtime,
+        # so this catches the "returned a string / dict / None-ish" class
+        # of plugin bug. Keep the runtime check; suppress the linter.
+        if not isinstance(replacement, MessageContent):  # pyright: ignore[reportUnnecessaryIsInstance]
+            logger.warning(
+                "plugin %r: transform() returned non-MessageContent %r; skipping",
+                transformer.name,
+                type(replacement).__name__,
+            )
+            continue
+        if not isinstance(replacement, transformer.applies_to):
+            logger.warning(
+                "plugin %r: transform() returned %r not matching "
+                "applies_to=%r; skipping",
+                transformer.name,
+                type(replacement).__name__,
+                tuple(t.__name__ for t in transformer.applies_to),
+            )
+            continue
+        return replacement
     return candidate
 
 

--- a/claude_code_log/plugins.py
+++ b/claude_code_log/plugins.py
@@ -1,0 +1,264 @@
+"""Plugin discovery and dispatch for claude-code-log.
+
+Implements the unified message-transformer plugin system described in
+``work/tool-renderer-plugins.md``.
+
+Plugins are discovered via the ``claude_code_log.plugins`` setuptools
+entry-point group. Each entry yields a class implementing the
+:class:`MessageTransformer` Protocol. The loader sorts transformers by
+``(priority, __module__, __qualname__)`` and exposes them to factories
+through :func:`apply_transformers`.
+
+v1 scope: transformers run as a *post-classification* pass — each
+factory builds its candidate ``MessageContent``, then the loader walks
+the priority-ordered transformer list and lets the first matching
+transformer (via ``applies_to`` MRO filter) rewrite the candidate.
+This deviates slightly from the RFC's "interleaved with built-in
+detectors" framing for implementation simplicity; the effect is the
+same for every use case the RFC names (clmail hook-demotion, MCP tool
+rendering) because plugin transformers always operate on a candidate
+that the built-in chain has already classified (typically as
+:class:`UserTextMessage` or generic :class:`ToolUseContent`).
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import EntryPoint, entry_points
+from typing import (
+    Any,
+    ClassVar,
+    Optional,
+    Protocol,
+    cast,
+    runtime_checkable,
+)
+
+from .models import MessageContent, MessageMeta
+
+logger = logging.getLogger(__name__)
+
+
+# Entry-point group plugins register under.
+ENTRY_POINT_GROUP = "claude_code_log.plugins"
+
+
+@runtime_checkable
+class MessageTransformer(Protocol):
+    """A plugin contribution that rewrites a parsed ``MessageContent``.
+
+    A transformer matches a candidate by its ``applies_to`` tuple (an
+    MRO/subclass check) and, when matched, may return a replacement
+    ``MessageContent`` (typically a plugin-defined subclass of one of
+    the ``applies_to`` types) or ``None`` to pass through.
+
+    Class attributes ``name``, ``priority``, ``applies_to`` are
+    required metadata; the loader validates their presence explicitly
+    because ``runtime_checkable`` only verifies method presence.
+
+    See ``work/tool-renderer-plugins.md`` for the design rationale,
+    priority table, and worked clmail example.
+    """
+
+    name: ClassVar[str]
+    priority: ClassVar[int]
+    applies_to: ClassVar[tuple[type[MessageContent], ...]]
+
+    def transform(
+        self,
+        content: MessageContent,
+        meta: MessageMeta,
+    ) -> Optional[MessageContent]: ...
+
+
+# ----------------------------------------------------------------------
+# Loader (cached at module level so discovery happens once per process)
+# ----------------------------------------------------------------------
+
+
+_cached_transformers: Optional[list[MessageTransformer]] = None
+
+
+def _validate_transformer_class(cls: type, ep_name: str) -> bool:
+    """Return True iff ``cls`` looks like a valid MessageTransformer.
+
+    Required class attributes:
+
+    - ``name``: non-empty str
+    - ``priority``: int
+    - ``applies_to``: non-empty tuple of MessageContent subclasses
+
+    ``transform`` is verified by the runtime_checkable Protocol on the
+    instance; this function checks only the ClassVar metadata.
+    """
+    # We intentionally introspect arbitrary classes here; pyright can't
+    # know their attribute types, so cast to Any for the metadata reads.
+    cls_any = cast(Any, cls)
+    missing: list[str] = [
+        attr for attr in ("name", "priority", "applies_to") if not hasattr(cls, attr)
+    ]
+    if missing:
+        logger.warning(
+            "plugin %r (%r) missing required class attribute(s): %s",
+            ep_name,
+            cls,
+            ", ".join(missing),
+        )
+        return False
+
+    name: Any = cls_any.name
+    if not isinstance(name, str) or not name:
+        logger.warning("plugin %r: name must be non-empty str (got %r)", ep_name, name)
+        return False
+    priority: Any = cls_any.priority
+    if not isinstance(priority, int):
+        logger.warning("plugin %r: priority must be int (got %r)", ep_name, priority)
+        return False
+    applies_to: Any = cls_any.applies_to
+    # All `repr(...)` calls here turn unknown-typed introspection values
+    # into plain strings up front, so pyright sees only ``str`` flowing
+    # into the logger args (avoids ``reportUnknownArgumentType``).
+    if not isinstance(applies_to, tuple) or not applies_to:
+        logger.warning(
+            "plugin %r: applies_to must be a non-empty tuple (got %s)",
+            ep_name,
+            repr(cast(object, applies_to)),
+        )
+        return False
+    for t in applies_to:  # pyright: ignore[reportUnknownVariableType]
+        if not isinstance(t, type) or not issubclass(t, MessageContent):
+            logger.warning(
+                "plugin %r: applies_to entry %s is not a MessageContent subclass",
+                ep_name,
+                repr(cast(object, t)),
+            )
+            return False
+    return True
+
+
+def _load_single(ep: EntryPoint) -> Optional[MessageTransformer]:
+    """Load and validate a single entry point. Returns instance or None."""
+    try:
+        cls = ep.load()
+    except Exception as e:  # noqa: BLE001 — surface any load failure as a warning
+        logger.warning("failed to load plugin entry point %r: %s", ep.name, e)
+        return None
+    if not isinstance(cls, type):
+        logger.warning(
+            "plugin %r: entry point must yield a class (got %r)", ep.name, cls
+        )
+        return None
+    if not _validate_transformer_class(cls, ep.name):
+        return None
+    try:
+        instance = cls()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("plugin %r: failed to instantiate %r: %s", ep.name, cls, e)
+        return None
+    if not isinstance(instance, MessageTransformer):
+        # Protocol check catches missing transform() method.
+        logger.warning(
+            "plugin %r: instance does not implement MessageTransformer "
+            "(missing transform() method?)",
+            ep.name,
+        )
+        return None
+    return instance
+
+
+def _sort_and_warn(transformers: list[MessageTransformer]) -> list[MessageTransformer]:
+    """Sort by (priority, __module__, __qualname__) and warn on collisions.
+
+    Tie-break key uses fully-qualified class identifier so two plugins
+    shipping classes with the same short name don't get OS-dependent
+    ordering. Collisions on (priority, applies_to) emit a warning.
+    """
+    transformers = sorted(
+        transformers,
+        key=lambda t: (t.priority, type(t).__module__, type(t).__qualname__),
+    )
+    for a, b in zip(transformers, transformers[1:]):
+        if a.priority == b.priority and a.applies_to == b.applies_to:
+            logger.warning(
+                "priority tie for applies_to=%r at priority=%d: "
+                "using %s.%s before %s.%s",
+                a.applies_to,
+                a.priority,
+                type(a).__module__,
+                type(a).__qualname__,
+                type(b).__module__,
+                type(b).__qualname__,
+            )
+    return transformers
+
+
+def load_transformers(*, force_reload: bool = False) -> list[MessageTransformer]:
+    """Discover and return the priority-sorted transformer list.
+
+    Cached at module scope; pass ``force_reload=True`` to re-scan
+    (primarily for tests that install/uninstall plugins mid-run).
+    """
+    global _cached_transformers
+    if _cached_transformers is not None and not force_reload:
+        return _cached_transformers
+
+    discovered: list[MessageTransformer] = []
+    for ep in entry_points(group=ENTRY_POINT_GROUP):
+        if transformer := _load_single(ep):
+            discovered.append(transformer)
+
+    _cached_transformers = _sort_and_warn(discovered)
+    return _cached_transformers
+
+
+def reset_cache() -> None:
+    """Clear the loader cache. Used by tests."""
+    global _cached_transformers
+    _cached_transformers = None
+
+
+# ----------------------------------------------------------------------
+# Dispatch helper for factories
+# ----------------------------------------------------------------------
+
+
+def apply_transformers(
+    candidate: MessageContent,
+    meta: MessageMeta,
+) -> MessageContent:
+    """Run transformers against ``candidate``; return the rewrite (or candidate).
+
+    Walks the priority-ordered transformer list, calling ``transform()``
+    on the first transformer whose ``applies_to`` matches the
+    candidate's class (subclass check). First non-None return wins;
+    candidate passes through unchanged if no transformer matches.
+
+    Transformer exceptions are caught and logged at WARNING so a buggy
+    plugin doesn't crash the whole conversion; the candidate falls
+    through to the next transformer (or out unchanged).
+    """
+    for transformer in load_transformers():
+        if not isinstance(candidate, transformer.applies_to):
+            continue
+        try:
+            replacement = transformer.transform(candidate, meta)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "plugin %r: transform() raised %s on %r; skipping",
+                transformer.name,
+                type(e).__name__,
+                type(candidate).__name__,
+            )
+            continue
+        if replacement is not None:
+            return replacement
+    return candidate
+
+
+__all__ = [
+    "ENTRY_POINT_GROUP",
+    "MessageTransformer",
+    "apply_transformers",
+    "load_transformers",
+    "reset_cache",
+]

--- a/claude_code_log/plugins.py
+++ b/claude_code_log/plugins.py
@@ -70,6 +70,22 @@ class MessageTransformer(Protocol):
         meta: MessageMeta,
     ) -> Optional[MessageContent]: ...
 
+    # Contract — v1 trust requirement (not runtime-enforced):
+    #
+    # When ``transform()`` returns a non-None replacement, the
+    # replacement SHOULD be an instance of either:
+    #   - one of the ``applies_to`` types, or
+    #   - a subclass thereof (typically a plugin-defined
+    #     specialization).
+    #
+    # Returning a wholly unrelated MessageContent subclass (e.g. a
+    # transformer with ``applies_to=(UserTextMessage,)`` returning a
+    # ``SystemMessage``) is accepted at runtime but breaks the
+    # caller's typing assumption (e.g. ``create_user_message``
+    # narrows to ``UserMessageContent``). A v2 enhancement may add a
+    # runtime isinstance check; v1 trusts plugin authors. Don't get
+    # clever.
+
 
 # ----------------------------------------------------------------------
 # Loader (cached at module level so discovery happens once per process)

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4290,21 +4290,26 @@ class Renderer:
     def title_content(self, message: TemplateMessage) -> str:
         """Get message title by dispatching to type-specific title method.
 
-        Looks for a method named title_{ClassName} (e.g., title_ToolUseMessage).
-        Falls back to type-based title derived from message_type.
+        Delegates to :meth:`_dispatch_title` so plugin-defined
+        ``MessageContent`` subclasses can supply their own class-side
+        ``title()`` method (Strategy 2 of the plugin dispatch contract).
+        Without delegation, the renderer-only MRO walk fires
+        ``title_ToolUseMessage`` on the base renderer before a plugin
+        subclass's class-side ``title()`` is reached — silently
+        ignoring the plugin's contribution at the top level.
 
-        Args:
-            message: TemplateMessage to get title for.
-
-        Returns:
-            Title string for the message header.
+        Falls back to a title-cased ``message_type`` when neither
+        strategy yields a title (which is what happens for built-in
+        message classes that have no renderer-side title method either).
         """
-        # Try title_{ClassName} dispatch
-        for cls in type(message.content).__mro__:
-            if cls is object:
-                break
-            if method := getattr(self, f"title_{cls.__name__}", None):
-                return method(message.content, message)
+        # Use `is not None` rather than truthiness: a handler that
+        # returns an empty string (e.g. title_ToolResultMessage for
+        # non-error results) is asserting "no header content needed",
+        # not "I didn't handle this". The walrus / truthy form would
+        # incorrectly fall through to the message_type default.
+        title = self._dispatch_title(message.content, message)
+        if title is not None:
+            return title
         # Fallback: convert message_type to title case
         return message.content.message_type.replace("_", " ").replace("-", " ").title()
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3207,6 +3207,13 @@ _DETAIL_ORDER: dict[DetailLevel, int] = {
     DetailLevel.USER_ONLY: 4,
 }
 
+# Guard against drift: if a new DetailLevel value is added without an
+# entry here, the visibility helper would raise KeyError silently on
+# first use. Fail loudly at import time instead.
+assert set(_DETAIL_ORDER.keys()) == set(DetailLevel), (
+    f"_DETAIL_ORDER missing entries for: {set(DetailLevel) - set(_DETAIL_ORDER.keys())}"
+)
+
 
 def _content_visible_at(content: "MessageContent", detail: DetailLevel) -> bool:
     """Return True iff ``content`` is visible at the given detail level.

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3194,6 +3194,57 @@ _USER_ONLY_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
 )
 
 
+# DetailLevel verbosity ordering: lower index = more verbose. A message
+# is visible iff ``current_detail`` is at least as verbose as the
+# required ``detail_visibility`` declared on its content class. With
+# this ordering "at least as verbose" reduces to
+# ``order[current] <= order[required]``.
+_DETAIL_ORDER: dict[DetailLevel, int] = {
+    DetailLevel.FULL: 0,
+    DetailLevel.HIGH: 1,
+    DetailLevel.LOW: 2,
+    DetailLevel.MINIMAL: 3,
+    DetailLevel.USER_ONLY: 4,
+}
+
+
+def _content_visible_at(content: "MessageContent", detail: DetailLevel) -> bool:
+    """Return True iff ``content`` is visible at the given detail level.
+
+    Resolution order (per RFC §detail_visibility semantics and built-in
+    bridge):
+
+    1. **Class attribute** ``detail_visibility: ClassVar[DetailLevel]``
+       on the content's class. Plugin-defined classes use this; future
+       migrations of built-ins to the class-attribute form do too.
+       Monotone-down: visible iff ``detail`` is at least as verbose as
+       the class's declared minimum.
+    2. **Bridge** to the legacy ``_HIGH_EXCLUDE_CLASSES`` /
+       ``_LOW_EXCLUDE_CLASSES`` / etc. registries for built-in classes
+       that have not been migrated yet. ``isinstance`` semantics
+       (matches subclasses too, so plugin classes that subclass a
+       built-in inherit the built-in's filter membership unless they
+       override via the class attribute).
+    3. **Default visible** when neither strategy excludes.
+    """
+    visibility = getattr(type(content), "detail_visibility", None)
+    if visibility is not None:
+        return _DETAIL_ORDER[detail] <= _DETAIL_ORDER[visibility]
+    # Bridge: only the active level's exclude registry applies.
+    exclude: tuple[type[MessageContent], ...]
+    if detail == DetailLevel.HIGH:
+        exclude = _HIGH_EXCLUDE_CLASSES
+    elif detail == DetailLevel.LOW:
+        exclude = _LOW_EXCLUDE_CLASSES
+    elif detail == DetailLevel.MINIMAL:
+        exclude = _MINIMAL_EXCLUDE_CLASSES
+    elif detail == DetailLevel.USER_ONLY:
+        exclude = _USER_ONLY_EXCLUDE_CLASSES
+    else:  # FULL
+        return True
+    return not isinstance(content, exclude)
+
+
 def _filter_by_detail(
     messages: list[TranscriptEntry],
     detail: DetailLevel,
@@ -3472,32 +3523,47 @@ def _filter_template_by_detail(
     messages: list[TemplateMessage],
     detail: DetailLevel,
 ) -> list[TemplateMessage]:
-    """Post-render filter: remove TemplateMessage types per detail level."""
-    if detail == DetailLevel.USER_ONLY:
-        exclude = _USER_ONLY_EXCLUDE_CLASSES
-    elif detail == DetailLevel.MINIMAL:
-        exclude = _MINIMAL_EXCLUDE_CLASSES
-    elif detail == DetailLevel.LOW:
-        exclude = _LOW_EXCLUDE_CLASSES
-    else:
-        exclude = _HIGH_EXCLUDE_CLASSES
+    """Post-render filter: remove TemplateMessage types per detail level.
 
+    Visibility is computed by :func:`_content_visible_at`, which
+    consults a content class's ``detail_visibility`` attribute first
+    (plugin path) and falls back to the legacy ``_*_EXCLUDE_CLASSES``
+    registries (built-in path). At ``LOW``, the ``_LOW_KEEP_TOOLS``
+    allowlist rescues specific tool names that the bridge would
+    otherwise drop.
+    """
     result: list[TemplateMessage] = []
     for msg in messages:
-        if isinstance(msg.content, exclude):
+        visible = _content_visible_at(msg.content, detail)
+
+        # LOW keep-list: ToolUseMessage / ToolResultMessage are NOT in
+        # _LOW_EXCLUDE_CLASSES (only in _MINIMAL_EXCLUDE_CLASSES), so
+        # the bridge passes them through at LOW. The keep-list then
+        # applies a *positive* filter: keep only tools whose tool_name
+        # is in _LOW_KEEP_TOOLS; drop the rest. Plugin classes
+        # carrying an explicit ``detail_visibility`` opt out of the
+        # keep-list — their declared visibility is authoritative,
+        # letting a plugin (e.g. clmail communicate) be visible at LOW
+        # without core needing to update _LOW_KEEP_TOOLS.
+        if (
+            visible
+            and detail == DetailLevel.LOW
+            and isinstance(msg.content, (ToolUseMessage, ToolResultMessage))
+            and not hasattr(type(msg.content), "detail_visibility")
+        ):
+            tool_name = getattr(msg.content, "tool_name", "")
+            if tool_name not in _LOW_KEEP_TOOLS:
+                visible = False
+
+        if not visible:
             continue
+
         if (
             detail in (DetailLevel.MINIMAL, DetailLevel.LOW, DetailLevel.USER_ONLY)
             and msg.is_sidechain
         ):
             continue
-        # LOW: drop tool_use/tool_result unless it's a kept tool
-        if detail == DetailLevel.LOW and isinstance(
-            msg.content, (ToolUseMessage, ToolResultMessage)
-        ):
-            tool_name = getattr(msg.content, "tool_name", "")
-            if tool_name not in _LOW_KEEP_TOOLS:
-                continue
+
         result.append(msg)
     return result
 
@@ -4140,22 +4206,64 @@ class Renderer:
     detail: DetailLevel = DetailLevel.FULL
     compact: bool = False
 
+    # Output format identifier consulted by the class-side dispatch path
+    # below. Subclasses override to ``"html"`` etc.; the default
+    # ``"markdown"`` makes the base Renderer behave correctly when used
+    # standalone (it emits markdown anyway). See _dispatch_format docstring.
+    _class_dispatch_format: str = "markdown"
+
     def _dispatch_format(self, obj: Any, message: TemplateMessage) -> str:
-        """Dispatch to format_{ClassName}(obj, message) based on object type."""
+        """Dispatch to format_{ClassName}(obj, message) based on object type.
+
+        Two-strategy resolution walking ``type(obj).__mro__``:
+
+        1. **Renderer-side** ``format_<ClassName>(self, obj, message)``
+           method. Preserves all built-in dispatch unchanged — the
+           renderer class carries hand-written format_BashInput /
+           format_ToolUseMessage / etc.
+        2. **Class-side** ``format_<output>(self, renderer, message)``
+           method on the content class itself (where ``<output>`` is
+           ``markdown`` or ``html`` per ``_class_dispatch_format``).
+           Used by plugin-defined ``MessageContent`` subclasses that
+           carry their own render methods.
+
+        Renderer-side wins first per MRO node (matrix in
+        ``work/tool-renderer-plugins.md`` §``_dispatch_format``
+        resolution order). A plugin subclass that wants to shadow a
+        built-in renderer method does so by defining the class-side
+        method on the *plugin* subclass — the MRO walk visits it
+        before the built-in's renderer method registers.
+        """
+        method_attr = f"format_{self._class_dispatch_format}"
         for cls in type(obj).__mro__:
             if cls is object:
                 break
+            # Strategy 1: renderer-side method.
             if method := getattr(self, f"format_{cls.__name__}", None):
                 return method(obj, message)
+            # Strategy 2: class-side method declared *on this MRO node*
+            # (intentionally not inherited — each class opts in).
+            class_method = cls.__dict__.get(method_attr)
+            if class_method is not None:
+                return class_method(obj, self, message)
         return ""
 
     def _dispatch_title(self, obj: Any, message: TemplateMessage) -> Optional[str]:
-        """Dispatch to title_{ClassName}(obj, message) based on object type."""
+        """Dispatch to title_{ClassName}(obj, message) based on object type.
+
+        Same two-strategy resolution as :meth:`_dispatch_format`:
+        renderer-side ``title_<ClassName>`` first, then class-side
+        ``title()`` declared on the MRO node. Returns ``None`` if no
+        handler exists (caller falls back to a default).
+        """
         for cls in type(obj).__mro__:
             if cls is object:
                 break
             if method := getattr(self, f"title_{cls.__name__}", None):
                 return method(obj, message)
+            class_method = cls.__dict__.get("title")
+            if class_method is not None:
+                return class_method(obj, self, message)
         return None
 
     def format_content(self, message: TemplateMessage) -> str:

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -36,6 +36,7 @@ for user-facing operations docs see [`docs/`](../docs/).
 | Performance profiling | [`renderer_timings.py`](../claude_code_log/renderer_timings.py) | inlined below (§ 2.8) |
 | Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.9) |
 | Adding a new tool renderer | [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), `html/tool_formatters.py` | [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md) (how-to) |
+| Plugin system (third-party message transformers) | [`plugins.py`](../claude_code_log/plugins.py), [`factories/priorities.py`](../claude_code_log/factories/priorities.py), `Renderer._dispatch_format` | [plugins.md](plugins.md) |
 
 A note on cross-cutting concerns: some behaviour spans several rows
 of the table above and isn't owned by any single subsystem. **Label
@@ -431,6 +432,9 @@ Common entry questions and their best first stop:
   → [messages.md](messages.md) plus the samples in `messages/`.
 - "I want to add support for a new Claude Code tool."
   → [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md).
+- "I want to write a third-party plugin (e.g. for an MCP tool we
+  don't ship)."
+  → [plugins.md](plugins.md).
 - "How does folding / collapsible content work?"
   → [message-hierarchy.md](message-hierarchy.md).
 - "What CSS classes does a message div get?"

--- a/dev-docs/plugins.md
+++ b/dev-docs/plugins.md
@@ -1,0 +1,515 @@
+# Plugin System
+
+`claude-code-log` exposes a plugin system that lets third-party
+packages rewrite parsed message content with their own typed
+subclasses and render them through their own format/title methods,
+without modifying core. This page is the as-built reference for
+**plugin authors** writing a new plugin, and for maintainers of the
+plugin machinery itself.
+
+For the design discussion that led here, see the RFC at
+[`work/tool-renderer-plugins.md`](../work/tool-renderer-plugins.md);
+that doc captures the alternatives considered. This page documents
+what shipped.
+
+---
+
+## 1. What a plugin does
+
+The pipeline (full overview in
+[application_model.md](application_model.md)) reads JSONL transcript
+entries, passes them through the [`factories/`](../claude_code_log/factories/)
+layer to build typed `MessageContent` instances, then dispatches to a
+renderer that emits HTML, Markdown, or JSON.
+
+A plugin inserts itself **between the factory output and the renderer
+dispatch**. It can:
+
+1. Match a candidate `MessageContent` by its class (an `applies_to`
+   MRO filter) — e.g. *every* `ToolUseMessage`, or *every*
+   `UserTextMessage`.
+2. Inspect the candidate (e.g. check `tool_name`, regex the text).
+3. Return a replacement `MessageContent` — typically a plugin-defined
+   subclass — that carries its own `format_markdown` /
+   `format_html` / `title` methods.
+
+Two motivating use cases drove the design:
+
+- **MCP tool rendering.** A specific MCP tool name (e.g.
+  `mcp__plugin_clmail_clmail__communicate`) deserves prettier output
+  than the generic JSON-dump fallback. A plugin specializes the
+  generic `ToolUseMessage` into a plugin-defined subclass with
+  bespoke `format_markdown`.
+- **Hook-style demotion.** A `UserTextMessage` whose body matches a
+  marker (e.g. `[hook] ...`) gets reclassified into a typed wrapper
+  so it can render compactly or be hidden at low detail levels.
+
+Plugins are **discovered through entry points**, so just `pip install`
+ing a plugin package wires it in — no edit to `claude-code-log`
+itself.
+
+---
+
+## 2. Quick start: write your first plugin
+
+The fastest path is to copy the **reference plugin** at
+[`test/_plugins/clmail/`](../test/_plugins/clmail/) and edit it. That
+package is the layer-4 test fixture for the plugin-system test suite
+AND the canonical author example — the two roles are intentionally
+combined so the doc cannot drift from working code.
+
+Steps:
+
+1. **Copy the layout.** A plugin is a normal Python package with one
+   declarative addition in `pyproject.toml`. Minimum tree:
+
+   ```
+   my_plugin/
+   ├── pyproject.toml
+   └── src/my_plugin/
+       ├── __init__.py
+       └── transformers/
+           ├── __init__.py
+           └── <one file per transformer>.py
+   ```
+
+2. **Declare the entry points.** In `pyproject.toml`:
+
+   ```toml
+   [project.entry-points."claude_code_log.plugins"]
+   my_thing = "my_plugin.transformers.thing:MyTransformer"
+   ```
+
+   The key on the left is a stable identifier the loader logs at
+   startup; the value on the right is `module:ClassName`. The class
+   must satisfy the [`MessageTransformer`](#3-the-messagetransformer-protocol)
+   Protocol (next section).
+
+3. **Write the transformer.** A `MessageTransformer` declares three
+   `ClassVar`s plus a `transform` method:
+
+   ```python
+   from typing import ClassVar, Optional
+   from claude_code_log.factories.priorities import TOOL_INPUT_GENERIC
+   from claude_code_log.models import (
+       MessageContent, MessageMeta, ToolUseMessage,
+   )
+
+   class MyTransformer:
+       name: ClassVar[str] = "my-plugin.my-thing"
+       priority: ClassVar[int] = TOOL_INPUT_GENERIC - 500
+       applies_to: ClassVar[tuple[type[MessageContent], ...]] = (
+           ToolUseMessage,
+       )
+
+       def transform(
+           self,
+           content: MessageContent,
+           meta: MessageMeta,
+       ) -> Optional[MessageContent]:
+           if not isinstance(content, ToolUseMessage):
+               return None  # defensive narrowing
+           if content.tool_name != "mcp__my_server__my_tool":
+               return None
+           return MyToolMessage(  # plugin-defined subclass; see §4
+               meta=content.meta,
+               input=content.input,
+               tool_use_id=content.tool_use_id,
+               tool_name=content.tool_name,
+               skill_body=content.skill_body,
+           )
+   ```
+
+4. **Write the message subclass.** Inherit from the matched type so
+   the [runtime contract](#7-runtime-contract-enforcement) accepts
+   your return value, then add `format_markdown` / `format_html` /
+   `title` methods. See [§4](#4-class-side-format--title-methods).
+
+5. **Install and run.** `pip install -e .` against your plugin
+   package; the next `claude-code-log` invocation discovers it.
+
+6. **Test it.** See [§9](#9-testing-your-plugin) for layer-by-layer
+   coverage suggestions.
+
+The reference plugin demonstrates both branches of the contract:
+
+- [`hook_demotion.py`](../test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/hook_demotion.py)
+  — rewrite a `UserTextMessage` based on text-prefix match.
+- [`tool_communicate.py`](../test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/tool_communicate.py)
+  — rewrite a `ToolUseMessage` based on `tool_name`.
+
+Read both before writing your own; together they cover ~95 % of the
+shapes a real plugin needs.
+
+---
+
+## 3. The `MessageTransformer` Protocol
+
+Defined in [`claude_code_log/plugins.py`](../claude_code_log/plugins.py).
+Three required `ClassVar` attributes plus one method:
+
+| Attribute / method | Type | Purpose |
+|---|---|---|
+| `name` | `ClassVar[str]` | Stable identifier surfaced in startup logs and collision warnings. Convention: `"<package>.<thing>"`. |
+| `priority` | `ClassVar[int]` | Sort key for the transformer chain. Lower runs first. Use the constants in [`factories/priorities.py`](../claude_code_log/factories/priorities.py) to position yourself relative to other plugins. |
+| `applies_to` | `ClassVar[tuple[type[MessageContent], ...]]` | The MRO filter: this transformer is asked only about candidates that are instances (via `isinstance`) of one of these classes. |
+| `transform(content, meta)` | `(MessageContent, MessageMeta) -> Optional[MessageContent]` | Inspect `content`; return a replacement, or `None` to pass through. |
+
+The Protocol is `runtime_checkable`, but `runtime_checkable` only
+verifies *methods*. The loader explicitly validates the three
+`ClassVar`s — missing or malformed metadata triggers a `WARNING` log
+and the plugin is silently dropped (the rest of `claude-code-log`
+keeps working).
+
+The class does NOT need to inherit from `MessageTransformer`. Any
+class matching the structural shape is accepted, which keeps plugins
+free of an import-time dependency on the Protocol object.
+
+---
+
+## 4. Class-side `format` / `title` methods
+
+Plugin-defined `MessageContent` subclasses carry their own render
+methods on the class itself (rather than on the renderer). The
+renderer's dispatcher consults them after the renderer's own
+`format_<ClassName>` methods (see [§5](#5-dispatch-resolution-order)).
+
+```python
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+from claude_code_log.models import DetailLevel, ToolUseMessage
+
+@dataclass
+class MyToolMessage(ToolUseMessage):
+    """Plugin-defined subclass; carries its own render methods."""
+
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
+
+    def format_markdown(self, _renderer, _message) -> str:
+        action = (self.input.input or {}).get("action", "?")
+        return f"_(my plugin) action={action}_"
+
+    def format_html(self, _renderer, _message) -> Optional[str]:
+        return None  # fall back to mistune(format_markdown)
+
+    def title(self, _renderer, _message) -> Optional[str]:
+        return "✉ my plugin"
+```
+
+Signature contract for each method:
+
+| Method | Signature | Return | Notes |
+|---|---|---|---|
+| `format_markdown` | `(self, renderer, message) -> str` | Markdown source string. | Always provide this; HTML can fall back to it. |
+| `format_html` | `(self, renderer, message) -> Optional[str]` | Raw HTML or `None`. | Returning `None` runs `format_markdown` through mistune. Most plugins do this. |
+| `title` | `(self, renderer, message) -> Optional[str]` | Heading text or `None`. | Return `None` for "headless" (inline) messages. Return `""` (empty string, not None) to suppress the heading explicitly — the dispatcher distinguishes the two. |
+
+The dispatcher looks up these methods on each MRO node's `__dict__`
+explicitly (not via `getattr`/inheritance). That means: **a class
+opts in by defining the method ON the class itself**. Inheriting
+`format_markdown` from a parent does NOT auto-enable dispatch for
+the subclass; the subclass must define its own or the MRO walk
+moves to the next ancestor.
+
+---
+
+## 5. Dispatch resolution order
+
+`Renderer._dispatch_format` and `_dispatch_title` (both in
+[`renderer.py`](../claude_code_log/renderer.py)) walk
+`type(obj).__mro__`, asking two questions at each node:
+
+| Strategy | Lookup | Caller signature |
+|---|---|---|
+| **1. Renderer-side** | `getattr(self, f"format_{cls.__name__}", None)` | `method(obj, message)` |
+| **2. Class-side** | `cls.__dict__.get(method_attr)` where `method_attr = f"format_{self._class_dispatch_format}"` | `method(obj, self, message)` |
+
+Strategy 1 wins per MRO node — the existing `format_BashInput`,
+`format_ToolUseMessage`, etc. on `HtmlRenderer`/`MarkdownRenderer`
+keep working unchanged. Strategy 2 is what plugins use.
+
+`_class_dispatch_format` is `"markdown"` on the base `Renderer` and
+overridden to `"html"` on `HtmlRenderer`. That's how the HTML
+renderer picks up your class-side `format_html` while the Markdown
+renderer ignores it and picks up `format_markdown`.
+
+**To shadow a built-in renderer method from a plugin**, define the
+class-side method on the *plugin subclass* — the MRO walk visits
+the plugin subclass before the built-in's renderer-side method, so
+Strategy 1 at the plugin subclass's name (which the renderer
+doesn't have) fails, Strategy 2 on the plugin subclass hits, and
+the dispatcher never reaches the parent's renderer-side method.
+
+`title_content` (the entry point for message headings) delegates to
+`_dispatch_title` for the same reason — without delegation, a
+`title_ToolUseMessage` on the base renderer would shadow your
+class-side `title()` at the top level.
+
+---
+
+## 6. `detail_visibility`
+
+`claude-code-log` filters messages per the `--detail` flag. Levels
+in order of decreasing verbosity:
+
+```
+FULL > HIGH > LOW > MINIMAL > USER_ONLY
+```
+
+Your plugin class declares a `ClassVar[DetailLevel]` to opt into
+class-based visibility:
+
+```python
+detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
+```
+
+**Semantics: monotone-down.** The message is visible iff the
+current detail level is *at least as verbose as* the declared
+minimum. With the ordering above:
+
+| Declared | Visible at |
+|---|---|
+| `FULL` | `FULL` only |
+| `HIGH` | `FULL`, `HIGH` |
+| `LOW` | `FULL`, `HIGH`, `LOW` |
+| `MINIMAL` | `FULL`, `HIGH`, `LOW`, `MINIMAL` |
+| `USER_ONLY` | all levels |
+
+The order is pinned in a `_DETAIL_ORDER` map in `renderer.py` (so a
+future reorder of the enum can't silently flip semantics), guarded
+by a module-load assertion that every `DetailLevel` value is mapped.
+
+**Opt-in nature.** Plugin classes that declare `detail_visibility`
+bypass the legacy `_HIGH_EXCLUDE_CLASSES` / `_LOW_KEEP_TOOLS`
+registries entirely — your declaration is authoritative. A plugin
+class that inherits from a built-in (e.g. `MyToolMessage(ToolUseMessage)`)
+but does NOT declare `detail_visibility` inherits the built-in's
+filter membership through the bridge.
+
+**Practical guide.** Pick based on user-perceived value:
+
+- `FULL` only — debug/dev signal that clutters normal viewing.
+- `HIGH` — interesting but optional; user has opted into detail.
+- `LOW` — should appear in the default summary view (the typical
+  choice for tool-rendering plugins; bypasses the `_LOW_KEEP_TOOLS`
+  allowlist that core would otherwise check).
+- `MINIMAL` — essential context (sparingly).
+- `USER_ONLY` — visible even in user-only views (almost never the
+  right choice for a tool/hook plugin; reserved for user-originated
+  content).
+
+---
+
+## 7. Runtime contract enforcement
+
+`apply_transformers` (in `plugins.py`) enforces two contracts at
+runtime; both surface as `WARNING` logs and pass-through:
+
+1. **Exception safety.** If `transform()` raises, the exception is
+   logged and the candidate falls through to the next transformer.
+   A buggy plugin cannot crash the whole conversion.
+
+2. **Return-type enforcement.** The replacement must satisfy
+   `isinstance(replacement, transformer.applies_to)`. A
+   `UserTextMessage`-targeting transformer returning a
+   `SystemMessage` (or worse, a string / dict) is rejected with a
+   warning. **In practice, this means your replacement class must
+   subclass one of the `applies_to` types** — not sit as a sibling.
+
+   The reference `TestHookNotificationMessage` is a `UserTextMessage`
+   subclass (not a bare `MessageContent` sibling) for exactly this
+   reason. The inherited `items` field stays empty if your class
+   carries the parsed data in dedicated fields.
+
+`transform()` returning `None` means "not my case"; the dispatcher
+moves to the next matching transformer. This is the right return
+value for a "specific tool name" filter pattern (see
+`tool_communicate.py`).
+
+---
+
+## 8. Discovery and ordering
+
+### 8.1 Entry-point group
+
+Plugins are discovered via the entry-point group:
+
+```toml
+[project.entry-points."claude_code_log.plugins"]
+my_thing = "my_plugin.transformers.thing:MyTransformer"
+```
+
+The loader (`load_transformers` in `plugins.py`) is process-scoped
+and cached. Tests call `reset_cache()` to force re-discovery.
+
+### 8.2 Priority ordering
+
+Transformers are sorted by `(priority, __module__, __qualname__)`:
+
+- **Primary key: `priority` (int).** Lower runs earlier. The
+  built-in priority constants in
+  [`factories/priorities.py`](../claude_code_log/factories/priorities.py)
+  describe notional positions on a numeric scale. Plugins position
+  themselves relative to these without core renumbering:
+
+  ```
+  COMMAND_MESSAGE        = 100
+  LOCAL_COMMAND_OUTPUT   = 200
+  BASH_INPUT_OUTPUT      = 300
+  TEAMMATE_MESSAGE       = 400
+  TASK_NOTIFICATION      = 500
+  HOOK_NOTIFICATION      = 600
+  SLASH_COMMAND_ISMETA   = 700
+  TEXT_FALLBACK          = 1000
+  TOOL_INPUT_GENERIC     = 5000
+  TOOL_OUTPUT_GENERIC    = 5100
+  ```
+
+  Gaps of 100 leave room for plugin insertion. Use the constant
+  (`TOOL_INPUT_GENERIC - 500`) rather than a literal so a future
+  core renumber stays consistent.
+
+- **Tie-breakers: `__module__`, `__qualname__`.** Deterministic
+  cross-environment ordering when two plugins land at the same
+  priority but in different packages. A `(priority, applies_to)`
+  collision still triggers a `WARNING` so you can detect overlap.
+
+**Important caveat about v1 semantics.** In v1, plugin transformers
+run as a **post-classification pass**: the built-in factory chain
+classifies every entry first, *then* the priority-ordered plugin
+list runs. So the priority ordering applies *among plugins*, not
+against the built-in classifiers (which have already finished by
+the time your plugin sees a candidate). The RFC's "interleaved with
+built-in detectors" framing is a v2 consideration; v1's
+post-classification scope covers every documented use case (clmail
+hook-demotion, MCP tool rendering) because plugins always operate
+on a candidate the built-in chain has classified (typically as
+`UserTextMessage` or generic `ToolUseMessage`).
+
+### 8.3 First non-`None` wins
+
+`apply_transformers` walks the priority-sorted list, asks each
+matching transformer (via `applies_to`), and returns the first
+non-`None` reply. A transformer that returns `None` for a candidate
+lets the next matching transformer try — this is the natural way to
+say "specific filter inside a broad `applies_to`".
+
+---
+
+## 9. Testing your plugin
+
+The plugin system ships with a four-layer test strategy in
+[`test/test_plugin_system.py`](../test/test_plugin_system.py); your
+own plugin should follow the same shape:
+
+| Layer | What it covers | How to write yours |
+|---|---|---|
+| **1. Loader unit** | Validator rejects malformed metadata; sort and tie-break warnings | Usually skip for a normal plugin — the core tests cover this. |
+| **2. Dispatch matrix** | Renderer-side vs class-side resolution; HTML vs Markdown output | Skip unless your plugin does something exotic with the dispatcher. |
+| **3. Transformer integration** | End-to-end: real `MessageContent` through your `transform()` and class-side render methods | Always write this. Drive your transformer with hand-built `MessageMeta.empty()` candidates; assert the replacement is an instance of your subclass and that the render methods return the expected text. |
+| **4. Text-equivalence** | If your plugin reads `UserTextMessage.items`, assert that the joined text matches what the factory's `extract_text_content` produces | Recommended for any plugin keying on user text — protects you against future core refactors that sneak normalization between extraction and the items list. |
+
+For an installable test plugin (your own or a fixture in your own
+repo), declare it as an editable dev-dependency and reset the loader
+cache in a test fixture:
+
+```python
+@pytest.fixture(autouse=True)
+def _reset_plugin_cache():
+    from claude_code_log.plugins import reset_cache
+    reset_cache()
+    yield
+    reset_cache()
+```
+
+To inject a plugin directly (bypassing entry-point discovery — useful
+for exception-safety tests):
+
+```python
+import claude_code_log.plugins as plugins
+plugins._cached_transformers = [MyTransformer()]
+```
+
+Always reset the cache in a `try/finally` or via the autouse fixture
+to avoid leaking state across tests.
+
+---
+
+## 10. Common patterns and pitfalls
+
+**Defensive narrowing in `transform`.** Even though `applies_to`
+filters the dispatch, write `if not isinstance(content, MyType):
+return None` as the first line. It costs nothing, makes the body's
+type-narrowing explicit to readers and to mypy/pyright, and survives
+a future plugin author copy-pasting your code with the wrong
+`applies_to`.
+
+**`format_html` returning `None`.** Most plugins should return `None`
+to fall back to mistune-rendered Markdown. Write a custom
+`format_html` only when the Markdown formulation can't capture what
+you want (e.g. embedded SVG, complex tables that mistune mangles).
+
+**Don't escape Markdown manually for code spans.** Backslashes do not
+escape backticks inside inline code spans (CommonMark explicit). If
+you embed user input in `` `...` ``, count the longest backtick run
+in the value and use a fence one tick longer. See `_inline_code` in
+`markdown/renderer.py` for the helper.
+
+**Inheriting from a built-in is mandatory for return-type
+enforcement.** A sibling `MessageContent` subclass will be rejected
+by `apply_transformers`. If you don't need the parent class's
+fields, set them with defaults (`items: list = field(default_factory=list)`)
+and ignore them in your render methods — that's what
+`TestHookNotificationMessage` does.
+
+**Priority constants, not literals.** Hard-coded `400` looks fine
+until core renumbers `TEAMMATE_MESSAGE` to `350` and your plugin
+silently changes order. Import from `factories.priorities`.
+
+**Cache invalidation in tests.** Every test that adds, removes, or
+modifies plugins (including injecting directly via
+`_cached_transformers`) must `reset_cache()` afterward — process-wide
+state otherwise leaks across tests.
+
+**`detail_visibility` is checked via `hasattr` for the LOW keep-list
+opt-out.** This means inheriting `detail_visibility` from a future
+core-migrated parent class behaves the same as declaring it
+yourself: the keep-list is bypassed. Usually what you want; mention
+it if you're debugging a "why is my plugin visible at LOW even though
+the tool isn't in `_LOW_KEEP_TOOLS`?" question.
+
+---
+
+## 11. Reference
+
+| Surface | Location |
+|---|---|
+| Protocol + loader + dispatch | [`claude_code_log/plugins.py`](../claude_code_log/plugins.py) |
+| Priority constants | [`claude_code_log/factories/priorities.py`](../claude_code_log/factories/priorities.py) |
+| Renderer dispatch | `Renderer._dispatch_format`, `Renderer._dispatch_title`, `HtmlRenderer._class_dispatch_format` in [`renderer.py`](../claude_code_log/renderer.py) / [`html/renderer.py`](../claude_code_log/html/renderer.py) |
+| Visibility filter | `_content_visible_at`, `_filter_template_by_detail`, `_DETAIL_ORDER` in [`renderer.py`](../claude_code_log/renderer.py) |
+| Reference plugin (canonical example) | [`test/_plugins/clmail/`](../test/_plugins/clmail/) + [`README.md`](../test/_plugins/clmail/README.md) |
+| Test suite (four layers) | [`test/test_plugin_system.py`](../test/test_plugin_system.py) |
+| Design discussion | [`work/tool-renderer-plugins.md`](../work/tool-renderer-plugins.md) |
+
+---
+
+## 12. v2 directions (informational)
+
+Out of scope for v1; mentioned here so contributors don't keep
+re-rediscovering them:
+
+- **Interleaved dispatch.** Let plugins run *between* built-in
+  detectors (e.g. before the generic `TextFallback` classifier), so
+  a plugin can claim a `UserTextMessage` before the built-in chain
+  has decided. Needs a redesign of the factory loop to call into
+  the plugin chain at each detector boundary.
+- **Renderer-side plugin extension.** Today only `MessageContent`
+  subclasses participate; a v2 plugin could contribute renderer-side
+  `format_<X>` methods for an existing core class without
+  subclassing. Lower priority — class-side dispatch already covers
+  90 % of the use cases.
+- **Priority namespacing.** A `priority: ClassVar[int]` is global;
+  large plugin ecosystems may want per-plugin priority namespaces
+  with explicit ordering hints (e.g. `before=other_plugin`). Not
+  needed at current scale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,4 +125,11 @@ dev = [
     "ty>=0.0.11",
     "pytest-playwright>=0.7.0",
     "syrupy>=5.0.0",
+    # Reference test plugin for the plugin-system test suite. Doubles as
+    # the canonical example for third-party plugin authors. See
+    # test/_plugins/clmail/README.md.
+    "claude-code-log-clmail-test",
 ]
+
+[tool.uv.sources]
+claude-code-log-clmail-test = { path = "test/_plugins/clmail", editable = true }

--- a/test/_plugins/clmail/README.md
+++ b/test/_plugins/clmail/README.md
@@ -1,0 +1,66 @@
+# Reference Test Plugin for `claude-code-log`
+
+This package is the layer-4 fixture for the plugin-system test suite
+**and** the canonical reference for third-party plugin authors. The
+two roles are intentionally combined per the RFC's
+`## Test-embedded reference plugin` section: tests against a real
+plugin (vs. mocks) give much higher confidence in the contract, and
+living code can't drift from the spec.
+
+## Layout
+
+```
+claude_code_log_clmail_test/
+├── __init__.py
+└── transformers/
+    ├── __init__.py
+    ├── hook_demotion.py        # UserTextMessage rewrite by text-prefix
+    └── tool_communicate.py     # ToolUseMessage rewrite by tool_name
+```
+
+## Entry-point declarations
+
+```toml
+[project.entry-points."claude_code_log.plugins"]
+testhook_demotion       = "claude_code_log_clmail_test.transformers.hook_demotion:TestHookDemotion"
+tool_clmail_communicate = "claude_code_log_clmail_test.transformers.tool_communicate:ClmailCommunicateInputTransformer"
+```
+
+Each `MessageTransformer` class declares:
+
+| ClassVar     | Purpose                                                                   |
+|--------------|---------------------------------------------------------------------------|
+| `name`       | Stable identifier surfaced in startup logs and collision warnings.        |
+| `priority`   | Integer; lower = runs earlier. Use module constants from `factories.priorities`. |
+| `applies_to` | Tuple of `MessageContent` subclasses the transformer matches via MRO.     |
+
+Plus a `transform(content, meta) -> Optional[MessageContent]` method
+that returns a replacement (or `None` to pass through).
+
+## Class-side format / title methods
+
+Plugin-defined `MessageContent` subclasses carry their own
+`format_markdown(self, renderer, message)`,
+`format_html(self, renderer, message)`, and
+`title(self, renderer, message)` methods. The renderer's
+`_dispatch_format` walks the MRO and consults these methods after
+exhausting the renderer-side `format_<ClassName>` chain (Strategy 2
+in the RFC). Returning `None` from `format_html` falls back to
+`mistune(format_markdown)` — consistent with the rest of the codebase.
+
+## `detail_visibility`
+
+A `ClassVar[DetailLevel]` on the plugin's `MessageContent` subclass
+declares the minimum detail level at which the message is rendered.
+Monotone-down: a message is visible iff `current_detail` is at least
+as verbose as `detail_visibility` (with `FULL` most verbose,
+`USER_ONLY` least). Plugin classes that opt into a class attribute
+bypass the legacy `_HIGH_EXCLUDE_CLASSES` / `_LOW_KEEP_TOOLS` logic
+entirely.
+
+## Installing this fixture for tests
+
+The test suite installs this package in editable mode via
+`uv pip install -e test/_plugins/clmail` during pytest collection
+(see `test/conftest.py`). Production installs of `claude-code-log`
+don't see it; only CI and local test runs do.

--- a/test/_plugins/clmail/pyproject.toml
+++ b/test/_plugins/clmail/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "claude-code-log-clmail-test"
+version = "0.0.1"
+description = "Test fixture plugin for claude-code-log's plugin system. Doubles as the canonical reference for plugin authors."
+requires-python = ">=3.10"
+dependencies = []
+
+[project.entry-points."claude_code_log.plugins"]
+# Hook-style transformer: rewrite UserTextMessage entries matching
+# a "[testhook]" prefix into a TaskNotificationMessage so the test
+# can observe the rewrite at the renderer.
+testhook_demotion = "claude_code_log_clmail_test.transformers.hook_demotion:TestHookDemotion"
+
+# Tool-style transformer: rewrite ToolUseMessage entries for a
+# specific MCP tool name into a plugin-defined subclass that
+# carries its own class-side format_markdown / format_html / title
+# methods (exercises Strategy 2 of _dispatch_format).
+tool_clmail_communicate = "claude_code_log_clmail_test.transformers.tool_communicate:ClmailCommunicateInputTransformer"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/claude_code_log_clmail_test"]

--- a/test/_plugins/clmail/src/claude_code_log_clmail_test/__init__.py
+++ b/test/_plugins/clmail/src/claude_code_log_clmail_test/__init__.py
@@ -1,0 +1,18 @@
+"""Reference test plugin for claude-code-log.
+
+Demonstrates both transformer-shape capabilities described in
+``work/tool-renderer-plugins.md``:
+
+- ``transformers.hook_demotion`` — UserTextMessage rewrite by text-prefix
+  match, returning an existing core MessageContent variant
+  (TaskNotificationMessage) so the test can observe the demotion.
+
+- ``transformers.tool_communicate`` — ToolUseMessage rewrite for a
+  specific MCP tool name, producing a plugin-defined subclass that
+  carries its own class-side format_markdown / format_html / title
+  methods (exercises Strategy 2 of _dispatch_format).
+
+This is intentionally minimal — the goal is contract coverage, not
+realistic clmail rendering. A real clmail plugin would target
+``mcp__plugin_clmail_clmail__communicate`` and ship richer formatters.
+"""

--- a/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/__init__.py
+++ b/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/__init__.py
@@ -1,0 +1,1 @@
+"""Transformer classes for the test plugin."""

--- a/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/hook_demotion.py
+++ b/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/hook_demotion.py
@@ -26,8 +26,19 @@ from claude_code_log.models import (
 
 
 @dataclass
-class TestHookNotificationMessage(MessageContent):
-    """Plugin-defined typed wrapper for ``[testhook] ...`` user turns."""
+class TestHookNotificationMessage(UserTextMessage):
+    """Plugin-defined typed wrapper for ``[testhook] ...`` user turns.
+
+    Subclasses ``UserTextMessage`` (not bare ``MessageContent``) so the
+    runtime contract in ``apply_transformers`` accepts it: a transformer
+    with ``applies_to=(UserTextMessage,)`` MUST return an instance of
+    that class or a subclass. Sibling rewrites would be rejected.
+
+    The inherited ``items`` field is set to an empty list by default;
+    this class carries the parsed ``source`` and ``text`` separately,
+    so ``items`` is unused at render time (the class-side
+    ``format_markdown`` reads ``self.source`` / ``self.text`` directly).
+    """
 
     source: str = ""
     text: str = ""
@@ -77,10 +88,17 @@ class TestHookDemotion:
         text = "\n".join(
             getattr(item, "text", "") for item in content.items if hasattr(item, "text")
         )
+        # Multi-line guard — checked on the *whole* text, before regex.
+        # The pattern's ``\s*`` after ``[testhook]`` would otherwise
+        # consume a newline immediately after the marker, hiding the
+        # multi-line shape from the post-match ``"\n" in m.group(1)``
+        # check. Real human prompts that happen to start with
+        # ``[testhook]`` and continue on the next line pass through
+        # unchanged.
+        if "\n" in text:
+            return None
         m = _PATTERN.match(text)
-        if m is None or "\n" in m.group(1):
-            # Multi-line guard: real human prompts that happen to start
-            # with [testhook] pass through unchanged.
+        if m is None:
             return None
         return TestHookNotificationMessage(
             meta=meta, source="testhook", text=m.group(1)

--- a/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/hook_demotion.py
+++ b/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/hook_demotion.py
@@ -1,0 +1,87 @@
+"""Hook-demotion transformer: rewrite UserTextMessage by text-prefix match.
+
+Exercises the user-side branch of the plugin contract:
+
+- ``applies_to = (UserTextMessage,)`` MRO filter
+- Reads ``content.items`` to access the user's text
+- Returns a plugin-defined ``MessageContent`` subclass
+- The subclass declares ``detail_visibility`` and carries its own
+  ``format_markdown`` / ``title`` methods (Strategy 2 of
+  ``_dispatch_format``)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from claude_code_log.factories.priorities import HOOK_NOTIFICATION
+from claude_code_log.models import (
+    DetailLevel,
+    MessageContent,
+    MessageMeta,
+    UserTextMessage,
+)
+
+
+@dataclass
+class TestHookNotificationMessage(MessageContent):
+    """Plugin-defined typed wrapper for ``[testhook] ...`` user turns."""
+
+    source: str = ""
+    text: str = ""
+
+    # Plugin-owned visibility: dropped at HIGH and below.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
+    @property
+    def message_type(self) -> str:
+        return "test_hook_notification"
+
+    # Class-side format/title methods (Strategy 2 of _dispatch_format).
+    # The dispatcher calls these with (self, renderer, message) when no
+    # renderer-side method shadows them.
+    def format_markdown(self, _renderer, _message) -> str:
+        return f"*[{self.source}] {self.text}*"
+
+    def format_html(self, _renderer, _message) -> Optional[str]:
+        # Return None to fall back to mistune(format_markdown).
+        return None
+
+    def title(self, _renderer, _message) -> Optional[str]:
+        # Headless — appears inline.
+        return None
+
+
+_PATTERN = re.compile(r"^\s*\[testhook\]\s*(.*?)\s*\Z", re.DOTALL)
+
+
+class TestHookDemotion:
+    """Match ``[testhook] <body>`` user turns; demote to a plugin class."""
+
+    name: ClassVar[str] = "test.hook-demotion"
+    priority: ClassVar[int] = HOOK_NOTIFICATION
+    applies_to: ClassVar[tuple[type[MessageContent], ...]] = (UserTextMessage,)
+
+    def transform(
+        self,
+        content: MessageContent,
+        meta: MessageMeta,
+    ) -> Optional[MessageContent]:
+        # Defensive: should always be true given applies_to, but the
+        # transformer protocol allows any MessageContent so we narrow.
+        if not isinstance(content, UserTextMessage):
+            return None
+        # Reconstruct the joined text from the user's content items.
+        text = "\n".join(
+            getattr(item, "text", "") for item in content.items if hasattr(item, "text")
+        )
+        m = _PATTERN.match(text)
+        if m is None or "\n" in m.group(1):
+            # Multi-line guard: real human prompts that happen to start
+            # with [testhook] pass through unchanged.
+            return None
+        return TestHookNotificationMessage(
+            meta=meta, source="testhook", text=m.group(1)
+        )

--- a/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/tool_communicate.py
+++ b/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/tool_communicate.py
@@ -66,7 +66,13 @@ class ClmailCommunicateInputTransformer:
     """Specialize ToolUseMessage for the test clmail communicate tool."""
 
     name: ClassVar[str] = "test.clmail.communicate.input"
-    # Run before generic tool classification (smaller number = earlier).
+    # Smaller number = earlier in the transformer chain. Under the v1
+    # post-classification implementation, this orders us against other
+    # transformers (not against built-in classifiers, which have already
+    # run). TOOL_INPUT_GENERIC is the priority slot conceptually
+    # associated with the generic ToolUseMessage classification; we
+    # sit 500 units before it so a future plugin targeting the same
+    # tool at TOOL_INPUT_GENERIC would lose to us.
     priority: ClassVar[int] = TOOL_INPUT_GENERIC - 500
     applies_to: ClassVar[tuple[type[MessageContent], ...]] = (ToolUseMessage,)
 

--- a/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/tool_communicate.py
+++ b/test/_plugins/clmail/src/claude_code_log_clmail_test/transformers/tool_communicate.py
@@ -1,0 +1,90 @@
+"""Tool-rendering transformer: specialize a ToolUseMessage for a known MCP tool.
+
+Exercises the tool-side branch of the plugin contract:
+
+- ``applies_to = (ToolUseMessage,)`` MRO filter
+- Narrows by ``content.tool_name`` inside ``transform()``
+- Returns a plugin-defined subclass of ``ToolUseMessage`` carrying its
+  own class-side ``format_markdown`` / ``title`` methods
+- The plugin subclass declares ``detail_visibility = LOW`` so it
+  shows up at ``--detail low`` without core needing to update
+  ``_LOW_KEEP_TOOLS``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from claude_code_log.factories.priorities import TOOL_INPUT_GENERIC
+from claude_code_log.models import (
+    DetailLevel,
+    MessageContent,
+    MessageMeta,
+    ToolUseMessage,
+)
+
+
+# The specific MCP tool name this transformer claims. The real clmail
+# plugin would use ``mcp__plugin_clmail_clmail__communicate``; we use
+# a test-fixture name to avoid colliding with any real tool that test
+# fixtures might emit.
+TOOL_NAME = "mcp__test_plugin__clmail__communicate"
+
+
+@dataclass
+class TestClmailCommunicateInputMessage(ToolUseMessage):
+    """Plugin-defined ToolUseMessage subclass with class-side formatters."""
+
+    # Plugin-owned visibility: visible at --detail low (the user-relevant
+    # default for "show me clmail-style mail-handling activity"). Bypasses
+    # the core _LOW_KEEP_TOOLS allowlist.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
+
+    def format_markdown(self, _renderer, _message) -> str:
+        # Pull the action out of the parsed input (or the raw input dict).
+        raw_input = getattr(self.input, "input", None)
+        if isinstance(raw_input, dict):
+            action = raw_input.get("action", "?")
+        else:
+            action = "?"
+        return f"_(test) ClMail communicate action={action}_"
+
+    def format_html(self, _renderer, _message) -> Optional[str]:
+        return None  # fall back to mistune(format_markdown)
+
+    def title(self, _renderer, _message) -> Optional[str]:
+        raw_input = getattr(self.input, "input", None)
+        if isinstance(raw_input, dict):
+            action = raw_input.get("action", "?")
+        else:
+            action = "?"
+        return f"✉ ClMail communicate · {action}"
+
+
+class ClmailCommunicateInputTransformer:
+    """Specialize ToolUseMessage for the test clmail communicate tool."""
+
+    name: ClassVar[str] = "test.clmail.communicate.input"
+    # Run before generic tool classification (smaller number = earlier).
+    priority: ClassVar[int] = TOOL_INPUT_GENERIC - 500
+    applies_to: ClassVar[tuple[type[MessageContent], ...]] = (ToolUseMessage,)
+
+    def transform(
+        self,
+        content: MessageContent,
+        _meta: MessageMeta,
+    ) -> Optional[MessageContent]:
+        if not isinstance(content, ToolUseMessage):
+            return None
+        if content.tool_name != TOOL_NAME:
+            return None
+        # Build a new instance carrying the same field values; the
+        # plugin subclass's class-side formatters take over at render.
+        return TestClmailCommunicateInputMessage(
+            meta=content.meta,
+            input=content.input,
+            tool_use_id=content.tool_use_id,
+            tool_name=content.tool_name,
+            skill_body=content.skill_body,
+        )

--- a/test/test_plugin_system.py
+++ b/test/test_plugin_system.py
@@ -144,11 +144,17 @@ class TestSortAndWarn:
     """``_sort_and_warn`` orders by (priority, module, qualname) and warns on ties."""
 
     def test_sorts_by_priority(self):
-        a = _GoodTransformer()
-        a.__class__.priority = 100  # shadow ClassVar for the test instance
-        b = _GoodTransformer()
-        sorted_ = _sort_and_warn([b, a])
-        assert sorted_[0].priority <= sorted_[1].priority
+        # Use local subclasses so we don't mutate _GoodTransformer's
+        # module-level ClassVar (which would leak into other tests in
+        # the same worker via class identity).
+        class _Low(_GoodTransformer):
+            priority = 100
+
+        class _High(_GoodTransformer):
+            priority = 900
+
+        sorted_ = _sort_and_warn([_High(), _Low()])
+        assert [t.priority for t in sorted_] == [100, 900]
 
     def test_warns_on_priority_tie_same_applies_to(
         self, caplog: pytest.LogCaptureFixture
@@ -356,8 +362,9 @@ class TestHookDemotionTransformer:
     @reference_plugin_required
     def test_multiline_after_prefix_passes_through(self):
         """Multi-line guard: real human prompts that happen to start with
-        ``[testhook]`` aren't demoted. The pattern's body capture rejects
-        newlines, so transform() returns None and the candidate passes."""
+        ``[testhook]`` aren't demoted. Pattern-level body check rejects
+        newlines in the body, so transform() returns None and the
+        candidate passes."""
         from claude_code_log.factories.user_factory import create_user_message
 
         meta = MessageMeta.empty()
@@ -365,6 +372,23 @@ class TestHookDemotionTransformer:
         items = [TextContent(type="text", text=text)]
         result = create_user_message(meta, items, text)
 
+        assert isinstance(result, UserTextMessage)
+
+    @reference_plugin_required
+    def test_newline_immediately_after_prefix_passes_through(self):
+        """Regression for the variant where the newline comes right after
+        ``[testhook]`` with no body text on the prefix line. The
+        pattern's ``\\s*`` after the marker would otherwise consume the
+        newline and slip a multi-line prompt past a body-only guard.
+        The pre-regex whole-text newline check catches this shape."""
+        from claude_code_log.factories.user_factory import create_user_message
+
+        meta = MessageMeta.empty()
+        text = "[testhook]\nactual prompt body here"
+        items = [TextContent(type="text", text=text)]
+        result = create_user_message(meta, items, text)
+
+        # Must pass through — this is a real prompt, not a hook injection.
         assert isinstance(result, UserTextMessage)
 
 
@@ -427,6 +451,138 @@ class TestApplyTransformersExceptionSafety:
             assert "transform()" in caplog.text or "transform" in caplog.text
         finally:
             reset_cache()
+
+
+class TestApplyTransformersReturnTypeEnforcement:
+    """The runtime contract: transformer's return must be a MessageContent
+    that subclass-matches the transformer's applies_to. Wholly-unrelated
+    returns are rejected with a warning; the candidate flows through to
+    the next transformer (or out unchanged)."""
+
+    def test_non_message_content_return_is_rejected(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        class _ReturnsString:
+            name = "test.returns-string"
+            priority = 100
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return "not a MessageContent"
+
+        import claude_code_log.plugins as plugins
+
+        plugins._cached_transformers = [_ReturnsString()]
+        try:
+            with caplog.at_level(logging.WARNING):
+                msg = UserTextMessage(meta=MessageMeta.empty(), items=[])
+                result = apply_transformers(msg, msg.meta)
+            assert result is msg
+            assert "non-MessageContent" in caplog.text
+        finally:
+            reset_cache()
+
+    def test_off_target_message_content_return_is_rejected(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """A UserTextMessage-targeting transformer returning a
+        SystemMessage gets rejected: the return doesn't match
+        ``applies_to``, even though it IS a MessageContent."""
+        from claude_code_log.models import SystemMessage
+
+        class _ReturnsOffTarget:
+            name = "test.returns-off-target"
+            priority = 100
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return SystemMessage(meta=meta, level="info", text="off-target")
+
+        import claude_code_log.plugins as plugins
+
+        plugins._cached_transformers = [_ReturnsOffTarget()]
+        try:
+            with caplog.at_level(logging.WARNING):
+                msg = UserTextMessage(meta=MessageMeta.empty(), items=[])
+                result = apply_transformers(msg, msg.meta)
+            assert result is msg
+            assert "applies_to" in caplog.text
+        finally:
+            reset_cache()
+
+    def test_matching_subclass_return_is_accepted(self):
+        """A return that's a subclass of one of ``applies_to`` is
+        accepted (the typical plugin pattern)."""
+        from dataclasses import dataclass
+
+        @dataclass
+        class _PluginText(UserTextMessage):
+            tag: str = ""
+
+        class _ReturnsSubclass:
+            name = "test.returns-subclass"
+            priority = 100
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return _PluginText(meta=meta, items=[], tag="ok")
+
+        import claude_code_log.plugins as plugins
+
+        plugins._cached_transformers = [_ReturnsSubclass()]
+        try:
+            msg = UserTextMessage(meta=MessageMeta.empty(), items=[])
+            result = apply_transformers(msg, msg.meta)
+            assert isinstance(result, _PluginText)
+            assert result.tag == "ok"
+        finally:
+            reset_cache()
+
+
+class TestSortAndWarnNonAdjacentCollision:
+    """Tie detection groups by (priority, applies_to), so collisions are
+    caught even when a same-priority but different-applies_to transformer
+    sits between the collision partners in the sort order."""
+
+    def test_non_adjacent_collision_is_warned(self, caplog: pytest.LogCaptureFixture):
+        from claude_code_log.models import ToolUseMessage
+
+        # All at priority=600; module/qualname sort puts them in
+        # alphabetical order T_aaa, T_bbb, T_ccc. T_aaa and T_ccc share
+        # applies_to=(UserTextMessage,); T_bbb sits between them with
+        # applies_to=(ToolUseMessage,). The old pairwise-adjacent check
+        # would have missed the (T_aaa, T_ccc) tie.
+        class T_aaa:  # noqa: N801
+            name = "test.t-aaa"
+            priority = 600
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return None
+
+        class T_bbb:  # noqa: N801
+            name = "test.t-bbb"
+            priority = 600
+            applies_to = (ToolUseMessage,)
+
+            def transform(self, content, meta):
+                return None
+
+        class T_ccc:  # noqa: N801
+            name = "test.t-ccc"
+            priority = 600
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return None
+
+        with caplog.at_level(logging.WARNING):
+            _sort_and_warn([T_aaa(), T_bbb(), T_ccc()])
+
+        # The (T_aaa, T_ccc) collision must surface.
+        assert "T_aaa" in caplog.text
+        assert "T_ccc" in caplog.text
+        assert "priority tie" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_plugin_system.py
+++ b/test/test_plugin_system.py
@@ -1,0 +1,506 @@
+"""Tests for the plugin system (loader, dispatch, transformers, equivalence).
+
+Four layers per the RFC's ``## Test strategy`` section:
+
+1. Loader unit tests (mock entry points) — validate priority sort,
+   tie-break warnings, malformed plugin rejection.
+2. ``_dispatch_format`` resolution-order matrix — four cells
+   (renderer-method only, class-method only, both present, neither).
+3. Transformer integration — drive a fixture-shaped JSONL through
+   the factories with the test-embedded reference plugin discoverable;
+   assert the right plugin classes flow through and render correctly.
+4. Text-equivalence guarantee — walk the existing JSONL test corpus
+   and assert ``UserTextMessage.text``-like joining is byte-equivalent
+   to the factory's ``extract_text_content``.
+
+The test-embedded reference plugin (``test/_plugins/clmail/``) is
+installed via the ``claude-code-log-clmail-test`` dev-dependency. If
+it's missing, several tests below ``importorskip`` rather than fail —
+this keeps the test file useful even when the fixture isn't installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from claude_code_log.models import (
+    MessageContent,
+    MessageMeta,
+    TextContent,
+    UserTextMessage,
+)
+from claude_code_log.plugins import (
+    ENTRY_POINT_GROUP,
+    _sort_and_warn,
+    _validate_transformer_class,
+    apply_transformers,
+    load_transformers,
+    reset_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Loader unit tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DummyMessage(MessageContent):
+    """Minimal MessageContent subclass for transformer-output tests."""
+
+    label: str = ""
+
+
+class _GoodTransformer:
+    name: ClassVar[str] = "test.good"
+    priority: ClassVar[int] = 500
+    applies_to: ClassVar[tuple[type[MessageContent], ...]] = (UserTextMessage,)
+
+    def transform(
+        self, content: MessageContent, meta: MessageMeta
+    ) -> Optional[MessageContent]:
+        if isinstance(content, UserTextMessage):
+            return _DummyMessage(meta=meta, label="good")
+        return None
+
+
+class _BadNoName:
+    priority: ClassVar[int] = 500
+    applies_to: ClassVar[tuple[type[MessageContent], ...]] = (UserTextMessage,)
+
+    def transform(self, content, meta):
+        return None
+
+
+class _BadPriorityType:
+    name: ClassVar[str] = "test.bad-priority"
+    priority: ClassVar[str] = "high"  # not int
+    applies_to: ClassVar[tuple[type[MessageContent], ...]] = (UserTextMessage,)
+
+    def transform(self, content, meta):
+        return None
+
+
+class _BadAppliesToEmpty:
+    name: ClassVar[str] = "test.bad-empty"
+    priority: ClassVar[int] = 500
+    applies_to: ClassVar[tuple] = ()  # empty
+
+    def transform(self, content, meta):
+        return None
+
+
+class _BadAppliesToNotSubclass:
+    name: ClassVar[str] = "test.bad-not-subclass"
+    priority: ClassVar[int] = 500
+    applies_to: ClassVar[tuple] = (str,)  # not a MessageContent subclass
+
+    def transform(self, content, meta):
+        return None
+
+
+class _NoTransformMethod:
+    name: ClassVar[str] = "test.no-transform"
+    priority: ClassVar[int] = 500
+    applies_to: ClassVar[tuple[type[MessageContent], ...]] = (UserTextMessage,)
+    # no transform() method
+
+
+class TestValidator:
+    """``_validate_transformer_class`` rejects classes missing or malformed metadata."""
+
+    def test_good_class_passes(self):
+        assert _validate_transformer_class(_GoodTransformer, "test") is True
+
+    def test_missing_name(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            assert _validate_transformer_class(_BadNoName, "ep_x") is False
+        assert "name" in caplog.text
+
+    def test_priority_wrong_type(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            assert _validate_transformer_class(_BadPriorityType, "ep_x") is False
+        assert "priority" in caplog.text
+
+    def test_applies_to_empty(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            assert _validate_transformer_class(_BadAppliesToEmpty, "ep_x") is False
+        assert "applies_to" in caplog.text
+
+    def test_applies_to_not_subclass(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            assert (
+                _validate_transformer_class(_BadAppliesToNotSubclass, "ep_x") is False
+            )
+        assert "MessageContent" in caplog.text
+
+
+class TestSortAndWarn:
+    """``_sort_and_warn`` orders by (priority, module, qualname) and warns on ties."""
+
+    def test_sorts_by_priority(self):
+        a = _GoodTransformer()
+        a.__class__.priority = 100  # shadow ClassVar for the test instance
+        b = _GoodTransformer()
+        sorted_ = _sort_and_warn([b, a])
+        assert sorted_[0].priority <= sorted_[1].priority
+
+    def test_warns_on_priority_tie_same_applies_to(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        class T1:
+            name = "test.t1"
+            priority = 600
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return None
+
+        class T2:
+            name = "test.t2"
+            priority = 600
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                return None
+
+        with caplog.at_level(logging.WARNING):
+            _sort_and_warn([T1(), T2()])
+        assert "priority tie" in caplog.text
+
+
+class TestLoader:
+    """``load_transformers`` uses the entry-point group and caches results."""
+
+    def setup_method(self):
+        reset_cache()
+
+    def teardown_method(self):
+        reset_cache()
+
+    def test_entry_point_group_constant(self):
+        assert ENTRY_POINT_GROUP == "claude_code_log.plugins"
+
+    def test_cache_returns_same_list(self):
+        first = load_transformers()
+        second = load_transformers()
+        assert first is second
+
+    def test_force_reload_invalidates_cache(self):
+        first = load_transformers()
+        second = load_transformers(force_reload=True)
+        assert first is not second
+        # Same content though (no plugins changed between calls).
+        assert [type(t).__name__ for t in first] == [type(t).__name__ for t in second]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: _dispatch_format resolution-order matrix
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchResolution:
+    """Four-way matrix: renderer method × class method, each present/absent.
+
+    Per RFC §``_dispatch_format`` resolution order:
+    - renderer-side ``format_<ClassName>`` wins first
+    - class-side ``format_<output>`` second
+    - MRO walk continues
+    """
+
+    def _make_renderer(self, has_renderer_method: bool, output: str = "markdown"):
+        """Build a minimal Renderer that may or may not carry the
+        renderer-side method ``format_RendererSideContent``.
+        """
+        from claude_code_log.renderer import Renderer
+
+        class _TestRenderer(Renderer):
+            _class_dispatch_format = output
+
+            if has_renderer_method:
+
+                def format_RendererSideContent(self, content, message):  # noqa: N802
+                    return "RENDERER_WON"
+
+                def title_RendererSideContent(self, content, message):  # noqa: N802
+                    return "RENDERER_TITLE"
+
+        return _TestRenderer()
+
+    def _make_content(self, has_class_method: bool):
+        @dataclass
+        class RendererSideContent(MessageContent):
+            label: str = ""
+
+        if has_class_method:
+
+            def format_markdown(self, _renderer, _message):
+                return "CLASS_WON"
+
+            def title(self, _renderer, _message):
+                return "CLASS_TITLE"
+
+            RendererSideContent.format_markdown = format_markdown  # type: ignore[attr-defined]
+            RendererSideContent.title = title  # type: ignore[attr-defined]
+
+        return RendererSideContent(meta=MessageMeta.empty(), label="x")
+
+    def test_both_present_renderer_wins(self):
+        renderer = self._make_renderer(has_renderer_method=True)
+        content = self._make_content(has_class_method=True)
+        result = renderer._dispatch_format(content, MagicMock())
+        assert result == "RENDERER_WON"
+        title = renderer._dispatch_title(content, MagicMock())
+        assert title == "RENDERER_TITLE"
+
+    def test_renderer_only(self):
+        renderer = self._make_renderer(has_renderer_method=True)
+        content = self._make_content(has_class_method=False)
+        assert renderer._dispatch_format(content, MagicMock()) == "RENDERER_WON"
+
+    def test_class_only(self):
+        renderer = self._make_renderer(has_renderer_method=False)
+        content = self._make_content(has_class_method=True)
+        assert renderer._dispatch_format(content, MagicMock()) == "CLASS_WON"
+        assert renderer._dispatch_title(content, MagicMock()) == "CLASS_TITLE"
+
+    def test_neither_present_returns_empty(self):
+        renderer = self._make_renderer(has_renderer_method=False)
+        content = self._make_content(has_class_method=False)
+        assert renderer._dispatch_format(content, MagicMock()) == ""
+        assert renderer._dispatch_title(content, MagicMock()) is None
+
+    def test_html_renderer_picks_format_html_via_class_dispatch(self):
+        """HtmlRenderer subclass dispatches to class-side ``format_html``."""
+        from claude_code_log.html.renderer import HtmlRenderer
+
+        @dataclass
+        class HtmlContent(MessageContent):
+            label: str = ""
+
+        HtmlContent.format_html = (  # type: ignore[attr-defined]
+            lambda self, r, m: f"<p>{self.label}</p>"
+        )
+        HtmlContent.format_markdown = (  # type: ignore[attr-defined]
+            lambda self, r, m: f"_{self.label}_"
+        )
+
+        renderer = HtmlRenderer(image_export_mode="placeholder")
+        content = HtmlContent(meta=MessageMeta.empty(), label="hi")
+        # HTML renderer's _class_dispatch_format is "html" so format_html wins.
+        assert renderer._dispatch_format(content, MagicMock()) == "<p>hi</p>"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Transformer integration (uses the embedded reference plugin)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_cache():
+    """Each test gets a freshly-loaded plugin list."""
+    reset_cache()
+    yield
+    reset_cache()
+
+
+def _have_embedded_plugin() -> bool:
+    try:
+        import claude_code_log_clmail_test  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+reference_plugin_required = pytest.mark.skipif(
+    not _have_embedded_plugin(),
+    reason="test-embedded reference plugin not installed; run `uv sync`",
+)
+
+
+class TestHookDemotionTransformer:
+    """The test plugin's hook-demotion transformer rewrites
+    ``[testhook] ...`` UserTextMessage entries into a plugin-defined
+    typed wrapper."""
+
+    @reference_plugin_required
+    def test_matching_text_demotes_to_plugin_class(self):
+        from claude_code_log.factories.user_factory import create_user_message
+        from claude_code_log_clmail_test.transformers.hook_demotion import (
+            TestHookNotificationMessage,
+        )
+
+        meta = MessageMeta.empty()
+        items = [TextContent(type="text", text="[testhook] hello world")]
+        result = create_user_message(meta, items, "[testhook] hello world")
+
+        assert isinstance(result, TestHookNotificationMessage)
+        assert result.source == "testhook"
+        assert result.text == "hello world"
+
+    @reference_plugin_required
+    def test_nonmatching_text_passes_through(self):
+        from claude_code_log.factories.user_factory import create_user_message
+
+        meta = MessageMeta.empty()
+        items = [TextContent(type="text", text="just a normal user message")]
+        result = create_user_message(meta, items, "just a normal user message")
+
+        assert isinstance(result, UserTextMessage)
+
+    @reference_plugin_required
+    def test_multiline_after_prefix_passes_through(self):
+        """Multi-line guard: real human prompts that happen to start with
+        ``[testhook]`` aren't demoted. The pattern's body capture rejects
+        newlines, so transform() returns None and the candidate passes."""
+        from claude_code_log.factories.user_factory import create_user_message
+
+        meta = MessageMeta.empty()
+        text = "[testhook] foo\n\nactually please continue with X"
+        items = [TextContent(type="text", text=text)]
+        result = create_user_message(meta, items, text)
+
+        assert isinstance(result, UserTextMessage)
+
+
+class TestToolTransformerWithClassSideRender:
+    """Tool transformer + plugin class-side format methods exercised end-to-end."""
+
+    @reference_plugin_required
+    def test_specialized_class_renders_via_class_method(self):
+        from claude_code_log.markdown.renderer import MarkdownRenderer
+        from claude_code_log.models import ToolUseContent
+        from claude_code_log_clmail_test.transformers.tool_communicate import (
+            TOOL_NAME,
+            TestClmailCommunicateInputMessage,
+        )
+
+        # Match what the factory hands the transformer for an unknown
+        # tool: a ToolUseContent wrapping the raw input dict (no
+        # specialized Pydantic model was registered).
+        tu = ToolUseContent(
+            type="tool_use",
+            id="tu_x",
+            name=TOOL_NAME,
+            input={"action": "read", "params": {"id": 42}},
+        )
+        instance = TestClmailCommunicateInputMessage(
+            meta=MessageMeta.empty(),
+            input=tu,
+            tool_use_id="tu_x",
+            tool_name=TOOL_NAME,
+        )
+        renderer = MarkdownRenderer()
+        out = renderer._dispatch_format(instance, MagicMock())
+        assert "action=read" in out
+        title = renderer._dispatch_title(instance, MagicMock())
+        assert title is not None
+        assert "ClMail communicate" in title
+
+
+class TestApplyTransformersExceptionSafety:
+    """A buggy plugin's transform() exception is logged and skipped."""
+
+    def test_exception_is_caught(self, caplog: pytest.LogCaptureFixture):
+        class _Boom:
+            name = "test.boom"
+            priority = 100
+            applies_to = (UserTextMessage,)
+
+            def transform(self, content, meta):
+                raise RuntimeError("plugin bug")
+
+        # Inject directly into the cache to avoid touching entry_points.
+        import claude_code_log.plugins as plugins
+
+        plugins._cached_transformers = [_Boom()]
+        try:
+            with caplog.at_level(logging.WARNING):
+                msg = UserTextMessage(meta=MessageMeta.empty(), items=[])
+                result = apply_transformers(msg, msg.meta)
+            assert result is msg  # passed through
+            assert "transform()" in caplog.text or "transform" in caplog.text
+        finally:
+            reset_cache()
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: Text-equivalence guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestTextEquivalenceGuarantee:
+    """``UserTextMessage.text``-style joining must be byte-equivalent to
+    the factory's ``extract_text_content``.
+
+    A future factory PR that introduces normalization (markdown
+    cleanup, whitespace folding) between extraction and assignment
+    would silently break plugin regex behaviour. This test catches
+    that drift by walking the existing JSONL test corpus.
+    """
+
+    def test_extract_text_content_matches_joined_items_for_corpus(self, test_data_dir):
+        from claude_code_log.converter import load_transcript
+        from claude_code_log.factories.user_factory import _classify_user_message
+        from claude_code_log.parser import extract_text_content
+
+        # Use a handful of representative real-shape fixtures.
+        candidates = [
+            test_data_dir / "dag_simple.jsonl",
+            test_data_dir / "dag_fork.jsonl",
+            test_data_dir / "cron_tools.jsonl",
+        ]
+        present = [p for p in candidates if p.exists()]
+        if not present:
+            pytest.skip("no JSONL corpus available")
+
+        checked = 0
+        for path in present:
+            for entry in load_transcript(path):
+                # Only user entries with content_list make sense here.
+                content_list = getattr(getattr(entry, "message", None), "content", None)
+                if not content_list or not isinstance(content_list, list):
+                    continue
+                if getattr(entry, "type", None) != "user":
+                    continue
+
+                # Skip image-only or non-text content.
+                has_text = any(hasattr(item, "text") for item in content_list)
+                if not has_text:
+                    continue
+
+                text_content = extract_text_content(content_list)
+                result = _classify_user_message(
+                    MessageMeta.empty(),
+                    content_list,
+                    text_content,
+                    is_slash_command=False,
+                )
+                if not isinstance(result, UserTextMessage):
+                    continue  # Only the fallback path is in-scope.
+
+                # Reconstruct the joined text the way detectors do.
+                reconstructed = "\n".join(
+                    getattr(item, "text", "")
+                    for item in result.items
+                    if hasattr(item, "text")
+                )
+                # The two strings need not be byte-identical (IDE
+                # notifications etc. get extracted), but the text that
+                # the *detector* would have seen must equal text_content.
+                # Concretely: extract_text_content joins via "\n".
+                assert text_content == reconstructed or text_content.startswith(
+                    reconstructed[:50]
+                ), (
+                    f"text-equivalence drift in {path.name}: "
+                    f"factory saw {text_content[:80]!r}, "
+                    f"UserTextMessage carries {reconstructed[:80]!r}"
+                )
+                checked += 1
+
+        assert checked > 0, "no UserTextMessage candidates in test corpus"

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "claude-code-log-clmail-test" },
     { name = "coverage", extra = ["toml"] },
     { name = "pyright" },
     { name = "pytest" },
@@ -166,6 +167,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "claude-code-log-clmail-test", editable = "test/_plugins/clmail" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.3.5" },
@@ -178,6 +180,11 @@ dev = [
     { name = "ty", specifier = ">=0.0.11" },
     { name = "vulture", specifier = ">=2.14" },
 ]
+
+[[package]]
+name = "claude-code-log-clmail-test"
+version = "0.0.1"
+source = { editable = "test/_plugins/clmail" }
 
 [[package]]
 name = "click"


### PR DESCRIPTION
## Summary

Implements the unified message-transformer plugin system specified in `work/tool-renderer-plugins.md` (RFC merged in #166).

Five linear commits, each leaving `just ci` clean:

1. **Loader infrastructure** — `plugins.py` (Protocol, entry-point loader, priority sort with tie-break, exception-safe dispatch) + `factories/priorities.py` (public constants for built-in detector positions).
2. **Factory wiring** — `apply_transformers` pass after `create_user_message`, `create_tool_use_message`, `create_tool_result_message`.
3. **Renderer dispatch + visibility** — `_dispatch_format` / `_dispatch_title` two-strategy resolution (renderer-side wins, class-side fallback); `detail_visibility` class attribute with `_HIGH_EXCLUDE_CLASSES` bridge for built-ins.
4. **Test-embedded reference plugin** — `test/_plugins/clmail/` exercises both branches of the contract; doubles as the canonical author example. Installed via dev-dependency.
5. **Tests** — four layers (loader unit / dispatch matrix / transformer integration / text-equivalence on JSONL corpus).

Net diff: +1290 / -22, including the test plugin and 506 lines of tests.

## v1 scope notes

- Transformers run as a **post-classification** pass (deviation from the RFC's "interleaved with built-in detectors" framing, documented in the `plugins.py` module docstring). Same effect for every v1 use case because plugins always operate on a candidate that the built-in chain has already classified (typically `UserTextMessage` or generic `ToolUseMessage`).
- Built-in `MessageContent` subclasses retain their `_HIGH_EXCLUDE_CLASSES` membership in v1; migration to per-class `detail_visibility` attributes is mechanical follow-up.
- The plugin-defined classes in the reference plugin demonstrate the full contract: class-side `format_markdown` / `format_html` / `title` methods + `detail_visibility` declaration + `applies_to` MRO filter.

## Test plan

- [x] `just test` (1892 passed, 7 skipped — includes 21 new plugin tests)
- [x] `just ci` clean (format + test-all + lint + pyright + ty)
- [ ] Monk review pass
- [ ] User ack for merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin system for post-classification message transformers with numeric priority constants and deterministic ordering.
  * Transformers are applied to user and tool messages so plugins can specialize content, formatting, and titles.
  * Renderer dispatch now honors per-content detail visibility and class-side formatting/title handlers.

* **Documentation**
  * Developer guide and architecture docs for the plugin system and authoring guidance.

* **Tests**
  * End-to-end test suite covering loader, dispatch, transformer integration, and robustness (exceptions, return-type enforcement, caching).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->