### PR TITLE
Compute branch preview once from the DAG-line

### DIFF
--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -722,17 +722,6 @@ def generate_template_messages(
     with log_timing("Pair Skill tool_uses", t_start):
         _pair_skill_tool_uses(ctx)
 
-    # Branch headers were composed by ``_render_messages`` based on the
-    # branch's first message — but real branches sometimes start with an
-    # assistant entry (e.g. "No response requested." after a `/exit`),
-    # leaving the body header bare ``Branch • <uuid8>``. Walk the branch
-    # contents now that ``ctx.messages`` is final, lift the first
-    # UserTextMessage's text as the preview, and re-label the branch
-    # header. This keeps the body header, the session/graph index, and
-    # the fork-point box all carrying the same ``Branch • <uuid8> •
-    # <preview>`` string.
-    _enrich_branch_titles(ctx)
-
     # Populate junction forward links on fork-point messages
     with log_timing("Link junction forwards", t_start):
         _link_junction_forwards(ctx)
@@ -894,6 +883,13 @@ def _extract_session_hierarchy(
             "is_branch": dag_line.is_branch,
             "original_session_id": dag_line.original_session_id,
             "first_uuid": dag_line.uuids[0] if dag_line.uuids else None,
+            # Full DAG-line uuid sequence. ``_build_branch_header``
+            # scans this to find the first user entry with text for
+            # the branch preview — needed when the branch's first
+            # entry is an assistant turn (e.g. "No response requested."
+            # after ``/exit``) and the trigger-message-only path
+            # would leave the preview empty.
+            "uuids": list(dag_line.uuids),
         }
 
     junction_targets: dict[str, list[str]] = {}
@@ -975,77 +971,6 @@ def prepare_session_summaries(messages: list[TranscriptEntry]) -> dict[str, str]
                 session_summaries[uuid_to_session_backup[leaf_uuid]] = message.summary
 
     return session_summaries
-
-
-def _enrich_branch_titles(ctx: RenderingContext) -> None:
-    """Lift each branch's first UserTextMessage as the header preview.
-
-    ``_render_messages`` sets the branch header title from the branch's
-    very first transcript entry. That fails when a branch starts with an
-    assistant turn (a "No response requested." after ``/exit``) or with a
-    tool_result — the user content arrives later. This pass scans the
-    final ``ctx.messages`` list, picks the first ``UserTextMessage``
-    associated with each branch's render_session_id, and re-labels the
-    header (sets both ``content.preview`` and ``content.title``) only
-    when the original pass left no preview behind. We never overwrite a
-    real preview the original pass captured — including short
-    slash-command captures like ``"/exit"`` — because the scanned
-    UserTextMessage may be less informative even when longer.
-
-    Run after ``_pair_skill_tool_uses`` so the message set is stable
-    (skill-folded slash commands removed, indices re-mapped). Idempotent.
-    """
-    branch_headers: dict[str, "TemplateMessage"] = {}
-    for msg in ctx.messages:
-        if isinstance(msg.content, SessionHeaderMessage) and msg.content.is_branch:
-            branch_headers.setdefault(msg.content.session_id, msg)
-
-    if not branch_headers:
-        return
-
-    # First user-text per branch sid (preserves chronological order from ctx.messages).
-    first_user_text: dict[str, str] = {}
-    for msg in ctx.messages:
-        rsid = msg.render_session_id
-        if rsid not in branch_headers or rsid in first_user_text:
-            continue
-        if not isinstance(msg.content, UserTextMessage):
-            continue
-        # Skip sub-agent / sidechain user prompts. ``render_session_id``
-        # for an agent's wrapped messages can be set to the agent's
-        # parent_session_id (i.e. a branch sid), so without this guard
-        # an agent's first inner user prompt could be lifted as the
-        # branch's preview instead of the actual branch-local human
-        # turn. See ``_render_messages`` agent-parent handling.
-        if msg.is_sidechain:
-            continue
-        parts = [
-            item.text for item in msg.content.items if isinstance(item, TextContent)
-        ]
-        text = " ".join(p for p in parts if p).strip()
-        if text:
-            first_user_text[rsid] = create_session_preview(text)
-
-    for sid, header in branch_headers.items():
-        scanned = first_user_text.get(sid, "")
-        if not scanned:
-            continue
-        # Only widen when the existing preview is empty or is the
-        # bare UUID-only fallback (i.e. the original
-        # ``_render_messages`` pass found nothing useful — the branch
-        # started with an assistant or tool_result). A real preview
-        # already on the header — including short slash-command bodies
-        # like ``"/exit"`` (5 chars) — must not be replaced by a longer
-        # but less informative scan result. The earlier
-        # length-comparison heuristic conflated "longer" with "more
-        # informative" and lost slash-command captures in pathological
-        # cases.
-        content = header.content
-        assert isinstance(content, SessionHeaderMessage)  # branch_headers filter
-        if content.preview:
-            continue
-        content.preview = scanned
-        content.title = _branch_label(sid, scanned)
 
 
 def branch_short_uuid(branch_sid: str) -> str:
@@ -1318,13 +1243,13 @@ def prepare_session_navigation(
     # Add branch pseudo-sessions from hierarchy
     if session_hierarchy:
         # Lift each branch's raw ``preview`` directly off its
-        # SessionHeaderMessage. The body header path
-        # (``_render_messages``) already extracted text from the
-        # branch's first user entry — handling plain text, slash
+        # SessionHeaderMessage. ``_build_branch_header`` already
+        # computed it by scanning the branch's DAG-line for the first
+        # user entry with non-empty text — handling plain text, slash
         # commands and other user shapes uniformly via
-        # ``extract_text_content`` — and stored the result; the
-        # ``_enrich_branch_titles`` post-pass widens it when the first
-        # entry was an assistant. We just read what's there.
+        # ``extract_text_content``, including the assistant-start
+        # case (the post-pass ``_enrich_branch_titles`` used to
+        # back-fill). We just read what's there.
         branch_previews: dict[str, str] = {}
         for msg in ctx.messages:
             if not isinstance(msg.content, SessionHeaderMessage):
@@ -3699,14 +3624,17 @@ def _build_branch_header(
     session_hierarchy: dict[str, dict[str, Any]] | None,
     session_summaries: dict[str, str] | None,
     session_team_names: dict[str, str] | None,
+    uuid_to_entry: dict[str, TranscriptEntry] | None,
     ctx: RenderingContext,
 ) -> SessionHeaderMessage:
     """Build the SessionHeaderMessage content for a within-session
     branch (fork) when first encountered. ``message`` is the first
-    entry of the branch — used to extract the preview text. Caller
-    handles ``TemplateMessage`` wrapping, ``render_session_id`` tagging,
-    ``ctx.register(...)``, and ``ctx.session_first_message`` updates so
-    positional placement (anchor stability) stays in the render loop.
+    entry of the branch (the trigger that opened the helper) and
+    ``uuid_to_entry`` is the DAG-line uuid → entry map used to scan
+    for the branch preview. Caller handles ``TemplateMessage``
+    wrapping, ``render_session_id`` tagging, ``ctx.register(...)``,
+    and ``ctx.session_first_message`` updates so positional placement
+    (anchor stability) stays in the render loop.
     """
     b_hier = (session_hierarchy or {}).get(branch_sid, {})
     parent_sid = b_hier.get("parent_session_id")
@@ -3724,13 +3652,41 @@ def _build_branch_header(
     original_sid = b_hier.get("original_session_id", message.sessionId)
     branch_summary = (session_summaries or {}).get(original_sid)
 
-    # Extract preview from the branch's first user message
+    # Compute the branch preview by scanning the branch's DAG-line
+    # uuids for the first user entry with non-empty text. This is the
+    # single source of truth for the preview — there is no post-pass
+    # widening it later.
+    #
+    # Why scan instead of just inspecting ``message`` (the trigger)?
+    # Branches sometimes start with an assistant turn ("No response
+    # requested." after ``/exit``) or a tool_result, leaving the
+    # trigger with no user text. The trigger-only path used to leave
+    # the preview empty and a separate ``_enrich_branch_titles`` pass
+    # would walk ``ctx.messages`` post-hoc to back-fill. Scanning the
+    # DAG-line uuids in order achieves the same outcome in one pass.
+    #
+    # ``extract_text_content`` is the same helper the
+    # ``UserSlashCommandMessage`` path uses, so slash-command bodies
+    # like ``<command-name>/exit</command-name>...`` collapse to
+    # ``/exit`` (5 chars) via ``create_session_preview`` — #129
+    # precedence is preserved structurally: a slash command at the
+    # branch root is the *first* user entry with text, so the scan
+    # picks it before any later (longer but less informative) user
+    # turn ever gets considered.
+    branch_uuids: list[str] = b_hier.get("uuids") or []
     branch_preview = ""
-    user_entry = as_user_entry(message)
-    if user_entry is not None:
-        branch_text = extract_text_content(user_entry.message.content)
-        if branch_text:
-            branch_preview = create_session_preview(branch_text)
+    if uuid_to_entry:
+        for branch_uuid in branch_uuids:
+            entry = uuid_to_entry.get(branch_uuid)
+            if entry is None:
+                continue
+            user_entry = as_user_entry(entry)
+            if user_entry is None:
+                continue
+            branch_text = extract_text_content(user_entry.message.content)
+            if branch_text:
+                branch_preview = create_session_preview(branch_text)
+                break
     branch_title = _branch_label(branch_sid, branch_preview)
 
     branch_header_meta = MessageMeta(
@@ -3816,6 +3772,18 @@ def _render_messages(
             if hier.get("is_branch") and hier.get("first_uuid"):
                 branch_start_uuids[hier["first_uuid"]] = sid
 
+    # uuid → entry map for branch-preview scanning. ``_build_branch_header``
+    # walks each branch's DAG-line uuids (from ``session_hierarchy[sid]
+    # ["uuids"]``) and looks up the entries here to find the first user
+    # entry with non-empty text. Built once over the filtered message
+    # list; entries removed by structural filtering are simply absent
+    # from the map and skipped by the scan.
+    uuid_to_entry: dict[str, TranscriptEntry] = {}
+    for entry in messages:
+        entry_uuid = getattr(entry, "uuid", "")
+        if entry_uuid:
+            uuid_to_entry.setdefault(entry_uuid, entry)
+
     # Track which sessions have had headers added
     seen_sessions: set[str] = set()
     # Track current effective render session (for branch assignment)
@@ -3855,6 +3823,7 @@ def _render_messages(
                     session_hierarchy,
                     session_summaries,
                     session_team_names,
+                    uuid_to_entry,
                     ctx,
                 )
                 branch_header = TemplateMessage(branch_header_content)

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -394,13 +394,15 @@ Terms that appear across multiple subsystems — defined once here.
   appears above each session's first real message. Two flavours:
   *trunk* headers for top-level sessions, and *branch* headers for
   fork branches (the "branch heading" you'll see referenced in bug
-  reports). The branch header's title is composed by `_branch_label`
-  and back-filled by `_enrich_branch_titles` (both in `renderer.py`)
-  in the shape `Branch • <uuid8> • <preview>`; the preview text
-  itself is built by `create_session_preview` in `utils.py` (which
-  calls `simplify_command_tags` to strip raw `<command-name>` XML
-  soup down to `/cmd`). When troubleshooting branch-heading
-  rendering, those four functions are the surface area.
+  reports). Both headers are constructed by `_build_trunk_header` /
+  `_build_branch_header` (in `renderer.py`); the branch header's
+  title is composed by `_branch_label` in the shape `Branch •
+  <uuid8> • <preview>`, with the preview computed once by scanning
+  the branch's DAG-line uuids for the first user entry with text
+  (via `extract_text_content` + `create_session_preview` in
+  `utils.py`, which calls `simplify_command_tags` to strip raw
+  `<command-name>` XML soup down to `/cmd`). When troubleshooting
+  branch-heading rendering, those are the functions to inspect.
 
 - **pair_first / pair_middle / pair_last**: a pair of messages
   rendered as one logical unit (tool_use + tool_result, Slash + UserSlash,

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -220,11 +220,15 @@ types created by factories (`BashInputMessage`, `BashOutputMessage`,
 because some content is identifiable only after factory dispatch (e.g.,
 distinguishing `BashInputMessage` from the tool_use that produced it).
 
-Important interaction: `_filter_template_by_detail` runs **before**
-`_pair_skill_tool_uses` and other reorder passes, so paired-message
-indices need re-mapping (`_reindex_filtered_context`). The reindex
-pass also has to update cached parent-message references on
-`SessionHeaderMessage` (see PR #131 fix).
+Important interaction: `_pair_skill_tool_uses` runs **before**
+`_filter_template_by_detail`, and each pass that drops messages calls
+`_reindex_filtered_context` to remap surviving indices (the skill-fold
+pass remaps after dropping the slash-command body and the redundant
+"Launching skill" tool_result; the detail filter remaps after dropping
+content types below `FULL`). The reindex pass also has to update
+cached parent-message references on `SessionHeaderMessage` (see PR
+#131 fix). See [rendering-architecture.md § 5](rendering-architecture.md)
+for the full pass order.
 
 ### 2.7 Image export
 
@@ -399,8 +403,8 @@ Terms that appear across multiple subsystems — defined once here.
   title is composed by `_branch_label` in the shape `Branch •
   <uuid8> • <preview>`, with the preview computed once by scanning
   the branch's DAG-line uuids for the first user entry with text
-  (via `extract_text_content` + `create_session_preview` in
-  `utils.py`, which calls `simplify_command_tags` to strip raw
+  (via `extract_text_content` in `parser.py` + `create_session_preview`
+  in `utils.py`, which calls `simplify_command_tags` to strip raw
   `<command-name>` XML soup down to `/cmd`). When troubleshooting
   branch-heading rendering, those are the functions to inspect.
 

--- a/dev-docs/dag.md
+++ b/dev-docs/dag.md
@@ -102,9 +102,8 @@ Where `s1`, `s2`, `s3` are synthesized session header messages.
 > <preview>` text) are assembled is a renderer concern, not a DAG
 > concern. See the `SessionHeaderMessage` glossary entry in
 > [application_model.md](application_model.md#4-cross-cutting-glossary)
-> for the four functions involved (`_branch_label`,
-> `_enrich_branch_titles`, `create_session_preview`,
-> `simplify_command_tags`).
+> for the functions involved (`_branch_label`, `_build_branch_header`,
+> `create_session_preview`, `simplify_command_tags`).
 
 #### Current: `d-{index}` anchors (combined transcript only)
 

--- a/dev-docs/rendering-architecture.md
+++ b/dev-docs/rendering-architecture.md
@@ -224,8 +224,10 @@ In code order, `generate_template_messages`:
    `_render_messages` (**Phase 1**: wrappers, session headers,
    registration), then `_pair_skill_tool_uses` (which calls
    `_reindex_filtered_context` internally).
-4. **Branch / junction linking** — `_enrich_branch_titles`, then
-   junction forward-link population on fork points.
+4. **Junction linking** — junction forward-link population on fork
+   points (`_link_junction_forwards`). Branch-header previews are
+   computed in step 3 by `_build_branch_header` scanning the
+   branch's DAG-line uuids; there's no separate back-fill pass.
 5. **Post-render detail filter** — `_filter_template_by_detail`
    followed immediately by `_reindex_filtered_context` (only below FULL).
 6. **Nav + structure** — `prepare_session_navigation`, then

--- a/test/test_branch_label_source.py
+++ b/test/test_branch_label_source.py
@@ -1,0 +1,269 @@
+"""Regression tests for branch-preview sourcing in ``_build_branch_header``.
+
+The branch ``SessionHeaderMessage.preview`` (which feeds the body
+header title, the session/graph index, and the fork-point box's
+backlink — all of which must agree on ``Branch • <uuid8> •
+<preview>``) is computed once by scanning the branch DAG-line for the
+first user entry with non-empty text, via ``extract_text_content``
+plus ``create_session_preview``.
+
+These tests pin two cases the single-source rule must handle:
+
+1. **Branch starts with an assistant turn** — the scan must walk past
+   the first entry (no user text) and pick up the later user entry's
+   preview. This is the case the now-deleted ``_enrich_branch_titles``
+   post-pass used to back-fill.
+2. **Branch starts with a slash-command user entry** — #129
+   precedence: the slash-command body (e.g. ``/exit``) is the first
+   user entry with text, so the scan picks it before any later
+   user turn ever gets considered. Length is irrelevant — DAG order
+   is the precedence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from claude_code_log.converter import load_directory_transcripts
+from claude_code_log.models import SessionHeaderMessage
+from claude_code_log.renderer import TemplateMessage, generate_template_messages
+
+
+# ----- fixture builders ----------------------------------------------------
+
+
+def _user_entry(
+    uuid: str,
+    parent_uuid: str | None,
+    text: str,
+    *,
+    session_id: str = "s1",
+    timestamp: str,
+) -> dict[str, Any]:
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "timestamp": timestamp,
+        "parentUuid": parent_uuid,
+        "isSidechain": False,
+        "userType": "human",
+        "cwd": "/tmp",
+        "sessionId": session_id,
+        "version": "1.0.0",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _assistant_entry(
+    uuid: str,
+    parent_uuid: str | None,
+    text: str,
+    *,
+    session_id: str = "s1",
+    timestamp: str,
+    request_id: str,
+) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "timestamp": timestamp,
+        "parentUuid": parent_uuid,
+        "isSidechain": False,
+        "userType": "human",
+        "cwd": "/tmp",
+        "sessionId": session_id,
+        "version": "1.0.0",
+        "requestId": request_id,
+        "message": {
+            "id": uuid,
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-sonnet",
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    }
+
+
+def _write_jsonl(path: Path, raw_entries: Iterable[dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for entry in raw_entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _branch_headers(roots: list[TemplateMessage]) -> list[SessionHeaderMessage]:
+    """Walk the rendered tree and return all branch SessionHeaderMessages
+    (any depth — within-fork branch headers hang under their parent)."""
+
+    def walk(messages: list[TemplateMessage]):
+        for msg in messages:
+            yield msg
+            yield from walk(msg.children)
+
+    return [
+        msg.content
+        for msg in walk(roots)
+        if isinstance(msg.content, SessionHeaderMessage) and msg.content.is_branch
+    ]
+
+
+# ----- the tests -----------------------------------------------------------
+
+
+class TestBranchPreviewFromDagLineScan:
+    """Pin that ``_build_branch_header`` computes the branch preview by
+    scanning the DAG-line uuids for the first user entry with text."""
+
+    def test_branch_starting_with_assistant_uses_later_user_text(
+        self, tmp_path: Path
+    ) -> None:
+        """A within-session fork whose first entry is an assistant turn
+        ("No response requested." after ``/exit`` is the canonical
+        production case) must still produce a non-empty preview by
+        scanning forward through the branch DAG-line to the next
+        user entry with text.
+
+        Before the single-source rewrite, ``_render_messages`` left the
+        preview empty for this case and a separate ``_enrich_branch_titles``
+        post-pass back-filled it. The new code does the scan up front
+        in ``_build_branch_header``.
+        """
+        # trunk: a (user) → b (assistant) → c (user "Fork point")
+        # branch off c, two children — both assistants so the DAG
+        # fork-collapse "tool-result side-branch" heuristic
+        # (``_stitch_tool_results``, which needs one user and one
+        # assistant child) doesn't stitch them and we get a real
+        # fork with two branches:
+        #   branch 1: d (assistant) → e (user "user text after assistant")
+        #   branch 2: f (assistant) — disambiguating sibling
+        entries = [
+            _user_entry("a", None, "Hello", timestamp="2025-07-01T10:00:00Z"),
+            _assistant_entry(
+                "b", "a", "Hi", timestamp="2025-07-01T10:01:00Z", request_id="r1"
+            ),
+            _user_entry("c", "b", "Fork point", timestamp="2025-07-01T10:02:00Z"),
+            # branch 1: assistant-first
+            _assistant_entry(
+                "d",
+                "c",
+                "Branch 1 leading assistant",
+                timestamp="2025-07-01T10:03:00Z",
+                request_id="r2",
+            ),
+            _user_entry(
+                "e",
+                "d",
+                "user text after assistant",
+                timestamp="2025-07-01T10:04:00Z",
+            ),
+            # branch 2: another assistant sibling (see comment above
+            # — both children must be the same role to bypass the
+            # tool-result stitch and produce a genuine fork)
+            _assistant_entry(
+                "f",
+                "c",
+                "alt branch first reply",
+                timestamp="2025-07-01T10:05:00Z",
+                request_id="r3",
+            ),
+        ]
+        project_dir = tmp_path / "asst-start-project"
+        project_dir.mkdir()
+        _write_jsonl(project_dir / "s1.jsonl", entries)
+
+        result, session_tree = load_directory_transcripts(project_dir, silent=True)
+        roots, _nav, _ctx = generate_template_messages(
+            result, session_tree=session_tree
+        )
+
+        branch_contents = _branch_headers(roots)
+        # Find the branch whose first uuid is 'd' (the assistant-start one).
+        asst_first = [b for b in branch_contents if b.first_uuid == "d"]
+        assert asst_first, (
+            "expected a branch header rooted at uuid 'd' (the assistant-start "
+            f"branch); got branches: {[(b.first_uuid, b.preview) for b in branch_contents]}"
+        )
+        b = asst_first[0]
+        assert b.preview == "user text after assistant", (
+            "assistant-start branch must scan the DAG-line to the next user "
+            f"entry with text; got preview={b.preview!r}"
+        )
+        # And the assembled title carries the same preview.
+        assert "user text after assistant" in (b.title or "")
+
+    def test_branch_starting_with_slash_command_preserves_129_precedence(
+        self, tmp_path: Path
+    ) -> None:
+        """A within-session fork whose first entry is a user-typed
+        slash command (e.g. ``/exit``, surfaced as the cleaned 5-char
+        form by ``create_session_preview`` → ``simplify_command_tags``)
+        must have THAT as its preview — not any later, longer-but-less-
+        informative user turn. The DAG-order scan picks the first user
+        entry with text and breaks; this structurally preserves the
+        #129 precedence rule (see ``test_utils.py::test_create_session_
+        preview_strips_slash_command_xml``).
+        """
+        slash_body = (
+            "<command-name>/exit</command-name>"
+            "<command-message>exit</command-message>"
+            "<command-args></command-args>"
+        )
+        # trunk: a → b → c (fork point)
+        # branch 1: d = /exit (user) → e (assistant "ack") → g (user "Much later, longer, less informative user reply")
+        # branch 2: f (user)         — sibling so c is a real junction
+        entries = [
+            _user_entry("a", None, "Hello", timestamp="2025-07-01T10:00:00Z"),
+            _assistant_entry(
+                "b", "a", "Hi", timestamp="2025-07-01T10:01:00Z", request_id="r1"
+            ),
+            _user_entry("c", "b", "Fork point", timestamp="2025-07-01T10:02:00Z"),
+            # branch 1: slash-command first
+            _user_entry("d", "c", slash_body, timestamp="2025-07-01T10:03:00Z"),
+            _assistant_entry(
+                "e", "d", "ack", timestamp="2025-07-01T10:04:00Z", request_id="r2"
+            ),
+            _user_entry(
+                "g",
+                "e",
+                "Much later, longer, less informative user reply that we must not pick",
+                timestamp="2025-07-01T10:05:00Z",
+            ),
+            # branch 2 sibling
+            _user_entry("f", "c", "second branch", timestamp="2025-07-01T10:06:00Z"),
+        ]
+        project_dir = tmp_path / "slash-first-project"
+        project_dir.mkdir()
+        _write_jsonl(project_dir / "s1.jsonl", entries)
+
+        result, session_tree = load_directory_transcripts(project_dir, silent=True)
+        roots, _nav, _ctx = generate_template_messages(
+            result, session_tree=session_tree
+        )
+
+        branch_contents = _branch_headers(roots)
+        slash_first = [b for b in branch_contents if b.first_uuid == "d"]
+        assert slash_first, (
+            "expected a branch header rooted at uuid 'd' (the slash-command-start "
+            f"branch); got branches: {[(b.first_uuid, b.preview) for b in branch_contents]}"
+        )
+        b = slash_first[0]
+        assert b.preview == "/exit", (
+            "slash-command branch root must surface as the cleaned '/exit' "
+            f"form (#129); got preview={b.preview!r}. A length-based pick "
+            "would wrongly choose the later longer reply."
+        )
+        # Title carries the cleaned form, NOT the raw <command-name> XML.
+        assert "/exit" in (b.title or "")
+        assert "<command-name>" not in (b.title or "")
+        assert "Much later" not in (b.title or "")

--- a/test/test_branch_label_source.py
+++ b/test/test_branch_label_source.py
@@ -7,7 +7,7 @@ backlink — all of which must agree on ``Branch • <uuid8> •
 first user entry with non-empty text, via ``extract_text_content``
 plus ``create_session_preview``.
 
-These tests pin two cases the single-source rule must handle:
+These tests pin three cases the single-source rule must handle:
 
 1. **Branch starts with an assistant turn** — the scan must walk past
    the first entry (no user text) and pick up the later user entry's
@@ -18,6 +18,16 @@ These tests pin two cases the single-source rule must handle:
    user entry with text, so the scan picks it before any later
    user turn ever gets considered. Length is irrelevant — DAG order
    is the precedence.
+3. **Branch contains a spawned subagent** — the deleted
+   ``_enrich_branch_titles`` had an explicit ``if msg.is_sidechain:
+   continue`` guard so an agent's inner first user prompt wouldn't be
+   lifted as the *branch's* preview. The new code has no such guard
+   because it scans the branch's own DAG-line uuids; agent entries
+   live in a separate ``{trunk}#agent-{id}`` DAG-line and are simply
+   not in ``branch_uuids``. This test pins that structural invariant:
+   if any future DAG-construction change ever leaked an agent uuid
+   into a branch line, the preview would silently regress and the
+   removed guard would be missed. The test fails loudly if so.
 """
 
 from __future__ import annotations
@@ -267,3 +277,356 @@ class TestBranchPreviewFromDagLineScan:
         assert "/exit" in (b.title or "")
         assert "<command-name>" not in (b.title or "")
         assert "Much later" not in (b.title or "")
+
+
+class TestBranchPreviewIgnoresAgentInnerPrompts:
+    """Pin the structural invariant that ``_build_branch_header``'s
+    DAG-line scan can NEVER lift a spawned subagent's inner first user
+    prompt as the *branch's* preview.
+
+    The deleted ``_enrich_branch_titles`` post-pass had an explicit
+    ``if msg.is_sidechain: continue`` guard for this — needed because
+    it iterated ``ctx.messages``, where an agent's wrapped messages
+    can carry the branch's ``render_session_id`` (see
+    ``_render_messages`` agent-parent handling). The new code has no
+    such guard because it walks ``branch_uuids`` (the branch's own
+    DAG-line), and agent entries live in a separate
+    ``{trunk}#agent-{id}`` DAG-line — re-parented by
+    ``_integrate_agent_entries`` before ``build_dag``.
+
+    These tests pin that invariant at two levels: a unit-level check
+    against ``_build_branch_header`` directly with crafted inputs
+    (the most direct expression of "scan is bounded to
+    ``branch_uuids``"), and a property check on
+    ``_extract_session_hierarchy`` confirming an agent's synthetic
+    sessionId is a *separate* DAG-line whose uuids do not bleed into
+    the branch's uuids.
+    """
+
+    def test_build_branch_header_scan_is_bounded_to_branch_uuids(self) -> None:
+        """Unit-level: even when ``uuid_to_entry`` contains a tempting
+        agent user entry, the scan ignores it because that uuid isn't
+        in ``branch_uuids``. This is the sharpest expression of the
+        invariant — a future change that widens the scan beyond
+        ``branch_uuids`` would fail this test immediately.
+        """
+        from claude_code_log.factories import create_transcript_entry
+        from claude_code_log.renderer import (
+            RenderingContext,
+            _build_branch_header,
+        )
+
+        # Branch's own DAG-line: an assistant-start branch (d → e),
+        # where e carries the legitimate branch-local user text. The
+        # agent's inner first user prompt (agent_first) is in
+        # `uuid_to_entry` but NOT in branch_uuids — it lives in a
+        # separate DAG-line, just as `_integrate_agent_entries` ensures.
+        d_entry = create_transcript_entry(
+            {
+                "type": "assistant",
+                "uuid": "d",
+                "timestamp": "2025-07-01T10:03:00Z",
+                "parentUuid": "c",
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "requestId": "r2",
+                "message": {
+                    "id": "d",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3",
+                    "content": [{"type": "text", "text": "Branch 1 leading asst"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            }
+        )
+        e_entry = create_transcript_entry(
+            {
+                "type": "user",
+                "uuid": "e",
+                "timestamp": "2025-07-01T10:04:00Z",
+                "parentUuid": "d",
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "BRANCH-LOCAL user turn"}],
+                },
+            }
+        )
+        agent_first_entry = create_transcript_entry(
+            {
+                "type": "user",
+                "uuid": "agent_first",
+                "timestamp": "2025-07-01T10:03:30Z",
+                "parentUuid": "d",
+                "isSidechain": True,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1#agent-ag1",
+                "version": "1.0.0",
+                "agentId": "ag1",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "AGENT INNER PROMPT — MUST NOT be lifted",
+                        }
+                    ],
+                },
+            }
+        )
+
+        # Branch hierarchy entry. Crucially, ``uuids`` lists ONLY the
+        # branch's own DAG-line — d, e — not the agent's inner uuid.
+        session_hierarchy = {
+            "s1@d_branch": {
+                "parent_session_id": "s1",
+                "attachment_uuid": "c",
+                "depth": 1,
+                "is_branch": True,
+                "original_session_id": "s1",
+                "first_uuid": "d",
+                "uuids": ["d", "e"],
+            },
+        }
+        # `uuid_to_entry` knows about ALL entries the renderer iterates
+        # over, including the agent's. The scan must IGNORE it.
+        uuid_to_entry = {
+            "d": d_entry,
+            "e": e_entry,
+            "agent_first": agent_first_entry,
+        }
+
+        result = _build_branch_header(
+            branch_sid="s1@d_branch",
+            message=d_entry,  # the trigger (branch's first DAG entry)
+            session_hierarchy=session_hierarchy,
+            session_summaries={},
+            session_team_names={},
+            uuid_to_entry=uuid_to_entry,
+            ctx=RenderingContext(),
+        )
+
+        assert result.preview == "BRANCH-LOCAL user turn", (
+            "branch preview must come from the branch-local user turn "
+            f"(uuid e), NOT the spawned agent's inner prompt; "
+            f"got preview={result.preview!r}"
+        )
+        # Belt-and-braces: the agent prompt text must not appear
+        # anywhere in the title either.
+        assert "AGENT INNER PROMPT" not in (result.title or "")
+
+    def test_extract_session_hierarchy_keeps_agent_uuids_in_separate_dag_line(
+        self, tmp_path: Path
+    ) -> None:
+        """Property check on the integration: an agent's synthetic
+        ``{trunk}#agent-{id}`` session gets its OWN DAG-line whose
+        uuids do not appear in any other session's ``uuids``. This is
+        the upstream guarantee that ``_build_branch_header``'s scan
+        relies on; pinning it here means a regression in
+        ``_integrate_agent_entries`` (or its consumers) trips this
+        test before it can silently leak agent uuids into a branch's
+        preview.
+        """
+
+        # Trunk with a Task tool_use spawn anchor. Two assistants off
+        # `c` so the fork-collapse heuristic doesn't absorb branch 2
+        # (see ``test_branch_starting_with_assistant_uses_later_user_text``
+        # for the same workaround and rationale).
+        task_tool_use_id = "toolu_spawn"
+        agent_id = "ag1"
+        trunk_entries: list[dict[str, Any]] = [
+            _user_entry("a", None, "Hello", timestamp="2025-07-01T10:00:00Z"),
+            _assistant_entry(
+                "b", "a", "Hi", timestamp="2025-07-01T10:01:00Z", request_id="r1"
+            ),
+            _user_entry("c", "b", "Fork", timestamp="2025-07-01T10:02:00Z"),
+            # branch 1: assistant-first with a Task tool_use anchoring
+            # an agent spawn
+            {
+                "type": "assistant",
+                "uuid": "d",
+                "timestamp": "2025-07-01T10:03:00Z",
+                "parentUuid": "c",
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "requestId": "r2",
+                "message": {
+                    "id": "d",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": task_tool_use_id,
+                            "name": "Task",
+                            "input": {
+                                "subagent_type": "general-purpose",
+                                "prompt": "do the thing",
+                            },
+                        }
+                    ],
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            },
+            # Tool result anchor for the agent (carries agentId so
+            # _integrate_agent_entries can re-parent the sidechain
+            # entries to this UUID).
+            {
+                "type": "user",
+                "uuid": "d_result",
+                "timestamp": "2025-07-01T10:03:30Z",
+                "parentUuid": "d",
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "agentId": agent_id,
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": task_tool_use_id,
+                            "content": "done",
+                        }
+                    ],
+                },
+            },
+            _user_entry(
+                "e",
+                "d_result",
+                "BRANCH-LOCAL user turn",
+                timestamp="2025-07-01T10:04:00Z",
+            ),
+            # branch 2 sibling assistant (bypasses fork-collapse)
+            _assistant_entry(
+                "f",
+                "c",
+                "alt branch first reply",
+                timestamp="2025-07-01T10:05:00Z",
+                request_id="r3",
+            ),
+        ]
+
+        # Agent sidechain entries — separate file, joined by the
+        # standard ``agent-<id>.jsonl`` legacy layout.
+        agent_entries: list[dict[str, Any]] = [
+            {
+                "type": "user",
+                "uuid": "agent_first",
+                "timestamp": "2025-07-01T10:03:35Z",
+                "parentUuid": "d_result",
+                "isSidechain": True,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "agentId": agent_id,
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "AGENT INNER PROMPT must not be lifted",
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": "agent_reply",
+                "timestamp": "2025-07-01T10:03:40Z",
+                "parentUuid": "agent_first",
+                "isSidechain": True,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "agentId": agent_id,
+                "requestId": "ra",
+                "message": {
+                    "id": "agent_reply",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3",
+                    "content": [{"type": "text", "text": "agent ack"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            },
+        ]
+
+        project_dir = tmp_path / "agent-in-branch-project"
+        project_dir.mkdir()
+        _write_jsonl(project_dir / "s1.jsonl", trunk_entries)
+        _write_jsonl(project_dir / f"agent-{agent_id}.jsonl", agent_entries)
+
+        result, session_tree = load_directory_transcripts(project_dir, silent=True)
+        # Property 1: the agent gets its own DAG-line whose session
+        # id is synthetic (`{trunk}#agent-{id}`).
+        assert session_tree is not None
+        agent_sid_candidates = [
+            sid for sid in session_tree.sessions if "#agent-" in sid
+        ]
+        assert agent_sid_candidates, (
+            "expected a synthetic `{trunk}#agent-{id}` DAG-line; "
+            f"got sessions: {list(session_tree.sessions)}"
+        )
+
+        # Property 2: that agent DAG-line's uuids do NOT bleed into
+        # any other session's `uuids`. If they ever did, the branch
+        # scan could lift the agent's prompt — the very thing the
+        # deleted is_sidechain guard used to prevent.
+        agent_uuids: set[str] = set()
+        for sid in agent_sid_candidates:
+            agent_uuids.update(session_tree.sessions[sid].uuids)
+        for sid, dl in session_tree.sessions.items():
+            if "#agent-" in sid:
+                continue
+            overlap = agent_uuids & set(dl.uuids)
+            assert not overlap, (
+                f"agent uuids leaked into non-agent DAG-line {sid!r}: "
+                f"{overlap}. This would let _build_branch_header's "
+                "DAG-line scan lift an agent's inner prompt as the "
+                "branch preview — the regression the deleted "
+                "is_sidechain guard used to prevent."
+            )
+
+        # Property 3 (end-to-end belt-and-braces): the rendered branch
+        # carrying the agent spawn picks the BRANCH-LOCAL preview,
+        # not the agent's inner text. This is what would visibly
+        # regress if properties 1+2 broke.
+        roots, _nav, _ctx = generate_template_messages(
+            result, session_tree=session_tree
+        )
+        branch_contents = _branch_headers(roots)
+        branch_d = [b for b in branch_contents if b.first_uuid == "d"]
+        assert branch_d, (
+            f"expected branch header rooted at 'd'; got: "
+            f"{[(b.first_uuid, b.preview) for b in branch_contents]}"
+        )
+        preview = branch_d[0].preview or ""
+        assert "BRANCH-LOCAL" in preview, (
+            f"branch preview must come from the branch-local user turn; "
+            f"got preview={preview!r}"
+        )
+        assert "AGENT INNER PROMPT" not in preview, (
+            f"branch preview leaked the agent's inner first user prompt; "
+            f"got preview={preview!r}"
+        )


### PR DESCRIPTION
## Summary

The branch `SessionHeaderMessage` preview — which feeds the body header title, the session/graph nav, and the fork-point box's backlink, all of which must agree on `Branch • <uuid8> • <preview>` — was computed in two coordinating places:

1. The render loop extracted text from the branch's first transcript entry (the trigger that opened the branch).
2. An `_enrich_branch_titles` post-pass walked `ctx.messages` and back-filled the preview when (1) found nothing — the case where a branch starts with an assistant turn ("No response requested." after `/exit`) or a tool_result.

This collapses the two into one: `_extract_session_hierarchy` exposes each branch's full DAG-line uuid sequence (`hierarchy[sid]["uuids"]`); the render loop builds a `uuid → entry` map once; and `_build_branch_header` scans those uuids in DAG order for the first user entry with non-empty text via the same `extract_text_content` + `create_session_preview` path the slash-command capture uses. The post-pass goes away. `_branch_label` remains the single label formatter.

> **Stacking note:** this PR targets `wf/simplify/factor-session-headers` (the previous PR in the simplification track), not `main`. The base will be retargeted to `main` after the parent merges. Reviewing against the previous branch keeps the diff scoped to just this opportunity's change.

## #129 slash-command precedence — preserved structurally

The previous rule ("never widen an existing preview, including a 5-char `/exit` body, with a longer-but-less-informative scan result") only existed because `_enrich_branch_titles` could overwrite. With a single computation, DAG order does the work: a slash-command user entry sits at `uuids[0]`; the scan picks it on the first iteration and breaks. Length never enters the comparison.

## Implicit sidechain invariant

The deleted `_enrich_branch_titles` had an explicit `if msg.is_sidechain: continue` guard to avoid lifting a subagent's inner first user prompt as the branch preview (agent messages can carry a branch's `render_session_id`). The new code does not need that guard because it scans the branch's own DAG-line uuids; agent entries live in a separate `{trunk}#agent-{id}` DAG-line (re-parented by `_integrate_agent_entries` before `build_dag`). The guard was an artifact of the old `ctx.messages`-iteration approach.

## What changed

- `claude_code_log/renderer.py` — `_extract_session_hierarchy` adds `"uuids"` to each entry; `_render_messages` builds the `uuid → entry` map and threads it into `_build_branch_header`; `_build_branch_header` does the DAG-line scan; `_enrich_branch_titles` and its call deleted; nav-pass comment refreshed.
- `test/test_branch_label_source.py` (new) — two regression tests:
  - `test_branch_starting_with_assistant_uses_later_user_text` — the case the deleted enrich pass back-filled.
  - `test_branch_starting_with_slash_command_preserves_129_precedence` — slash-command body at branch root wins over later longer user reply.
- `dev-docs/dag.md`, `dev-docs/application_model.md`, `dev-docs/rendering-architecture.md` — replace `_enrich_branch_titles` references with the new `_build_branch_header` surface.

Net: `renderer.py` -83 lines; one new test module (+245); three doc files lightly touched.

## Test plan

- [x] `just test` — 1912 passed, 7 skipped (1910 prior + 2 new).
- [x] `just ci` — clean (ruff, pyright, ty).
- [x] HTML + Markdown snapshot suites — byte-identical (zero `.ambr` churn — single-source picks the same preview as trigger + back-fill).
- [x] Fork / session / detail-level + async-agents suites green.
- [x] `test_branch_label_source` — 2 new tests pass via the real `load_directory_transcripts` → `generate_template_messages` pipeline.

Plan reference: `work/simplify-converter-renderer.md` §3 row 7, §4 "dev/simplify-branch-label-source".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Branch header previews are now computed during header construction by scanning each branch’s message sequence for the first user text, removing a separate post-render backfill step.

* **Tests**
  * Added regression tests for preview selection edge cases: assistant-first branches, slash-command precedence, and ensuring agent/sidechain messages are not used for branch previews.

* **Documentation**
  * Updated architecture and model docs to reflect the new preview-generation ordering and message reindexing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daaain/claude-code-log/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->