### PR TITLE
Move detail-visibility predicate onto MessageContent

### DIFF
--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -81,10 +81,12 @@ _DETAIL_ORDER: dict[DetailLevel, int] = {
 
 # Guard against drift: if a new DetailLevel value is added without an
 # entry here, ``includes`` would raise KeyError silently on first use.
-# Fail loudly at import time instead.
-assert set(_DETAIL_ORDER.keys()) == set(DetailLevel), (
-    f"_DETAIL_ORDER missing entries for: {set(DetailLevel) - set(_DETAIL_ORDER.keys())}"
-)
+# Fail loudly at import time instead. Uses ``if ... raise`` rather than
+# ``assert`` so the check survives ``python -O`` / ``PYTHONOPTIMIZE``.
+if set(_DETAIL_ORDER.keys()) != set(DetailLevel):
+    raise RuntimeError(
+        f"_DETAIL_ORDER missing entries for: {set(DetailLevel) - set(_DETAIL_ORDER.keys())}"
+    )
 
 
 # =============================================================================

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -58,6 +58,34 @@ class DetailLevel(str, Enum):
     MINIMAL = "minimal"  # User + assistant messages only
     USER_ONLY = "user-only"  # User prompts + steering only (for downstream agents)
 
+    def includes(self, threshold: "DetailLevel") -> bool:
+        """Return True iff this level is verbose enough to show content
+        whose ``detail_visibility`` is declared at ``threshold``.
+
+        Monotone-down: ``FULL.includes(X)`` is True for every ``X``;
+        ``USER_ONLY.includes(X)`` is True only for ``USER_ONLY`` itself.
+        """
+        return _DETAIL_ORDER[self] <= _DETAIL_ORDER[threshold]
+
+
+# Verbosity ordering: lower index = more verbose. The ``DetailLevel.includes``
+# predicate (and ``MessageContent.visible_at``) treats a level as "verbose
+# enough" iff ``order[current] <= order[threshold]``.
+_DETAIL_ORDER: dict[DetailLevel, int] = {
+    DetailLevel.FULL: 0,
+    DetailLevel.HIGH: 1,
+    DetailLevel.LOW: 2,
+    DetailLevel.MINIMAL: 3,
+    DetailLevel.USER_ONLY: 4,
+}
+
+# Guard against drift: if a new DetailLevel value is added without an
+# entry here, ``includes`` would raise KeyError silently on first use.
+# Fail loudly at import time instead.
+assert set(_DETAIL_ORDER.keys()) == set(DetailLevel), (
+    f"_DETAIL_ORDER missing entries for: {set(DetailLevel) - set(_DETAIL_ORDER.keys())}"
+)
+
 
 # =============================================================================
 # JSONL Content Models (Pydantic)
@@ -422,6 +450,27 @@ class MessageContent:
         """
         return False
 
+    def visible_at(self, detail: DetailLevel) -> bool:
+        """Return True iff this content is visible at ``detail``.
+
+        Resolution: each subclass MAY declare a class-level
+        ``detail_visibility: ClassVar[DetailLevel]`` that names the LEAST
+        verbose level at which it should still render. The predicate is
+        monotone-down — a class declared at ``HIGH`` is visible at
+        ``FULL`` and ``HIGH`` and dropped at ``LOW`` and below
+        (see :meth:`DetailLevel.includes`).
+
+        Classes without a declared threshold are always visible — useful
+        for built-ins like ``UserTextMessage`` that have no level-based
+        filtering rule. Plugin subclasses inherit the threshold from
+        their base via normal ClassVar inheritance unless they declare
+        their own (documented contract — see ``dev-docs/plugins.md``).
+        """
+        threshold = getattr(type(self), "detail_visibility", None)
+        if threshold is None:
+            return True
+        return detail.includes(threshold)
+
 
 @dataclass
 class SystemMessage(MessageContent):
@@ -429,6 +478,9 @@ class SystemMessage(MessageContent):
 
     Used for info, warning, and error system messages.
     """
+
+    # System info/warning/error noise — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
 
     level: str  # "info", "warning", "error"
     text: str  # Raw text content (may contain ANSI codes)
@@ -457,6 +509,9 @@ class HookSummaryMessage(MessageContent):
 
     Used for subtype="stop_hook_summary" system messages.
     """
+
+    # Hook noise — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
 
     has_output: bool
     hook_errors: list[str]  # Error messages from hooks
@@ -504,7 +559,7 @@ class HookAttachmentMessage(MessageContent):
     hook invocation captured by the harness as an attachment, with
     full payload (command, exit code, stdout/stderr, duration). Visible
     only at ``DetailLevel.FULL``; dropped at HIGH and below alongside
-    other hook noise (see ``_HIGH_EXCLUDE_CLASSES``).
+    other hook noise (see ``detail_visibility`` below).
 
     ``kind`` distinguishes the attachment flavour:
 
@@ -519,6 +574,9 @@ class HookAttachmentMessage(MessageContent):
       reported an error but didn't block. Same shape as ``success``
       but with non-zero ``exitCode``.
     """
+
+    # Hook attachment noise — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
 
     kind: str  # success / additional_context / blocking_error / non_blocking_error
     hook_event: str = ""  # PostToolUse / UserPromptSubmit / Stop / SessionStart / ...
@@ -552,6 +610,9 @@ class SlashCommandMessage(MessageContent):
     command-contents tags parsed from the text.
     """
 
+    # Slash-command framing — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
     command_name: str
     command_args: str
     command_contents: str
@@ -568,6 +629,9 @@ class CommandOutputMessage(MessageContent):
     These are user messages containing local-command-stdout tags.
     """
 
+    # Local-command output — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
     stdout: str
     is_markdown: bool  # True if content appears to be markdown
 
@@ -583,6 +647,9 @@ class BashInputMessage(MessageContent):
     These are user messages containing bash-input tags.
     """
 
+    # Inline bash — kept through HIGH, dropped at LOW and below.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.HIGH
+
     command: str
 
     @property
@@ -596,6 +663,9 @@ class BashOutputMessage(MessageContent):
 
     These are user messages containing bash-stdout and/or bash-stderr tags.
     """
+
+    # Inline bash output — kept through HIGH, dropped at LOW and below.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.HIGH
 
     stdout: Optional[str] = None  # Raw stdout content (may contain ANSI codes)
     stderr: Optional[str] = None  # Raw stderr content (may contain ANSI codes)
@@ -619,6 +689,9 @@ class CompactedSummaryMessage(MessageContent):
     format_compacted_summary_content() in html/user_formatters.py.
     """
 
+    # /compact framing — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
     summary_text: str
 
     @property
@@ -639,6 +712,9 @@ class UserMemoryMessage(MessageContent):
     format_user_memory_content() in html/user_formatters.py.
     """
 
+    # Memory-input framing — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
+
     memory_text: str
 
     @property
@@ -654,6 +730,9 @@ class UserSlashCommandMessage(MessageContent):
     The text is markdown formatted and rendered as such.
     Formatted by format_user_slash_command_content() in html/user_formatters.py.
     """
+
+    # Slash-command expansion framing — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
 
     text: str
 
@@ -879,6 +958,10 @@ class AssistantTextMessage(MessageContent):
     Empty items list indicates no content.
     """
 
+    # Assistant prose — visible at MINIMAL and above; dropped only at
+    # USER_ONLY (which keeps user prompts + steering only).
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.MINIMAL
+
     # Interleaved content items preserving original order
     items: list[  # pyright: ignore[reportUnknownVariableType]
         TextContent | ImageContent
@@ -907,6 +990,9 @@ class ThinkingMessage(MessageContent):
     for parsing JSONL). This dataclass is for rendering purposes.
     """
 
+    # Thinking blocks — kept through HIGH, dropped at LOW and below.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.HIGH
+
     thinking: str
     signature: Optional[str] = None
 
@@ -933,6 +1019,9 @@ class UnknownMessage(MessageContent):
     Used as a fallback when encountering content types that don't have
     specific handlers. Stores the type name for display purposes.
     """
+
+    # Unknown content — visible only at FULL.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.FULL
 
     type_name: str  # The name/description of the unknown type
 
@@ -999,6 +1088,11 @@ class ToolResultMessage(MessageContent):
     needed for rendering, such as the associated tool name and file path.
     """
 
+    # Tool results — kept through LOW (narrowed there by the orthogonal
+    # tool-name keep-list in ``_filter_template_by_detail``), dropped at
+    # MINIMAL and below.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
+
     tool_use_id: str
     output: (
         "ToolOutput"  # Specialized (ReadOutput, etc.) or generic (ToolResultContent)
@@ -1024,6 +1118,11 @@ class ToolUseMessage(MessageContent):
     Wraps ToolUseContent with the parsed input for specialized formatting.
     Falls back to the original ToolUseContent when no specialized parser exists.
     """
+
+    # Tool invocations — kept through LOW (narrowed there by the orthogonal
+    # tool-name keep-list in ``_filter_template_by_detail``), dropped at
+    # MINIMAL and below.
+    detail_visibility: ClassVar[DetailLevel] = DetailLevel.LOW
 
     input: "ToolInput"  # Specialized (BashInput, etc.) or ToolUseContent fallback
     tool_use_id: str  # From ToolUseContent.id

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3175,101 +3175,22 @@ def _filter_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntry]:
 # teammate transcripts keep their spawn-and-result pairs at low detail.
 _LOW_KEEP_TOOLS = {"WebSearch", "WebFetch", "Task", "Agent"}
 
-# Post-render classes excluded per level (cumulative: each level adds to the
-# previous). HIGH excludes system/hook noise; LOW adds bash and tools; MINIMAL
-# adds everything except user/assistant text.
-_HIGH_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
-    SlashCommandMessage,
-    UserSlashCommandMessage,
-    CommandOutputMessage,
-    CompactedSummaryMessage,
-    UserMemoryMessage,
-    SystemMessage,
-    HookSummaryMessage,
-    HookAttachmentMessage,
-    UnknownMessage,
-)
-
-# AwaySummaryMessage is governed by its own class attribute
-# (detail_visibility = HIGH in models.py), not these registries: recaps are
-# narrative content (has_markdown=True, assistant-side visual treatment),
-# kept at HIGH and dropped from LOW down. The pre-render `_filter_by_detail`
-# carries a matching whitelist for SystemTranscriptEntry subtype="away_summary".
-_LOW_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
-    *_HIGH_EXCLUDE_CLASSES,
-    BashInputMessage,
-    BashOutputMessage,
-    ThinkingMessage,
-)
-
-_MINIMAL_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
-    *_LOW_EXCLUDE_CLASSES,
-    ToolUseMessage,
-    ToolResultMessage,
-)
-
-_USER_ONLY_EXCLUDE_CLASSES: tuple[type[MessageContent], ...] = (
-    *_MINIMAL_EXCLUDE_CLASSES,
-    AssistantTextMessage,
-)
-
-
-# DetailLevel verbosity ordering: lower index = more verbose. A message
-# is visible iff ``current_detail`` is at least as verbose as the
-# required ``detail_visibility`` declared on its content class. With
-# this ordering "at least as verbose" reduces to
-# ``order[current] <= order[required]``.
-_DETAIL_ORDER: dict[DetailLevel, int] = {
-    DetailLevel.FULL: 0,
-    DetailLevel.HIGH: 1,
-    DetailLevel.LOW: 2,
-    DetailLevel.MINIMAL: 3,
-    DetailLevel.USER_ONLY: 4,
-}
-
-# Guard against drift: if a new DetailLevel value is added without an
-# entry here, the visibility helper would raise KeyError silently on
-# first use. Fail loudly at import time instead.
-assert set(_DETAIL_ORDER.keys()) == set(DetailLevel), (
-    f"_DETAIL_ORDER missing entries for: {set(DetailLevel) - set(_DETAIL_ORDER.keys())}"
-)
+# Per-class detail-level filtering lives on the content classes themselves
+# via ``MessageContent.visible_at`` / the ``detail_visibility`` ClassVar
+# (see ``models.py`` and ``dev-docs/plugins.md`` §6). The thin wrapper
+# below survives only because it is called from many sites in this
+# module; new code should call ``content.visible_at(detail)`` directly.
 
 
 def _content_visible_at(content: "MessageContent", detail: DetailLevel) -> bool:
     """Return True iff ``content`` is visible at the given detail level.
 
-    Resolution order (per RFC §detail_visibility semantics and built-in
-    bridge):
-
-    1. **Class attribute** ``detail_visibility: ClassVar[DetailLevel]``
-       on the content's class. Plugin-defined classes use this; future
-       migrations of built-ins to the class-attribute form do too.
-       Monotone-down: visible iff ``detail`` is at least as verbose as
-       the class's declared minimum.
-    2. **Bridge** to the legacy ``_HIGH_EXCLUDE_CLASSES`` /
-       ``_LOW_EXCLUDE_CLASSES`` / etc. registries for built-in classes
-       that have not been migrated yet. ``isinstance`` semantics
-       (matches subclasses too, so plugin classes that subclass a
-       built-in inherit the built-in's filter membership unless they
-       override via the class attribute).
-    3. **Default visible** when neither strategy excludes.
+    Thin delegate to :meth:`MessageContent.visible_at`, which reads the
+    class-side ``detail_visibility`` ClassVar via the monotone-down
+    ordering on :class:`DetailLevel`. Plugin classes participate
+    automatically through the same predicate.
     """
-    visibility = getattr(type(content), "detail_visibility", None)
-    if visibility is not None:
-        return _DETAIL_ORDER[detail] <= _DETAIL_ORDER[visibility]
-    # Bridge: only the active level's exclude registry applies.
-    exclude: tuple[type[MessageContent], ...]
-    if detail == DetailLevel.HIGH:
-        exclude = _HIGH_EXCLUDE_CLASSES
-    elif detail == DetailLevel.LOW:
-        exclude = _LOW_EXCLUDE_CLASSES
-    elif detail == DetailLevel.MINIMAL:
-        exclude = _MINIMAL_EXCLUDE_CLASSES
-    elif detail == DetailLevel.USER_ONLY:
-        exclude = _USER_ONLY_EXCLUDE_CLASSES
-    else:  # FULL
-        return True
-    return not isinstance(content, exclude)
+    return content.visible_at(detail)
 
 
 def _filter_by_detail(
@@ -3549,35 +3470,38 @@ def _filter_template_by_detail(
 ) -> list[TemplateMessage]:
     """Post-render filter: remove TemplateMessage types per detail level.
 
-    Visibility is computed by :func:`_content_visible_at`, which
-    consults a content class's ``detail_visibility`` attribute first
-    (plugin path) and falls back to the legacy ``_*_EXCLUDE_CLASSES``
-    registries (built-in path). At ``LOW``, the ``_LOW_KEEP_TOOLS``
-    allowlist rescues specific tool names that the bridge would
-    otherwise drop.
+    Visibility is computed by :func:`_content_visible_at`, which delegates
+    to each content class's ``visible_at`` predicate / ``detail_visibility``
+    ClassVar. At ``LOW``, the ``_LOW_KEEP_TOOLS`` allowlist narrows
+    built-in tool messages further to a specific set of tool names.
     """
     result: list[TemplateMessage] = []
     for msg in messages:
         visible = _content_visible_at(msg.content, detail)
 
-        # LOW keep-list: ToolUseMessage / ToolResultMessage are NOT in
-        # _LOW_EXCLUDE_CLASSES (only in _MINIMAL_EXCLUDE_CLASSES), so
-        # the bridge passes them through at LOW. The keep-list then
-        # applies a *positive* filter: keep only tools whose tool_name
-        # is in _LOW_KEEP_TOOLS; drop the rest. Plugin classes
-        # carrying an explicit ``detail_visibility`` opt out of the
-        # keep-list — their declared visibility is authoritative,
-        # letting a plugin (e.g. clmail communicate) be visible at LOW
-        # without core needing to update _LOW_KEEP_TOOLS.
-        if (
-            visible
-            and detail == DetailLevel.LOW
-            and isinstance(msg.content, (ToolUseMessage, ToolResultMessage))
-            and not hasattr(type(msg.content), "detail_visibility")
-        ):
-            tool_name = getattr(msg.content, "tool_name", "")
-            if tool_name not in _LOW_KEEP_TOOLS:
-                visible = False
+        # LOW keep-list: built-in ToolUseMessage / ToolResultMessage declare
+        # ``detail_visibility = LOW``, so the predicate keeps them at LOW;
+        # the keep-list then narrows that set to a few specific tool names
+        # (Web/Task/Agent). Plugin subclasses that declare *their own*
+        # ``detail_visibility`` opt out — their declared visibility is
+        # authoritative, letting a plugin (e.g. clmail communicate) be
+        # visible at LOW without core needing to update _LOW_KEEP_TOOLS.
+        # Detection: the class introduces ``detail_visibility`` in its own
+        # ``__dict__`` AND is not one of the built-in bases (which declare
+        # the LOW baseline that this keep-list is designed to narrow).
+        if visible and detail == DetailLevel.LOW:
+            content_cls = type(msg.content)
+            declares_own_visibility = (
+                "detail_visibility" in content_cls.__dict__
+                and content_cls not in (ToolUseMessage, ToolResultMessage)
+            )
+            if (
+                isinstance(msg.content, (ToolUseMessage, ToolResultMessage))
+                and not declares_own_visibility
+            ):
+                tool_name = getattr(msg.content, "tool_name", "")
+                if tool_name not in _LOW_KEEP_TOOLS:
+                    visible = False
 
         if not visible:
             continue

--- a/dev-docs/plugins.md
+++ b/dev-docs/plugins.md
@@ -389,16 +389,20 @@ minimum. With the ordering above:
 | `MINIMAL` | `FULL`, `HIGH`, `LOW`, `MINIMAL` |
 | `USER_ONLY` | all levels |
 
-The order is pinned in a `_DETAIL_ORDER` map in `renderer.py` (so a
-future reorder of the enum can't silently flip semantics), guarded
-by a module-load assertion that every `DetailLevel` value is mapped.
+The order is pinned in a `_DETAIL_ORDER` map next to `DetailLevel` in
+`models.py` (so a future reorder of the enum can't silently flip
+semantics), guarded by a module-load assertion that every
+`DetailLevel` value is mapped. The predicate itself lives on each
+content class as `MessageContent.visible_at(detail)` and consults the
+class-side `detail_visibility` ClassVar via `DetailLevel.includes`.
 
-**Opt-in nature.** Plugin classes that declare `detail_visibility`
-bypass the legacy `_HIGH_EXCLUDE_CLASSES` / `_LOW_KEEP_TOOLS`
-registries entirely — your declaration is authoritative. A plugin
-class that inherits from a built-in (e.g. `MyToolMessage(ToolUseMessage)`)
-but does NOT declare `detail_visibility` inherits the built-in's
-filter membership through the bridge.
+**Opt-in nature.** Built-in `MessageContent` classes declare their own
+`detail_visibility` (e.g. `ToolUseMessage = LOW`, `SystemMessage = FULL`),
+so a plugin class that subclasses a built-in inherits the built-in's
+threshold through normal ClassVar inheritance unless it declares its
+own. Declaring your own opts you out of the orthogonal `_LOW_KEEP_TOOLS`
+tool-name allowlist (for `ToolUseMessage`/`ToolResultMessage`
+subclasses) — your declared visibility is authoritative.
 
 **Practical guide.** Pick based on user-perceived value:
 
@@ -701,7 +705,7 @@ NOT already wrap. Synthesis classes leave `has_markdown` alone.
 | Protocol + loader + dispatch | [`claude_code_log/plugins.py`](../claude_code_log/plugins.py) |
 | Priority constants | [`claude_code_log/factories/priorities.py`](../claude_code_log/factories/priorities.py) |
 | Renderer dispatch | `Renderer._dispatch_format`, `Renderer._dispatch_title`, `HtmlRenderer._class_dispatch_format` in [`renderer.py`](../claude_code_log/renderer.py) / [`html/renderer.py`](../claude_code_log/html/renderer.py) |
-| Visibility filter | `_content_visible_at`, `_filter_template_by_detail`, `_DETAIL_ORDER` in [`renderer.py`](../claude_code_log/renderer.py) |
+| Visibility predicate | `MessageContent.visible_at`, `DetailLevel.includes`, `_DETAIL_ORDER` in [`models.py`](../claude_code_log/models.py); `_filter_template_by_detail` (post-render driver) in [`renderer.py`](../claude_code_log/renderer.py) |
 | Reference plugin (canonical example) | [`test/_plugins/clmail/`](../test/_plugins/clmail/) + [`README.md`](../test/_plugins/clmail/README.md) |
 | Test suite (four layers) | [`test/test_plugin_system.py`](../test/test_plugin_system.py) |
 | Design discussion | [`work/tool-renderer-plugins.md`](../work/tool-renderer-plugins.md) |

--- a/dev-docs/plugins.md
+++ b/dev-docs/plugins.md
@@ -396,13 +396,19 @@ semantics), guarded by a module-load assertion that every
 content class as `MessageContent.visible_at(detail)` and consults the
 class-side `detail_visibility` ClassVar via `DetailLevel.includes`.
 
-**Opt-in nature.** Built-in `MessageContent` classes declare their own
-`detail_visibility` (e.g. `ToolUseMessage = LOW`, `SystemMessage = FULL`),
-so a plugin class that subclasses a built-in inherits the built-in's
-threshold through normal ClassVar inheritance unless it declares its
-own. Declaring your own opts you out of the orthogonal `_LOW_KEEP_TOOLS`
-tool-name allowlist (for `ToolUseMessage`/`ToolResultMessage`
-subclasses) — your declared visibility is authoritative.
+**Opt-in nature.** Most built-in `MessageContent` classes declare their
+own `detail_visibility` (e.g. `ToolUseMessage = LOW`, `SystemMessage =
+FULL`), and a plugin class subclassing such a built-in inherits the
+parent's threshold through normal ClassVar inheritance unless it
+declares its own. A handful of built-ins (`UserTextMessage`,
+`TeammateMessage`, `TaskNotificationMessage`, `SessionHeaderMessage`)
+do *not* declare a threshold and fall through to the base predicate's
+"visible when unset" default — a plugin subclassing one of those
+inherits no threshold and is likewise visible-by-default unless it
+declares its own. Declaring your own opts you out of the orthogonal
+`_LOW_KEEP_TOOLS` tool-name allowlist (for `ToolUseMessage` /
+`ToolResultMessage` subclasses) — your declared visibility is
+authoritative.
 
 **Practical guide.** Pick based on user-perceived value:
 

--- a/dev-docs/plugins.md
+++ b/dev-docs/plugins.md
@@ -405,10 +405,12 @@ declares its own. A handful of built-ins (`UserTextMessage`,
 do *not* declare a threshold and fall through to the base predicate's
 "visible when unset" default — a plugin subclassing one of those
 inherits no threshold and is likewise visible-by-default unless it
-declares its own. Declaring your own opts you out of the orthogonal
-`_LOW_KEEP_TOOLS` tool-name allowlist (for `ToolUseMessage` /
-`ToolResultMessage` subclasses) — your declared visibility is
-authoritative.
+declares its own. The same applies transitively: `UserSteeringMessage`
+subclasses `UserTextMessage`, neither declares, so `UserSteeringMessage`
+also lands on the default-visible path. Declaring your own opts you out
+of the orthogonal `_LOW_KEEP_TOOLS` tool-name allowlist (for
+`ToolUseMessage` / `ToolResultMessage` subclasses) — your declared
+visibility is authoritative.
 
 **Practical guide.** Pick based on user-perceived value:
 

--- a/test/_plugins/clmail/README.md
+++ b/test/_plugins/clmail/README.md
@@ -54,9 +54,9 @@ A `ClassVar[DetailLevel]` on the plugin's `MessageContent` subclass
 declares the minimum detail level at which the message is rendered.
 Monotone-down: a message is visible iff `current_detail` is at least
 as verbose as `detail_visibility` (with `FULL` most verbose,
-`USER_ONLY` least). Plugin classes that opt into a class attribute
-bypass the legacy `_HIGH_EXCLUDE_CLASSES` / `_LOW_KEEP_TOOLS` logic
-entirely.
+`USER_ONLY` least). Plugin classes that declare their own
+`detail_visibility` bypass the orthogonal `_LOW_KEEP_TOOLS` tool-name
+allowlist — their declared visibility is authoritative.
 
 ## Installing this fixture for tests
 

--- a/work/refactor-reindex-with-ghosting.md
+++ b/work/refactor-reindex-with-ghosting.md
@@ -33,9 +33,13 @@ Two callers, both in `claude_code_log/renderer.py`:
    the Skill `tool_use`'s `skill_body`, and the redundant
    "Launching skill: …" tool_result).
 2. **`_filter_template_by_detail`** (line ~3002) — drops
-   potentially many messages, by content type (`HIGH/LOW/MINIMAL/
-   USER_ONLY` exclusion sets), sidechain status, or LOW-tool
-   whitelist.
+   potentially many messages, by content type (each class's
+   `detail_visibility` ClassVar — see
+   `MessageContent.visible_at` in `models.py`; previously expressed
+   as cumulative `_*_EXCLUDE_CLASSES` tuples in `renderer.py`,
+   collapsed onto the model in
+   `wf/simplify/detail-visibility-method`), sidechain status, or
+   the orthogonal LOW-tool whitelist.
 
 Both callers run **before** hierarchy build (`_build_message_hierarchy`,
 line ~2024 sets `message.ancestry`), pair identification
@@ -153,12 +157,41 @@ formatter.
   async-agents support; landed the targeted ghost for
   `TaskNotificationMessage` at LOW.
 
+## The single-axis end-state
+
+Detail filtering currently runs on **two axes**: a pre-render pass
+(`_filter_by_detail` on raw `TranscriptEntry`, which strips content
+*items* within an entry) and a post-render pass (`visible_at` /
+`_filter_template_by_detail` on `MessageContent`). The pre-render
+axis is not a documented performance decision — the only stated
+rationale for two passes
+(`application_model.md` §2.6) is that some content is identifiable
+only after factory dispatch. Functionally, *everything* the
+pre-render pass does is expressible post-render, because the factory
+already splits a single entry's content items into separate messages.
+The pre-render axis earns its keep today only by keeping dropped
+content **out of the message index**, which sidesteps
+`_reindex_filtered_context`.
+
+**End-state.** One filtering axis (post-render) + ghosting (dropped
+messages keep their index slot) + one per-class visibility predicate
+(`MessageContent.visible_at`, landed in
+`wf/simplify/detail-visibility-method`) ⇒ delete *both*
+`_filter_by_detail` (pre-render) **and**
+`_reindex_filtered_context`. The post-render path becomes the
+single axis; the pre-render path is absorbed into it.
+
+This is the broader scope this epic now covers — the per-class
+predicate is the foundation the ghosting/single-axis work routes
+the post-render path through.
+
 ## Out of scope for this work item
 
 - Sidechain duplicate cleanup
   (`_cleanup_sidechain_duplicates`) does **not** call
   `_reindex_filtered_context` — it mutates `parent.children`
   in place without touching `ctx.messages`. No ghosting needed.
-- The pre-render filter `_filter_by_detail` (entries level,
-  before `_render_messages`) is a different layer and not part
-  of this remap surface.
+- `_LOW_KEEP_TOOLS` (the tool-name allowlist that narrows
+  `ToolUseMessage`/`ToolResultMessage` at LOW) is orthogonal to
+  the visibility predicate and stays in
+  `_filter_template_by_detail`.

--- a/work/tool-renderer-plugins.md
+++ b/work/tool-renderer-plugins.md
@@ -14,7 +14,7 @@ the items the RFC explicitly deferred to v2.
 - **MCP namespace sugar.** Match `clmail__communicate` against any `mcp__*__clmail__communicate`. Declined for v1; plugins declare exact verbatim tool names. Revisit once we have two MCP servers exposing the same tool name.
 - **Icon centralization.** Follow-up could migrate scattered icon literals (`html/renderer.py:843–930`) into a registry populated by plugin classes' icon declarations. v1 keeps icons in title methods.
 - **Built-in migration to class-method pattern.** Mechanical follow-up after v1 lands. Reduces the renderer classes' surface area and unifies dispatch. Not blocking.
-- **Built-in migration from `_HIGH_EXCLUDE_CLASSES` to `detail_visibility`.** Same: mechanical follow-up.
+- ~~**Built-in migration from `_HIGH_EXCLUDE_CLASSES` to `detail_visibility`.**~~ **Done** (`wf/simplify/detail-visibility-method`, 2026-05-29): built-ins declare `detail_visibility` ClassVars and the four `_*_EXCLUDE_CLASSES` tuples are gone; the visibility predicate (`MessageContent.visible_at`) lives on the model.
 - **Transformer chaining.** First non-None wins in v1; no chaining. Revisit only with a concrete use case.
 - **Interleaved dispatch.** Today plugins run as a post-classification pass. Letting plugins run *between* built-in detectors (e.g. before the generic `TextFallback` classifier) would let a plugin claim a `UserTextMessage` before the built-in chain has decided. Needs a redesign of the factory loop to call into the plugin chain at each detector boundary.
 - **Namespace-collision diagnosis.** No `--list-plugins` CLI in v1. Startup warning logs cover the worst case (two transformers with same priority and `applies_to`). Follow-up if needed.


### PR DESCRIPTION
## Summary

Each `MessageContent` subclass now owns its detail-level filtering rule via a `detail_visibility: ClassVar[DetailLevel]` declaration, consulted by the predicate `MessageContent.visible_at(detail)` through the monotone-down `DetailLevel.includes` ordering. The `_DETAIL_ORDER` map and its import-time guard move next to the enum in `models.py`.

This replaces the four cumulative `_*_EXCLUDE_CLASSES` tuples in `renderer.py`; `_content_visible_at` survives only as a thin delegate to `visible_at`. The orthogonal `_LOW_KEEP_TOOLS` tool-name allowlist stays in `_filter_template_by_detail`, its plugin-opt-out condition rewritten to detect "this class declares its own `detail_visibility` independently of the built-in baseline" via `__dict__` inspection.

This is the **detail-visibility-method** step of the converter/renderer simplification effort, now rebased atomically onto `main` after Wave A (#175–#178) merged.

## Built-in visibility mapping
- **FULL only:** SlashCommand / UserSlashCommand / CommandOutput / CompactedSummary / UserMemory / System / HookSummary / HookAttachment / Unknown
- **HIGH:** BashInput / BashOutput / Thinking (AwaySummary already declared)
- **LOW:** ToolUse / ToolResult (still narrowed at LOW by the keep-list)
- **MINIMAL:** AssistantText

## Forward link
Amends `work/refactor-reindex-with-ghosting.md` with the single-axis end-state: `visible_at` is the foundation the eventual ghosting migration routes the post-render path through, after which both `_filter_by_detail` (pre-render) and `_reindex_filtered_context` can be deleted.

## Testing
Behavior-neutral. Full unit + snapshot suite green and unchanged across all five detail levels (1907 passed, 7 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified per-message visibility so verbosity consistently controls which messages display.
  * Adjusted visibility thresholds: system/hook and user-command content shown only at highest verbosity; assistant text visible at minimal; inline shell at high; tool-related output at low (omitted at minimal).
  * Plugin-defined visibility now takes precedence over the renderer’s legacy tool keeplist for more precise opt-in behavior.

* **Documentation**
  * Updated docs and plugin guidance to describe the new visibility model and opt-in behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->