### PR TITLE
Co-locate the away-summary detail rule on AwaySummaryMessage

### DIFF
--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Union, Optional, Literal
+from typing import Any, ClassVar, Union, Optional, Literal
 
 from pydantic import BaseModel, Field
 
@@ -476,6 +476,12 @@ class AwaySummaryMessage(MessageContent):
     user comes back to a session. Distinct from HookSummaryMessage (tool noise)
     and the level-bearing SystemMessage (info/warning/error).
     """
+
+    # Recaps are narrative content, not noise: visible at FULL and HIGH,
+    # dropped at LOW and below (alongside bash/thinking). Declared via the
+    # class-attribute detail-visibility mechanism so the rule lives with the
+    # content type rather than in renderer.py's exclude registries.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.HIGH
 
     text: str  # Recap prose; may contain light markdown.
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3169,14 +3169,13 @@ _HIGH_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
     UnknownMessage,
 )
 
-# AwaySummaryMessage is intentionally absent from _HIGH_EXCLUDE_CLASSES:
-# recaps are narrative content (has_markdown=True, assistant-side visual
-# treatment), not noise. They're kept at HIGH and dropped from LOW down,
-# alongside bash/thinking. The pre-render `_filter_by_detail` carries a
-# matching whitelist for SystemTranscriptEntry with subtype="away_summary".
+# AwaySummaryMessage is governed by its own class attribute
+# (detail_visibility = HIGH in models.py), not these registries: recaps are
+# narrative content (has_markdown=True, assistant-side visual treatment),
+# kept at HIGH and dropped from LOW down. The pre-render `_filter_by_detail`
+# carries a matching whitelist for SystemTranscriptEntry subtype="away_summary".
 _LOW_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
     *_HIGH_EXCLUDE_CLASSES,
-    AwaySummaryMessage,
     BashInputMessage,
     BashOutputMessage,
     ThinkingMessage,
@@ -3296,12 +3295,9 @@ def _filter_by_detail(
     filtered: list[TranscriptEntry] = []
     for message in messages:
         # HIGH/LOW/MINIMAL/USER_ONLY: drop system entries (factory creates SystemMessage)
-        # — except `away_summary` recaps at HIGH detail. Recaps are
-        # narrative content (Claude summarising recent activity); the
-        # post-render `_HIGH_EXCLUDE_CLASSES` keeps them by intentionally
-        # omitting AwaySummaryMessage, but they'd never reach that filter
-        # without this pre-render whitelist. At LOW and below, recaps are
-        # dropped along with bash/thinking via `_LOW_EXCLUDE_CLASSES`.
+        # — except `away_summary` recaps at HIGH detail, which must survive this
+        # pre-render pass to reach the post-render filter that keeps them at HIGH
+        # (see AwaySummaryMessage.detail_visibility in models.py).
         if not isinstance(message, allowed_types):
             if (
                 detail == DetailLevel.HIGH


### PR DESCRIPTION
## What

Declares `detail_visibility: ClassVar[DetailLevel] = HIGH` on `AwaySummaryMessage` (models.py) instead of encoding its detail rule via membership in renderer.py's `_LOW_EXCLUDE_CLASSES`.

## Why

`_content_visible_at` already prefers a content class's `detail_visibility` attribute over the legacy exclude registries, so the outcome is **identical across all five detail levels** (visible at FULL/HIGH, dropped at LOW/MINIMAL/USER_ONLY) — the registry membership was simply a second, redundant source of truth for the same rule. This is the first built-in content type to use the class-attribute detail-visibility mechanism that plugins already rely on, keeping the rule next to the type it governs.

`ClassVar` is excluded from dataclass fields, so the constructor is unaffected. The pre-render `_filter_by_detail` whitelist (entry-level, before the factory exists) is unchanged; its comment now cross-references the class attribute.

## Verification

Full unit + snapshot suite **1916 passed, 7 skipped** (snapshots unchanged); `pyright` + `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal message visibility control mechanism for improved alignment between visibility declarations and filtering operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->