### PR TITLE
Derive render_session_id from the SessionTree, not a loop variable

### DIFF
--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3886,6 +3886,45 @@ def _render_messages(
             and effective_session not in seen_sessions
             and not is_agent_session(msg_session_id)
         ):
+            # Ensure the branch's PARENT trunk session header is
+            # registered FIRST. At non-FULL detail every trunk
+            # message of the branch's parent session can be
+            # filtered out, leaving a branch descendant as the
+            # first surviving entry for that trunk session. Without
+            # this guard, the branch header would register before
+            # any trunk header → ``_reorder_session_template_messages``
+            # (which preserves session-header encounter order) would
+            # emit the branch header as a root section instead of
+            # nesting it under its parent trunk, and the branch
+            # header's ``parent_message_index`` would also be
+            # ``None`` because the trunk header isn't in
+            # ``ctx.session_first_message`` yet. Closes the
+            # CodeRabbit-flagged regression on PR #190.
+            #
+            # ``msg_session_id`` is the JSONL ``sessionId`` of the
+            # branch's own entry (the trunk session id, e.g. ``s1``
+            # — branch sids only exist in the in-memory DAG, never
+            # in the source JSONL). Use it as the parent trunk sid.
+            parent_trunk_sid = msg_session_id or "unknown"
+            if (
+                parent_trunk_sid
+                and parent_trunk_sid not in seen_sessions
+                and not is_agent_session(parent_trunk_sid)
+            ):
+                seen_sessions.add(parent_trunk_sid)
+                trunk_summary = sessions.get(parent_trunk_sid, {}).get("summary")
+                trunk_header_content = _build_trunk_header(
+                    parent_trunk_sid,
+                    trunk_summary,
+                    session_hierarchy,
+                    session_summaries,
+                    session_team_names,
+                    ctx,
+                )
+                trunk_header = TemplateMessage(trunk_header_content)
+                msg_index = ctx.register(trunk_header)
+                ctx.session_first_message[parent_trunk_sid] = msg_index
+
             seen_sessions.add(effective_session)
             branch_header_content = _build_branch_header(
                 effective_session,

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -899,6 +899,62 @@ def _extract_session_hierarchy(
     return hierarchy, junction_targets
 
 
+def _build_uuid_to_render_sid(
+    session_hierarchy: dict[str, dict[str, Any]] | None,
+) -> dict[str, str]:
+    """Build a ``uuid → render_session_id`` map from the SessionTree.
+
+    Each rendered ``TemplateMessage`` carries a ``render_session_id``
+    that groups it with the correct session in the final tree
+    (trunk, within-session branch, or agent's parent). Pre-D11 this
+    was tracked by a loop-local ``current_render_session`` variable
+    flipped on each branch-start trigger — a re-derivation of what
+    the ``SessionTree`` already knew authoritatively. The loop
+    variable carried a latent bug: if a branch's ``first_uuid`` was
+    dropped by ``_filter_by_detail`` at non-FULL detail, the trigger
+    never fired and subsequent branch messages silently inherited
+    the *previous* branch's sid (or ``None``).
+
+    Reading the map up front fixes this — every uuid in a branch
+    DAG-line maps to that branch's sid regardless of which entries
+    survive filtering.
+
+    Map contents:
+
+    - **Branch lines** (``is_branch=True``, sid contains ``@``) —
+      every uuid maps to the branch sid.
+    - **Agent lines** (sid contains ``#agent-``) — every uuid maps
+      to the agent's *immediate* parent (``parent_session_id`` from
+      the hierarchy, falling back to ``get_parent_session_id(sid)``).
+      Immediate means: a nested agent B inside agent A maps to A's
+      synthetic sid, NOT transitively to the trunk. Replicates the
+      pre-D11 inline resolution.
+    - **Trunk lines** — uuids are OMITTED. The caller's
+      ``map.get(uuid)`` returns ``None``, leaving the
+      ``TemplateMessage``'s ``_render_session_id`` unset, which
+      then falls back to ``meta.session_id`` at read time
+      (``TemplateMessage.render_session_id`` property).
+
+    Returns the empty map if ``session_hierarchy`` is ``None`` or
+    empty — every uuid falls through to the trunk path.
+    """
+    result: dict[str, str] = {}
+    if not session_hierarchy:
+        return result
+    for sid, hier in session_hierarchy.items():
+        line_uuids: list[str] = hier.get("uuids") or []
+        if is_agent_session(sid):
+            parent = hier.get("parent_session_id") or get_parent_session_id(sid)
+            if parent:
+                for uuid in line_uuids:
+                    result[uuid] = parent
+        elif hier.get("is_branch"):
+            for uuid in line_uuids:
+                result[uuid] = sid
+        # Trunk sessions are deliberately omitted — see docstring.
+    return result
+
+
 def prepare_session_team_names(messages: list[TranscriptEntry]) -> dict[str, str]:
     """Extract the teamName per session (teammates feature).
 
@@ -3722,7 +3778,13 @@ def _build_branch_header(
         attachment_uuid=b_hier.get("attachment_uuid"),
         is_branch=True,
         original_session_id=original_sid,
-        first_uuid=getattr(message, "uuid", ""),
+        # Canonical first uuid of the branch DAG-line, NOT the
+        # trigger's uuid. Post-D11 the trigger may be a later entry
+        # (the first one to survive ``_filter_by_detail``) rather
+        # than ``dag_line.uuids[0]`` itself, so reading from the
+        # hierarchy keeps the header's ``first_uuid`` field pointing
+        # at the canonical entry regardless of filtering.
+        first_uuid=b_hier.get("first_uuid") or "",
         team_name=branch_team_name,
         preview=branch_preview or None,
     )
@@ -3765,12 +3827,19 @@ def _render_messages(
     if junction_targets:
         ctx.junction_targets = junction_targets
 
-    # Build branch_start_uuids: map first UUID of each branch → branch pseudo-session ID
-    branch_start_uuids: dict[str, str] = {}
-    if session_hierarchy:
-        for sid, hier in session_hierarchy.items():
-            if hier.get("is_branch") and hier.get("first_uuid"):
-                branch_start_uuids[hier["first_uuid"]] = sid
+    # uuid → render_session_id map, derived once up front from the
+    # SessionTree (via ``session_hierarchy``). Single source of truth
+    # for how each rendered TemplateMessage is grouped:
+    #   - branch uuids → the branch sid;
+    #   - agent uuids → the agent's immediate parent sid (matches the
+    #     pre-D11 ``hier.get("parent_session_id")`` resolution);
+    #   - trunk uuids → omitted from the map (lookup returns None,
+    #     TemplateMessage.render_session_id falls back to
+    #     meta.session_id at read time).
+    # Replaces the pre-D11 ``current_render_session`` loop variable.
+    # See ``_build_uuid_to_render_sid`` for the latent-bug fix this
+    # closes at non-FULL detail.
+    uuid_to_render_sid = _build_uuid_to_render_sid(session_hierarchy)
 
     # uuid → entry map for branch-preview scanning. ``_build_branch_header``
     # walks each branch's DAG-line uuids (from ``session_hierarchy[sid]
@@ -3784,59 +3853,59 @@ def _render_messages(
         if entry_uuid:
             uuid_to_entry.setdefault(entry_uuid, entry)
 
-    # Track which sessions have had headers added
+    # Track which sessions have had headers added.
     seen_sessions: set[str] = set()
-    # Track current effective render session (for branch assignment)
-    current_render_session: Optional[str] = None
 
     for message in messages:
         message_type = message.type
-
-        # Determine if this message belongs to an agent sidechain session.
-        # Agent messages use the parent session's render_session_id so they
-        # stay grouped with the correct session (trunk or branch).
         msg_session_id = getattr(message, "sessionId", "") or ""
-        agent_parent_session: Optional[str] = None
-        if is_agent_session(msg_session_id):
-            # Use session hierarchy to find the actual parent (may be a branch
-            # pseudo-session if the anchor is inside a within-session fork)
-            if session_hierarchy:
-                hier = session_hierarchy.get(msg_session_id, {})
-                agent_parent_session = hier.get("parent_session_id")
-            if not agent_parent_session:
-                # Fallback: extract original session from synthetic ID
-                agent_parent_session = get_parent_session_id(msg_session_id)
+        message_uuid = getattr(message, "uuid", "") or ""
 
-        # Check if this message starts a new branch (within-session fork)
-        # Must happen before system/summary handling so branch state is
-        # correct when tagging those messages with render_session_id.
-        message_uuid = getattr(message, "uuid", "")
-        if message_uuid and message_uuid in branch_start_uuids:
-            branch_sid = branch_start_uuids[message_uuid]
-            if branch_sid not in seen_sessions:
-                seen_sessions.add(branch_sid)
-                current_render_session = branch_sid
+        # Pre-D11 inline derivation (``current_render_session`` +
+        # agent-parent resolution) collapsed into one map lookup.
+        # ``None`` for trunk uuids — the TemplateMessage's
+        # ``_render_session_id`` stays unset and falls back to
+        # ``meta.session_id`` at read time.
+        effective_session: Optional[str] = uuid_to_render_sid.get(message_uuid)
 
-                branch_header_content = _build_branch_header(
-                    branch_sid,
-                    message,
-                    session_hierarchy,
-                    session_summaries,
-                    session_team_names,
-                    uuid_to_entry,
-                    ctx,
-                )
-                branch_header = TemplateMessage(branch_header_content)
-                branch_header.render_session_id = branch_sid
-                msg_index = ctx.register(branch_header)
-                ctx.session_first_message[branch_sid] = msg_index
+        # Branch header: fires off the SAME map-driven trigger that
+        # assigns ``render_session_id``. A branch sid contains ``@``;
+        # agent messages whose parent is a branch ALSO have such a
+        # mapping, but the branch header is owned by the branch's own
+        # entries — skip the trigger when the message's own sessionId
+        # is an agent (``#agent-`` in the id), so the agent's
+        # presence inside a branch doesn't double-create a header
+        # for that branch via an out-of-order agent entry. (The
+        # branch's own first surviving entry always precedes its
+        # agents in the message stream because
+        # ``_integrate_agent_entries`` splices agents at the anchor
+        # tool_result, which is itself a branch-line entry.)
+        if (
+            effective_session
+            and "@" in effective_session
+            and effective_session not in seen_sessions
+            and not is_agent_session(msg_session_id)
+        ):
+            seen_sessions.add(effective_session)
+            branch_header_content = _build_branch_header(
+                effective_session,
+                message,
+                session_hierarchy,
+                session_summaries,
+                session_team_names,
+                uuid_to_entry,
+                ctx,
+            )
+            branch_header = TemplateMessage(branch_header_content)
+            branch_header.render_session_id = effective_session
+            msg_index = ctx.register(branch_header)
+            ctx.session_first_message[effective_session] = msg_index
 
         # Handle system messages (already filtered in pass 1)
         if isinstance(message, SystemTranscriptEntry):
             system_content = create_system_message(message)
             if system_content:
                 system_msg = TemplateMessage(system_content)
-                effective_session = agent_parent_session or current_render_session
                 if effective_session:
                     system_msg.render_session_id = effective_session
                 ctx.register(system_msg)
@@ -3849,7 +3918,6 @@ def _render_messages(
             attachment_content = create_attachment_message(message)
             if attachment_content:
                 attachment_msg = TemplateMessage(attachment_content)
-                effective_session = agent_parent_session or current_render_session
                 if effective_session:
                     attachment_msg.render_session_id = effective_session
                 ctx.register(attachment_msg)
@@ -3915,7 +3983,10 @@ def _render_messages(
         if session_id not in seen_sessions:
             seen_sessions.add(session_id)
             if not is_agent:
-                current_render_session = None  # Reset branch tracking
+                # Pre-D11 also reset ``current_render_session`` here;
+                # the new map-driven derivation needs no reset (each
+                # uuid carries its own render_session_id via the
+                # ``uuid_to_render_sid`` lookup above).
                 session_header_content = _build_trunk_header(
                     session_id,
                     session_summary,
@@ -3985,7 +4056,6 @@ def _render_messages(
                     continue
 
                 chunk_msg = TemplateMessage(content_model)
-                effective_session = agent_parent_session or current_render_session
                 if effective_session:
                     chunk_msg.render_session_id = effective_session
                 ctx.register(chunk_msg)
@@ -4036,7 +4106,6 @@ def _render_messages(
                     continue
 
                 tool_msg = TemplateMessage(tool_result.content)
-                effective_session = agent_parent_session or current_render_session
                 if effective_session:
                     tool_msg.render_session_id = effective_session
                 ctx.register(tool_msg)

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1268,6 +1268,164 @@ class TestRenderSessionResetAcrossSessions:
         assert c1_sid in branch_sids
         assert c2_sid in branch_sids
 
+    def test_trunk_header_registers_before_branch_when_trunk_msgs_filtered(
+        self, tmp_path: Path
+    ) -> None:
+        """CodeRabbit-flagged regression on the D11 map-driven trigger.
+
+        Scenario: every trunk-session entry is filtered out at non-
+        FULL detail (e.g., all the trunk's assistants are tool_use-
+        only and stripped at MINIMAL), so the FIRST surviving
+        message processed for that trunk session is a BRANCH
+        descendant. Without the trunk-header-before-branch-header
+        guard, the branch trigger registers the branch header before
+        any trunk message has registered the trunk header. Result:
+
+        - ``ctx.messages`` order: branch_header(0), trunk_header(1),
+          branch's content(2)...
+        - ``_reorder_session_template_messages`` preserves the
+          session-header encounter order → branch ends up as a root
+          section, NOT nested under its parent trunk session.
+        - The branch header's ``parent_message_index`` is also
+          ``None`` because the trunk header isn't in
+          ``ctx.session_first_message`` yet when the branch header
+          is built.
+
+        The fix: when about to register a branch header, FIRST
+        ensure the branch's parent trunk session header is in
+        ``seen_sessions`` and ``ctx.session_first_message``; create
+        it on the fly if not. Pre-D11 the bug couldn't manifest
+        because the branch trigger fired only on the branch's
+        ``first_uuid``, and that uuid's own meta.session_id is the
+        trunk sid which would create the trunk header on the same
+        message iteration before any branch content; D11's wider
+        trigger (any surviving branch line uuid) exposed the gap.
+
+        Fixture: trunk's only message ``a1`` is a tool_use-only
+        assistant (filtered at MINIMAL). Two branches off it, each
+        also starting with a tool_use-only assistant (filtered)
+        then a surviving user-text. At MINIMAL only ``c1`` and
+        ``c2`` survive — both are branch descendants whose parent
+        trunk has no surviving entry.
+
+        Asserts (failure modes the fix prevents):
+
+        - Trunk header for ``s1`` exists in ``ctx.messages`` and
+          appears BEFORE any branch header for ``s1@...``.
+        - Every branch header's ``parent_message_index`` points to
+          a registered message (NOT ``None``).
+        """
+        from claude_code_log.models import DetailLevel, SessionHeaderMessage
+        from claude_code_log.renderer import generate_template_messages
+
+        def _make_assistant_tool_only(
+            uuid: str, parent_uuid: str | None, timestamp: str
+        ) -> dict[str, Any]:
+            return {
+                "type": "assistant",
+                "timestamp": timestamp,
+                "parentUuid": parent_uuid,
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "uuid": uuid,
+                "requestId": f"req_{uuid}",
+                "message": {
+                    "id": uuid,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3-sonnet",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"toolu_{uuid}",
+                            "name": "Grep",
+                            "input": {"pattern": "x"},
+                        }
+                    ],
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            }
+
+        # Trunk root is a tool-only assistant → filtered at MINIMAL.
+        # Fork at a1 → two tool-only assistant siblings (both
+        # filtered) each followed by a surviving user-text.
+        entries = [
+            _make_assistant_tool_only("a1", None, "2025-09-01T10:01:00.000Z"),
+            _make_assistant_tool_only("b1", "a1", "2025-09-01T10:02:00.000Z"),
+            _make_user_entry(
+                "c1", "s1", "2025-09-01T10:03:00.000Z", "b1", "BRANCH 1 LOCAL"
+            ),
+            _make_assistant_tool_only("b2", "a1", "2025-09-01T10:04:00.000Z"),
+            _make_user_entry(
+                "c2", "s1", "2025-09-01T10:05:00.000Z", "b2", "BRANCH 2 LOCAL"
+            ),
+        ]
+        _write_jsonl(tmp_path / "s1.jsonl", entries)
+
+        messages, session_tree = load_directory_transcripts(tmp_path, silent=True)
+        assert session_tree is not None
+        branch_sids = sorted(sid for sid in session_tree.sessions if "@" in sid)
+        assert len(branch_sids) == 2, (
+            f"fixture must produce 2 branches; got {branch_sids}"
+        )
+
+        _, _, ctx = generate_template_messages(
+            messages,
+            session_tree=session_tree,
+            detail=DetailLevel.MINIMAL,
+        )
+
+        # Collect every session header in encounter order.
+        header_order: list[tuple[int, str, bool, object]] = []
+        for i, m in enumerate(ctx.messages):
+            if isinstance(m.content, SessionHeaderMessage):
+                header_order.append(
+                    (
+                        i,
+                        m.content.session_id,
+                        m.content.is_branch,
+                        m.content.parent_message_index,
+                    )
+                )
+
+        # 1) Trunk header for "s1" MUST be registered (and it must
+        #    NOT be a branch header).
+        trunk_headers = [h for h in header_order if h[1] == "s1" and not h[2]]
+        assert len(trunk_headers) == 1, (
+            "expected exactly 1 trunk header for 's1' in ctx.messages; "
+            f"got {trunk_headers}. Full header order: {header_order}"
+        )
+        trunk_idx = trunk_headers[0][0]
+
+        # 2) Every branch header for an "s1@..." sid MUST appear
+        #    AFTER the trunk header.
+        branch_headers = [h for h in header_order if h[2]]
+        assert len(branch_headers) == 2, (
+            f"expected 2 branch headers; got {branch_headers}"
+        )
+        for idx, sid, _is_branch, parent_msg_idx in branch_headers:
+            assert idx > trunk_idx, (
+                f"branch header {sid!r} at index {idx} appears BEFORE "
+                f"trunk header at index {trunk_idx} — _reorder_session_"
+                f"template_messages will emit it as a root, not nested "
+                "under the trunk. Header order: " + str(header_order)
+            )
+            # 3) Branch header's parent_message_index points to a
+            #    REGISTERED message (the trunk header), not None.
+            assert parent_msg_idx is not None, (
+                f"branch header {sid!r} has parent_message_index=None — "
+                "the trunk header wasn't in ctx.session_first_message "
+                "when the branch header was built. Header order: " + str(header_order)
+            )
+            assert parent_msg_idx == trunk_idx, (
+                f"branch header {sid!r}.parent_message_index={parent_msg_idx} "
+                f"should point to trunk header at {trunk_idx}"
+            )
+
 
 # =============================================================================
 # Test: PassthroughTranscriptEntry for DAG chain continuity

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1109,6 +1109,165 @@ class TestRenderSessionResetAcrossSessions:
                 f"expected 's2' — branch tracking from s1 leaked into s2"
             )
 
+    def test_branch_first_uuid_filtered_out_still_groups_correctly(
+        self, tmp_path: Path
+    ) -> None:
+        """The D11 latent-bug regression.
+
+        Pre-D11 the renderer derived ``render_session_id`` from a
+        loop-local ``current_render_session`` variable flipped at
+        the branch-start trigger (the line whose uuid matched the
+        branch's ``first_uuid``). If ``_filter_by_detail`` dropped
+        that ``first_uuid`` entry at non-FULL detail, the trigger
+        never fired and subsequent surviving branch entries silently
+        inherited a stale render_session_id — landing in the wrong
+        session group in the final tree.
+
+        D11 replaces the loop variable with a precomputed
+        ``uuid_to_render_sid`` map derived from the SessionTree.
+        Every uuid in a branch DAG-line maps to that branch's sid
+        regardless of which entries survive filtering, so the fix
+        is structural.
+
+        Fixture shape that triggers the bug:
+
+        - Trunk: ``u`` (user) → ``a`` (assistant, ends in tool_use).
+        - Fork at ``a``: two assistant children with ONLY a
+          ``tool_use`` content item (no text). Both are dropped by
+          ``_filter_by_detail`` at MINIMAL (strip_types = ThinkingContent,
+          ToolUseContent, ToolResultContent → no text_items left).
+        - Branch 1 continues: ``c1`` (user, parent ``b1``).
+        - Branch 2 continues: ``c2`` (user, parent ``b2``).
+
+        At MINIMAL, ``b1`` and ``b2`` are stripped from
+        ``filtered_messages``, so the pre-D11 branch-start trigger
+        never fires for either branch. ``c1`` and ``c2`` would
+        then both fall through to the trunk's ``render_session_id``
+        ("s1") instead of their respective branch sids — the bug.
+
+        The map-driven derivation reads grouping from the
+        SessionTree (built from PRE-filter messages), so
+        ``uuid_to_render_sid[c1]`` is branch1's sid and
+        ``uuid_to_render_sid[c2]`` is branch2's sid regardless of
+        filtering.
+        """
+        from claude_code_log.models import DetailLevel
+        from claude_code_log.renderer import generate_template_messages
+
+        # Helper: assistant with ONLY a tool_use content item (no
+        # text). At MINIMAL detail, _filter_by_detail strips
+        # ToolUseContent and drops the entry entirely (no surviving
+        # text_items).
+        def _make_assistant_tool_only(
+            uuid: str, parent_uuid: str, timestamp: str
+        ) -> dict[str, Any]:
+            return {
+                "type": "assistant",
+                "timestamp": timestamp,
+                "parentUuid": parent_uuid,
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "uuid": uuid,
+                "requestId": f"req_{uuid}",
+                "message": {
+                    "id": uuid,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3-sonnet",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"toolu_{uuid}",
+                            "name": "Grep",
+                            "input": {"pattern": "x"},
+                        }
+                    ],
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            }
+
+        entries = [
+            _make_user_entry("u", "s1", "2025-07-01T10:00:00.000Z", None, "hello"),
+            _make_assistant_entry(
+                "a", "s1", "2025-07-01T10:01:00.000Z", "u", "going to fork"
+            ),
+            # Branch 1: tool_use-only first entry (will be filtered out
+            # at MINIMAL) → text-bearing user message (survives).
+            _make_assistant_tool_only("b1", "a", "2025-07-01T10:02:00.000Z"),
+            _make_user_entry(
+                "c1", "s1", "2025-07-01T10:03:00.000Z", "b1", "BRANCH 1 LOCAL"
+            ),
+            # Branch 2 sibling — same shape (the fork-collapse logic in
+            # dag.py treats this as a real fork because both children
+            # have non-dead descendants).
+            _make_assistant_tool_only("b2", "a", "2025-07-01T10:04:00.000Z"),
+            _make_user_entry(
+                "c2", "s1", "2025-07-01T10:05:00.000Z", "b2", "BRANCH 2 LOCAL"
+            ),
+        ]
+        _write_jsonl(tmp_path / "s1.jsonl", entries)
+
+        messages, session_tree = load_directory_transcripts(tmp_path, silent=True)
+        # Sanity: the SessionTree (built pre-filter) MUST see both
+        # branches — otherwise the fixture doesn't actually exercise
+        # the bug.
+        assert session_tree is not None
+        branch_sids = [sid for sid in session_tree.sessions if "@" in sid]
+        assert len(branch_sids) == 2, (
+            f"fixture must produce 2 branches; got {branch_sids}. "
+            "If this fails, the fork-collapse heuristic in dag.py "
+            "absorbed one of the siblings — adjust the fixture so "
+            "both children have non-dead descendants of distinct types."
+        )
+
+        # Render at MINIMAL — b1 and b2 are stripped.
+        _, _, ctx = generate_template_messages(
+            messages,
+            session_tree=session_tree,
+            detail=DetailLevel.MINIMAL,
+        )
+
+        # b1 and b2 should NOT appear in the rendered messages
+        # (sanity: confirms the filter is doing what we expect).
+        rendered_uuids = {m.meta.uuid for m in ctx.messages if m.meta.uuid}
+        assert "b1" not in rendered_uuids, (
+            f"b1 should be filtered out at MINIMAL; got rendered_uuids={rendered_uuids}"
+        )
+        assert "b2" not in rendered_uuids
+
+        # c1 and c2 SHOULD appear and resolve to their respective
+        # branch sids — NOT to "s1" (trunk).
+        by_uuid = {m.meta.uuid: m for m in ctx.messages if m.meta.uuid in ("c1", "c2")}
+        assert set(by_uuid) == {"c1", "c2"}, (
+            f"expected c1+c2 in rendered messages; got {set(by_uuid)}"
+        )
+
+        # Each branch's surviving user message should have render_session_id
+        # equal to one of the branch sids (and NOT "s1").
+        c1_sid = by_uuid["c1"].render_session_id
+        c2_sid = by_uuid["c2"].render_session_id
+        assert c1_sid != "s1", (
+            "c1.render_session_id == 's1' — the loop-variable bug. "
+            "Expected a branch sid ('s1@<uuid12>')."
+        )
+        assert c2_sid != "s1"
+        assert "@" in c1_sid, (
+            f"c1.render_session_id must be a branch sid; got {c1_sid!r}"
+        )
+        assert "@" in c2_sid
+        # The two branches must be DIFFERENT (each user message
+        # belongs to its own branch, not to both).
+        assert c1_sid != c2_sid, (
+            f"c1 and c2 must resolve to DIFFERENT branch sids; got both = {c1_sid!r}"
+        )
+        # And each must be one of the SessionTree-known branch sids.
+        assert c1_sid in branch_sids
+        assert c2_sid in branch_sids
+
 
 # =============================================================================
 # Test: PassthroughTranscriptEntry for DAG chain continuity

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1045,16 +1045,27 @@ class TestAgentDagIntegration:
 
 
 # =============================================================================
-# Test: current_render_session reset across sessions
+# Test: render_session_id does not leak across sessions
 # =============================================================================
 
 
 class TestRenderSessionResetAcrossSessions:
-    """Test that current_render_session is reset when entering a new session.
+    """Pin that a within-session branch in session A doesn't leak its
+    render_session_id into session B.
 
-    Bug: _render_messages() sets current_render_session when entering a
-    within-session fork branch but never clears it on new sessions,
-    causing subsequent session messages to inherit a stale branch ID.
+    Historical context: pre-D11 the renderer tracked the current
+    render session via a loop-local ``current_render_session``
+    variable, set on each branch-start trigger and cleared on each
+    new trunk session. An early bug let the variable carry across
+    sessions and pollute the next trunk's messages with a stale
+    branch sid. D11 (``crux-derive-render-session-id-from-dag``)
+    replaced the loop variable with a precomputed
+    ``uuid_to_render_sid`` map derived from the SessionTree, so the
+    polluted-state shape is structurally impossible — each uuid's
+    render_session_id is determined by its DAG line, not by walk
+    order. The test still pins the OUTCOME (s2 messages resolve to
+    ``s2``), which is what any future implementation must continue
+    to guarantee.
     """
 
     def test_second_session_not_polluted_by_first_session_branch(


### PR DESCRIPTION
## Summary

Replaces the loop-local `current_render_session` variable in `_render_messages` with a precomputed `uuid_to_render_sid` map built once from the `SessionTree` via the existing `session_hierarchy`. The map drives **both** `render_session_id` assignment **and** branch-header creation off the same trigger — the first surviving uuid in a branch DAG-line creates the header AND gets its `render_session_id` set, with no possibility of one happening without the other.

## Why

The loop variable carried a latent bug: `_filter_by_detail` can drop a branch's `first_uuid` at non-FULL detail (e.g., a `tool_use`-only assistant entry that opens a fork gets filtered at MINIMAL because all its content items are stripped). In that case, the branch-start trigger never fires; the loop variable stays at the previous branch's sid (or `None`) and every surviving branch entry that follows silently inherits a stale `render_session_id` — landing in the wrong session group in the final tree.

The map-driven approach reads grouping from the authoritative DAG, so the trigger fires off whichever branch entry survives, regardless of which one was originally first.

## Map shape

- **Branch lines** (`is_branch=True`, sid contains `@`) — every uuid → branch sid.
- **Agent lines** (sid contains `#agent-`) — every uuid → `parent_session_id` (the *immediate* parent; a nested agent B inside agent A maps to A's sid, not transitively to the trunk).
- **Trunk lines** — OMITTED. The caller's `map.get(uuid)` returns `None`, the `TemplateMessage`'s `_render_session_id` stays unset, and `TemplateMessage.render_session_id` falls back to `meta.session_id` at read time. Same behavior as the previous `not is_agent → current_render_session = None` reset.

## Removed

- `branch_start_uuids` dict (the `first_uuid → branch sid` lookup).
- `current_render_session` loop variable + its set on branch enter and reset on new trunk session.
- `agent_parent_session` inline derivation (now folded into the map's agent-line entry).
- The `effective_session = agent_parent_session or current_render_session` composition at every register site — replaced by a single map lookup at the top of the loop.

## Branch header trigger contract preserved

The main risk: "a branch message tagged to a branch sid with no header lands in the `_reorder_session_template_messages` unmatched tail." Fixed by unifying header creation and `render_session_id` assignment under the same map-driven check. The trigger now fires when:

```
(effective_render_sid is a branch sid)
  AND (branch not yet seen)
  AND (message's own sessionId is NOT an agent session)
```

That last clause keeps an agent-message-whose-parent-is-a-branch from incorrectly creating the branch header out of order. In practice the branch's own anchor entry (the Task tool_result that parents the agent) is itself a branch-line entry and always precedes the agent in the stream because `_integrate_agent_entries` splices agents at the anchor, so the branch header is always created by the anchor and the agent's later entries just look up the already-seen branch sid.

`_build_branch_header.first_uuid` field also updated: was `getattr(message, "uuid", "")` (trigger's uuid), now `b_hier.get("first_uuid")` (the canonical first uuid of the DAG line). The trigger may now be a later survivor rather than the original first; the canonical first uuid documents the branch on the header itself.

## Latent-bug regression test

`test/test_dag_integration.py::TestRenderSessionResetAcrossSessions::test_branch_first_uuid_filtered_out_still_groups_correctly`.

Constructs the exact shape the previous loop variable mishandled: trunk + a fork whose two assistant children have *only* a `tool_use` content item (no text). At MINIMAL, `_filter_by_detail` strips `ToolUseContent` and drops the entries entirely. The branch's surviving user message asserts its `render_session_id` is a branch sid (`s1@...`), not `s1` (trunk).

The test FAILS on `main` (the loop-variable bug — `c1.render_session_id == "s1"`) and PASSES with the map-driven derivation in place. Pins the structural fix.

The `TestRenderSessionResetAcrossSessions` class's existing `test_second_session_not_polluted_by_first_session_branch` test body is unchanged; the class docstring + sibling test are rewritten to reflect the new derivation.

## Test plan

- [x] `just test` — 1923 passed, 7 skipped (1922 prior + 1 new). No snapshot regenerations needed (existing fixtures don't include the filtered-first_uuid shape).
- [x] `just ci` — clean (ruff, pyright, ty).
- [x] HTML + Markdown snapshot suites — 15 passed, byte-identical.
- [x] Fork/session/detail/async-agents suites — green.
- [x] Failing-on-main contract verified in a `/tmp` throwaway worktree.

Diff: `claude_code_log/renderer.py` (+116 / -59 net +57 — the map builder + its docstring + the unified-trigger comment outweigh the deletions). `test/test_dag_integration.py` (+177 / -4 — one new regression test + class-doc rewrite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messages now consistently render under their correct branch session IDs even when intermediate entries are filtered.
  * Branch headers anchor to the canonical branch start for stable rendering and filtering.
  * Trunk session headers are registered before branch headers when trunk messages are filtered, preserving header ordering.

* **Tests**
  * Added regression tests covering branch grouping, render-session assignment, and trunk-vs-branch header ordering under minimal/detail filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->