### PR TITLE
Fix AskUserQuestion result rendering + highlight chosen options (#180)

### DIFF
--- a/claude_code_log/factories/tool_factory.py
+++ b/claude_code_log/factories/tool_factory.py
@@ -593,6 +593,66 @@ def _parse_askuserquestion_text(content: str) -> Optional[AskUserQuestionOutput]
     return AskUserQuestionOutput(answers=answers, raw_message=content)
 
 
+_ASKUSERQUESTION_CLARIFY_Q_RE = re.compile(r'-\s+"(.*)"$')
+_ASKUSERQUESTION_CLARIFY_A_RE = re.compile(r"Answer:\s*(.*)$")
+
+
+def _parse_askuserquestion_clarify(content: str) -> Optional[AskUserQuestionOutput]:
+    """Parse the "clarify" rejection result (issue #180).
+
+    When the user types a free-form reply instead of picking an option, the
+    tool use is rejected and the result is an ``is_error`` message of the form::
+
+        The user doesn't want to proceed with this tool use. ...
+            Questions asked:
+        - "<question>"
+          Answer: <free-form reply>
+        - "<question>"
+          (No answer provided)
+
+    We surface it as a normal answered card: each question with the user's
+    free-form reply as the chosen answer (empty when none was given). Options
+    are recovered later from the paired tool_use input by the renderer.
+    """
+    if "Questions asked:" not in content:
+        return None
+    lowered = content.lower()
+    if "clarify" not in lowered and "doesn't want to proceed" not in lowered:
+        return None
+
+    tail = content.split("Questions asked:", 1)[1]
+    answers: list[AskUserQuestionAnswer] = []
+    cur_q: Optional[str] = None
+    cur_ans: list[str] = []
+    no_answer = False
+
+    def flush() -> None:
+        nonlocal cur_q, cur_ans, no_answer
+        if cur_q is not None:
+            answer = "" if no_answer else "\n".join(cur_ans).strip()
+            answers.append(AskUserQuestionAnswer(question=cur_q, answer=answer))
+        cur_q, cur_ans, no_answer = None, [], False
+
+    for raw in tail.splitlines():
+        line = raw.strip()
+        if q_match := _ASKUSERQUESTION_CLARIFY_Q_RE.match(line):
+            flush()
+            cur_q = q_match.group(1)
+        elif cur_q is None:
+            continue
+        elif line == "(No answer provided)":
+            no_answer = True
+        elif a_match := _ASKUSERQUESTION_CLARIFY_A_RE.match(line):
+            cur_ans.append(a_match.group(1))
+        elif line:
+            cur_ans.append(line)
+    flush()
+
+    if not answers:
+        return None
+    return AskUserQuestionOutput(answers=answers, raw_message=content)
+
+
 def parse_askuserquestion_output(
     tool_result: ToolResultContent,
     file_path: Optional[str],
@@ -621,7 +681,9 @@ def parse_askuserquestion_output(
             return structured
     if not (content := _extract_tool_result_text(tool_result)):
         return None
-    return _parse_askuserquestion_text(content)
+    return _parse_askuserquestion_text(content) or _parse_askuserquestion_clarify(
+        content
+    )
 
 
 def parse_exitplanmode_output(
@@ -1519,12 +1581,19 @@ def create_tool_result_message(
         tool_use_result,
     )
 
+    # An AskUserQuestion "clarify" rejection arrives as an ``is_error`` result,
+    # but we re-present it as a normal answered card (questions + the user's
+    # free-form reply), so drop the error framing (#180).
+    is_error = tool_result.is_error or False
+    if is_error and isinstance(parsed_output, AskUserQuestionOutput):
+        is_error = False
+
     # Create content model with rendering context
     content_model: MessageContent = ToolResultMessage(
         meta,
         tool_use_id=tool_result.tool_use_id,
         output=parsed_output,
-        is_error=tool_result.is_error or False,
+        is_error=is_error,
         tool_name=result_tool_name,
         file_path=result_file_path,
     )
@@ -1537,5 +1606,5 @@ def create_tool_result_message(
         message_type="tool_result",
         content=content_model,
         tool_use_id=tool_result.tool_use_id,
-        is_error=tool_result.is_error or False,
+        is_error=is_error,
     )

--- a/claude_code_log/factories/tool_factory.py
+++ b/claude_code_log/factories/tool_factory.py
@@ -15,13 +15,14 @@ import re
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from .agent_metadata_factory import parse_agent_result_metadata
 from ..plugins import apply_transformers
 from ..models import (
     # Tool input models
     AskUserQuestionInput,
+    AskUserQuestionItem,
     BashInput,
     EditInput,
     ExitPlanModeInput,
@@ -522,48 +523,105 @@ def parse_bash_output(
     return BashOutput(content=content, has_ansi=has_ansi, background_task_id=bg_task_id)
 
 
+# The result summary sentence has carried two wordings across harness
+# versions: the original "User has answered your question(s): ..." and the
+# current "Your questions have been answered: ..." (issue #180). Accept both.
+_ASKUSERQUESTION_SUMMARY_RE = re.compile(
+    r"(?:User has answered your questions?|Your questions have been answered): "
+    r"(.+)\. You can now continue",
+    re.DOTALL,
+)
+_ASKUSERQUESTION_PAIR_RE = re.compile(r'"([^"]+)"="([^"]+)"')
+
+
+def _parse_askuserquestion_structured(
+    data: dict[str, Any],
+) -> Optional[AskUserQuestionOutput]:
+    """Build the output from the structured ``toolUseResult`` (preferred).
+
+    ``toolUseResult`` carries an ``answers`` map (question text → chosen
+    answer) plus the original ``questions`` (with headers/options), which is
+    both more robust than scraping the summary sentence and rich enough to
+    render the offered options with the chosen one highlighted.
+    """
+    raw_answers = data.get("answers")
+    if not isinstance(raw_answers, dict) or not raw_answers:
+        return None
+    answers_map = cast(dict[Any, Any], raw_answers)
+
+    # Index the original questions by their text for header/option lookup.
+    questions_by_text: dict[str, AskUserQuestionItem] = {}
+    raw_questions = data.get("questions")
+    if isinstance(raw_questions, list):
+        for rq in cast(list[Any], raw_questions):
+            try:
+                item = AskUserQuestionItem.model_validate(rq)
+            except ValidationError:
+                continue
+            if item.question:
+                questions_by_text[item.question] = item
+
+    answers: list[AskUserQuestionAnswer] = []
+    for q_text, a_text in answers_map.items():
+        if not isinstance(q_text, str) or not isinstance(a_text, str):
+            continue
+        item = questions_by_text.get(q_text)
+        answers.append(
+            AskUserQuestionAnswer(
+                question=q_text,
+                answer=a_text,
+                header=item.header if item else None,
+                options=list(item.options) if item else [],
+                multi_select=item.multiSelect if item else False,
+            )
+        )
+
+    if not answers:
+        return None
+    return AskUserQuestionOutput(answers=answers, raw_message="")
+
+
+def _parse_askuserquestion_text(content: str) -> Optional[AskUserQuestionOutput]:
+    """Fallback: scrape the result summary sentence for Q/A pairs."""
+    match = _ASKUSERQUESTION_SUMMARY_RE.match(content)
+    if not match:
+        return None
+    pairs = _ASKUSERQUESTION_PAIR_RE.findall(match.group(1))
+    if not pairs:
+        return None
+    answers = [AskUserQuestionAnswer(question=q, answer=a) for q, a in pairs]
+    return AskUserQuestionOutput(answers=answers, raw_message=content)
+
+
 def parse_askuserquestion_output(
-    tool_result: ToolResultContent, file_path: Optional[str]
+    tool_result: ToolResultContent,
+    file_path: Optional[str],
+    tool_use_result: Optional[ToolUseResult] = None,
 ) -> Optional[AskUserQuestionOutput]:
     """Parse AskUserQuestion tool result into structured content.
 
-    Parses the result format:
-    'User has answered your questions: "Q1"="A1", "Q2"="A2". You can now continue...'
+    Prefers the structured ``toolUseResult`` (answers map + original
+    questions); falls back to parsing the summary sentence, which has used
+    two wordings across harness versions (issue #180):
+    'User has answered your questions: "Q1"="A1", ...' and
+    'Your questions have been answered: "Q1"="A1", ...'.
 
     Args:
-        tool_result: The tool result content
+        tool_result: The tool result content (used for the text fallback)
         file_path: Unused for AskUserQuestion tool
+        tool_use_result: Structured toolUseResult when available
 
     Returns:
-        AskUserQuestionOutput with Q&A pairs
+        AskUserQuestionOutput with Q&A pairs, or None.
     """
     del file_path  # Unused
+    if isinstance(tool_use_result, dict):
+        structured = _parse_askuserquestion_structured(tool_use_result)
+        if structured is not None:
+            return structured
     if not (content := _extract_tool_result_text(tool_result)):
         return None
-    # Check if this is a successful answer
-    if not content.startswith("User has answered your question"):
-        return None
-
-    # Extract the Q&A portion between the colon and the final sentence
-    match = re.match(
-        r"User has answered your questions?: (.+)\. You can now continue",
-        content,
-        re.DOTALL,
-    )
-    if not match:
-        return None
-
-    qa_portion = match.group(1)
-
-    # Parse "Question"="Answer" pairs
-    qa_pattern = re.compile(r'"([^"]+)"="([^"]+)"')
-    pairs = qa_pattern.findall(qa_portion)
-
-    if not pairs:
-        return None
-
-    answers = [AskUserQuestionAnswer(question=q, answer=a) for q, a in pairs]
-    return AskUserQuestionOutput(answers=answers, raw_message=content)
+    return _parse_askuserquestion_text(content)
 
 
 def parse_exitplanmode_output(
@@ -1321,6 +1379,7 @@ PARSERS_WITH_TOOL_USE_RESULT: set[str] = {
     "Bash",
     "TaskStop",
     "Read",
+    "AskUserQuestion",
 }
 
 

--- a/claude_code_log/factories/tool_factory.py
+++ b/claude_code_log/factories/tool_factory.py
@@ -523,11 +523,13 @@ def parse_bash_output(
     return BashOutput(content=content, has_ansi=has_ansi, background_task_id=bg_task_id)
 
 
-# The result summary sentence has carried two wordings across harness
-# versions: the original "User has answered your question(s): ..." and the
-# current "Your questions have been answered: ..." (issue #180). Accept both.
+# The result summary sentence has carried a few wordings across harness
+# versions: "User has answered your question:" / "...questions:" / the literal
+# "...question(s):", and the current "Your questions have been answered: ..."
+# (issue #180). Accept them all.
 _ASKUSERQUESTION_SUMMARY_RE = re.compile(
-    r"(?:User has answered your questions?|Your questions have been answered): "
+    r"(?:User has answered your question(?:s|\(s\))?"
+    r"|Your questions have been answered): "
     r"(.+)\. You can now continue",
     re.DOTALL,
 )

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -26,6 +26,7 @@ from ..models import (
     TaskNotificationMessage,
     TeammateMessage,
     ThinkingMessage,
+    ToolResultMessage,
     ToolUseMessage,
     TranscriptEntry,
     UnknownMessage,
@@ -34,6 +35,7 @@ from ..models import (
     UserTextMessage,
     # Tool input types
     AskUserQuestionInput,
+    AskUserQuestionItem,
     BashInput,
     EditInput,
     ExitPlanModeInput,
@@ -88,6 +90,7 @@ from ..models import (
 )
 from ..renderer import (
     Renderer,
+    RenderingContext,
     TemplateMessage,
     generate_template_messages,
     prepare_projects_index,
@@ -342,6 +345,10 @@ class HtmlRenderer(Renderer):
         # the id; it's minted on creation and only appears on the
         # tool_result).
         self._task_id_by_tool_use: dict[str, dict[str, str]] = {}
+        # RenderingContext snapshot for the current render, so format methods
+        # can resolve a message's pair partner (pair_first/pair_last) by index
+        # — mirrors MarkdownRenderer._ctx. Reset each render.
+        self._ctx: Optional[RenderingContext] = None
 
     # -------------------------------------------------------------------------
     # Private Utility Methods
@@ -356,6 +363,83 @@ class HtmlRenderer(Renderer):
         """
         sid = message.meta.session_id if message.meta else ""
         return self._teammate_colors_by_session.get(sid, {})
+
+    def _askuserquestion_questions_for(
+        self, message: TemplateMessage
+    ) -> dict[str, "AskUserQuestionItem"]:
+        """Map question-text → original question for *message*'s pair partner.
+
+        Used by the AskUserQuestion result formatter to recover the offered
+        options/header when its own structured data lacks them (text-fallback
+        and clarify-rejection paths), by reaching into the paired tool_use's
+        ``AskUserQuestionInput``.
+        """
+        if self._ctx is None or message.pair_first is None:
+            return {}
+        pair_msg = self._ctx.get(message.pair_first)
+        if pair_msg is None or not isinstance(pair_msg.content, ToolUseMessage):
+            return {}
+        input_content = pair_msg.content.input
+        if not isinstance(input_content, AskUserQuestionInput):
+            return {}
+        return {q.question: q for q in input_content.questions if q.question}
+
+    def _collapse_askuserquestion_pairs(self, ctx: RenderingContext) -> None:
+        """Make answered AskUserQuestion results self-contained, single cards.
+
+        For each result paired with its tool_use: bake the offered
+        options/header/multiSelect from the input onto the result's answers (so
+        the result card shows the full question even on the text-fallback and
+        clarify-rejection paths), then drop the result's pair role so it renders
+        as a standalone card. The paired input card is ghosted separately by
+        ``format_AskUserQuestionInput`` / ``title_ToolUseMessage`` — its
+        ``pair_last`` link stays intact so that ghosting still fires (#180).
+        """
+        for msg in ctx.messages:
+            content = msg.content
+            if not isinstance(content, ToolResultMessage):
+                continue
+            output = content.output
+            if not isinstance(output, AskUserQuestionOutput):
+                continue
+            if msg.pair_first is None:
+                continue
+            input_msg = ctx.get(msg.pair_first)
+            if input_msg is None or not isinstance(input_msg.content, ToolUseMessage):
+                continue
+            input_content = input_msg.content.input
+            if not isinstance(input_content, AskUserQuestionInput):
+                continue
+            qmap = {q.question: q for q in input_content.questions if q.question}
+            for ans in output.answers:
+                q = qmap.get(ans.question)
+                if q is None:
+                    continue
+                if not ans.options:
+                    ans.options = list(q.options)
+                if ans.header is None:
+                    ans.header = q.header
+                if not ans.multi_select:
+                    ans.multi_select = q.multiSelect
+            # Render the result standalone — no dangling "second half of a pair"
+            # merge band now that its companion input card is ghosted.
+            msg.pair_first = None
+            msg.pair_duration = None
+
+    def _paired_answer_supersedes(self, message: TemplateMessage) -> bool:
+        """True when *message* (an AskUserQuestion tool_use) is paired with a
+        result that already re-renders the questions + the user's choice.
+
+        In that case the input card is pure duplication and is ghosted. When
+        there is no such pair (e.g. a transcript captured while still blocked
+        on the question), the input card stays.
+        """
+        if self._ctx is None or not message.is_first_in_pair:
+            return False
+        result_msg = self._ctx.get(message.pair_last) if message.pair_last else None
+        if result_msg is None or not isinstance(result_msg.content, ToolResultMessage):
+            return False
+        return isinstance(result_msg.content.output, AskUserQuestionOutput)
 
     def _format_image(self, image: ImageContent) -> str:
         """Format image based on export mode."""
@@ -528,9 +612,15 @@ class HtmlRenderer(Renderer):
         return format_todowrite_input(input)
 
     def format_AskUserQuestionInput(
-        self, input: AskUserQuestionInput, _: TemplateMessage
+        self, input: AskUserQuestionInput, message: TemplateMessage
     ) -> str:
-        """Format → questions as definition list."""
+        """Format → questions as definition list.
+
+        Ghosted (empty) when a paired result already re-renders the questions
+        plus the user's choice — see ``_paired_answer_supersedes``.
+        """
+        if self._paired_answer_supersedes(message):
+            return ""
         return format_askuserquestion_input(input)
 
     def format_ExitPlanModeInput(
@@ -640,10 +730,16 @@ class HtmlRenderer(Renderer):
         return base + extras if extras else base
 
     def format_AskUserQuestionOutput(
-        self, output: AskUserQuestionOutput, _: TemplateMessage
+        self, output: AskUserQuestionOutput, message: TemplateMessage
     ) -> str:
-        """Format → user's answers as definition list."""
-        return format_askuserquestion_output(output)
+        """Format → each question with its options, the chosen one highlighted.
+
+        Options/headers missing from the result's own data (text-fallback and
+        clarify-rejection paths) are recovered from the paired tool_use input.
+        """
+        return format_askuserquestion_output(
+            output, self._askuserquestion_questions_for(message)
+        )
 
     def format_ExitPlanModeOutput(
         self, output: ExitPlanModeOutput, _: TemplateMessage
@@ -794,6 +890,20 @@ class HtmlRenderer(Renderer):
     ) -> str:
         """Title → '❓ Asking questions...'."""
         return "❓ Asking questions..."
+
+    def title_ToolUseMessage(
+        self, content: ToolUseMessage, message: TemplateMessage
+    ) -> str:
+        """Tool-use title, with one ghost case: an AskUserQuestion whose paired
+        result already re-renders the questions returns an empty title so the
+        whole input card elides (empty title + empty body + no children) —
+        ``title_ToolUseMessage`` otherwise falls back to the tool name, which
+        would leave a bare residual card."""
+        if isinstance(
+            content.input, AskUserQuestionInput
+        ) and self._paired_answer_supersedes(message):
+            return ""
+        return super().title_ToolUseMessage(content, message)
 
     def title_TaskInput(self, input: TaskInput, message: TemplateMessage) -> str:
         """Title → '🔧 Task <desc> (subagent_type) [async #<id>]'.
@@ -1305,6 +1415,10 @@ class HtmlRenderer(Renderer):
         self._task_id_by_tool_use = {
             sid: dict(ids) for sid, ids in ctx.task_id_for_tool_use.items()
         }
+        # Snapshot the context so format methods can resolve pair partners.
+        self._ctx = ctx
+        # Collapse answered AskUserQuestion pairs into a single result card (#180).
+        self._collapse_askuserquestion_pairs(ctx)
 
         # Flatten tree via pre-order traversal, formatting content along the way
         with log_timing("Content formatting (pre-order)", t_start):

--- a/claude_code_log/html/templates/components/todo_styles.css
+++ b/claude_code_log/html/templates/components/todo_styles.css
@@ -174,6 +174,23 @@
     font-size: 0.9em;
 }
 
+/* The option the user actually chose (issue #180): highlight it within the
+   answered card so the result reads as "offered → picked" on its own. */
+.question-option.selected {
+    background-color: var(--answer-bg);
+    border-color: var(--user-color);
+    border-left: 3px solid var(--user-color);
+}
+
+.question-option.selected .option-check {
+    color: var(--user-color);
+    font-weight: 700;
+}
+
+.question-option:not(.selected) {
+    opacity: 0.7;
+}
+
 /* ExitPlanMode tool styling */
 .plan-content {
     font-family: var(--font-ui);

--- a/claude_code_log/html/templates/components/todo_styles.css
+++ b/claude_code_log/html/templates/components/todo_styles.css
@@ -187,7 +187,9 @@
     font-weight: 700;
 }
 
-.question-option:not(.selected) {
+/* Only dim unchosen options in the answered/result card — the input question
+   card has no selection, so its options must stay full-opacity. */
+.askuserquestion-result .question-option:not(.selected) {
     opacity: 0.7;
 }
 

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -18,18 +18,20 @@ import base64
 import binascii
 import json
 import re
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from .utils import (
     escape_html,
     render_collapsible_code,
     render_file_content_collapsible,
     render_markdown_collapsible,
+    render_markdown_inline,
 )
 from ..utils import strip_error_tags
 from ..models import (
     AskUserQuestionInput,
     AskUserQuestionItem,
+    AskUserQuestionOption,
     AskUserQuestionOutput,
     BashInput,
     BashOutput,
@@ -71,35 +73,48 @@ from .renderer_code import render_single_diff
 # -- AskUserQuestion Tool -----------------------------------------------------
 
 
-def _render_question_item(q: AskUserQuestionItem) -> str:
-    """Render a single question item to HTML."""
-    html_parts: list[str] = ['<div class="question-block">']
-
-    # Header (if present)
-    if q.header:
-        escaped_header = escape_html(q.header)
-        html_parts.append(f'<div class="question-header">{escaped_header}</div>')
-
-    # Question text with Q: label
-    question_text = escape_html(q.question)
-    html_parts.append(
-        f'<div class="question-text"><span class="qa-label">Q:</span> {question_text}</div>'
+def _render_question_heading(header: Optional[str], question: str) -> list[str]:
+    """Header chip + ``Q:`` line. Question text and header are LLM-authored,
+    so render them as inline Markdown (issue #180)."""
+    parts: list[str] = []
+    if header:
+        parts.append(
+            f'<div class="question-header">{render_markdown_inline(header)}</div>'
+        )
+    parts.append(
+        f'<div class="question-text"><span class="qa-label">Q:</span> '
+        f"{render_markdown_inline(question)}</div>"
     )
+    return parts
 
-    # Options (if present)
+
+def _render_option_li(opt: AskUserQuestionOption, selected: bool) -> str:
+    """One option ``<li>``; ``selected`` marks the user's choice (issue #180).
+
+    Label and description are LLM-authored Markdown, rendered inline."""
+    li_class = "question-option selected" if selected else "question-option"
+    check = (
+        '<span class="option-check" aria-hidden="true">✓</span> ' if selected else ""
+    )
+    if opt.description:
+        desc_html = f'<span class="option-desc"> — {render_markdown_inline(opt.description)}</span>'
+    else:
+        desc_html = ""
+    label = render_markdown_inline(opt.label)
+    return f'<li class="{li_class}">{check}<strong>{label}</strong>{desc_html}</li>'
+
+
+def _render_question_item(q: AskUserQuestionItem) -> str:
+    """Render a single (unanswered) question item to HTML."""
+    html_parts: list[str] = ['<div class="question-block">']
+    html_parts.extend(_render_question_heading(q.header, q.question))
+
     if q.options:
         select_hint = "(select multiple)" if q.multiSelect else "(select one)"
         html_parts.append(f'<div class="question-options-hint">{select_hint}</div>')
         html_parts.append('<ul class="question-options">')
         for opt in q.options:
-            label = escape_html(opt.label)
-            if opt.description:
-                desc_html = f'<span class="option-desc"> — {escape_html(opt.description)}</span>'
-            else:
-                desc_html = ""
-            html_parts.append(
-                f'<li class="question-option"><strong>{label}</strong>{desc_html}</li>'
-            )
+            html_parts.append(_render_option_li(opt, selected=False))
         html_parts.append("</ul>")
 
     html_parts.append("</div>")  # Close question-block
@@ -536,70 +551,58 @@ def _answer_selections(answer: str, multi_select: bool) -> set[str]:
     return {s for s in selections if s}
 
 
-def format_askuserquestion_output(output: AskUserQuestionOutput) -> str:
-    """Format AskUserQuestion tool result with styled Q&A pairs.
+def format_askuserquestion_output(
+    output: AskUserQuestionOutput,
+    questions_by_text: Optional[dict[str, AskUserQuestionItem]] = None,
+) -> str:
+    """Format AskUserQuestion tool result with styled, answered Q&A blocks.
 
-    When the structured ``toolUseResult`` supplied the original options
-    (issue #180), each answered question renders the offered options with the
-    chosen one(s) highlighted — a self-contained "what was offered, what was
-    picked" card. Without options (text-fallback parse) it degrades to a plain
-    Q→A line.
+    Each answered question renders the offered options with the chosen one(s)
+    highlighted — a self-contained "what was offered → what was picked" card
+    (issue #180). Options/header come from the answer's own structured data, or
+    from ``questions_by_text`` (the paired tool_use input) when the result text
+    alone didn't carry them (text-fallback and clarify-rejection paths).
 
-    Args:
-        output: Parsed AskUserQuestionOutput with Q&A pairs
-
-    Returns:
-        HTML string with styled question/answer blocks
+    Selection handling:
+    - An answer matching an offered option highlights that option.
+    - A free-form answer (matches no option) renders as an extra *selected*
+      block after the options, so the user's typed reply is shown as the choice.
+    - An empty answer (the user left that question unanswered) shows the options
+      with none selected.
     """
+    questions_by_text = questions_by_text or {}
     html_parts: list[str] = [
         '<div class="askuserquestion-content askuserquestion-result">'
     ]
 
     for qa in output.answers:
-        html_parts.append('<div class="question-block answered">')
-        if qa.header:
-            html_parts.append(
-                f'<div class="question-header">{escape_html(qa.header)}</div>'
-            )
-        html_parts.append(
-            f'<div class="question-text"><span class="qa-label">Q:</span> '
-            f"{escape_html(qa.question)}</div>"
-        )
+        paired = questions_by_text.get(qa.question)
+        header = qa.header or (paired.header if paired else None)
+        options = qa.options or (paired.options if paired else [])
+        multi_select = qa.multi_select or (paired.multiSelect if paired else False)
 
-        selections = _answer_selections(qa.answer, qa.multi_select)
+        html_parts.append('<div class="question-block answered">')
+        html_parts.extend(_render_question_heading(header, qa.question))
+
+        selections = (
+            _answer_selections(qa.answer, multi_select) if qa.answer else set[str]()
+        )
         matched_any = False
-        if qa.options:
+        if options:
             html_parts.append('<ul class="question-options">')
-            for opt in qa.options:
+            for opt in options:
                 is_selected = opt.label in selections
                 matched_any = matched_any or is_selected
-                li_class = (
-                    "question-option selected" if is_selected else "question-option"
-                )
-                check = (
-                    '<span class="option-check" aria-hidden="true">✓</span> '
-                    if is_selected
-                    else ""
-                )
-                if opt.description:
-                    desc_html = (
-                        f'<span class="option-desc"> — '
-                        f"{escape_html(opt.description)}</span>"
-                    )
-                else:
-                    desc_html = ""
-                html_parts.append(
-                    f'<li class="{li_class}">{check}'
-                    f"<strong>{escape_html(opt.label)}</strong>{desc_html}</li>"
-                )
+                html_parts.append(_render_option_li(opt, selected=is_selected))
             html_parts.append("</ul>")
 
-        # Show the explicit answer line when there are no options to highlight,
-        # or when the answer didn't match any offered option (e.g. free text).
-        if not qa.options or not matched_any:
+        if qa.answer and not matched_any:
+            # Free-form reply (or no options to match against): show the typed
+            # answer as the selected block so it reads as the user's choice.
             html_parts.append(
-                f'<div class="answer-text"><span class="qa-label answer">A:</span> '
-                f"{escape_html(qa.answer)}</div>"
+                '<ul class="question-options"><li class="question-option selected">'
+                '<span class="option-check" aria-hidden="true">✓</span> '
+                f"<strong>{render_markdown_inline(qa.answer)}</strong></li></ul>"
             )
 
         html_parts.append("</div>")

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -141,19 +141,18 @@ def format_askuserquestion_result(content: str) -> str:
 
     Returns HTML with styled Q&A blocks matching the input styling.
     """
-    # Check if this is a successful answer
-    if not content.startswith("User has answered your question"):
-        # Return as-is for errors or unexpected format
-        return ""
-
-    # Extract the Q&A portion between the colon and the final sentence
-    # Pattern: 'User has answered your questions: "Q"="A", "Q"="A". You can now...'
+    # Extract the Q&A portion between the colon and the final sentence. The
+    # summary sentence has used two wordings across harness versions (#180):
+    # 'User has answered your questions: "Q"="A", ... . You can now continue...'
+    # 'Your questions have been answered: "Q"="A", ... . You can now continue...'
     match = re.match(
-        r"User has answered your questions?: (.+)\. You can now continue",
+        r"(?:User has answered your questions?|Your questions have been answered): "
+        r"(.+)\. You can now continue",
         content,
         re.DOTALL,
     )
     if not match:
+        # Return as-is for errors or unexpected format
         return ""
 
     qa_portion = match.group(1)
@@ -524,8 +523,27 @@ def format_task_output(output: TaskOutput) -> str:
     return "".join(parts)
 
 
+def _answer_selections(answer: str, multi_select: bool) -> set[str]:
+    """Return the set of option labels the answer selected.
+
+    Single-select answers equal one option label verbatim (so an exact match
+    handles labels that themselves contain a comma). Multi-select answers join
+    the chosen labels with ", " — split on that delimiter and match each part.
+    """
+    selections = {answer.strip()}
+    if multi_select:
+        selections.update(part.strip() for part in answer.split(", "))
+    return {s for s in selections if s}
+
+
 def format_askuserquestion_output(output: AskUserQuestionOutput) -> str:
     """Format AskUserQuestion tool result with styled Q&A pairs.
+
+    When the structured ``toolUseResult`` supplied the original options
+    (issue #180), each answered question renders the offered options with the
+    chosen one(s) highlighted — a self-contained "what was offered, what was
+    picked" card. Without options (text-fallback parse) it degrades to a plain
+    Q→A line.
 
     Args:
         output: Parsed AskUserQuestionOutput with Q&A pairs
@@ -538,15 +556,52 @@ def format_askuserquestion_output(output: AskUserQuestionOutput) -> str:
     ]
 
     for qa in output.answers:
-        escaped_q = escape_html(qa.question)
-        escaped_a = escape_html(qa.answer)
         html_parts.append('<div class="question-block answered">')
+        if qa.header:
+            html_parts.append(
+                f'<div class="question-header">{escape_html(qa.header)}</div>'
+            )
         html_parts.append(
-            f'<div class="question-text"><span class="qa-label">Q:</span> {escaped_q}</div>'
+            f'<div class="question-text"><span class="qa-label">Q:</span> '
+            f"{escape_html(qa.question)}</div>"
         )
-        html_parts.append(
-            f'<div class="answer-text"><span class="qa-label answer">A:</span> {escaped_a}</div>'
-        )
+
+        selections = _answer_selections(qa.answer, qa.multi_select)
+        matched_any = False
+        if qa.options:
+            html_parts.append('<ul class="question-options">')
+            for opt in qa.options:
+                is_selected = opt.label in selections
+                matched_any = matched_any or is_selected
+                li_class = (
+                    "question-option selected" if is_selected else "question-option"
+                )
+                check = (
+                    '<span class="option-check" aria-hidden="true">✓</span> '
+                    if is_selected
+                    else ""
+                )
+                if opt.description:
+                    desc_html = (
+                        f'<span class="option-desc"> — '
+                        f"{escape_html(opt.description)}</span>"
+                    )
+                else:
+                    desc_html = ""
+                html_parts.append(
+                    f'<li class="{li_class}">{check}'
+                    f"<strong>{escape_html(opt.label)}</strong>{desc_html}</li>"
+                )
+            html_parts.append("</ul>")
+
+        # Show the explicit answer line when there are no options to highlight,
+        # or when the answer didn't match any offered option (e.g. free text).
+        if not qa.options or not matched_any:
+            html_parts.append(
+                f'<div class="answer-text"><span class="qa-label answer">A:</span> '
+                f"{escape_html(qa.answer)}</div>"
+            )
+
         html_parts.append("</div>")
 
     html_parts.append("</div>")

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -15,6 +15,7 @@ HTML-specific output.
 
 import functools
 import html
+import re
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
 
@@ -309,13 +310,18 @@ def render_markdown(text: str) -> str:
         return str(renderer(text))
 
 
+_INLINE_PARA_BOUNDARY_RE = re.compile(r"</p>\s*<p>")
+
+
 def render_markdown_inline(text: str) -> str:
-    """Render markdown but unwrap a single enclosing ``<p>`` for inline use.
+    """Render markdown collapsed to inline-safe HTML.
 
     Question/option text from AskUserQuestion is LLM-authored, so it carries
-    real Markdown (inline code, emphasis, links). Rendering it inline lets a
-    label or one-line question keep its formatting without a block ``<p>``
-    breaking the surrounding flow. Multi-paragraph content keeps its blocks.
+    real Markdown (inline code, emphasis, links). Callers embed the result
+    inside inline wrappers (``<strong>``, ``<li>``), so this unwraps the
+    enclosing ``<p>`` and folds any paragraph boundaries into ``<br>`` —
+    a multi-paragraph free-form reply must not emit block ``<p>`` inside an
+    inline element.
 
     Uses the ``escape=True`` renderer so raw HTML in the text (``<script>``,
     ``<option>``, …) is escaped to literal characters rather than injected —
@@ -323,10 +329,11 @@ def render_markdown_inline(text: str) -> str:
     """
     with timing_stat("_markdown_timings"):
         renderer = _get_user_markdown_renderer()
-        html = str(renderer(text)).strip()
-    if html.startswith("<p>") and html.endswith("</p>") and html.count("<p>") == 1:
-        return html[len("<p>") : -len("</p>")]
-    return html
+        rendered = str(renderer(text)).strip()
+    if rendered.startswith("<p>") and rendered.endswith("</p>"):
+        inner = rendered[len("<p>") : -len("</p>")]
+        return _INLINE_PARA_BOUNDARY_RE.sub("<br>", inner)
+    return rendered
 
 
 @functools.lru_cache(maxsize=1)

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -309,6 +309,26 @@ def render_markdown(text: str) -> str:
         return str(renderer(text))
 
 
+def render_markdown_inline(text: str) -> str:
+    """Render markdown but unwrap a single enclosing ``<p>`` for inline use.
+
+    Question/option text from AskUserQuestion is LLM-authored, so it carries
+    real Markdown (inline code, emphasis, links). Rendering it inline lets a
+    label or one-line question keep its formatting without a block ``<p>``
+    breaking the surrounding flow. Multi-paragraph content keeps its blocks.
+
+    Uses the ``escape=True`` renderer so raw HTML in the text (``<script>``,
+    ``<option>``, …) is escaped to literal characters rather than injected —
+    these short fields were previously HTML-escaped, so keep that contract.
+    """
+    with timing_stat("_markdown_timings"):
+        renderer = _get_user_markdown_renderer()
+        html = str(renderer(text)).strip()
+    if html.startswith("<p>") and html.endswith("</p>") and html.count("<p>") == 1:
+        return html[len("<p>") : -len("</p>")]
+    return html
+
+
 @functools.lru_cache(maxsize=1)
 def _get_user_markdown_renderer() -> mistune.Markdown:
     """Markdown renderer for user-authored text.

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -1745,10 +1745,21 @@ class GrepOutput:
 
 @dataclass
 class AskUserQuestionAnswer:
-    """Single Q&A pair from AskUserQuestion result."""
+    """Single Q&A pair from AskUserQuestion result.
+
+    When the structured ``toolUseResult`` is available it also carries the
+    originating question's ``header`` / ``options`` / ``multi_select`` so the
+    answer can be rendered as a self-contained card (the offered options with
+    the chosen one highlighted) instead of a bare Q→A line.
+    """
 
     question: str
     answer: str
+    header: Optional[str] = None
+    options: list[AskUserQuestionOption] = field(
+        default_factory=lambda: list[AskUserQuestionOption]()
+    )
+    multi_select: bool = False
 
 
 @dataclass

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -2194,6 +2194,23 @@
       font-size: 0.9em;
   }
   
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
+  }
+  
   /* ExitPlanMode tool styling */
   .plan-content {
       font-family: var(--font-ui);
@@ -8108,6 +8125,23 @@
   .question-option .option-desc {
       color: var(--text-muted);
       font-size: 0.9em;
+  }
+  
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
   }
   
   /* ExitPlanMode tool styling */
@@ -16118,6 +16152,23 @@
       font-size: 0.9em;
   }
   
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
+  }
+  
   /* ExitPlanMode tool styling */
   .plan-content {
       font-family: var(--font-ui);
@@ -22137,6 +22188,23 @@
   .question-option .option-desc {
       color: var(--text-muted);
       font-size: 0.9em;
+  }
+  
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
   }
   
   /* ExitPlanMode tool styling */
@@ -28391,6 +28459,23 @@
       font-size: 0.9em;
   }
   
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
+  }
+  
   /* ExitPlanMode tool styling */
   .plan-content {
       font-family: var(--font-ui);
@@ -34509,6 +34594,23 @@
   .question-option .option-desc {
       color: var(--text-muted);
       font-size: 0.9em;
+  }
+  
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
   }
   
   /* ExitPlanMode tool styling */
@@ -40686,6 +40788,23 @@
   .question-option .option-desc {
       color: var(--text-muted);
       font-size: 0.9em;
+  }
+  
+  /* The option the user actually chose (issue #180): highlight it within the
+     answered card so the result reads as "offered → picked" on its own. */
+  .question-option.selected {
+      background-color: var(--answer-bg);
+      border-color: var(--user-color);
+      border-left: 3px solid var(--user-color);
+  }
+  
+  .question-option.selected .option-check {
+      color: var(--user-color);
+      font-weight: 700;
+  }
+  
+  .question-option:not(.selected) {
+      opacity: 0.7;
   }
   
   /* ExitPlanMode tool styling */

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -2207,7 +2207,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   
@@ -8140,7 +8142,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   
@@ -16165,7 +16169,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   
@@ -22203,7 +22209,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   
@@ -28472,7 +28480,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   
@@ -34609,7 +34619,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   
@@ -40803,7 +40815,9 @@
       font-weight: 700;
   }
   
-  .question-option:not(.selected) {
+  /* Only dim unchosen options in the answered/result card — the input question
+     card has no selection, so its options must stay full-opacity. */
+  .askuserquestion-result .question-option:not(.selected) {
       opacity: 0.7;
   }
   

--- a/test/test_askuserquestion_rendering.py
+++ b/test/test_askuserquestion_rendering.py
@@ -398,6 +398,18 @@ class TestAskUserQuestionParser:
         )
         assert parse_askuserquestion_output(tool_result, None, None) is None
 
+    def test_parse_legacy_paren_s_wording(self):
+        """The legacy literal 'question(s)' wording also parses (CR on #189)."""
+        tool_result = ToolResultContent(
+            type="tool_result",
+            tool_use_id="toolu_x",
+            content='User has answered your question(s): "Q1"="A1". '
+            "You can now continue with the user's answers in mind.",
+        )
+        out = parse_askuserquestion_output(tool_result, None, None)
+        assert out is not None
+        assert [(a.question, a.answer) for a in out.answers] == [("Q1", "A1")]
+
     def test_parse_clarify_rejection_free_form(self):
         """The 'clarify' rejection (free-form reply) parses to per-question
         answers — free-form text where given, empty where not (#180)."""
@@ -474,6 +486,17 @@ class TestAskUserQuestionEnrichedOutput:
             self._output(multi_select=True, answer="PostgreSQL, SQLite")
         )
         assert html.count('class="question-option selected"') == 2
+
+    def test_multiparagraph_free_form_answer_is_inline_safe(self):
+        """A multi-paragraph free-form reply must not emit block <p> inside the
+        inline <strong> wrapper of the selected block (CR on PR #189)."""
+        html = format_askuserquestion_output(
+            self._output(answer="First paragraph.\n\nSecond paragraph.")
+        )
+        assert "<strong><p>" not in html
+        assert "</p>" not in html  # no stray block tags in the inline block
+        assert "<br>" in html  # paragraph break folded to <br>
+        assert "First paragraph." in html and "Second paragraph." in html
 
 
 def _render_transcript(entries: list[dict]) -> str:
@@ -574,7 +597,7 @@ class TestAskUserQuestionCollapse:
         ]
         html = _render_transcript(entries)
         # Input card is ghosted: the "Asking questions..." title is gone.
-        assert "Asking questions" not in html
+        assert "❓ Asking questions" not in html
         # The result card highlights the chosen option…
         assert 'class="question-option selected"' in html
         # …and Markdown in the question renders (backticks → <code>).
@@ -583,7 +606,7 @@ class TestAskUserQuestionCollapse:
     def test_unpaired_question_keeps_input_card(self):
         """A tool_use with no answering result (session blocked) still shows."""
         html = _render_transcript([_auq_tool_use("a1", None, "t1", self.QUESTIONS)])
-        assert "Asking questions" in html
+        assert "❓ Asking questions" in html
 
     def test_free_form_reply_not_rendered_as_error(self):
         q = self.QUESTIONS

--- a/test/test_askuserquestion_rendering.py
+++ b/test/test_askuserquestion_rendering.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 """Test cases for AskUserQuestion tool rendering."""
 
+from claude_code_log.factories.tool_factory import parse_askuserquestion_output
 from claude_code_log.html import (
     format_askuserquestion_input,
+    format_askuserquestion_output,
     format_askuserquestion_result,
 )
 from claude_code_log.models import (
+    AskUserQuestionAnswer,
     AskUserQuestionInput,
     AskUserQuestionItem,
     AskUserQuestionOption,
+    AskUserQuestionOutput,
+    ToolResultContent,
 )
 
 
@@ -301,3 +306,145 @@ class TestAskUserQuestionResultRendering:
 
         assert "Preference?" in html
         assert "Option with comma, here" in html
+
+    def test_format_result_new_wording(self):
+        """Regression for #180: the current harness wording must parse.
+
+        The result sentence changed from 'User has answered your questions:'
+        to 'Your questions have been answered:'. Both must render styled Q&A.
+        """
+        content = (
+            'Your questions have been answered: "Which DB?"="PostgreSQL". '
+            "You can now continue with these answers in mind."
+        )
+        html = format_askuserquestion_result(content)
+        assert 'class="question-block answered"' in html
+        assert "Which DB?" in html
+        assert "PostgreSQL" in html
+
+
+def _result_content(tool_use_result):
+    """A ToolResultContent whose text is irrelevant (structured path wins)."""
+    return ToolResultContent(
+        type="tool_result",
+        tool_use_id="toolu_x",
+        content="Your questions have been answered: ... You can now continue.",
+    ), tool_use_result
+
+
+class TestAskUserQuestionParser:
+    """parse_askuserquestion_output: structured-first, text fallback (#180)."""
+
+    def test_parse_structured_carries_options(self):
+        """Structured toolUseResult yields answers enriched with options."""
+        tool_use_result = {
+            "questions": [
+                {
+                    "question": "Which DB?",
+                    "header": "Database",
+                    "multiSelect": False,
+                    "options": [
+                        {"label": "PostgreSQL", "description": "Relational."},
+                        {"label": "SQLite", "description": "Embedded."},
+                    ],
+                }
+            ],
+            "answers": {"Which DB?": "PostgreSQL"},
+        }
+        tool_result, tur = _result_content(tool_use_result)
+        out = parse_askuserquestion_output(tool_result, None, tur)
+        assert out is not None
+        assert len(out.answers) == 1
+        qa = out.answers[0]
+        assert qa.question == "Which DB?"
+        assert qa.answer == "PostgreSQL"
+        assert qa.header == "Database"
+        assert [o.label for o in qa.options] == ["PostgreSQL", "SQLite"]
+        assert qa.multi_select is False
+
+    def test_parse_structured_preferred_over_text(self):
+        """When both are present, the structured answers map wins."""
+        tool_use_result = {"answers": {"Q?": "A from structure"}}
+        tool_result = ToolResultContent(
+            type="tool_result",
+            tool_use_id="toolu_x",
+            content='Your questions have been answered: "Q?"="A from text". '
+            "You can now continue.",
+        )
+        out = parse_askuserquestion_output(tool_result, None, tool_use_result)
+        assert out is not None
+        assert out.answers[0].answer == "A from structure"
+
+    def test_parse_text_fallback_new_wording(self):
+        """No structured data → fall back to the new-wording summary string."""
+        tool_result = ToolResultContent(
+            type="tool_result",
+            tool_use_id="toolu_x",
+            content='Your questions have been answered: "Q1"="A1", "Q2"="A2". '
+            "You can now continue with these answers in mind.",
+        )
+        out = parse_askuserquestion_output(tool_result, None, None)
+        assert out is not None
+        assert [(a.question, a.answer) for a in out.answers] == [
+            ("Q1", "A1"),
+            ("Q2", "A2"),
+        ]
+        # Text fallback has no option context.
+        assert out.answers[0].options == []
+
+    def test_parse_non_answer_returns_none(self):
+        tool_result = ToolResultContent(
+            type="tool_result", tool_use_id="toolu_x", content="User cancelled."
+        )
+        assert parse_askuserquestion_output(tool_result, None, None) is None
+
+
+class TestAskUserQuestionEnrichedOutput:
+    """format_askuserquestion_output: options with the chosen one marked."""
+
+    def _output(self, multi_select=False, answer="PostgreSQL"):
+        return AskUserQuestionOutput(
+            answers=[
+                AskUserQuestionAnswer(
+                    question="Which DB?",
+                    answer=answer,
+                    header="Database",
+                    multi_select=multi_select,
+                    options=[
+                        AskUserQuestionOption(label="PostgreSQL", description="Rel."),
+                        AskUserQuestionOption(label="SQLite", description="Emb."),
+                    ],
+                )
+            ],
+            raw_message="",
+        )
+
+    def test_selected_option_marked_others_not(self):
+        html = format_askuserquestion_output(self._output())
+        # The chosen option gets the selected class + check mark.
+        assert 'class="question-option selected"' in html
+        assert "option-check" in html
+        # The unchosen option is a plain option (no 'selected').
+        assert html.count('class="question-option selected"') == 1
+        assert 'class="question-option"' in html
+        # Header preserved.
+        assert "Database" in html
+
+    def test_no_redundant_answer_line_when_option_matched(self):
+        """When an option is highlighted, the bare 'A:' line is dropped."""
+        html = format_askuserquestion_output(self._output())
+        assert "qa-label answer" not in html
+
+    def test_free_text_answer_falls_back_to_answer_line(self):
+        """An answer matching no option still shows explicitly as 'A:'."""
+        html = format_askuserquestion_output(self._output(answer="MongoDB"))
+        assert "question-option selected" not in html
+        assert "qa-label answer" in html
+        assert "MongoDB" in html
+
+    def test_multiselect_marks_each_chosen_option(self):
+        html = format_askuserquestion_output(
+            self._output(multi_select=True, answer="PostgreSQL, SQLite")
+        )
+        assert html.count('class="question-option selected"') == 2
+        assert "qa-label answer" not in html

--- a/test/test_askuserquestion_rendering.py
+++ b/test/test_askuserquestion_rendering.py
@@ -398,6 +398,29 @@ class TestAskUserQuestionParser:
         )
         assert parse_askuserquestion_output(tool_result, None, None) is None
 
+    def test_parse_clarify_rejection_free_form(self):
+        """The 'clarify' rejection (free-form reply) parses to per-question
+        answers — free-form text where given, empty where not (#180)."""
+        content = (
+            "The user doesn't want to proceed with this tool use. "
+            "To tell you how to proceed, the user said:\n"
+            "The user wants to clarify these questions.\n\n"
+            "    Questions asked:\n"
+            '- "Which DB?"\n'
+            "  Answer: Actually, let's use DuckDB\n"
+            '- "Enable caching?"\n'
+            "  (No answer provided)"
+        )
+        tool_result = ToolResultContent(
+            type="tool_result", tool_use_id="toolu_x", content=content
+        )
+        out = parse_askuserquestion_output(tool_result, None, None)
+        assert out is not None
+        assert [(a.question, a.answer) for a in out.answers] == [
+            ("Which DB?", "Actually, let's use DuckDB"),
+            ("Enable caching?", ""),
+        ]
+
 
 class TestAskUserQuestionEnrichedOutput:
     """format_askuserquestion_output: options with the chosen one marked."""
@@ -430,21 +453,172 @@ class TestAskUserQuestionEnrichedOutput:
         # Header preserved.
         assert "Database" in html
 
-    def test_no_redundant_answer_line_when_option_matched(self):
-        """When an option is highlighted, the bare 'A:' line is dropped."""
+    def test_only_matched_option_is_selected(self):
+        """When the answer matches an option, exactly that option is selected
+        and no extra free-form block is appended."""
         html = format_askuserquestion_output(self._output())
-        assert "qa-label answer" not in html
+        # One selected option, no second selected block for the answer text.
+        assert html.count('class="question-option selected"') == 1
 
-    def test_free_text_answer_falls_back_to_answer_line(self):
-        """An answer matching no option still shows explicitly as 'A:'."""
+    def test_free_text_answer_renders_as_selected_block(self):
+        """A free-form answer (matches no option) renders as an extra selected
+        block after the offered options (issue #180)."""
         html = format_askuserquestion_output(self._output(answer="MongoDB"))
-        assert "question-option selected" not in html
-        assert "qa-label answer" in html
+        # The offered options stay unselected; the typed reply is the choice.
+        assert html.count('class="question-option selected"') == 1
         assert "MongoDB" in html
+        assert "PostgreSQL" in html  # offered options still shown
 
     def test_multiselect_marks_each_chosen_option(self):
         html = format_askuserquestion_output(
             self._output(multi_select=True, answer="PostgreSQL, SQLite")
         )
         assert html.count('class="question-option selected"') == 2
-        assert "qa-label answer" not in html
+
+
+def _render_transcript(entries: list[dict]) -> str:
+    import json
+    import tempfile
+    from pathlib import Path
+
+    from claude_code_log.converter import load_transcript
+    from claude_code_log.html.renderer import generate_html
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    ) as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+        path = Path(f.name)
+    try:
+        return generate_html(load_transcript(path), "AUQ")
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _auq_tool_use(uuid: str, parent, tool_id: str, questions: list[dict]) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": "2026-05-29T11:02:40Z",
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": "s",
+        "version": "2.1.156",
+        "uuid": uuid,
+        "message": {
+            "role": "assistant",
+            "id": "m-" + uuid,
+            "type": "message",
+            "model": "claude",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": "AskUserQuestion",
+                    "input": {"questions": questions},
+                }
+            ],
+        },
+    }
+
+
+class TestAskUserQuestionCollapse:
+    """Integration (#180): answered pairs collapse to one self-contained card;
+    unpaired inputs are kept; free-form replies aren't shown as errors."""
+
+    QUESTIONS = [
+        {
+            "question": "Use `PostgreSQL` or SQLite?",
+            "header": "Database",
+            "multiSelect": False,
+            "options": [
+                {"label": "PostgreSQL", "description": "Robust `relational` DB."},
+                {"label": "SQLite", "description": "Embedded."},
+            ],
+        }
+    ]
+
+    def test_answered_pair_collapses_input_card(self):
+        q = self.QUESTIONS
+        entries = [
+            _auq_tool_use("a1", None, "t1", q),
+            {
+                "type": "user",
+                "timestamp": "2026-05-29T11:02:47Z",
+                "parentUuid": "a1",
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s",
+                "version": "2.1.156",
+                "uuid": "u1",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t1",
+                            "content": "Your questions have been answered: "
+                            '"Use `PostgreSQL` or SQLite?"="PostgreSQL". '
+                            "You can now continue.",
+                        }
+                    ],
+                },
+                "toolUseResult": {
+                    "questions": q,
+                    "answers": {"Use `PostgreSQL` or SQLite?": "PostgreSQL"},
+                },
+            },
+        ]
+        html = _render_transcript(entries)
+        # Input card is ghosted: the "Asking questions..." title is gone.
+        assert "Asking questions" not in html
+        # The result card highlights the chosen option…
+        assert 'class="question-option selected"' in html
+        # …and Markdown in the question renders (backticks → <code>).
+        assert "<code>PostgreSQL</code>" in html
+
+    def test_unpaired_question_keeps_input_card(self):
+        """A tool_use with no answering result (session blocked) still shows."""
+        html = _render_transcript([_auq_tool_use("a1", None, "t1", self.QUESTIONS)])
+        assert "Asking questions" in html
+
+    def test_free_form_reply_not_rendered_as_error(self):
+        q = self.QUESTIONS
+        entries = [
+            _auq_tool_use("a1", None, "t1", q),
+            {
+                "type": "user",
+                "timestamp": "2026-05-29T11:02:47Z",
+                "parentUuid": "a1",
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": "s",
+                "version": "2.1.156",
+                "uuid": "u1",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t1",
+                            "is_error": True,
+                            "content": "The user doesn't want to proceed with this "
+                            "tool use. The user wants to clarify these questions.\n"
+                            "    Questions asked:\n"
+                            '- "Use `PostgreSQL` or SQLite?"\n'
+                            "  Answer: Neither — let's use DuckDB",
+                        }
+                    ],
+                },
+            },
+        ]
+        html = _render_transcript(entries)
+        # The clarify result is shown as a normal answered card, not "Error".
+        assert ">Error<" not in html
+        assert "DuckDB" in html
+        # The user's free-form reply is the selected block.
+        assert 'class="question-option selected"' in html


### PR DESCRIPTION
Fixes #180.

## Part 1 — regression fix (the bug in the screenshot)

The AskUserQuestion **result** card rendered the raw `Your questions have been answered: "Q"="A", …` string as a tiny gray fallback dump instead of styled Q&A.

Root cause: the parser/formatter gated on the literal wording `"User has answered your question(s):"`, but the current harness emits `"Your questions have been answered:"`. The match failed, so parsing returned `None`.

The parser now:
- **Prefers the structured `toolUseResult`** — it carries an `answers` map *and* the original `questions` (headers/options/multiSelect). This is more robust than scraping the summary sentence and richer. `AskUserQuestion` is added to `PARSERS_WITH_TOOL_USE_RESULT` so the parser receives it.
- **Accepts both summary wordings** in the text-fallback path.

This also restores the Markdown renderer, which shares the parser.

## Part 2 — enriched "all-in-one" answer card (proposal)

When options are available, each answered question now renders the **offered options with the chosen one highlighted** (✓ + accent border; unchosen dimmed) instead of a bare `Q → A` line — the result card reads as "what was offered → what was picked" on its own. Degrades to the plain `A:` line when options are absent (text fallback) or the answer matches no option (free text). New `.question-option.selected` styling.

## Before / after (synthetic, sanitized fixture)

| State | What you see |
|-------|--------------|
| before | result card = raw `Your questions have been answered: …` gray text |
| Part 1 only | result card = styled `Q:` / `A:` pairs restored |
| Part 1 + Part 2 | result card = options listed, chosen one highlighted ✓ |

## Open design fork

Part 2's enriched result card now visibly duplicates the input "Asking questions…" card's option menu. The natural next step — collapsing to a true single card (e.g. suppressing the redundant input card, or showing only the picks on the result side) — is a maintainer call and intentionally **not** included here. Part 2 is self-contained and can be dropped if only the Part 1 restore is wanted.

## Tests

- Parser: structured-first, structured-preferred-over-text, new-wording fallback, non-answer → None.
- Enriched output: selected marking, no redundant `A:` line when matched, free-text fallback, multiSelect marks each chosen option.
- Snapshots updated serially (`-n0`) for the embedded-CSS change; no structural HTML in existing fixtures changed.
- `just ci` green (format, unit/TUI/browser, ruff, pyright, ty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual selection indicators (highlighting, left accent, checkmarks) for answered questions; unselected options dimmed
  * Multi-select support and richer display of offered options
  * Answered Q&A collapse into a single, self-contained result card
  * Inline-safe rendering of question/option Markdown

* **Improvements**
  * Prefer structured tool results, with regex fallback for legacy phrasings
  * Free-form and “clarify” replies render as normal answered cards (not errors)

* **Tests**
  * Added parser and rendering tests for formats, enrichment, and collapse behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->