### PR TITLE
Remove vestigial progress-chain parent repair

### DIFF
--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -114,51 +114,6 @@ def get_index_filename(format: str) -> str:
     return "all-projects-summary.json" if ext == "json" else f"index.{ext}"
 
 
-# =============================================================================
-# Progress Chain Repair
-# =============================================================================
-
-
-def _scan_file_progress(path: Path, chain: dict[str, Optional[str]]) -> None:
-    """Extract progress entry uuid->parentUuid from a single JSONL file."""
-    try:
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                if "progress" not in line:  # Fast pre-filter
-                    continue
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    raw = json.loads(line)
-                    if not isinstance(raw, dict):
-                        continue
-                    d = cast(dict[str, Any], raw)
-                    if d.get("type") == "progress":
-                        uuid = d.get("uuid")
-                        if isinstance(uuid, str):
-                            chain[uuid] = d.get("parentUuid")
-                except json.JSONDecodeError:
-                    continue
-    except FileNotFoundError:
-        pass  # Race condition: file may have been deleted
-
-
-def _scan_progress_chains(*paths: Path) -> dict[str, Optional[str]]:
-    """Fast scan of JSONL files for progress entry uuid->parentUuid mappings."""
-    chain: dict[str, Optional[str]] = {}
-    for path in paths:
-        if path.is_file():
-            _scan_file_progress(path, chain)
-        elif path.is_dir():
-            for f in path.glob("*.jsonl"):
-                _scan_file_progress(f, chain)
-            # Also scan subagent directories
-            for f in path.glob("*/subagents/*.jsonl"):
-                _scan_file_progress(f, chain)
-    return chain
-
-
 def _scan_sidechain_uuids(directory: Path) -> set[str]:
     """Collect UUIDs from sidechain/subagent files not loaded into the DAG.
 
@@ -186,44 +141,6 @@ def _scan_sidechain_uuids(directory: Path) -> set[str]:
         except FileNotFoundError:
             pass
     return uuids
-
-
-def _repair_parent_chains(
-    messages: list[TranscriptEntry],
-    progress_chain: dict[str, Optional[str]],
-) -> None:
-    """Repair parentUuid fields that point to dropped progress entries.
-
-    Walks the progress chain to find the nearest non-progress ancestor.
-    Only repairs links to progress entries that are NOT in the messages
-    list (i.e. those that were truly dropped, not preserved as
-    PassthroughTranscriptEntry).
-    Mutates entries in place (Pydantic v2 models are mutable by default).
-    """
-    if not progress_chain:
-        return
-    # Filter out progress UUIDs that are present as parsed entries —
-    # those are PassthroughTranscriptEntry nodes in the DAG and valid parents.
-    present_uuids = {getattr(m, "uuid", None) for m in messages}
-    dropped_progress = {
-        uuid: parent
-        for uuid, parent in progress_chain.items()
-        if uuid not in present_uuids
-    }
-    if not dropped_progress:
-        return
-    for msg in messages:
-        parent = getattr(msg, "parentUuid", None)
-        if parent and parent in dropped_progress:
-            current: Optional[str] = parent
-            seen: set[str] = set()
-            while current is not None and current in dropped_progress:
-                if current in seen:
-                    current = None
-                    break
-                seen.add(current)
-                current = dropped_progress[current]
-            msg.parentUuid = current  # type: ignore[union-attr]
 
 
 # =============================================================================
@@ -756,10 +673,6 @@ def load_directory_transcripts(
             jsonl_file, cache_manager, from_date, to_date, silent
         )
         all_messages.extend(messages)
-
-    # Repair parent chains: progress entries create UUID gaps
-    progress_chain = _scan_progress_chains(directory_path)
-    _repair_parent_chains(all_messages, progress_chain)
 
     # Parent agent entries and assign synthetic session IDs so they
     # form separate DAG-lines spliced at their anchor points.
@@ -1580,9 +1493,6 @@ def convert_jsonl_to(
         if output_path is None:
             output_path = input_path.with_suffix(f"{suffix}.{ext}")
         messages = load_transcript(input_path, silent=silent)
-        # Repair progress chain gaps for single-file mode
-        progress_chain = _scan_progress_chains(input_path)
-        _repair_parent_chains(messages, progress_chain)
         # Parent agent entries and assign synthetic session IDs (same as
         # directory mode) so DAG-based ordering handles sidechain placement.
         _integrate_agent_entries(messages)

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -13,11 +13,8 @@ from typing import Any
 from claude_code_log.converter import (
     load_directory_transcripts,
     _build_session_data_from_messages,
-    _scan_progress_chains,
-    _repair_parent_chains,
 )
 from claude_code_log.models import (
-    BaseTranscriptEntry,
     SummaryTranscriptEntry,
     QueueOperationTranscriptEntry,
 )
@@ -431,118 +428,17 @@ def _make_progress_entry(uuid: str, parent_uuid: str | None = None) -> dict[str,
     }
 
 
-class TestScanProgressChains:
-    """Unit tests for _scan_progress_chains helper."""
+class TestProgressEntryPassthrough:
+    """Progress entries are bridged into the DAG as PassthroughTranscriptEntry.
 
-    def test_scan_empty_directory(self, tmp_path: Path) -> None:
-        """Empty directory produces empty chain."""
-        chain = _scan_progress_chains(tmp_path)
-        assert chain == {}
+    Historically a `_scan_progress_chains` / `_repair_parent_chains` pass
+    rewrote parentUuids around dropped `progress` entries. Once `progress`
+    entries (which carry uuid+sessionId) became `PassthroughTranscriptEntry`
+    nodes, that repair became a no-op and was removed; these tests pin the
+    behaviour the Passthrough mechanism now provides on its own.
+    """
 
-    def test_scan_file_with_no_progress(self, tmp_path: Path) -> None:
-        """File with no progress entries produces empty chain."""
-        entries = [
-            _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", None),
-        ]
-        _write_jsonl(tmp_path / "session.jsonl", entries)
-        chain = _scan_progress_chains(tmp_path)
-        assert chain == {}
-
-    def test_scan_file_with_progress(self, tmp_path: Path) -> None:
-        """File with progress entries produces correct chain."""
-        entries = [
-            _make_progress_entry("p1", None),
-            _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", "p1"),
-            _make_progress_entry("p2", "a"),
-        ]
-        _write_jsonl(tmp_path / "session.jsonl", entries)
-        chain = _scan_progress_chains(tmp_path)
-        assert chain == {"p1": None, "p2": "a"}
-
-    def test_scan_single_file_path(self, tmp_path: Path) -> None:
-        """Can scan a single file (not just a directory)."""
-        entries = [_make_progress_entry("p1", "parent1")]
-        path = tmp_path / "session.jsonl"
-        _write_jsonl(path, entries)
-        chain = _scan_progress_chains(path)
-        assert chain == {"p1": "parent1"}
-
-    def test_scan_real_data(self) -> None:
-        """Scan real test data with 11 progress entries."""
-        chain = _scan_progress_chains(EXPERIMENTS_IDEAS_DIR)
-        assert len(chain) == 11
-
-
-class TestRepairParentChains:
-    """Unit tests for _repair_parent_chains helper."""
-
-    def test_no_progress_noop(self, tmp_path: Path) -> None:
-        """No progress entries means no repairs needed."""
-        entries = [
-            _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", None),
-            _make_assistant_entry("b", "s1", "2025-07-01T10:01:00.000Z", "a"),
-        ]
-        _write_jsonl(tmp_path / "session.jsonl", entries)
-        from claude_code_log.converter import load_transcript
-
-        messages = load_transcript(tmp_path / "session.jsonl", silent=True)
-        _repair_parent_chains(messages, {})
-        assert isinstance(messages[0], BaseTranscriptEntry)
-        assert isinstance(messages[1], BaseTranscriptEntry)
-        assert messages[0].parentUuid is None
-        assert messages[1].parentUuid == "a"
-
-    def test_single_progress_gap(self, tmp_path: Path) -> None:
-        """Progress entry with uuid+sessionId becomes PassthroughTranscriptEntry.
-
-        With passthrough entries in the DAG, the chain is intact —
-        no repair needed for progress entries that have uuid+sessionId.
-        """
-        from claude_code_log.models import PassthroughTranscriptEntry
-
-        entries = [
-            _make_progress_entry("p1", None),
-            _make_user_entry("a", "s1", "2025-07-01T10:00:00.000Z", "p1"),
-        ]
-        _write_jsonl(tmp_path / "session.jsonl", entries)
-        from claude_code_log.converter import load_transcript
-
-        messages = load_transcript(tmp_path / "session.jsonl", silent=True)
-        progress_chain = {"p1": None}
-        _repair_parent_chains(messages, progress_chain)
-        # p1 is now a PassthroughTranscriptEntry (not dropped)
-        assert isinstance(messages[0], PassthroughTranscriptEntry)
-        assert messages[0].uuid == "p1"
-        # user(a).parentUuid remains "p1" — chain intact via passthrough
-        user_a = [m for m in messages if getattr(m, "uuid", None) == "a"][0]
-        assert isinstance(user_a, BaseTranscriptEntry)
-        assert user_a.parentUuid == "p1"
-
-    def test_chained_progress_gap(self, tmp_path: Path) -> None:
-        """Chain of passthrough progress entries preserves DAG links."""
-        # real_parent → progress(p1) → progress(p2) → user(a)
-        entries = [
-            _make_user_entry("real_parent", "s1", "2025-07-01T10:00:00.000Z", None),
-            _make_progress_entry("p1", "real_parent"),
-            _make_progress_entry("p2", "p1"),
-            _make_user_entry("a", "s1", "2025-07-01T10:01:00.000Z", "p2"),
-        ]
-        _write_jsonl(tmp_path / "session.jsonl", entries)
-        from claude_code_log.converter import load_transcript
-
-        messages = load_transcript(tmp_path / "session.jsonl", silent=True)
-        progress_chain = {"p1": "real_parent", "p2": "p1"}
-        _repair_parent_chains(messages, progress_chain)
-        # With passthrough entries, chain is intact: a → p2 → p1 → real_parent
-        user_a = [m for m in messages if getattr(m, "uuid", None) == "a"][0]
-        assert isinstance(user_a, BaseTranscriptEntry)
-        assert user_a.parentUuid == "p2"  # NOT repaired — p2 is in the DAG
-
-
-class TestProgressChainRepairIntegration:
-    """Integration tests for progress chain repair in load_directory_transcripts."""
-
-    def test_progress_chain_repair_directory(self, caplog: Any) -> None:
+    def test_no_orphan_warnings_from_progress_entries(self, caplog: Any) -> None:
         """Progress entries are bridged: no orphan warnings from DAG build."""
         with caplog.at_level(logging.WARNING):
             result, _ = load_directory_transcripts(EXPERIMENTS_IDEAS_DIR, silent=True)
@@ -558,17 +454,10 @@ class TestProgressChainRepairIntegration:
             f"Expected no orphan warnings, got: {orphan_warnings}"
         )
 
-    def test_progress_chain_repair_single_file(self) -> None:
-        """Single-file mode: progress entries are PassthroughTranscriptEntry nodes.
-
-        With passthrough entries, progress entries are in the DAG and don't
-        need repair. Entries pointing to them have valid parents.
-        """
-        from claude_code_log.converter import (
-            load_transcript,
-            _scan_progress_chains,
-            _repair_parent_chains,
-        )
+    def test_progress_entries_become_passthrough_real_data(self) -> None:
+        """Real-data single file: progress entries land as Passthrough nodes
+        and downstream entries still point at them (chain intact, no repair)."""
+        from claude_code_log.converter import load_transcript
         from claude_code_log.models import PassthroughTranscriptEntry
 
         single_file = (
@@ -576,45 +465,22 @@ class TestProgressChainRepairIntegration:
         )
         messages = load_transcript(single_file, silent=True)
 
-        # Progress entries are now PassthroughTranscriptEntry in messages
-        progress_chain = _scan_progress_chains(single_file)
-        assert len(progress_chain) == 11
-
-        # Progress entries should be in the messages list
-        passthrough_uuids = {
+        # Progress entries are present in the messages list as Passthrough nodes
+        progress_uuids = {
             m.uuid
             for m in messages
             if isinstance(m, PassthroughTranscriptEntry) and m.type == "progress"
         }
-        assert len(passthrough_uuids) > 0
+        assert len(progress_uuids) > 0
 
-        # Repair should be a no-op since all progress entries are present
-        _repair_parent_chains(messages, progress_chain)
-
-        # Entries still point to progress UUIDs (which is correct —
-        # those are valid PassthroughTranscriptEntry nodes in the DAG)
+        # Entries point at those progress UUIDs — valid DAG nodes, no repair needed
         entries_with_progress_parents = sum(
-            1 for m in messages if getattr(m, "parentUuid", None) in progress_chain
+            1 for m in messages if getattr(m, "parentUuid", None) in progress_uuids
         )
-        assert entries_with_progress_parents > 0  # Chain intact through passthrough
-
-    def test_progress_chain_preserves_entry_count(self) -> None:
-        """Repair doesn't add or remove entries, only mutates parentUuid."""
-        from claude_code_log.converter import load_transcript
-
-        single_file = (
-            EXPERIMENTS_IDEAS_DIR / "03eb5929-52b3-4b13-ada3-b93ae35806b8.jsonl"
-        )
-        messages = load_transcript(single_file, silent=True)
-        count_before = len(messages)
-
-        progress_chain = _scan_progress_chains(single_file)
-        _repair_parent_chains(messages, progress_chain)
-
-        assert len(messages) == count_before
+        assert entries_with_progress_parents > 0
 
     def test_dag_chain_fully_connected(self) -> None:
-        """After repair, DAG build produces a single connected chain."""
+        """DAG build over real data produces a connected chain."""
         from claude_code_log.dag import build_dag_from_entries
 
         result, _ = load_directory_transcripts(EXPERIMENTS_IDEAS_DIR, silent=True)


### PR DESCRIPTION
## What

Removes the `_scan_file_progress` / `_scan_progress_chains` / `_repair_parent_chains` trio from `converter.py` and its two call sites (directory and single-file load).

Net: **−90 lines** of code, plus a test-file trim (+20 / −244 overall).

## Why it's safe

The trio was superseded by the `PassthroughTranscriptEntry` mechanism. Since `progress` entries carry `uuid`+`sessionId`, they are parsed as Passthrough nodes that sit in the DAG as valid parents — so `_repair_parent_chains` (which explicitly skips entries already present in the parsed set) could only ever fire for a `progress` entry lacking a `sessionId`. That case occurs in **none** of the real fixtures (0/11 progress entries), and even the synthetic test helper sets a `sessionId`, so the prior unit tests already asserted no-op behavior.

In that (unreachable) case the new behavior is not byte-identical to the old repair: instead of re-nesting the orphaned child under the dropped entry's nearest surviving ancestor, `build_dag` clears the dangling `parentUuid` and promotes the child to a root — a tree-shape difference, plus possibly an orphan warning. It degrades gracefully and never crashes.

Removing the trio also eliminates a redundant directory re-scan in the directory-load path.

## Verification

- Neutering `_repair_parent_chains` to a no-op left the **full unit + snapshot suite passing unchanged**, confirming behavior-neutrality on all reachable inputs.
- After the change: full unit + snapshot suite **1907 passed, 7 skipped**; `pyright claude_code_log/converter.py` clean; `ruff` check + format clean.

## Tests

Drops the unit tests that exercised the deleted helpers (they asserted no-op behavior). Keeps the genuine behavioral guarantees — no orphan warnings, and progress-as-Passthrough on real data — under a renamed `TestProgressEntryPassthrough`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified transcript DAG construction by restructuring progress entry handling. Progress entries are now represented as distinct node types within the transcript hierarchy instead of being processed through an automatic repair mechanism. Removed automatic parent link adjustments that previously corrected UUID references when progress entries were dropped during conversion operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->