### PR TITLE
Dedup requestId tokens in pagination cache-miss fallback

### DIFF
--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1096,6 +1096,16 @@ def _build_session_data_from_messages(
 
     # Group messages by session
     sessions: Dict[str, Dict[str, Any]] = {}
+    # Track requestIds already credited so a retried/repeated assistant
+    # entry isn't counted twice. Mirrors the intent of the canonical
+    # cache path (_update_cache_with_session_data) but, per the
+    # simplification plan (§4 opp 1 / §5 requestId-dedup invariant),
+    # only suppresses *repeats* of an already-seen id — assistant
+    # entries with no requestId at all are still counted. A literal
+    # mirror of the cache guard (`request_id and request_id not in
+    # seen`) would silently drop un-keyed usage. Reconciliation of
+    # the two paths into a single canonical rule is deferred to opp 9.
+    seen_request_ids: set[str] = set()
     for message in messages:
         if not hasattr(message, "sessionId") or isinstance(
             message,
@@ -1155,19 +1165,27 @@ def _build_session_data_from_messages(
         ):
             msg_data = message.message
             if hasattr(msg_data, "usage") and msg_data.usage:
-                usage = msg_data.usage
-                sessions[session_id]["total_input_tokens"] += (
-                    getattr(usage, "input_tokens", 0) or 0
-                )
-                sessions[session_id]["total_output_tokens"] += (
-                    getattr(usage, "output_tokens", 0) or 0
-                )
-                sessions[session_id]["total_cache_creation_tokens"] += (
-                    getattr(usage, "cache_creation_input_tokens", 0) or 0
-                )
-                sessions[session_id]["total_cache_read_tokens"] += (
-                    getattr(usage, "cache_read_input_tokens", 0) or 0
-                )
+                request_id = getattr(message, "requestId", None)
+                if request_id is not None and request_id in seen_request_ids:
+                    # Already credited via an earlier entry with the
+                    # same requestId — skip to avoid double-counting.
+                    pass
+                else:
+                    if request_id is not None:
+                        seen_request_ids.add(request_id)
+                    usage = msg_data.usage
+                    sessions[session_id]["total_input_tokens"] += (
+                        getattr(usage, "input_tokens", 0) or 0
+                    )
+                    sessions[session_id]["total_output_tokens"] += (
+                        getattr(usage, "output_tokens", 0) or 0
+                    )
+                    sessions[session_id]["total_cache_creation_tokens"] += (
+                        getattr(usage, "cache_creation_input_tokens", 0) or 0
+                    )
+                    sessions[session_id]["total_cache_read_tokens"] += (
+                        getattr(usage, "cache_read_input_tokens", 0) or 0
+                    )
 
     # Convert to Dict[str, SessionCacheData]
     result: Dict[str, SessionCacheData] = {}

--- a/test/test_pagination.py
+++ b/test/test_pagination.py
@@ -886,3 +886,167 @@ class TestPaginationFallbackWithoutCache:
         assert "Message 0 from user" in page1_content or "Response" in page1_content, (
             "Paginated HTML should contain messages when cache is unavailable"
         )
+
+
+class TestBuildSessionDataRequestIdDedup:
+    """Pin the requestId-dedup behavior of ``_build_session_data_from_messages``
+    — the cache-miss fallback exercised when ``get_cached_project_data``
+    returns ``None`` during pagination.
+
+    The function must:
+
+    1. Dedup repeat assistant entries that carry the SAME requestId
+       (e.g. a retried request preserved in the JSONL stream) so their
+       usage is counted exactly once.
+    2. KEEP counting assistant entries that have NO requestId at all.
+
+    The literal mirror of the canonical cache path's guard
+    (``request_id and request_id not in seen``) would silently drop
+    rule 2 — these tests guard against that regression.
+    """
+
+    def _make_assistant_entry(
+        self,
+        session_id: str,
+        seq: int,
+        request_id,
+        input_tokens: int,
+        output_tokens: int,
+    ):
+        """Helper: one assistant JSONL entry with a chosen requestId
+        (``None`` means the key is omitted entirely, mirroring real
+        transcripts that pre-date the field).
+        """
+        entry = {
+            "type": "assistant",
+            "uuid": f"{session_id}-assistant-{seq}",
+            "timestamp": f"2023-01-01T10:00:{seq:02d}Z",
+            "sessionId": session_id,
+            "version": "1.0.0",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "assistant",
+            "cwd": "/test",
+            "message": {
+                "id": f"msg-{session_id}-{seq}",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3",
+                "content": [{"type": "text", "text": f"Response {seq}"}],
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                },
+            },
+        }
+        if request_id is not None:
+            entry["requestId"] = request_id
+        return entry
+
+    def _make_user_entry(self, session_id: str, seq: int):
+        return {
+            "type": "user",
+            "uuid": f"{session_id}-user-{seq}",
+            "timestamp": f"2023-01-01T09:00:{seq:02d}Z",
+            "sessionId": session_id,
+            "version": "1.0.0",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "user",
+            "cwd": "/test",
+            "message": {"role": "user", "content": f"Hi {seq}"},
+        }
+
+    def _build(self, raw_entries):
+        """Write a single JSONL, parse via ``load_transcript`` (real
+        path) and feed the result to ``_build_session_data_from_messages``.
+        """
+        from claude_code_log.converter import (
+            load_transcript,
+            _build_session_data_from_messages,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            jsonl = Path(tmp) / "session.jsonl"
+            with open(jsonl, "w", encoding="utf-8") as f:
+                for entry in raw_entries:
+                    f.write(json.dumps(entry) + "\n")
+            messages = load_transcript(jsonl)
+        return _build_session_data_from_messages(messages)
+
+    def test_repeated_request_id_is_counted_once(self):
+        """Two assistant entries sharing a requestId count as one
+        usage credit — guards against a retried/duplicated request
+        inflating session totals on the cache-miss path."""
+        sid = "session-dedup"
+        entries = [
+            self._make_user_entry(sid, 0),
+            self._make_assistant_entry(sid, 1, "req-dup", 100, 50),
+            self._make_assistant_entry(sid, 2, "req-dup", 100, 50),
+        ]
+        data = self._build(entries)
+
+        assert sid in data
+        assert data[sid].total_input_tokens == 100, (
+            "duplicate requestId must not double-count input_tokens "
+            f"(got {data[sid].total_input_tokens})"
+        )
+        assert data[sid].total_output_tokens == 50, (
+            "duplicate requestId must not double-count output_tokens "
+            f"(got {data[sid].total_output_tokens})"
+        )
+
+    def test_assistant_entry_without_request_id_is_still_counted(self):
+        """Assistant entries with NO requestId must still contribute
+        their usage. This is the whole point of opp 1: do not adopt
+        the canonical cache path's truthy guard, which would silently
+        drop these entries.
+        """
+        sid = "session-unkeyed"
+        entries = [
+            self._make_user_entry(sid, 0),
+            self._make_assistant_entry(sid, 1, None, 30, 10),
+        ]
+        data = self._build(entries)
+
+        assert sid in data
+        assert data[sid].total_input_tokens == 30, (
+            "un-keyed assistant usage must be counted "
+            f"(got {data[sid].total_input_tokens}; a literal mirror "
+            "of the canonical guard would drop it)"
+        )
+        assert data[sid].total_output_tokens == 10
+
+    def test_distinct_request_ids_both_counted(self):
+        """Two assistant entries with DIFFERENT requestIds each
+        contribute their usage — the dedup set must not over-fire."""
+        sid = "session-distinct"
+        entries = [
+            self._make_user_entry(sid, 0),
+            self._make_assistant_entry(sid, 1, "req-A", 10, 5),
+            self._make_assistant_entry(sid, 2, "req-B", 20, 7),
+        ]
+        data = self._build(entries)
+
+        assert sid in data
+        assert data[sid].total_input_tokens == 30
+        assert data[sid].total_output_tokens == 12
+
+    def test_mixed_keyed_and_unkeyed(self):
+        """End-to-end mix: a fresh requestId (counted), a repeat of
+        that id (dedup'd), and an un-keyed entry (counted). Pins
+        rules 1 + 2 together on one session."""
+        sid = "session-mixed"
+        entries = [
+            self._make_user_entry(sid, 0),
+            self._make_assistant_entry(sid, 1, "req-X", 7, 3),
+            self._make_assistant_entry(sid, 2, "req-X", 7, 3),
+            self._make_assistant_entry(sid, 3, None, 4, 2),
+        ]
+        data = self._build(entries)
+
+        assert sid in data
+        # 7 (req-X first) + 0 (req-X repeat dedup'd) + 4 (un-keyed) = 11
+        assert data[sid].total_input_tokens == 11
+        # 3 + 0 + 2 = 5
+        assert data[sid].total_output_tokens == 5


### PR DESCRIPTION
## Summary

`_build_session_data_from_messages` is the cache-miss path used when `get_cached_project_data()` returns `None` during pagination. It had no requestId dedup, so any assistant entry that appeared twice with the same requestId (e.g. a retried request preserved in the JSONL stream) double-counted its usage in the per-session totals.

The canonical cache path (`_update_cache_with_session_data`) already guards against this with a `seen_request_ids: set[str]`. This PR adds the same guard here, with one deliberate nuance: the canonical path's guard reads `request_id and request_id not in seen_request_ids`, which silently *drops* assistant entries that have no requestId at all. The fallback's existing behavior credits those entries, and preserving that is the explicit ask from the simplification plan (§4 opp 1, §5 requestId-dedup invariant). Reconciling the two paths into a single canonical rule is deferred to a later step (opp 9).

Token totals are not part of the staleness comparison key (which uses `message_count` and `last_timestamp`), so this change causes no cache invalidation churn — it is a pure correctness alignment.

## What changed

- `claude_code_log/converter.py` — `_build_session_data_from_messages` gets a `seen_request_ids: set[str]` and dedups *repeats* of a present requestId; entries with no requestId are still counted.
- `test/test_pagination.py` — new `TestBuildSessionDataRequestIdDedup` class with four regression tests pinning the behavior:
  - `test_repeated_request_id_is_counted_once` — same requestId twice → tokens counted once.
  - `test_assistant_entry_without_request_id_is_still_counted` — the guardrail against a future "simplification" silently adopting the canonical truthy-guard and dropping un-keyed usage.
  - `test_distinct_request_ids_both_counted` — sanity that the dedup set does not over-fire.
  - `test_mixed_keyed_and_unkeyed` — both rules together on one session.

All four route through the real `load_transcript` → `_build_session_data_from_messages` pipeline (not a hand-built model), so they exercise actual parsing alongside the function under change.

## Test plan

- [x] `just test` — 1910 passed, 7 skipped.
- [x] `just ci` — clean (ruff, pyright, ty).
- [x] `test/test_pagination.py::TestBuildSessionDataRequestIdDedup` — 4 passed (serial and parallel).
- [x] `test/test_dag_integration.py::test_agent_messages_coalesced_into_parent_session` — passes unchanged (helper sets unique requestIds, exercising the dedup branch without altering the count).
- [x] No snapshot moves.

Plan reference: `work/simplify-converter-renderer.md` §3 row 1, §4 "dev/simplify-pagination-token-dedup (opp 1)", §5 requestId-dedup invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage calculation to prevent double-counting when requests are retried or repeated, ensuring accurate token usage metrics.

* **Tests**
  * Added comprehensive test coverage for deduplication logic across various request scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->