### PR TITLE
Render message tree as nested DOM (PR0 for #174)

### DIFF
--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -1255,25 +1255,31 @@ class HtmlRenderer(Renderer):
             return f"🔄 Async result <code>#{escape_html(content.task_id)}</code>"
         return "🔄 Async result"
 
-    def _flatten_preorder(
+    def _annotate_tree_for_render(
         self, roots: list[TemplateMessage]
-    ) -> list[Tuple[TemplateMessage, str, str, str]]:
-        """Flatten message tree via pre-order traversal, formatting each message.
+    ) -> list[TemplateMessage]:
+        """Format every message in the tree, annotating it in place.
 
-        Traverses the tree depth-first (pre-order), computes title and formats
-        content to HTML, building a flat list of (message, title, html, timestamp) tuples.
+        Walks the tree depth-first (pre-order), computing each message's
+        title + HTML + timestamp and storing them on the message
+        (``rendered_title`` / ``rendered_html`` / ``rendered_timestamp``)
+        so the recursive template macro can render the tree directly as
+        nested DOM. Returns the root messages unchanged (the tree is
+        rendered by recursing over ``message.children``).
 
-        Also tracks and reports timing statistics for Markdown and Pygments operations
-        when DEBUG_TIMING is enabled.
+        Previously this flattened the tree into a list of tuples for a
+        flat template loop with ``d-N`` ancestry CSS classes; the nested
+        DOM removes that flattening (see work/rendering-next.md §1).
+
+        Also tracks and reports timing statistics for Markdown and Pygments
+        operations when DEBUG_TIMING is enabled.
 
         Args:
             roots: Root messages (typically session headers) with children populated
 
         Returns:
-            Flat list of (message, title, html_content, formatted_timestamp) tuples
+            The same root messages, each subtree annotated for rendering.
         """
-        flat: list[Tuple[TemplateMessage, str, str, str]] = []
-
         # Initialize timing tracking for expensive operations
         markdown_timings: list[Tuple[float, str]] = []
         pygments_timings: list[Tuple[float, str]] = []
@@ -1300,14 +1306,17 @@ class HtmlRenderer(Renderer):
             title = self.title_content(msg)
             html = self.format_content(msg)
             formatted_ts = format_timestamp(msg.meta.timestamp if msg.meta else None)
+            msg.rendered_title = title
+            msg.rendered_html = html
+            msg.rendered_timestamp = formatted_ts
             # Skip messages with nothing to show — e.g. TaskCreate /
             # TaskUpdate tool_results whose output formatter returns "".
             # Without this they render as a bare timestamp-only card.
-            # Children still render at the same flat-list level since
-            # the recursion below is unconditional.
-            if title or html or msg.children:
-                flat.append((msg, title, html, formatted_ts))
-            else:
+            # A skipped node is always a leaf (the condition includes
+            # ``msg.children``), so the macro simply emits no card for it
+            # and there are no orphaned descendants to reparent.
+            msg.should_render = bool(title or html or msg.children)
+            if not msg.should_render:
                 # Skipped message: if it's the second half of a pair
                 # (msg.pair_first → first message's index), clear the
                 # first half's `pair_last` so it loses its `pair_first`
@@ -1334,7 +1343,7 @@ class HtmlRenderer(Renderer):
                 ]
             )
 
-        return flat
+        return roots
 
     def generate(
         self,
@@ -1420,9 +1429,10 @@ class HtmlRenderer(Renderer):
         # Collapse answered AskUserQuestion pairs into a single result card (#180).
         self._collapse_askuserquestion_pairs(ctx)
 
-        # Flatten tree via pre-order traversal, formatting content along the way
+        # Format every message (pre-order), annotating the tree in place
+        # so the template can recurse over it as nested DOM.
         with log_timing("Content formatting (pre-order)", t_start):
-            template_messages = self._flatten_preorder(root_messages)
+            render_roots = self._annotate_tree_for_render(root_messages)
 
         # Render template
         with log_timing("Template environment setup", t_start):
@@ -1435,7 +1445,7 @@ class HtmlRenderer(Renderer):
             html_output = str(
                 template.render(
                     title=title,
-                    messages=template_messages,
+                    roots=render_roots,
                     sessions=session_nav,
                     combined_transcript_link=combined_transcript_link,
                     library_version=get_library_version(),

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -1,4 +1,15 @@
 /* Message and content styles */
+
+/* Structural wrapper around a message card and its nested .children
+   (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+   border/background/shadow/margins live on .message and must frame only the
+   card, not the subtree. The wrapper is a plain full-width block so the
+   per-type horizontal margins on .message resolve against the full content
+   width (absolute type-based positioning), not a parent card's inset. */
+.message-node {
+    /* structural only — intentionally no visual properties */
+}
+
 .message {
     margin-bottom: 1em;
     padding: var(--message-padding);

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -103,6 +103,10 @@
     {%- set formatted_timestamp = message.rendered_timestamp %}
     {% if is_session_header(message) %}
     {% if not message.is_branch_header %}<div class="session-divider"></div>{% endif %}
+    {# Structural wrapper: the message card and its nested .children render as
+       SIBLINGS here, so the card's border/background/margins frame only the
+       card itself, not the whole subtree (issue #174 nested-DOM follow-up). #}
+    <div class='message-node'>
     <div class='message session-header{% if message.is_branch_header %} branch-header{% endif %}' data-message-id='{{ message.message_id }}' data-session-id='{{ message.session_id }}' id='msg-{{ message.message_id }}'{% if message.branch_depth %} style='margin-left: {{ message.branch_depth * 2 }}em'{% endif %}>
         <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}</div>
         {% if message.has_children %}
@@ -126,15 +130,28 @@
             {% endif %}
         </div>
         {% endif %}
-        {% if message.children %}
-        <div class='children'>
-            {% for child in message.children %}{{ render_message(child) }}{% endfor %}
+    </div>
+    {% if message.children %}
+    <div class='children'>
+        {% for child in message.children %}{{ render_message(child) }}{% endfor %}
+    </div>
+    {% endif %}
+    {% if message.junction_forward_links %}
+    {# Fork point element — structural navigation marker, sibling of the card #}
+    <div class='fork-point'>
+        <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
+        <div class='fork-point-branches'>
+            {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
+            <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
+            {% endfor %}
         </div>
-        {% endif %}
+    </div>
+    {% endif %}
     </div>
     {% elif message.should_render %}
     {%- set msg_css_class = css_class_from_message(message) %}
     {% set markdown = message.content.has_markdown if message.content else false %}
+    <div class='message-node'>
     <div class='message {{ msg_css_class }}{% if message.is_paired %} {{ message.pair_role }}{% endif %}' data-message-id='{{ message.message_id }}' id='msg-{{ message.message_id }}'>
         <div class='header'>
             {% set msg_emoji = get_message_emoji(message) -%}
@@ -173,15 +190,14 @@
             {% endif %}
         </div>
         {% endif %}
-        {% if message.children %}
-        <div class='children'>
-            {% for child in message.children %}{{ render_message(child) }}{% endfor %}
-        </div>
-        {% endif %}
+    </div>
+    {% if message.children %}
+    <div class='children'>
+        {% for child in message.children %}{{ render_message(child) }}{% endfor %}
     </div>
     {% endif %}
-    {% if message.junction_forward_links and message.should_render %}
-    {# Fork point element — rendered OUTSIDE the message box as a structural navigation element #}
+    {% if message.junction_forward_links %}
+    {# Fork point element — structural navigation marker, sibling of the card #}
     <div class='fork-point'>
         <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
         <div class='fork-point-branches'>
@@ -189,6 +205,8 @@
             <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
             {% endfor %}
         </div>
+    </div>
+    {% endif %}
     </div>
     {% endif %}
     {% endmacro %}
@@ -666,11 +684,16 @@
                 return document.querySelector('.message[data-message-id="' + sel + '"]');
             }
             function getChildrenContainer(messageEl) {
-                return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                // .children is now a SIBLING of the card inside the shared
+                // .message-node wrapper (dissociated DOM), not a descendant.
+                const wrapper = messageEl ? messageEl.parentElement : null;
+                return wrapper ? wrapper.querySelector(':scope > .children') : null;
             }
             function getImmediateChildMessages(messageEl) {
                 const cc = getChildrenContainer(messageEl);
-                return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                // Each child is wrapped in its own .message-node; its card is
+                // that wrapper's direct .message child.
+                return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
             }
             function setSectionState(section, folded, icon) {
                 if (!section) return;
@@ -766,24 +789,26 @@
             setInitialFoldState();
 
             // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-            // jumped to from the session index) is actually visible. Ancestry
-            // is now DOM nesting, so walk up the .children/.message chain and
-            // reveal each ancestor's children container.
+            // jumped to from the session index) is actually visible. In the
+            // dissociated DOM a card's ancestors are .message-node and
+            // .children wrappers, NOT the parent .message cards — so walk up
+            // and reveal each hidden .children container, syncing the
+            // controlling card's fold bar (its sibling within the node).
             function unfoldAncestorsOf(hash) {
                 if (!hash || !hash.startsWith('#msg-')) return;
                 const target = document.getElementById(hash.slice(1));
                 if (!target) return;
                 let node = target.parentElement;
                 while (node) {
-                    if (node.classList && node.classList.contains('message')) {
-                        const cc = getChildrenContainer(node);
-                        if (cc && cc.style.display === 'none') {
-                            cc.style.display = '';
-                            const foldBar = node.querySelector(':scope > .fold-bar');
-                            if (foldBar) {
-                                setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                            }
+                    if (node.classList && node.classList.contains('children')
+                        && node.style.display === 'none') {
+                        node.style.display = '';
+                        const wrapper = node.parentElement; // .message-node
+                        const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                        const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                        if (foldBar) {
+                            setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                            setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                         }
                     }
                     node = node.parentElement;

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -97,10 +97,13 @@
     {{ render_session_nav(sessions, "toc") }}
     {% endif %}
 
-    {% for message, message_title, html_content, formatted_timestamp in messages %}
+    {% macro render_message(message) %}
+    {%- set message_title = message.rendered_title %}
+    {%- set html_content = message.rendered_html %}
+    {%- set formatted_timestamp = message.rendered_timestamp %}
     {% if is_session_header(message) %}
     {% if not message.is_branch_header %}<div class="session-divider"></div>{% endif %}
-    <div class='message session-header{% if message.is_branch_header %} branch-header{% endif %}{% for ancestor_index in message.ancestry %} d-{{ ancestor_index }}{% endfor %}' data-message-id='{{ message.message_id }}' data-session-id='{{ message.session_id }}' id='msg-{{ message.message_id }}'{% if message.branch_depth %} style='margin-left: {{ message.branch_depth * 2 }}em'{% endif %}>
+    <div class='message session-header{% if message.is_branch_header %} branch-header{% endif %}' data-message-id='{{ message.message_id }}' data-session-id='{{ message.session_id }}' id='msg-{{ message.message_id }}'{% if message.branch_depth %} style='margin-left: {{ message.branch_depth * 2 }}em'{% endif %}>
         <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}</div>
         {% if message.has_children %}
         <div class='fold-bar' data-message-id='{{ message.message_id }}' data-border-color='session-header'>
@@ -123,11 +126,16 @@
             {% endif %}
         </div>
         {% endif %}
+        {% if message.children %}
+        <div class='children'>
+            {% for child in message.children %}{{ render_message(child) }}{% endfor %}
+        </div>
+        {% endif %}
     </div>
     {% else %}
     {%- set msg_css_class = css_class_from_message(message) %}
     {% set markdown = message.content.has_markdown if message.content else false %}
-    <div class='message {{ msg_css_class }}{% if message.is_paired %} {{ message.pair_role }}{% endif %}{% for ancestor_index in message.ancestry %} d-{{ ancestor_index }}{% endfor %}' data-message-id='{{ message.message_id }}' id='msg-{{ message.message_id }}'>
+    <div class='message {{ msg_css_class }}{% if message.is_paired %} {{ message.pair_role }}{% endif %}' data-message-id='{{ message.message_id }}' id='msg-{{ message.message_id }}'>
         <div class='header'>
             {% set msg_emoji = get_message_emoji(message) -%}
             <span{% if message.title_hint %} title="{{ message.title_hint }}"{% endif %}>{% if message_title %}{%
@@ -165,11 +173,16 @@
             {% endif %}
         </div>
         {% endif %}
+        {% if message.children %}
+        <div class='children'>
+            {% for child in message.children %}{{ render_message(child) }}{% endfor %}
+        </div>
+        {% endif %}
     </div>
     {% endif %}
     {% if message.junction_forward_links %}
     {# Fork point element — rendered OUTSIDE the message box as a structural navigation element #}
-    <div class='fork-point{% for ancestor_index in message.ancestry %} d-{{ ancestor_index }}{% endfor %}'>
+    <div class='fork-point'>
         <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
         <div class='fork-point-branches'>
             {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
@@ -178,7 +191,9 @@
         </div>
     </div>
     {% endif %}
-    {% endfor %}
+    {% endmacro %}
+
+    {% for root in roots %}{{ render_message(root) }}{% endfor %}
 
     <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
     <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter">🔍</button>
@@ -644,210 +659,86 @@
                 section.setAttribute('title', tooltip);
             }
 
-            function handleFoldOne(targetId, isFolded, sectionElement) {
-                // Find all messages in the document
-                const allMessages = document.querySelectorAll('.message');
-
-                // Find immediate children: messages that have targetId as their LAST ancestor
-                const immediateChildren = Array.from(allMessages).filter(msg => {
-                    const classList = Array.from(msg.classList);
-                    // Check if targetId is in the class list (ancestor)
-                    if (!classList.includes(targetId)) return false;
-
-                    // Check if it's an immediate child by finding all ancestor IDs
-                    // Ancestor IDs use unified d-XXX format
-                    const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                    const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                    return lastAncestor === targetId;
-                });
-
-                if (isFolded) {
-                    // Unfold: show immediate children
-                    immediateChildren.forEach(msg => {
-                        msg.style.display = '';
-
-                        // Set newly revealed children to folded state
-                        const foldBar = msg.querySelector('.fold-bar');
-                        if (foldBar) {
-                            const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                            const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-
-                            if (foldOneBtn) {
-                                foldOneBtn.classList.add('folded');
-                                foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                updateTooltip(foldOneBtn);
-                            }
-                            if (foldAllBtn) {
-                                foldAllBtn.classList.add('folded');
-                                foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                updateTooltip(foldAllBtn);
-                            }
-                        }
-                    });
-                    sectionElement.classList.remove('folded');
-                    sectionElement.querySelector('.fold-icon').textContent = '▼';
-                    updateTooltip(sectionElement);
-                    // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                } else {
-                    // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                    const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                    allDescendants.forEach(msg => {
-                        msg.style.display = 'none';
-                    });
-                    sectionElement.classList.add('folded');
-                    sectionElement.querySelector('.fold-icon').textContent = '▶';
-                    updateTooltip(sectionElement);
-
-                    // Coordinate: If we folded immediate children, all descendants are hidden
-                    // So update the "fold all" button to ▶▶ state
-                    const foldBar = sectionElement.parentElement;
-                    const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                    if (foldAllSection) {
-                        foldAllSection.classList.add('folded');
-                        foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                        updateTooltip(foldAllSection);
-                    }
+            // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+            function getMessageEl(messageId) {
+                if (!messageId) return null;
+                const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                return document.querySelector('.message[data-message-id="' + sel + '"]');
+            }
+            function getChildrenContainer(messageEl) {
+                return messageEl ? messageEl.querySelector(':scope > .children') : null;
+            }
+            function getImmediateChildMessages(messageEl) {
+                const cc = getChildrenContainer(messageEl);
+                return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+            }
+            function setSectionState(section, folded, icon) {
+                if (!section) return;
+                if (folded) section.classList.add('folded');
+                else section.classList.remove('folded');
+                const iconEl = section.querySelector('.fold-icon');
+                if (iconEl) iconEl.textContent = icon;
+                updateTooltip(section);
+            }
+            // Apply a fold state to a message by toggling its OWN .children
+            // container. DOM nesting means hiding that container hides the whole
+            // subtree (fork-points included), so we only touch this message.
+            //   'folded' = hide children; 'first' = show immediate children but
+            //   fold each of their subtrees; 'open' = show all descendants.
+            function applyFoldState(messageEl, state) {
+                const cc = getChildrenContainer(messageEl);
+                const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                if (state === 'folded') {
+                    if (cc) cc.style.display = 'none';
+                    setSectionState(oneSection, true, '▶');
+                    setSectionState(allSection, true, '▶▶');
+                } else if (state === 'first') {
+                    if (cc) cc.style.display = '';
+                    getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                    setSectionState(oneSection, false, '▼');
+                    setSectionState(allSection, true, '▶▶');
+                } else {  // 'open'
+                    if (cc) cc.style.display = '';
+                    getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                    setSectionState(oneSection, false, '▼');
+                    setSectionState(allSection, false, '▼▼');
                 }
+            }
+
+            function handleFoldOne(targetId, isFolded, sectionElement) {
+                const messageEl = getMessageEl(targetId);
+                if (!messageEl) return;
+                // Currently folded → reveal first level; else collapse fully.
+                applyFoldState(messageEl, isFolded ? 'first' : 'folded');
             }
 
             function handleFoldAll(targetId, isFolded, sectionElement) {
-                // Find all descendants (messages with targetId in their class list)
-                const descendants = document.querySelectorAll(`.message.${targetId}`);
-
-                if (isFolded) {
-                    // Unfold: show all descendants (State A/B → State C)
-                    descendants.forEach(msg => {
-                        msg.style.display = '';
-
-                        // Also update fold bars of all descendants to unfolded state
-                        const foldBar = msg.querySelector('.fold-bar');
-                        if (foldBar) {
-                            const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                            const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-
-                            if (foldOneBtn) {
-                                foldOneBtn.classList.remove('folded');
-                                foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                updateTooltip(foldOneBtn);
-                            }
-                            if (foldAllBtn) {
-                                foldAllBtn.classList.remove('folded');
-                                foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                updateTooltip(foldAllBtn);
-                            }
-                        }
-                    });
-                    sectionElement.classList.remove('folded');
-                    sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                    updateTooltip(sectionElement);
-
-                    // Coordinate: If we unfolded all levels, immediate children are now visible
-                    // So update the "fold one" button to ▼ state
-                    const foldBar = sectionElement.parentElement;
-                    const foldOneSection = foldBar.querySelector('.fold-one-level');
-                    if (foldOneSection) {
-                        foldOneSection.classList.remove('folded');
-                        foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                        updateTooltip(foldOneSection);
-                    }
-                } else {
-                    // Fold: show first level only, hide deeper descendants (State C → State B)
-                    descendants.forEach(msg => {
-                        const classList = Array.from(msg.classList);
-                        const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                        const lastAncestor = ancestorIds[ancestorIds.length - 1];
-
-                        // Show immediate children, hide non-immediate children
-                        if (lastAncestor === targetId) {
-                            msg.style.display = '';  // Show immediate child
-
-                            // Set immediate children to folded state
-                            const foldBar = msg.querySelector('.fold-bar');
-                            if (foldBar) {
-                                const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-
-                                if (foldOneBtn) {
-                                    foldOneBtn.classList.add('folded');
-                                    foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                    updateTooltip(foldOneBtn);
-                                }
-                                if (foldAllBtn) {
-                                    foldAllBtn.classList.add('folded');
-                                    foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                    updateTooltip(foldAllBtn);
-                                }
-                            }
-                        } else {
-                            msg.style.display = 'none';  // Hide deeper descendants
-                        }
-                    });
-                    sectionElement.classList.add('folded');
-                    sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                    updateTooltip(sectionElement);
-
-                    // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                    const foldBar = sectionElement.parentElement;
-                    const foldOneSection = foldBar.querySelector('.fold-one-level');
-                    if (foldOneSection) {
-                        foldOneSection.classList.remove('folded');
-                        foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                        updateTooltip(foldOneSection);
-                    }
-                }
+                const messageEl = getMessageEl(targetId);
+                if (!messageEl) return;
+                // Currently folded → open all levels; else collapse to first level.
+                applyFoldState(messageEl, isFolded ? 'open' : 'first');
             }
 
-            // Set initial fold state on page load
+            // Set initial fold state on page load. Each message sets only its
+            // OWN children container + fold buttons, so iteration order is
+            // irrelevant — DOM nesting encodes the hierarchy.
             function setInitialFoldState() {
-                // Get all messages once
                 const allMessages = document.querySelectorAll('.message');
-
-                // Build hierarchy lookup structure in a single pass - O(n)
-                const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-
                 allMessages.forEach(msg => {
-                    const classList = Array.from(msg.classList);
-                    const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-
-                    if (ancestorIds.length > 0) {
-                        const lastAncestor = ancestorIds[ancestorIds.length - 1];
-
-                        // Track immediate children
-                        if (!messagesByParentId[lastAncestor]) {
-                            messagesByParentId[lastAncestor] = [];
-                        }
-                        messagesByParentId[lastAncestor].push(msg);
-
-                        // Track all descendants
-                        ancestorIds.forEach(ancestorId => {
-                            if (!allDescendantsByParentId[ancestorId]) {
-                                allDescendantsByParentId[ancestorId] = [];
-                            }
-                            allDescendantsByParentId[ancestorId].push(msg);
-                        });
-                    }
-                });
-
-                // Now process each message using cached hierarchy - O(n)
-                allMessages.forEach(msg => {
-                    const messageId = msg.getAttribute('data-message-id');
-                    if (!messageId) return;
-
+                    const foldBar = msg.querySelector(':scope > .fold-bar');
+                    if (!foldBar) return;
+                    const oneSection = foldBar.querySelector('.fold-one-level');
+                    const allSection = foldBar.querySelector('.fold-all-levels');
                     const isSession = msg.classList.contains('session-header');
                     const isUser = msg.classList.contains('user');
-                    const foldBar = msg.querySelector('.fold-bar');
 
-                    if (!foldBar) return;
-
-                    const foldOneSection = foldBar.querySelector('.fold-one-level');
-                    const foldAllSection = foldBar.querySelector('.fold-all-levels');
-
-                    // Check if user message has only tools (no assistant/system/thinking children)
+                    // A user whose immediate children are all tools collapses
+                    // fully, like a non-session/non-user message.
                     let hasOnlyTools = false;
                     if (isUser) {
-                        const immediateChildren = messagesByParentId[messageId] || [];
-
+                        const immediateChildren = getImmediateChildMessages(msg);
                         const hasNonToolChildren = immediateChildren.some(child =>
                             child.classList.contains('assistant') ||
                             child.classList.contains('system') ||
@@ -856,68 +747,17 @@
                         hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                     }
 
-                    // Sessions and user messages (unless they have only tools): unfolded at first level
+                    const cc = getChildrenContainer(msg);
                     if ((isSession || isUser) && !hasOnlyTools) {
-                        // First level is visible (▼), all levels are not (▶▶)
-                        if (foldOneSection) {
-                            foldOneSection.classList.remove('folded');
-                            foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                            updateTooltip(foldOneSection);
-                        }
-                        if (foldAllSection) {
-                            foldAllSection.classList.add('folded');
-                            foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                            updateTooltip(foldAllSection);
-                        }
-
-                        // Show immediate children, hide deeper descendants
-                        const allDescendants = allDescendantsByParentId[messageId] || [];
-                        const immediateChildren = messagesByParentId[messageId] || [];
-
-                        allDescendants.forEach(descendant => {
-                            // Show immediate children, hide non-immediate children
-                            if (immediateChildren.includes(descendant)) {
-                                descendant.style.display = '';  // Show immediate child
-
-                                // Set immediate children to folded state (▶/▶▶)
-                                const childFoldBar = descendant.querySelector('.fold-bar');
-                                if (childFoldBar) {
-                                    const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                    const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-
-                                    if (childFoldOne) {
-                                        childFoldOne.classList.add('folded');
-                                        childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                        updateTooltip(childFoldOne);
-                                    }
-                                    if (childFoldAll) {
-                                        childFoldAll.classList.add('folded');
-                                        childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                        updateTooltip(childFoldAll);
-                                    }
-                                }
-                            } else {
-                                descendant.style.display = 'none';  // Hide deeper descendants
-                            }
-                        });
+                        // First level visible (▼), deeper levels folded (▶▶)
+                        if (cc) cc.style.display = '';
+                        setSectionState(oneSection, false, '▼');
+                        setSectionState(allSection, true, '▶▶');
                     } else {
-                        // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                        if (foldOneSection) {
-                            foldOneSection.classList.add('folded');
-                            foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                            updateTooltip(foldOneSection);
-                        }
-                        if (foldAllSection) {
-                            foldAllSection.classList.add('folded');
-                            foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                            updateTooltip(foldAllSection);
-                        }
-
-                        // Hide all descendants
-                        const allDescendants = allDescendantsByParentId[messageId] || [];
-                        allDescendants.forEach(descendant => {
-                            descendant.style.display = 'none';
-                        });
+                        // Fully folded
+                        if (cc) cc.style.display = 'none';
+                        setSectionState(oneSection, true, '▶');
+                        setSectionState(allSection, true, '▶▶');
                     }
                 });
             }
@@ -926,32 +766,28 @@
             setInitialFoldState();
 
             // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-            // jumped to from the session index) is actually visible. Ancestor
-            // message_ids appear as `d-X` classes on the target, outer-first.
+            // jumped to from the session index) is actually visible. Ancestry
+            // is now DOM nesting, so walk up the .children/.message chain and
+            // reveal each ancestor's children container.
             function unfoldAncestorsOf(hash) {
                 if (!hash || !hash.startsWith('#msg-')) return;
                 const target = document.getElementById(hash.slice(1));
                 if (!target) return;
-                const ancestorIds = Array.from(target.classList).filter(
-                    cls => cls.startsWith('d-')
-                );
-                ancestorIds.forEach(id => {
-                    const ancestorMsg = document.querySelector(
-                        `.message[data-message-id="${id}"]`
-                    );
-                    if (!ancestorMsg) return;
-                    const foldBar = ancestorMsg.querySelector('.fold-bar');
-                    if (!foldBar) return;
-                    // Single-level parents only render `.fold-one-level.full-width`
-                    // — no `.fold-all-levels` exists — so anchors under those
-                    // folded ancestors stay hidden unless we fall back.
-                    const foldControl =
-                        foldBar.querySelector('.fold-all-levels') ||
-                        foldBar.querySelector('.fold-one-level.full-width');
-                    if (foldControl && foldControl.classList.contains('folded')) {
-                        foldControl.click();
+                let node = target.parentElement;
+                while (node) {
+                    if (node.classList && node.classList.contains('message')) {
+                        const cc = getChildrenContainer(node);
+                        if (cc && cc.style.display === 'none') {
+                            cc.style.display = '';
+                            const foldBar = node.querySelector(':scope > .fold-bar');
+                            if (foldBar) {
+                                setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                            }
+                        }
                     }
-                });
+                    node = node.parentElement;
+                }
                 // Re-trigger the browser's scroll-to-anchor now that
                 // the target is no longer display:none.
                 if (target.scrollIntoView) {

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -131,20 +131,22 @@
         </div>
         {% endif %}
     </div>
-    {% if message.children %}
+    {% if message.children or message.junction_forward_links %}
     <div class='children'>
-        {% for child in message.children %}{{ render_message(child) }}{% endfor %}
-    </div>
-    {% endif %}
-    {% if message.junction_forward_links %}
-    {# Fork point element — structural navigation marker, sibling of the card #}
-    <div class='fork-point'>
-        <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
-        <div class='fork-point-branches'>
-            {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
-            <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
-            {% endfor %}
+        {% for child in message.children %}{{ render_message(child) }}{% endfor %}{% if message.junction_forward_links %}
+        {# Fork point — rendered INSIDE .children so it folds together with the
+           subtree (folding hides .children). For a childless junction it is the
+           sole occupant. The opening tag is glued to endfor so non-junction
+           nodes emit no extra whitespace. #}
+        <div class='fork-point'>
+            <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
+            <div class='fork-point-branches'>
+                {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
+                <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
+                {% endfor %}
+            </div>
         </div>
+        {% endif %}
     </div>
     {% endif %}
     </div>
@@ -191,20 +193,22 @@
         </div>
         {% endif %}
     </div>
-    {% if message.children %}
+    {% if message.children or message.junction_forward_links %}
     <div class='children'>
-        {% for child in message.children %}{{ render_message(child) }}{% endfor %}
-    </div>
-    {% endif %}
-    {% if message.junction_forward_links %}
-    {# Fork point element — structural navigation marker, sibling of the card #}
-    <div class='fork-point'>
-        <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
-        <div class='fork-point-branches'>
-            {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
-            <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
-            {% endfor %}
+        {% for child in message.children %}{{ render_message(child) }}{% endfor %}{% if message.junction_forward_links %}
+        {# Fork point — rendered INSIDE .children so it folds together with the
+           subtree (folding hides .children). For a childless junction it is the
+           sole occupant. The opening tag is glued to endfor so non-junction
+           nodes emit no extra whitespace. #}
+        <div class='fork-point'>
+            <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
+            <div class='fork-point-branches'>
+                {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
+                <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
+                {% endfor %}
+            </div>
         </div>
+        {% endif %}
     </div>
     {% endif %}
     </div>
@@ -705,7 +709,9 @@
             }
             // Apply a fold state to a message by toggling its OWN .children
             // container. DOM nesting means hiding that container hides the whole
-            // subtree (fork-points included), so we only touch this message.
+            // subtree — including the fork-point marker, which the template
+            // renders INSIDE .children precisely so it folds with the subtree
+            // rather than orphaning. So we only touch this message.
             //   'folded' = hide children; 'first' = show immediate children but
             //   fold each of their subtrees; 'open' = show all descendants.
             function applyFoldState(messageEl, state) {

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -132,7 +132,7 @@
         </div>
         {% endif %}
     </div>
-    {% else %}
+    {% elif message.should_render %}
     {%- set msg_css_class = css_class_from_message(message) %}
     {% set markdown = message.content.has_markdown if message.content else false %}
     <div class='message {{ msg_css_class }}{% if message.is_paired %} {{ message.pair_role }}{% endif %}' data-message-id='{{ message.message_id }}' id='msg-{{ message.message_id }}'>
@@ -180,7 +180,7 @@
         {% endif %}
     </div>
     {% endif %}
-    {% if message.junction_forward_links %}
+    {% if message.junction_forward_links and message.should_render %}
     {# Fork point element — rendered OUTSIDE the message box as a structural navigation element #}
     <div class='fork-point'>
         <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -231,6 +231,17 @@ class TemplateMessage:
         # Children for tree-based rendering
         self.children: list["TemplateMessage"] = []
 
+        # Per-render annotations populated by the HTML renderer's tree walk
+        # (HtmlRenderer._annotate_tree_for_render). The recursive template
+        # macro reads these instead of receiving a flat (msg, title, html,
+        # ts) tuple. ``should_render`` is False for leaf nodes that format
+        # to nothing (e.g. TaskCreate/TaskUpdate tool_results) so the macro
+        # emits no card for them.
+        self.rendered_title: str = ""
+        self.rendered_html: str = ""
+        self.rendered_timestamp: str = ""
+        self.should_render: bool = True
+
         # Within-session fork tracking: effective session/branch ID for grouping
         self._render_session_id: Optional[str] = None
 

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -4093,6 +4093,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='eb000000-0000-4000-8000-000000000001' id='msg-d-0'>
@@ -4112,13 +4114,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -4146,13 +4147,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span title="ID: tu_Task_async_001">🔧 Task <span class='tool-summary'>Coverage analysis</span> <span class='tool-subagent'>(Explore)</span> <span class='task-async-hint'>[async <a class='task-id-forward-link' href='#msg-d-7'><code>#cccc333</code></a>]</span></span>
               <div class='header-info'>
@@ -4166,13 +4166,14 @@
           <div class='content'><div class="task-prompt markdown"><p>Analyze the coverage gaps and report back with a summary.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Run</dt><dd>background</dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-1' data-message-id='d-3' id='msg-d-3'>
+      <div class='message tool_result pair_last' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span title="ID: tu_Task_async_001"></span>
               <div class='header-info'>
@@ -4203,13 +4204,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant sidechain d-0 d-1 d-3' data-message-id='d-5' id='msg-d-5'>
+      <div class='message assistant sidechain' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
               <div class='header-info'>
@@ -4223,13 +4223,20 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Reading the source files now...</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use pair_first d-0 d-1' data-message-id='d-7' id='msg-d-7'>
+      <div class='message tool_use pair_first' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span title="ID: tu_TaskOutput_001">🔍 TaskOutput <a class='task-id-backlink' href='#msg-d-2'><code>#cccc333</code></a></span>
               <div class='header-info'>
@@ -4242,13 +4249,14 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card task-output-card"><dt>Block</dt><dd><code>true</code></dd><dt>Timeout</dt><dd><code>60000 ms</code></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-1' data-message-id='d-8' id='msg-d-8'>
+      <div class='message tool_result pair_last' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tu_TaskOutput_001"></span>
               <div class='header-info'>
@@ -4261,13 +4269,14 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card task-output-card"><dt>Retrieval</dt><dd><code>success</code></dd><dt>Type</dt><dd><code>local_agent</code></dd><dt>Status</dt><dd><span class='task-status status-in_progress'>in_progress</span></dd><dt>Transcript</dt><dd><code>/tmp/claude-1000/synthetic/tasks/cccc333.output</code></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message user task-notification d-0 d-1' data-message-id='d-9' id='msg-d-9'>
+      <div class='message user task-notification' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span>🔄 Async result <span class='tool-summary'>Agent &quot;Coverage analysis&quot; completed</span></span>
               <div class='header-info'>
@@ -4280,13 +4289,14 @@
           <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card task-notification-card"><dt>Task ID</dt><dd><a class='task-notification-backlink' href='#msg-d-2'><code>cccc333</code></a></dd><dt>Status</dt><dd><span class='task-status status-completed'>completed</span></dd><dt>Tokens</dt><dd><code>23,099</code></dd><dt>Tool uses</dt><dd><code>2</code></dd><dt>Duration</dt><dd><code>15.5s</code></dd><dt>Transcript</dt><dd><code>/tmp/claude-1000/synthetic/tasks/cccc333.output</code></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-1' data-message-id='d-10' id='msg-d-10'>
+      <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -4299,6 +4309,19 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content markdown'><div class="assistant-text markdown"><p>Coverage report received. Done.</p>
   </div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -4883,210 +4906,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -5095,68 +4994,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -5165,32 +5013,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {
@@ -10042,6 +9886,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='eb000000-0000-4000-8000-000000000001' id='msg-d-0'>
@@ -10061,13 +9907,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -10091,13 +9936,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span title="ID: tu_Task_async_001">🔧 Task <span class='tool-summary'>Coverage analysis</span> <span class='tool-subagent'>(Explore)</span> <span class='task-async-hint'>[async <code>#cccc333</code>]</span></span>
               <div class='header-info'>
@@ -10111,13 +9955,14 @@
           <div class='content'><div class="task-prompt markdown"><p>Analyze the coverage gaps and report back with a summary.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Run</dt><dd>background</dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-1' data-message-id='d-3' id='msg-d-3'>
+      <div class='message tool_result pair_last' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span title="ID: tu_Task_async_001"></span>
               <div class='header-info'>
@@ -10138,13 +9983,34 @@
   <p>All uncovered branches are now exercised.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Agent</dt><dd><code>cccc333</code></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-1' data-message-id='d-5' id='msg-d-5'>
+      <div class='message user task-notification' data-message-id='d-4' id='msg-d-4'>
+          <div class='header'>
+              <span></span>
+              <div class='header-info'>
+                  <div class='timestamp-row'>
+                      <span class='timestamp' data-timestamp='2026-04-19T10:06:00.000Z'>2026-04-19 10:06:00</span>
+                  </div>
+                  
+              </div>
+          </div>
+          <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
+          <div class='content'></div>
+          
+          
+      </div>
+      
+      
+      
+      
+      
+      <div class='message assistant' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -10157,6 +10023,19 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content markdown'><div class="assistant-text markdown"><p>Coverage report received. Done.</p>
   </div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -10741,210 +10620,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -10953,68 +10708,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -11023,32 +10727,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {
@@ -18083,6 +17783,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='test_session' id='msg-d-0'>
@@ -18102,13 +17804,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -18132,13 +17833,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -18173,13 +17873,20 @@
   </code></pre>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-3' id='msg-d-3'>
+      <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -18203,13 +17910,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-3' data-message-id='d-4' id='msg-d-4'>
+      <div class='message tool_use pair_first' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tool_001">📝 Edit <span class='tool-summary'>/tmp/decorator_example.py</span></span>
               <div class='header-info'>
@@ -18222,13 +17928,14 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-3' data-message-id='d-5' id='msg-d-5'>
+      <div class='message tool_result pair_last' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span title="ID: tool_001"></span>
               <div class='header-info'>
@@ -18241,13 +17948,14 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-3' data-message-id='d-6' id='msg-d-6'>
+      <div class='message assistant' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -18275,13 +17983,20 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-7' id='msg-d-7'>
+      <div class='message user' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -18305,13 +18020,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-7' data-message-id='d-8' id='msg-d-8'>
+      <div class='message tool_use pair_first' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tool_002">💻 Bash <span class='tool-summary'>Run the decorator example to show output</span></span>
               <div class='header-info'>
@@ -18324,13 +18038,14 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-7' data-message-id='d-9' id='msg-d-9'>
+      <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_002"></span>
               <div class='header-info'>
@@ -18345,13 +18060,14 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-7' data-message-id='d-10' id='msg-d-10'>
+      <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -18375,13 +18091,20 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-11' id='msg-d-11'>
+      <div class='message user' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -18394,6 +18117,13 @@
           <div class='debug-info'>msg_011</div>
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</p>
   </div><pre class='user-raw'>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -18978,210 +18708,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -19190,68 +18796,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -19260,32 +18815,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {
@@ -24137,6 +23688,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='ef000000-0000-4000-8000-000000000001' id='msg-d-0'>
@@ -24156,13 +23709,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -24190,13 +23742,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span title="ID: tu_TeamCreate_001">🛠️ TeamCreate</span>
               <div class='header-info'>
@@ -24209,13 +23760,14 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card team-card"><dt>Team</dt><dd>test-coverage</dd><dt>Agent type</dt><dd>team-lead</dd><dt>Description</dt><dd>Parallel test coverage work</dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-1' data-message-id='d-3' id='msg-d-3'>
+      <div class='message tool_result pair_last' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span title="ID: tu_TeamCreate_001"></span>
               <div class='header-info'>
@@ -24228,13 +23780,14 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card team-card team-create-output"><dt>Team</dt><dd>test-coverage</dd><dt>Lead</dt><dd>team-lead@test-coverage</dd><dt>Config</dt><dd><code>/home/synthetic/teams/test-coverage/config.json</code></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use d-0 d-1' data-message-id='d-4' id='msg-d-4'>
+      <div class='message tool_use' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tu_TaskCreate_alice">🛠️ Task <code>#1</code> <span class='tool-summary'>Add relay tests</span> <span class='task-action'>[created]</span></span>
               <div class='header-info'>
@@ -24249,13 +23802,34 @@
   <p>Raise relay.py coverage.</p>
   </div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use d-0 d-1' data-message-id='d-6' id='msg-d-6'>
+      <div class='message tool_result pair_last' data-message-id='d-5' id='msg-d-5'>
+          <div class='header'>
+              <span title="ID: tu_TaskCreate_alice"></span>
+              <div class='header-info'>
+                  <div class='timestamp-row'>
+                      <span class='timestamp' data-timestamp='2026-04-19T10:05:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:05:00</span>
+                  </div>
+                  
+              </div>
+          </div>
+          <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
+          <div class='content'></div>
+          
+          
+      </div>
+      
+      
+      
+      
+      
+      <div class='message tool_use' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span title="ID: tu_TaskCreate_bob">🛠️ Task <code>#2</code> <span class='tool-summary'>Add server tests</span> <span class='task-action'>[created]</span></span>
               <div class='header-info'>
@@ -24270,13 +23844,34 @@
   <p>Raise server.py coverage.</p>
   </div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use d-0 d-1' data-message-id='d-8' id='msg-d-8'>
+      <div class='message tool_result pair_last' data-message-id='d-7' id='msg-d-7'>
+          <div class='header'>
+              <span title="ID: tu_TaskCreate_bob"></span>
+              <div class='header-info'>
+                  <div class='timestamp-row'>
+                      <span class='timestamp' data-timestamp='2026-04-19T10:07:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:07:00</span>
+                  </div>
+                  
+              </div>
+          </div>
+          <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
+          <div class='content'></div>
+          
+          
+      </div>
+      
+      
+      
+      
+      
+      <div class='message tool_use' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tu_TaskUpdate_001">🛠️ Task <a class='task-id-backlink' href='#msg-d-4'><code>#1</code></a> <span class='tool-summary'>Add relay tests</span> <span class='task-action'>[updated]</span></span>
               <div class='header-info'>
@@ -24289,13 +23884,34 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card task-update-card"><dt>Owner</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Status</dt><dd><span class='task-status status-in_progress'>in_progress</span></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use pair_first d-0 d-1' data-message-id='d-10' id='msg-d-10'>
+      <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
+          <div class='header'>
+              <span title="ID: tu_TaskUpdate_001"></span>
+              <div class='header-info'>
+                  <div class='timestamp-row'>
+                      <span class='timestamp' data-timestamp='2026-04-19T10:09:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:09:00</span>
+                  </div>
+                  
+              </div>
+          </div>
+          <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
+          <div class='content'></div>
+          
+          
+      </div>
+      
+      
+      
+      
+      
+      <div class='message tool_use pair_first' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span title="ID: tu_Task_alice">🔧 Task <span class='tool-summary'>Run alice&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span></span>
               <div class='header-info'>
@@ -24309,13 +23925,14 @@
           <div class='content'><div class="task-prompt markdown"><p>You are <strong>alice</strong>, a teammate in the test-coverage team. Add unit tests for the relay module and report back.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Teammate</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Team</dt><dd>test-coverage</dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-1' data-message-id='d-11' id='msg-d-11'>
+      <div class='message tool_result pair_last' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span title="ID: tu_Task_alice"></span>
               <div class='header-info'>
@@ -24339,13 +23956,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant sidechain d-0 d-1 d-11' data-message-id='d-13' id='msg-d-13'>
+      <div class='message assistant sidechain' data-message-id='d-13' id='msg-d-13'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
               <div class='header-info'>
@@ -24359,13 +23975,14 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Starting relay coverage work.</p>
   </div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant sidechain d-0 d-1 d-11' data-message-id='d-14' id='msg-d-14'>
+      <div class='message assistant sidechain' data-message-id='d-14' id='msg-d-14'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
               <div class='header-info'>
@@ -24379,13 +23996,20 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Relay module coverage is now 96%.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use pair_first d-0 d-1' data-message-id='d-15' id='msg-d-15'>
+      <div class='message tool_use pair_first' data-message-id='d-15' id='msg-d-15'>
           <div class='header'>
               <span title="ID: tu_Task_bob">🔧 Task <span class='tool-summary'>Run bob&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span></span>
               <div class='header-info'>
@@ -24399,13 +24023,14 @@
           <div class='content'><div class="task-prompt markdown"><p>You are <strong>bob</strong>, a teammate in the test-coverage team. Add unit tests for the server module and report back.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Teammate</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></dd><dt>Team</dt><dd>test-coverage</dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-1' data-message-id='d-16' id='msg-d-16'>
+      <div class='message tool_result pair_last' data-message-id='d-16' id='msg-d-16'>
           <div class='header'>
               <span title="ID: tu_Task_bob"></span>
               <div class='header-info'>
@@ -24429,13 +24054,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user teammate sidechain d-0 d-1 d-16' data-message-id='d-17' id='msg-d-17'>
+      <div class='message user teammate sidechain' data-message-id='d-17' id='msg-d-17'>
           <div class='header'>
               <span>Teammate</span>
               <div class='header-info'>
@@ -24449,13 +24073,14 @@
           <div class='content markdown'><div class="teammate-message" style="--cc-color: var(--cc-cyan); --cc-color-bg: var(--cc-cyan-bg);"><div class="teammate-message-header"><span class="teammate-badge" style="--cc-color: var(--cc-cyan); --cc-color-bg: var(--cc-cyan-bg);"><span class="teammate-icon">▎</span>team-lead</span><span class="teammate-summary">task spawn</span></div><div class="teammate-body"><p>You are <strong>bob</strong>, a teammate in the test-coverage team. Add unit tests for the server module and report back.</p>
   </div></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant sidechain d-0 d-1 d-16' data-message-id='d-18' id='msg-d-18'>
+      <div class='message assistant sidechain' data-message-id='d-18' id='msg-d-18'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
               <div class='header-info'>
@@ -24469,13 +24094,14 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Starting server coverage work.</p>
   </div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant sidechain d-0 d-1 d-16' data-message-id='d-19' id='msg-d-19'>
+      <div class='message assistant sidechain' data-message-id='d-19' id='msg-d-19'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
               <div class='header-info'>
@@ -24489,13 +24115,26 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Server module coverage is now 88%.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user teammate d-0' data-message-id='d-20' id='msg-d-20'>
+      <div class='message user teammate' data-message-id='d-20' id='msg-d-20'>
           <div class='header'>
               <span>Teammate</span>
               <div class='header-info'>
@@ -24513,13 +24152,14 @@
   </ul>
   </div></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message user teammate d-0' data-message-id='d-21' id='msg-d-21'>
+      <div class='message user teammate' data-message-id='d-21' id='msg-d-21'>
           <div class='header'>
               <span>Teammate</span>
               <div class='header-info'>
@@ -24545,13 +24185,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-21' data-message-id='d-22' id='msg-d-22'>
+      <div class='message tool_use pair_first' data-message-id='d-22' id='msg-d-22'>
           <div class='header'>
               <span title="ID: tu_TaskList_001">🛠️ TaskList</span>
               <div class='header-info'>
@@ -24564,13 +24203,14 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-21' data-message-id='d-23' id='msg-d-23'>
+      <div class='message tool_result pair_last' data-message-id='d-23' id='msg-d-23'>
           <div class='header'>
               <span title="ID: tu_TaskList_001"></span>
               <div class='header-info'>
@@ -24583,13 +24223,14 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><table class='task-list'><thead><tr><th class='task-id'>#</th><th class='task-status'>Status</th><th class='task-subject'>Subject</th><th class='task-owner'>Owner</th></tr></thead><tbody><tr><td class='task-id'>#1</td><td class='task-status status-completed'>completed</td><td class='task-subject'>Add relay tests</td><td class='task-owner'><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></td></tr><tr><td class='task-id'>#2</td><td class='task-status status-completed'>completed</td><td class='task-subject'>Add server tests</td><td class='task-owner'><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></td></tr></tbody></table></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use pair_first d-0 d-21' data-message-id='d-24' id='msg-d-24'>
+      <div class='message tool_use pair_first' data-message-id='d-24' id='msg-d-24'>
           <div class='header'>
               <span title="ID: tu_SendMessage_001">✉️ SendMessage <span class='tool-summary'>to <span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></span></span>
               <div class='header-info'>
@@ -24603,13 +24244,14 @@
           <div class='content'><div class="send-message-type">Type: <code>shutdown_request</code></div><div class="send-message-body markdown"><p>Thanks alice — shutting down.</p>
   </div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-21' data-message-id='d-25' id='msg-d-25'>
+      <div class='message tool_result pair_last' data-message-id='d-25' id='msg-d-25'>
           <div class='header'>
               <span title="ID: tu_SendMessage_001"></span>
               <div class='header-info'>
@@ -24622,13 +24264,14 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card send-message-card"><dt>Status</dt><dd>Sent</dd><dt>Target</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Request</dt><dd><code>shutdown-0001@alice</code></dd><dt>Message</dt><dd>Shutdown request sent to alice. Request ID: shutdown-0001@alice</dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_use pair_first d-0 d-21' data-message-id='d-26' id='msg-d-26'>
+      <div class='message tool_use pair_first' data-message-id='d-26' id='msg-d-26'>
           <div class='header'>
               <span title="ID: tu_TeamDelete_001">🛠️ TeamDelete</span>
               <div class='header-info'>
@@ -24641,13 +24284,14 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><div class="teammate-tool-card team-card team-delete-input"></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-21' data-message-id='d-27' id='msg-d-27'>
+      <div class='message tool_result pair_last' data-message-id='d-27' id='msg-d-27'>
           <div class='header'>
               <span title="ID: tu_TeamDelete_001"></span>
               <div class='header-info'>
@@ -24660,13 +24304,14 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card team-card team-delete-output teammate-refused"><dt>Status</dt><dd>Refused</dd><dt>Team</dt><dd>test-coverage</dd><dt>Message</dt><dd>Cannot cleanup team with 1 active member(s): bob. Use SendMessage shutdown_request first.</dd><dt>Active members</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></dd></dl></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-21' data-message-id='d-28' id='msg-d-28'>
+      <div class='message assistant' data-message-id='d-28' id='msg-d-28'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -24679,6 +24324,19 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content markdown'><div class="assistant-text markdown"><p>Team test-coverage has one member still active. Shut down bob before retrying.</p>
   </div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -25263,210 +24921,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -25475,68 +25009,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -25545,32 +25028,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {
@@ -30422,6 +29901,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='edge_cases' id='msg-d-0'>
@@ -30441,13 +29922,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -30471,13 +29951,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -30531,13 +30010,20 @@
   <p>The markdown renderer handles all of this automatically!</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-3' id='msg-d-3'>
+      <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -30561,13 +30047,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-3' data-message-id='d-4' id='msg-d-4'>
+      <div class='message tool_use pair_first' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tool_edge_001">🛠️ FailingTool</span>
               <div class='header-info'>
@@ -30585,13 +30070,14 @@
               </tr>
           </table></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result error pair_last d-0 d-3' data-message-id='d-5' id='msg-d-5'>
+      <div class='message tool_result error pair_last' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span title="ID: tool_edge_001">🚨 Error</span>
               <div class='header-info'>
@@ -30604,13 +30090,20 @@
           <div class='debug-info'>edge_005</div>
           <div class='content'><pre>Error: Tool execution failed with error: Command not found</pre></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user slash-command pair_first d-0' data-message-id='d-6' id='msg-d-6'>
+      <div class='message user slash-command pair_first' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤷 Slash Command</span>
               <div class='header-info'>
@@ -30625,13 +30118,14 @@
   line breaks
   </pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message user command-output pair_last d-0' data-message-id='d-7' id='msg-d-7'>
+      <div class='message user command-output pair_last' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span></span>
               <div class='header-info'>
@@ -30663,13 +30157,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant d-0 d-7' data-message-id='d-8' id='msg-d-8'>
+      <div class='message assistant' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -30695,13 +30188,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use d-0 d-7 d-8' data-message-id='d-9' id='msg-d-9'>
+      <div class='message tool_use' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_edge_002">🛠️ MultiEdit</span>
               <div class='header-info'>
@@ -30714,13 +30206,26 @@
           <div class='debug-info'>edge_009</div>
           <div class='content'><div class='multiedit-tool-content'><div class='multiedit-file-path'>📝 /tmp/complex_example.py</div><div class='multiedit-count'>Applying 1 edits</div><div class='multiedit-item'><div class='multiedit-item-header'>Edit #1</div><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>#!/usr/bin/env python3</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>&quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>Complex example with multiple operations.</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>&quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>import json</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>import sys</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>from typing import List, Dict, Any</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def process_data(items: List[Dict[str, Any]]) -&gt; None:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    &quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    Process a list of data items.</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    &quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    for item in items:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        print(f&quot;Processing: {item[&#x27;name&#x27;]}&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        if item.get(&#x27;active&#x27;, False):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            print(f&quot;  Status: Active&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        else:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            print(f&quot;  Status: Inactive&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>if __name__ == &quot;__main__&quot;:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    sample_data = [</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 1&quot;, &quot;active&quot;: True},</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 2&quot;, &quot;active&quot;: False},</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 3&quot;, &quot;active&quot;: True}</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    ]</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    process_data(sample_data)</div></div></div></div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-10' id='msg-d-10'>
+      <div class='message user' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -30734,13 +30239,14 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>Testing special characters: café, naïve, résumé, 中文, العربية, русский, 🎉 emojis 🚀 and symbols ∑∆√π∞</p>
   </div><pre class='user-raw'>Testing special characters: café, naïve, résumé, 中文, العربية, русский, 🎉 emojis 🚀 and symbols ∑∆√π∞</pre></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-13' id='msg-d-13'>
+      <div class='message user' data-message-id='d-13' id='msg-d-13'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -30753,6 +30259,13 @@
           <div class='debug-info'>edge_010</div>
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>wow error</p>
   </div><pre class='user-raw'>wow error</pre></div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -30773,13 +30286,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use d-11' data-message-id='d-12' id='msg-d-12'>
+      <div class='message tool_use' data-message-id='d-12' id='msg-d-12'>
           <div class='header'>
               <span title="ID: toolu_todowrite_002">🛠️ TodoWrite</span>
               <div class='header-info'>
@@ -30832,6 +30344,13 @@
                       </td>
               </tr>
           </table></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -31416,210 +30935,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -31628,68 +31023,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -31698,32 +31042,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {
@@ -36636,6 +35976,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='session_b' id='msg-d-0'>
@@ -36655,13 +35997,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -36685,13 +36026,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -36707,13 +36047,20 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Indeed! This message is from a different JSONL file, which should help test the session divider logic. Only the first session should show a divider.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-3' id='msg-d-3'>
+      <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -36726,6 +36073,13 @@
           <div class='debug-info'>session_b_00</div>
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>Perfect! This should appear without any session divider above it.</p>
   </div><pre class='user-raw'>Perfect! This should appear without any session divider above it.</pre></div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -36750,13 +36104,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-4' data-message-id='d-5' id='msg-d-5'>
+      <div class='message user' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -36780,13 +36133,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant d-4 d-5' data-message-id='d-6' id='msg-d-6'>
+      <div class='message assistant' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -36821,13 +36173,20 @@
   </code></pre>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-4' data-message-id='d-7' id='msg-d-7'>
+      <div class='message user' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -36851,13 +36210,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-4 d-7' data-message-id='d-8' id='msg-d-8'>
+      <div class='message tool_use pair_first' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tool_001">📝 Edit <span class='tool-summary'>/tmp/decorator_example.py</span></span>
               <div class='header-info'>
@@ -36870,13 +36228,14 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-4 d-7' data-message-id='d-9' id='msg-d-9'>
+      <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_001"></span>
               <div class='header-info'>
@@ -36889,13 +36248,14 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-4 d-7' data-message-id='d-10' id='msg-d-10'>
+      <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -36923,13 +36283,20 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-4' data-message-id='d-11' id='msg-d-11'>
+      <div class='message user' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -36953,13 +36320,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-4 d-11' data-message-id='d-12' id='msg-d-12'>
+      <div class='message tool_use pair_first' data-message-id='d-12' id='msg-d-12'>
           <div class='header'>
               <span title="ID: tool_002">💻 Bash <span class='tool-summary'>Run the decorator example to show output</span></span>
               <div class='header-info'>
@@ -36972,13 +36338,14 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-4 d-11' data-message-id='d-13' id='msg-d-13'>
+      <div class='message tool_result pair_last' data-message-id='d-13' id='msg-d-13'>
           <div class='header'>
               <span title="ID: tool_002"></span>
               <div class='header-info'>
@@ -36993,13 +36360,14 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-4 d-11' data-message-id='d-14' id='msg-d-14'>
+      <div class='message assistant' data-message-id='d-14' id='msg-d-14'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -37023,13 +36391,20 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-4' data-message-id='d-15' id='msg-d-15'>
+      <div class='message user' data-message-id='d-15' id='msg-d-15'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -37042,6 +36417,13 @@
           <div class='debug-info'>msg_011</div>
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</p>
   </div><pre class='user-raw'>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -37626,210 +37008,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -37838,68 +37096,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -37908,32 +37115,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {
@@ -42785,6 +41988,8 @@
       
   
       
+  
+      
       
       <div class="session-divider"></div>
       <div class='message session-header' data-message-id='d-0' data-session-id='test_session' id='msg-d-0'>
@@ -42804,13 +42009,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message user d-0' data-message-id='d-1' id='msg-d-1'>
+      <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -42834,13 +42038,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message assistant d-0 d-1' data-message-id='d-2' id='msg-d-2'>
+      <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -42875,13 +42078,20 @@
   </code></pre>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-3' id='msg-d-3'>
+      <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -42905,13 +42115,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-3' data-message-id='d-4' id='msg-d-4'>
+      <div class='message tool_use pair_first' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tool_001">📝 Edit <span class='tool-summary'>/tmp/decorator_example.py</span></span>
               <div class='header-info'>
@@ -42924,13 +42133,14 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-3' data-message-id='d-5' id='msg-d-5'>
+      <div class='message tool_result pair_last' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span title="ID: tool_001"></span>
               <div class='header-info'>
@@ -42943,13 +42153,14 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-3' data-message-id='d-6' id='msg-d-6'>
+      <div class='message assistant' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -42977,13 +42188,20 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-7' id='msg-d-7'>
+      <div class='message user' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -43007,13 +42225,12 @@
               
           </div>
           
-      </div>
+          
+          <div class='children'>
+              
       
       
-      
-      
-      
-      <div class='message tool_use pair_first d-0 d-7' data-message-id='d-8' id='msg-d-8'>
+      <div class='message tool_use pair_first' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tool_002">💻 Bash <span class='tool-summary'>Run the decorator example to show output</span></span>
               <div class='header-info'>
@@ -43026,13 +42243,14 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last d-0 d-7' data-message-id='d-9' id='msg-d-9'>
+      <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_002"></span>
               <div class='header-info'>
@@ -43047,13 +42265,14 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
+          
       </div>
       
       
       
       
       
-      <div class='message assistant d-0 d-7' data-message-id='d-10' id='msg-d-10'>
+      <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>
@@ -43077,13 +42296,20 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
+          
+      </div>
+      
+      
+      
+          </div>
+          
       </div>
       
       
       
       
       
-      <div class='message user d-0' data-message-id='d-11' id='msg-d-11'>
+      <div class='message user' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span>🤷 User</span>
               <div class='header-info'>
@@ -43096,6 +42322,13 @@
           <div class='debug-info'>msg_011</div>
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</p>
   </div><pre class='user-raw'>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div></div>
+          
+          
+      </div>
+      
+      
+      
+          </div>
           
       </div>
       
@@ -43680,210 +42913,86 @@
                   section.setAttribute('title', tooltip);
               }
   
-              function handleFoldOne(targetId, isFolded, sectionElement) {
-                  // Find all messages in the document
-                  const allMessages = document.querySelectorAll('.message');
-  
-                  // Find immediate children: messages that have targetId as their LAST ancestor
-                  const immediateChildren = Array.from(allMessages).filter(msg => {
-                      const classList = Array.from(msg.classList);
-                      // Check if targetId is in the class list (ancestor)
-                      if (!classList.includes(targetId)) return false;
-  
-                      // Check if it's an immediate child by finding all ancestor IDs
-                      // Ancestor IDs use unified d-XXX format
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                      const lastAncestor = ancestorIds[ancestorIds.length - 1];
-                      return lastAncestor === targetId;
-                  });
-  
-                  if (isFolded) {
-                      // Unfold: show immediate children
-                      immediateChildren.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Set newly revealed children to folded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.add('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.add('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼';
-                      updateTooltip(sectionElement);
-                      // Note: Second button stays ▶▶ (we haven't unfolded everything)
-                  } else {
-                      // Fold: hide ALL descendants (same approach as handleFoldAll for O(n) performance)
-                      const allDescendants = document.querySelectorAll(`.message.${targetId}`);
-                      allDescendants.forEach(msg => {
-                          msg.style.display = 'none';
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we folded immediate children, all descendants are hidden
-                      // So update the "fold all" button to ▶▶ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-                      if (foldAllSection) {
-                          foldAllSection.classList.add('folded');
-                          foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                          updateTooltip(foldAllSection);
-                      }
+              // --- DOM-nesting fold helpers (replaced the d-N ancestry-class scheme) ---
+              function getMessageEl(messageId) {
+                  if (!messageId) return null;
+                  const sel = (window.CSS && CSS.escape) ? CSS.escape(messageId) : messageId;
+                  return document.querySelector('.message[data-message-id="' + sel + '"]');
+              }
+              function getChildrenContainer(messageEl) {
+                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+              }
+              function getImmediateChildMessages(messageEl) {
+                  const cc = getChildrenContainer(messageEl);
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+              }
+              function setSectionState(section, folded, icon) {
+                  if (!section) return;
+                  if (folded) section.classList.add('folded');
+                  else section.classList.remove('folded');
+                  const iconEl = section.querySelector('.fold-icon');
+                  if (iconEl) iconEl.textContent = icon;
+                  updateTooltip(section);
+              }
+              // Apply a fold state to a message by toggling its OWN .children
+              // container. DOM nesting means hiding that container hides the whole
+              // subtree (fork-points included), so we only touch this message.
+              //   'folded' = hide children; 'first' = show immediate children but
+              //   fold each of their subtrees; 'open' = show all descendants.
+              function applyFoldState(messageEl, state) {
+                  const cc = getChildrenContainer(messageEl);
+                  const foldBar = messageEl.querySelector(':scope > .fold-bar');
+                  const oneSection = foldBar ? foldBar.querySelector('.fold-one-level') : null;
+                  const allSection = foldBar ? foldBar.querySelector('.fold-all-levels') : null;
+                  if (state === 'folded') {
+                      if (cc) cc.style.display = 'none';
+                      setSectionState(oneSection, true, '▶');
+                      setSectionState(allSection, true, '▶▶');
+                  } else if (state === 'first') {
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'folded'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, true, '▶▶');
+                  } else {  // 'open'
+                      if (cc) cc.style.display = '';
+                      getImmediateChildMessages(messageEl).forEach(child => applyFoldState(child, 'open'));
+                      setSectionState(oneSection, false, '▼');
+                      setSectionState(allSection, false, '▼▼');
                   }
+              }
+  
+              function handleFoldOne(targetId, isFolded, sectionElement) {
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → reveal first level; else collapse fully.
+                  applyFoldState(messageEl, isFolded ? 'first' : 'folded');
               }
   
               function handleFoldAll(targetId, isFolded, sectionElement) {
-                  // Find all descendants (messages with targetId in their class list)
-                  const descendants = document.querySelectorAll(`.message.${targetId}`);
-  
-                  if (isFolded) {
-                      // Unfold: show all descendants (State A/B → State C)
-                      descendants.forEach(msg => {
-                          msg.style.display = '';
-  
-                          // Also update fold bars of all descendants to unfolded state
-                          const foldBar = msg.querySelector('.fold-bar');
-                          if (foldBar) {
-                              const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                              const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                              if (foldOneBtn) {
-                                  foldOneBtn.classList.remove('folded');
-                                  foldOneBtn.querySelector('.fold-icon').textContent = '▼';
-                                  updateTooltip(foldOneBtn);
-                              }
-                              if (foldAllBtn) {
-                                  foldAllBtn.classList.remove('folded');
-                                  foldAllBtn.querySelector('.fold-icon').textContent = '▼▼';
-                                  updateTooltip(foldAllBtn);
-                              }
-                          }
-                      });
-                      sectionElement.classList.remove('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▼▼';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: If we unfolded all levels, immediate children are now visible
-                      // So update the "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  } else {
-                      // Fold: show first level only, hide deeper descendants (State C → State B)
-                      descendants.forEach(msg => {
-                          const classList = Array.from(msg.classList);
-                          const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Show immediate children, hide non-immediate children
-                          if (lastAncestor === targetId) {
-                              msg.style.display = '';  // Show immediate child
-  
-                              // Set immediate children to folded state
-                              const foldBar = msg.querySelector('.fold-bar');
-                              if (foldBar) {
-                                  const foldOneBtn = foldBar.querySelector('.fold-one-level');
-                                  const foldAllBtn = foldBar.querySelector('.fold-all-levels');
-  
-                                  if (foldOneBtn) {
-                                      foldOneBtn.classList.add('folded');
-                                      foldOneBtn.querySelector('.fold-icon').textContent = '▶';
-                                      updateTooltip(foldOneBtn);
-                                  }
-                                  if (foldAllBtn) {
-                                      foldAllBtn.classList.add('folded');
-                                      foldAllBtn.querySelector('.fold-icon').textContent = '▶▶';
-                                      updateTooltip(foldAllBtn);
-                                  }
-                              }
-                          } else {
-                              msg.style.display = 'none';  // Hide deeper descendants
-                          }
-                      });
-                      sectionElement.classList.add('folded');
-                      sectionElement.querySelector('.fold-icon').textContent = '▶▶';
-                      updateTooltip(sectionElement);
-  
-                      // Coordinate: First level is now visible, so update "fold one" button to ▼ state
-                      const foldBar = sectionElement.parentElement;
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      if (foldOneSection) {
-                          foldOneSection.classList.remove('folded');
-                          foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                          updateTooltip(foldOneSection);
-                      }
-                  }
+                  const messageEl = getMessageEl(targetId);
+                  if (!messageEl) return;
+                  // Currently folded → open all levels; else collapse to first level.
+                  applyFoldState(messageEl, isFolded ? 'open' : 'first');
               }
   
-              // Set initial fold state on page load
+              // Set initial fold state on page load. Each message sets only its
+              // OWN children container + fold buttons, so iteration order is
+              // irrelevant — DOM nesting encodes the hierarchy.
               function setInitialFoldState() {
-                  // Get all messages once
                   const allMessages = document.querySelectorAll('.message');
-  
-                  // Build hierarchy lookup structure in a single pass - O(n)
-                  const messagesByParentId = {};  // Maps parent ID -> immediate children elements
-                  const allDescendantsByParentId = {};  // Maps parent ID -> all descendant elements
-  
                   allMessages.forEach(msg => {
-                      const classList = Array.from(msg.classList);
-                      const ancestorIds = classList.filter(cls => cls.startsWith('d-'));
-  
-                      if (ancestorIds.length > 0) {
-                          const lastAncestor = ancestorIds[ancestorIds.length - 1];
-  
-                          // Track immediate children
-                          if (!messagesByParentId[lastAncestor]) {
-                              messagesByParentId[lastAncestor] = [];
-                          }
-                          messagesByParentId[lastAncestor].push(msg);
-  
-                          // Track all descendants
-                          ancestorIds.forEach(ancestorId => {
-                              if (!allDescendantsByParentId[ancestorId]) {
-                                  allDescendantsByParentId[ancestorId] = [];
-                              }
-                              allDescendantsByParentId[ancestorId].push(msg);
-                          });
-                      }
-                  });
-  
-                  // Now process each message using cached hierarchy - O(n)
-                  allMessages.forEach(msg => {
-                      const messageId = msg.getAttribute('data-message-id');
-                      if (!messageId) return;
-  
+                      const foldBar = msg.querySelector(':scope > .fold-bar');
+                      if (!foldBar) return;
+                      const oneSection = foldBar.querySelector('.fold-one-level');
+                      const allSection = foldBar.querySelector('.fold-all-levels');
                       const isSession = msg.classList.contains('session-header');
                       const isUser = msg.classList.contains('user');
-                      const foldBar = msg.querySelector('.fold-bar');
   
-                      if (!foldBar) return;
-  
-                      const foldOneSection = foldBar.querySelector('.fold-one-level');
-                      const foldAllSection = foldBar.querySelector('.fold-all-levels');
-  
-                      // Check if user message has only tools (no assistant/system/thinking children)
+                      // A user whose immediate children are all tools collapses
+                      // fully, like a non-session/non-user message.
                       let hasOnlyTools = false;
                       if (isUser) {
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
+                          const immediateChildren = getImmediateChildMessages(msg);
                           const hasNonToolChildren = immediateChildren.some(child =>
                               child.classList.contains('assistant') ||
                               child.classList.contains('system') ||
@@ -43892,68 +43001,17 @@
                           hasOnlyTools = immediateChildren.length > 0 && !hasNonToolChildren;
                       }
   
-                      // Sessions and user messages (unless they have only tools): unfolded at first level
+                      const cc = getChildrenContainer(msg);
                       if ((isSession || isUser) && !hasOnlyTools) {
-                          // First level is visible (▼), all levels are not (▶▶)
-                          if (foldOneSection) {
-                              foldOneSection.classList.remove('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▼';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Show immediate children, hide deeper descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          const immediateChildren = messagesByParentId[messageId] || [];
-  
-                          allDescendants.forEach(descendant => {
-                              // Show immediate children, hide non-immediate children
-                              if (immediateChildren.includes(descendant)) {
-                                  descendant.style.display = '';  // Show immediate child
-  
-                                  // Set immediate children to folded state (▶/▶▶)
-                                  const childFoldBar = descendant.querySelector('.fold-bar');
-                                  if (childFoldBar) {
-                                      const childFoldOne = childFoldBar.querySelector('.fold-one-level');
-                                      const childFoldAll = childFoldBar.querySelector('.fold-all-levels');
-  
-                                      if (childFoldOne) {
-                                          childFoldOne.classList.add('folded');
-                                          childFoldOne.querySelector('.fold-icon').textContent = '▶';
-                                          updateTooltip(childFoldOne);
-                                      }
-                                      if (childFoldAll) {
-                                          childFoldAll.classList.add('folded');
-                                          childFoldAll.querySelector('.fold-icon').textContent = '▶▶';
-                                          updateTooltip(childFoldAll);
-                                      }
-                                  }
-                              } else {
-                                  descendant.style.display = 'none';  // Hide deeper descendants
-                              }
-                          });
+                          // First level visible (▼), deeper levels folded (▶▶)
+                          if (cc) cc.style.display = '';
+                          setSectionState(oneSection, false, '▼');
+                          setSectionState(allSection, true, '▶▶');
                       } else {
-                          // Assistant, system, thinking, tools, sidechains, OR user messages with only tools: fully folded
-                          if (foldOneSection) {
-                              foldOneSection.classList.add('folded');
-                              foldOneSection.querySelector('.fold-icon').textContent = '▶';
-                              updateTooltip(foldOneSection);
-                          }
-                          if (foldAllSection) {
-                              foldAllSection.classList.add('folded');
-                              foldAllSection.querySelector('.fold-icon').textContent = '▶▶';
-                              updateTooltip(foldAllSection);
-                          }
-  
-                          // Hide all descendants
-                          const allDescendants = allDescendantsByParentId[messageId] || [];
-                          allDescendants.forEach(descendant => {
-                              descendant.style.display = 'none';
-                          });
+                          // Fully folded
+                          if (cc) cc.style.display = 'none';
+                          setSectionState(oneSection, true, '▶');
+                          setSectionState(allSection, true, '▶▶');
                       }
                   });
               }
@@ -43962,32 +43020,28 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestor
-              // message_ids appear as `d-X` classes on the target, outer-first.
+              // jumped to from the session index) is actually visible. Ancestry
+              // is now DOM nesting, so walk up the .children/.message chain and
+              // reveal each ancestor's children container.
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
-                  const ancestorIds = Array.from(target.classList).filter(
-                      cls => cls.startsWith('d-')
-                  );
-                  ancestorIds.forEach(id => {
-                      const ancestorMsg = document.querySelector(
-                          `.message[data-message-id="${id}"]`
-                      );
-                      if (!ancestorMsg) return;
-                      const foldBar = ancestorMsg.querySelector('.fold-bar');
-                      if (!foldBar) return;
-                      // Single-level parents only render `.fold-one-level.full-width`
-                      // — no `.fold-all-levels` exists — so anchors under those
-                      // folded ancestors stay hidden unless we fall back.
-                      const foldControl =
-                          foldBar.querySelector('.fold-all-levels') ||
-                          foldBar.querySelector('.fold-one-level.full-width');
-                      if (foldControl && foldControl.classList.contains('folded')) {
-                          foldControl.click();
+                  let node = target.parentElement;
+                  while (node) {
+                      if (node.classList && node.classList.contains('message')) {
+                          const cc = getChildrenContainer(node);
+                          if (cc && cc.style.display === 'none') {
+                              cc.style.display = '';
+                              const foldBar = node.querySelector(':scope > .fold-bar');
+                              if (foldBar) {
+                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
+                              }
+                          }
                       }
-                  });
+                      node = node.parentElement;
+                  }
                   // Re-trigger the browser's scroll-to-anchor now that
                   // the target is no longer display:none.
                   if (target.scrollIntoView) {

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -353,6 +353,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -4097,6 +4108,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='eb000000-0000-4000-8000-000000000001' id='msg-d-0'>
           <div class='header'>Session: eb000000</div>
           
@@ -4114,11 +4127,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -4147,11 +4162,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span title="ID: tu_Task_async_001">🔧 Task <span class='tool-summary'>Coverage analysis</span> <span class='tool-subagent'>(Explore)</span> <span class='task-async-hint'>[async <a class='task-id-forward-link' href='#msg-d-7'><code>#cccc333</code></a>]</span></span>
@@ -4166,13 +4183,15 @@
           <div class='content'><div class="task-prompt markdown"><p>Analyze the coverage gaps and report back with a summary.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Run</dt><dd>background</dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span title="ID: tu_Task_async_001"></span>
@@ -4204,11 +4223,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant sidechain' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
@@ -4223,19 +4244,21 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Reading the source files now...</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span title="ID: tu_TaskOutput_001">🔍 TaskOutput <a class='task-id-backlink' href='#msg-d-2'><code>#cccc333</code></a></span>
@@ -4249,13 +4272,15 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card task-output-card"><dt>Block</dt><dd><code>true</code></dd><dt>Timeout</dt><dd><code>60000 ms</code></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tu_TaskOutput_001"></span>
@@ -4269,13 +4294,15 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card task-output-card"><dt>Retrieval</dt><dd><code>success</code></dd><dt>Type</dt><dd><code>local_agent</code></dd><dt>Status</dt><dd><span class='task-status status-in_progress'>in_progress</span></dd><dt>Transcript</dt><dd><code>/tmp/claude-1000/synthetic/tasks/cccc333.output</code></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message user task-notification' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span>🔄 Async result <span class='tool-summary'>Agent &quot;Coverage analysis&quot; completed</span></span>
@@ -4289,13 +4316,15 @@
           <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card task-notification-card"><dt>Task ID</dt><dd><a class='task-notification-backlink' href='#msg-d-2'><code>cccc333</code></a></dd><dt>Status</dt><dd><span class='task-status status-completed'>completed</span></dd><dt>Tokens</dt><dd><code>23,099</code></dd><dt>Tool uses</dt><dd><code>2</code></dd><dt>Duration</dt><dd><code>15.5s</code></dd><dt>Transcript</dt><dd><code>/tmp/claude-1000/synthetic/tasks/cccc333.output</code></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -4310,21 +4339,22 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Coverage report received. Done.</p>
   </div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -4913,11 +4943,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -5013,24 +5048,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;
@@ -6146,6 +6183,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -9890,6 +9938,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='eb000000-0000-4000-8000-000000000001' id='msg-d-0'>
           <div class='header'>Session: eb000000</div>
           
@@ -9907,11 +9957,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -9936,11 +9988,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span title="ID: tu_Task_async_001">🔧 Task <span class='tool-summary'>Coverage analysis</span> <span class='tool-subagent'>(Explore)</span> <span class='task-async-hint'>[async <code>#cccc333</code>]</span></span>
@@ -9955,13 +10009,15 @@
           <div class='content'><div class="task-prompt markdown"><p>Analyze the coverage gaps and report back with a summary.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Run</dt><dd>background</dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span title="ID: tu_Task_async_001"></span>
@@ -9983,33 +10039,17 @@
   <p>All uncovered branches are now exercised.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Agent</dt><dd><code>cccc333</code></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
       
-      <div class='message user task-notification' data-message-id='d-4' id='msg-d-4'>
-          <div class='header'>
-              <span></span>
-              <div class='header-info'>
-                  <div class='timestamp-row'>
-                      <span class='timestamp' data-timestamp='2026-04-19T10:06:00.000Z'>2026-04-19 10:06:00</span>
-                  </div>
-                  
-              </div>
-          </div>
-          <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
-          <div class='content'></div>
-          
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -10024,21 +10064,22 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Coverage report received. Done.</p>
   </div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -10627,11 +10668,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -10727,24 +10773,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;
@@ -14043,6 +14091,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -17787,6 +17846,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='test_session' id='msg-d-0'>
           <div class='header'>Session: test_ses</div>
           
@@ -17804,11 +17865,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -17833,11 +17896,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -17873,19 +17938,21 @@
   </code></pre>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
@@ -17910,11 +17977,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tool_001">📝 Edit <span class='tool-summary'>/tmp/decorator_example.py</span></span>
@@ -17928,13 +17997,15 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span title="ID: tool_001"></span>
@@ -17948,13 +18019,15 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -17983,19 +18056,21 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span>🤷 User</span>
@@ -18020,11 +18095,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tool_002">💻 Bash <span class='tool-summary'>Run the decorator example to show output</span></span>
@@ -18038,13 +18115,15 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_002"></span>
@@ -18060,13 +18139,15 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -18091,19 +18172,21 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span>🤷 User</span>
@@ -18118,15 +18201,16 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</p>
   </div><pre class='user-raw'>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -18715,11 +18799,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -18815,24 +18904,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;
@@ -19948,6 +20039,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -23692,6 +23794,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='ef000000-0000-4000-8000-000000000001' id='msg-d-0'>
           <div class='header'>Session: ef000000<span class="session-team-badge" style="--cc-color: var(--cc-purple); --cc-color-bg: var(--cc-purple-bg);"><span class="session-team-icon">👥</span>Team: test-coverage</span></div>
           
@@ -23709,11 +23813,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -23742,11 +23848,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span title="ID: tu_TeamCreate_001">🛠️ TeamCreate</span>
@@ -23760,13 +23868,15 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card team-card"><dt>Team</dt><dd>test-coverage</dd><dt>Agent type</dt><dd>team-lead</dd><dt>Description</dt><dd>Parallel test coverage work</dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span title="ID: tu_TeamCreate_001"></span>
@@ -23780,13 +23890,15 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card team-card team-create-output"><dt>Team</dt><dd>test-coverage</dd><dt>Lead</dt><dd>team-lead@test-coverage</dd><dt>Config</dt><dd><code>/home/synthetic/teams/test-coverage/config.json</code></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_use' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tu_TaskCreate_alice">🛠️ Task <code>#1</code> <span class='tool-summary'>Add relay tests</span> <span class='task-action'>[created]</span></span>
@@ -23802,33 +23914,17 @@
   <p>Raise relay.py coverage.</p>
   </div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last' data-message-id='d-5' id='msg-d-5'>
-          <div class='header'>
-              <span title="ID: tu_TaskCreate_alice"></span>
-              <div class='header-info'>
-                  <div class='timestamp-row'>
-                      <span class='timestamp' data-timestamp='2026-04-19T10:05:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:05:00</span>
-                  </div>
-                  
-              </div>
-          </div>
-          <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
-          <div class='content'></div>
-          
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message tool_use' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span title="ID: tu_TaskCreate_bob">🛠️ Task <code>#2</code> <span class='tool-summary'>Add server tests</span> <span class='task-action'>[created]</span></span>
@@ -23844,33 +23940,17 @@
   <p>Raise server.py coverage.</p>
   </div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last' data-message-id='d-7' id='msg-d-7'>
-          <div class='header'>
-              <span title="ID: tu_TaskCreate_bob"></span>
-              <div class='header-info'>
-                  <div class='timestamp-row'>
-                      <span class='timestamp' data-timestamp='2026-04-19T10:07:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:07:00</span>
-                  </div>
-                  
-              </div>
-          </div>
-          <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
-          <div class='content'></div>
-          
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message tool_use' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tu_TaskUpdate_001">🛠️ Task <a class='task-id-backlink' href='#msg-d-4'><code>#1</code></a> <span class='tool-summary'>Add relay tests</span> <span class='task-action'>[updated]</span></span>
@@ -23884,33 +23964,17 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><dl class="teammate-tool-card task-update-card"><dt>Owner</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Status</dt><dd><span class='task-status status-in_progress'>in_progress</span></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
       
-      <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
-          <div class='header'>
-              <span title="ID: tu_TaskUpdate_001"></span>
-              <div class='header-info'>
-                  <div class='timestamp-row'>
-                      <span class='timestamp' data-timestamp='2026-04-19T10:09:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:09:00</span>
-                  </div>
-                  
-              </div>
-          </div>
-          <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
-          <div class='content'></div>
-          
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span title="ID: tu_Task_alice">🔧 Task <span class='tool-summary'>Run alice&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span></span>
@@ -23925,13 +23989,15 @@
           <div class='content'><div class="task-prompt markdown"><p>You are <strong>alice</strong>, a teammate in the test-coverage team. Add unit tests for the relay module and report back.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Teammate</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Team</dt><dd>test-coverage</dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span title="ID: tu_Task_alice"></span>
@@ -23956,11 +24022,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant sidechain' data-message-id='d-13' id='msg-d-13'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
@@ -23975,13 +24043,15 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Starting relay coverage work.</p>
   </div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant sidechain' data-message-id='d-14' id='msg-d-14'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
@@ -23996,19 +24066,21 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Relay module coverage is now 96%.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-15' id='msg-d-15'>
           <div class='header'>
               <span title="ID: tu_Task_bob">🔧 Task <span class='tool-summary'>Run bob&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span></span>
@@ -24023,13 +24095,15 @@
           <div class='content'><div class="task-prompt markdown"><p>You are <strong>bob</strong>, a teammate in the test-coverage team. Add unit tests for the server module and report back.</p>
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Teammate</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></dd><dt>Team</dt><dd>test-coverage</dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-16' id='msg-d-16'>
           <div class='header'>
               <span title="ID: tu_Task_bob"></span>
@@ -24054,11 +24128,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user teammate sidechain' data-message-id='d-17' id='msg-d-17'>
           <div class='header'>
               <span>Teammate</span>
@@ -24073,13 +24149,15 @@
           <div class='content markdown'><div class="teammate-message" style="--cc-color: var(--cc-cyan); --cc-color-bg: var(--cc-cyan-bg);"><div class="teammate-message-header"><span class="teammate-badge" style="--cc-color: var(--cc-cyan); --cc-color-bg: var(--cc-cyan-bg);"><span class="teammate-icon">▎</span>team-lead</span><span class="teammate-summary">task spawn</span></div><div class="teammate-body"><p>You are <strong>bob</strong>, a teammate in the test-coverage team. Add unit tests for the server module and report back.</p>
   </div></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant sidechain' data-message-id='d-18' id='msg-d-18'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
@@ -24094,13 +24172,15 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Starting server coverage work.</p>
   </div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant sidechain' data-message-id='d-19' id='msg-d-19'>
           <div class='header'>
               <span>🔗 Sub-assistant</span>
@@ -24115,25 +24195,27 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Server module coverage is now 88%.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-          </div>
-          
-      </div>
-      
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user teammate' data-message-id='d-20' id='msg-d-20'>
           <div class='header'>
               <span>Teammate</span>
@@ -24152,13 +24234,15 @@
   </ul>
   </div></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message user teammate' data-message-id='d-21' id='msg-d-21'>
           <div class='header'>
               <span>Teammate</span>
@@ -24185,11 +24269,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-22' id='msg-d-22'>
           <div class='header'>
               <span title="ID: tu_TaskList_001">🛠️ TaskList</span>
@@ -24203,13 +24289,15 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-23' id='msg-d-23'>
           <div class='header'>
               <span title="ID: tu_TaskList_001"></span>
@@ -24223,13 +24311,15 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><table class='task-list'><thead><tr><th class='task-id'>#</th><th class='task-status'>Status</th><th class='task-subject'>Subject</th><th class='task-owner'>Owner</th></tr></thead><tbody><tr><td class='task-id'>#1</td><td class='task-status status-completed'>completed</td><td class='task-subject'>Add relay tests</td><td class='task-owner'><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></td></tr><tr><td class='task-id'>#2</td><td class='task-status status-completed'>completed</td><td class='task-subject'>Add server tests</td><td class='task-owner'><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></td></tr></tbody></table></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-24' id='msg-d-24'>
           <div class='header'>
               <span title="ID: tu_SendMessage_001">✉️ SendMessage <span class='tool-summary'>to <span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></span></span>
@@ -24244,13 +24334,15 @@
           <div class='content'><div class="send-message-type">Type: <code>shutdown_request</code></div><div class="send-message-body markdown"><p>Thanks alice — shutting down.</p>
   </div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-25' id='msg-d-25'>
           <div class='header'>
               <span title="ID: tu_SendMessage_001"></span>
@@ -24264,13 +24356,15 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card send-message-card"><dt>Status</dt><dd>Sent</dd><dt>Target</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Request</dt><dd><code>shutdown-0001@alice</code></dd><dt>Message</dt><dd>Shutdown request sent to alice. Request ID: shutdown-0001@alice</dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-26' id='msg-d-26'>
           <div class='header'>
               <span title="ID: tu_TeamDelete_001">🛠️ TeamDelete</span>
@@ -24284,13 +24378,15 @@
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
           <div class='content'><div class="teammate-tool-card team-card team-delete-input"></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-27' id='msg-d-27'>
           <div class='header'>
               <span title="ID: tu_TeamDelete_001"></span>
@@ -24304,13 +24400,15 @@
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
           <div class='content'><dl class="teammate-tool-card team-card team-delete-output teammate-refused"><dt>Status</dt><dd>Refused</dd><dt>Team</dt><dd>test-coverage</dd><dt>Message</dt><dd>Cannot cleanup team with 1 active member(s): bob. Use SendMessage shutdown_request first.</dd><dt>Active members</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></dd></dl></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-28' id='msg-d-28'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -24325,21 +24423,22 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Team test-coverage has one member still active. Shut down bob before retrying.</p>
   </div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -24928,11 +25027,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -25028,24 +25132,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;
@@ -26161,6 +26267,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -29905,6 +30022,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='edge_cases' id='msg-d-0'>
           <div class='header'>Session: Tested various edge cases including markdown formatting, long text, tool errors, system messages, command outputs, special characters and emojis. All message types render correctly in the transcript viewer. • edge_cas</div>
           
@@ -29922,11 +30041,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -29951,11 +30072,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -30010,19 +30133,21 @@
   <p>The markdown renderer handles all of this automatically!</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
@@ -30047,11 +30172,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tool_edge_001">🛠️ FailingTool</span>
@@ -30070,13 +30197,15 @@
               </tr>
           </table></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result error pair_last' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span title="ID: tool_edge_001">🚨 Error</span>
@@ -30090,19 +30219,21 @@
           <div class='debug-info'>edge_005</div>
           <div class='content'><pre>Error: Tool execution failed with error: Command not found</pre></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user slash-command pair_first' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤷 Slash Command</span>
@@ -30118,13 +30249,15 @@
   line breaks
   </pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message user command-output pair_last' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span></span>
@@ -30157,11 +30290,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -30188,11 +30323,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_edge_002">🛠️ MultiEdit</span>
@@ -30206,25 +30343,27 @@
           <div class='debug-info'>edge_009</div>
           <div class='content'><div class='multiedit-tool-content'><div class='multiedit-file-path'>📝 /tmp/complex_example.py</div><div class='multiedit-count'>Applying 1 edits</div><div class='multiedit-item'><div class='multiedit-item-header'>Edit #1</div><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>#!/usr/bin/env python3</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>&quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>Complex example with multiple operations.</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>&quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>import json</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>import sys</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>from typing import List, Dict, Any</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def process_data(items: List[Dict[str, Any]]) -&gt; None:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    &quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    Process a list of data items.</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    &quot;&quot;&quot;</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    for item in items:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        print(f&quot;Processing: {item[&#x27;name&#x27;]}&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        if item.get(&#x27;active&#x27;, False):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            print(f&quot;  Status: Active&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        else:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            print(f&quot;  Status: Inactive&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>if __name__ == &quot;__main__&quot;:</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    sample_data = [</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 1&quot;, &quot;active&quot;: True},</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 2&quot;, &quot;active&quot;: False},</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        {&quot;name&quot;: &quot;Item 3&quot;, &quot;active&quot;: True}</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    ]</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    process_data(sample_data)</div></div></div></div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-          </div>
-          
-      </div>
-      
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤷 User</span>
@@ -30239,13 +30378,15 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>Testing special characters: café, naïve, résumé, 中文, العربية, русский, 🎉 emojis 🚀 and symbols ∑∆√π∞</p>
   </div><pre class='user-raw'>Testing special characters: café, naïve, résumé, 中文, العربية, русский, 🎉 emojis 🚀 and symbols ∑∆√π∞</pre></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-13' id='msg-d-13'>
           <div class='header'>
               <span>🤷 User</span>
@@ -30260,19 +30401,22 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>wow error</p>
   </div><pre class='user-raw'>wow error</pre></div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
       
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-11' data-session-id='todowrite_session' id='msg-d-11'>
           <div class='header'>Session: todowrit</div>
           
@@ -30286,11 +30430,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use' data-message-id='d-12' id='msg-d-12'>
           <div class='header'>
               <span title="ID: toolu_todowrite_002">🛠️ TodoWrite</span>
@@ -30345,15 +30491,16 @@
               </tr>
           </table></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -30942,11 +31089,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -31042,24 +31194,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;
@@ -32175,6 +32329,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -35980,6 +36145,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='session_b' id='msg-d-0'>
           <div class='header'>Session: session_</div>
           
@@ -35997,11 +36164,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -36026,11 +36195,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -36047,19 +36218,21 @@
           <div class='content markdown'><div class="assistant-text markdown"><p>Indeed! This message is from a different JSONL file, which should help test the session divider logic. Only the first session should show a divider.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
@@ -36074,19 +36247,22 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>Perfect! This should appear without any session divider above it.</p>
   </div><pre class='user-raw'>Perfect! This should appear without any session divider above it.</pre></div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
       
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-4' data-session-id='test_session' id='msg-d-4'>
           <div class='header'>Session: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. • test_ses</div>
           
@@ -36104,11 +36280,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span>🤷 User</span>
@@ -36133,11 +36311,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -36173,19 +36353,21 @@
   </code></pre>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span>🤷 User</span>
@@ -36210,11 +36392,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tool_001">📝 Edit <span class='tool-summary'>/tmp/decorator_example.py</span></span>
@@ -36228,13 +36412,15 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_001"></span>
@@ -36248,13 +36434,15 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -36283,19 +36471,21 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span>🤷 User</span>
@@ -36320,11 +36510,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-12' id='msg-d-12'>
           <div class='header'>
               <span title="ID: tool_002">💻 Bash <span class='tool-summary'>Run the decorator example to show output</span></span>
@@ -36338,13 +36530,15 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-13' id='msg-d-13'>
           <div class='header'>
               <span title="ID: tool_002"></span>
@@ -36360,13 +36554,15 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-14' id='msg-d-14'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -36391,19 +36587,21 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-15' id='msg-d-15'>
           <div class='header'>
               <span>🤷 User</span>
@@ -36418,15 +36616,16 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</p>
   </div><pre class='user-raw'>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -37015,11 +37214,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -37115,24 +37319,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;
@@ -38248,6 +38454,17 @@
       }
   }
   /* Message and content styles */
+  
+  /* Structural wrapper around a message card and its nested .children
+     (dissociated nested DOM, issue #174). Carries NO box styling: the card's
+     border/background/shadow/margins live on .message and must frame only the
+     card, not the subtree. The wrapper is a plain full-width block so the
+     per-type horizontal margins on .message resolve against the full content
+     width (absolute type-based positioning), not a parent card's inset. */
+  .message-node {
+      /* structural only — intentionally no visual properties */
+  }
+  
   .message {
       margin-bottom: 1em;
       padding: var(--message-padding);
@@ -41992,6 +42209,8 @@
       
       
       <div class="session-divider"></div>
+      
+      <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='test_session' id='msg-d-0'>
           <div class='header'>Session: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. • test_ses</div>
           
@@ -42009,11 +42228,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message user' data-message-id='d-1' id='msg-d-1'>
           <div class='header'>
               <span>🤷 User</span>
@@ -42038,11 +42259,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -42078,19 +42301,21 @@
   </code></pre>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-3' id='msg-d-3'>
           <div class='header'>
               <span>🤷 User</span>
@@ -42115,11 +42340,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-4' id='msg-d-4'>
           <div class='header'>
               <span title="ID: tool_001">📝 Edit <span class='tool-summary'>/tmp/decorator_example.py</span></span>
@@ -42133,13 +42360,15 @@
           <div class='debug-info'>msg_004</div>
           <div class='content'><div class='edit-tool-content'><div class='edit-diff'><div class='diff-line diff-added'><span class='diff-marker'>+</span>def repeat(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    def decorator(func):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        def wrapper(*args, **kwargs):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            for _ in range(times):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>                result = func(*args, **kwargs)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>            return result</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>        return wrapper</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    return decorator</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>@repeat(3)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>def greet(name):</div><div class='diff-line diff-added'><span class='diff-marker'>+</span>    print(f&quot;Hello, {name}!&quot;)</div><div class='diff-line diff-added'><span class='diff-marker'>+</span></div><div class='diff-line diff-added'><span class='diff-marker'>+</span>greet(&quot;Alice&quot;)</div></div></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-5' id='msg-d-5'>
           <div class='header'>
               <span title="ID: tool_001"></span>
@@ -42153,13 +42382,15 @@
           <div class='debug-info'>msg_005</div>
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-6' id='msg-d-6'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -42188,19 +42419,21 @@
   <p>When you run this code, it will print &quot;Hello, Alice!&quot; three times.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-7' id='msg-d-7'>
           <div class='header'>
               <span>🤷 User</span>
@@ -42225,11 +42458,13 @@
               
           </div>
           
+      </div>
+      
+      <div class='children'>
           
-          <div class='children'>
-              
       
       
+      <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-8' id='msg-d-8'>
           <div class='header'>
               <span title="ID: tool_002">💻 Bash <span class='tool-summary'>Run the decorator example to show output</span></span>
@@ -42243,13 +42478,15 @@
           <div class='debug-info'>msg_008</div>
           <div class='content'><div class='bash-tool-content'><pre class='bash-tool-command'>python /tmp/decorator_example.py</pre></div></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message tool_result pair_last' data-message-id='d-9' id='msg-d-9'>
           <div class='header'>
               <span title="ID: tool_002"></span>
@@ -42265,13 +42502,15 @@
   Hello, Alice!
   Hello, Alice!</pre></div>
           
-          
+      </div>
+      
+      
       </div>
       
       
       
       
-      
+      <div class='message-node'>
       <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
@@ -42296,19 +42535,21 @@
   <p>The pattern is always the same: decorator factory → decorator → wrapper function.</p>
   </div></div>
           
-          
+      </div>
+      
+      
+      </div>
+      
+      
+      </div>
+      
+      
       </div>
       
       
       
-          </div>
-          
-      </div>
       
-      
-      
-      
-      
+      <div class='message-node'>
       <div class='message user' data-message-id='d-11' id='msg-d-11'>
           <div class='header'>
               <span>🤷 User</span>
@@ -42323,15 +42564,16 @@
           <div class='content'><div class='user-content'><button type='button' class='user-view-toggle' aria-label='Toggle between Markdown and raw view' title='Toggle Markdown / raw view'>raw</button><div class='user-md'><p>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</p>
   </div><pre class='user-raw'>This is really helpful! Let me try to implement a timing decorator myself. Can you help me if I get stuck?</pre></div></div>
           
-          
       </div>
       
       
-      
-          </div>
-          
       </div>
       
+      
+      </div>
+      
+      
+      </div>
       
       
   
@@ -42920,11 +43162,16 @@
                   return document.querySelector('.message[data-message-id="' + sel + '"]');
               }
               function getChildrenContainer(messageEl) {
-                  return messageEl ? messageEl.querySelector(':scope > .children') : null;
+                  // .children is now a SIBLING of the card inside the shared
+                  // .message-node wrapper (dissociated DOM), not a descendant.
+                  const wrapper = messageEl ? messageEl.parentElement : null;
+                  return wrapper ? wrapper.querySelector(':scope > .children') : null;
               }
               function getImmediateChildMessages(messageEl) {
                   const cc = getChildrenContainer(messageEl);
-                  return cc ? Array.from(cc.querySelectorAll(':scope > .message')) : [];
+                  // Each child is wrapped in its own .message-node; its card is
+                  // that wrapper's direct .message child.
+                  return cc ? Array.from(cc.querySelectorAll(':scope > .message-node > .message')) : [];
               }
               function setSectionState(section, folded, icon) {
                   if (!section) return;
@@ -43020,24 +43267,26 @@
               setInitialFoldState();
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
-              // jumped to from the session index) is actually visible. Ancestry
-              // is now DOM nesting, so walk up the .children/.message chain and
-              // reveal each ancestor's children container.
+              // jumped to from the session index) is actually visible. In the
+              // dissociated DOM a card's ancestors are .message-node and
+              // .children wrappers, NOT the parent .message cards — so walk up
+              // and reveal each hidden .children container, syncing the
+              // controlling card's fold bar (its sibling within the node).
               function unfoldAncestorsOf(hash) {
                   if (!hash || !hash.startsWith('#msg-')) return;
                   const target = document.getElementById(hash.slice(1));
                   if (!target) return;
                   let node = target.parentElement;
                   while (node) {
-                      if (node.classList && node.classList.contains('message')) {
-                          const cc = getChildrenContainer(node);
-                          if (cc && cc.style.display === 'none') {
-                              cc.style.display = '';
-                              const foldBar = node.querySelector(':scope > .fold-bar');
-                              if (foldBar) {
-                                  setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
-                                  setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
-                              }
+                      if (node.classList && node.classList.contains('children')
+                          && node.style.display === 'none') {
+                          node.style.display = '';
+                          const wrapper = node.parentElement; // .message-node
+                          const card = wrapper ? wrapper.querySelector(':scope > .message') : null;
+                          const foldBar = card ? card.querySelector(':scope > .fold-bar') : null;
+                          if (foldBar) {
+                              setSectionState(foldBar.querySelector('.fold-one-level'), false, '▼');
+                              setSectionState(foldBar.querySelector('.fold-all-levels'), false, '▼▼');
                           }
                       }
                       node = node.parentElement;

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -4185,7 +4185,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -4246,12 +4245,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -4274,7 +4271,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -4296,7 +4292,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -4317,7 +4312,6 @@
           <div class='content'><dl class="teammate-tool-card task-notification-card"><dt>Task ID</dt><dd><a class='task-notification-backlink' href='#msg-d-2'><code>cccc333</code></a></dd><dt>Status</dt><dd><span class='task-status status-completed'>completed</span></dd><dt>Tokens</dt><dd><code>23,099</code></dd><dt>Tool uses</dt><dd><code>2</code></dd><dt>Duration</dt><dd><code>15.5s</code></dd><dt>Transcript</dt><dd><code>/tmp/claude-1000/synthetic/tasks/cccc333.output</code></dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -4341,18 +4335,15 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -4964,7 +4955,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {
@@ -10011,7 +10004,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -10041,7 +10033,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -10066,18 +10057,15 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -10689,7 +10677,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {
@@ -17940,12 +17930,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -17999,7 +17987,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -18020,7 +18007,6 @@
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
       </div>
-      
       
       </div>
       
@@ -18058,12 +18044,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -18117,7 +18101,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -18140,7 +18123,6 @@
   Hello, Alice!</pre></div>
           
       </div>
-      
       
       </div>
       
@@ -18174,12 +18156,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -18203,12 +18183,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -18820,7 +18798,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {
@@ -23870,7 +23850,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -23891,7 +23870,6 @@
           <div class='content'><dl class="teammate-tool-card team-card team-create-output"><dt>Team</dt><dd>test-coverage</dd><dt>Lead</dt><dd>team-lead@test-coverage</dd><dt>Config</dt><dd><code>/home/synthetic/teams/test-coverage/config.json</code></dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -23915,7 +23893,6 @@
   </div></div>
           
       </div>
-      
       
       </div>
       
@@ -23942,7 +23919,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -23965,7 +23941,6 @@
           <div class='content'><dl class="teammate-tool-card task-update-card"><dt>Owner</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Status</dt><dd><span class='task-status status-in_progress'>in_progress</span></dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -23990,7 +23965,6 @@
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Teammate</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Team</dt><dd>test-coverage</dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -24045,7 +24019,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -24068,12 +24041,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -24096,7 +24067,6 @@
   </div><dl class="teammate-tool-card teammate-spawn-card"><dt>Teammate</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></dd><dt>Team</dt><dd>test-coverage</dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -24151,7 +24121,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -24173,7 +24142,6 @@
   </div></div>
           
       </div>
-      
       
       </div>
       
@@ -24197,18 +24165,15 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -24235,7 +24200,6 @@
   </div></div></div>
           
       </div>
-      
       
       </div>
       
@@ -24291,7 +24255,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -24312,7 +24275,6 @@
           <div class='content'><table class='task-list'><thead><tr><th class='task-id'>#</th><th class='task-status'>Status</th><th class='task-subject'>Subject</th><th class='task-owner'>Owner</th></tr></thead><tbody><tr><td class='task-id'>#1</td><td class='task-status status-completed'>completed</td><td class='task-subject'>Add relay tests</td><td class='task-owner'><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></td></tr><tr><td class='task-id'>#2</td><td class='task-status status-completed'>completed</td><td class='task-subject'>Add server tests</td><td class='task-owner'><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></td></tr></tbody></table></div>
           
       </div>
-      
       
       </div>
       
@@ -24336,7 +24298,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -24357,7 +24318,6 @@
           <div class='content'><dl class="teammate-tool-card send-message-card"><dt>Status</dt><dd>Sent</dd><dt>Target</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-blue); --cc-color-bg: var(--cc-blue-bg);"><span class="teammate-icon">▎</span>alice</span></dd><dt>Request</dt><dd><code>shutdown-0001@alice</code></dd><dt>Message</dt><dd>Shutdown request sent to alice. Request ID: shutdown-0001@alice</dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -24380,7 +24340,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -24401,7 +24360,6 @@
           <div class='content'><dl class="teammate-tool-card team-card team-delete-output teammate-refused"><dt>Status</dt><dd>Refused</dd><dt>Team</dt><dd>test-coverage</dd><dt>Message</dt><dd>Cannot cleanup team with 1 active member(s): bob. Use SendMessage shutdown_request first.</dd><dt>Active members</dt><dd><span class="teammate-badge" style="--cc-color: var(--cc-green); --cc-color-bg: var(--cc-green-bg);"><span class="teammate-icon">▎</span>bob</span></dd></dl></div>
           
       </div>
-      
       
       </div>
       
@@ -24425,18 +24383,15 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -25048,7 +25003,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {
@@ -30135,12 +30092,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -30199,7 +30154,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -30221,12 +30175,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -30250,7 +30202,6 @@
   </pre></div>
           
       </div>
-      
       
       </div>
       
@@ -30345,18 +30296,15 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -30380,7 +30328,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -30403,12 +30350,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -30493,12 +30438,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -31110,7 +31053,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {
@@ -36220,12 +36165,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -36249,12 +36192,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -36355,12 +36296,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -36414,7 +36353,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -36435,7 +36373,6 @@
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
       </div>
-      
       
       </div>
       
@@ -36473,12 +36410,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -36532,7 +36467,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -36555,7 +36489,6 @@
   Hello, Alice!</pre></div>
           
       </div>
-      
       
       </div>
       
@@ -36589,12 +36522,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -36618,12 +36549,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -37235,7 +37164,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {
@@ -42303,12 +42234,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -42362,7 +42291,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -42383,7 +42311,6 @@
           <div class='content'><pre>File created successfully at: /tmp/decorator_example.py</pre></div>
           
       </div>
-      
       
       </div>
       
@@ -42421,12 +42348,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -42480,7 +42405,6 @@
           
       </div>
       
-      
       </div>
       
       
@@ -42503,7 +42427,6 @@
   Hello, Alice!</pre></div>
           
       </div>
-      
       
       </div>
       
@@ -42537,12 +42460,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -42566,12 +42487,10 @@
           
       </div>
       
-      
       </div>
       
       
       </div>
-      
       
       </div>
       
@@ -43183,7 +43102,9 @@
               }
               // Apply a fold state to a message by toggling its OWN .children
               // container. DOM nesting means hiding that container hides the whole
-              // subtree (fork-points included), so we only touch this message.
+              // subtree — including the fork-point marker, which the template
+              // renders INSIDE .children precisely so it folds with the subtree
+              // rather than orphaning. So we only touch this message.
               //   'folded' = hide children; 'first' = show immediate children but
               //   fold each of their subtrees; 'open' = show all descendants.
               function applyFoldState(messageEl, state) {

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -653,8 +653,14 @@ class TestWithinSessionForkRealData:
                 self.fork_inside_children = 0
 
             def handle_starttag(self, tag, attrs):
+                # Track only <div> nesting so pushes here stay balanced with
+                # the <div>-only pops in handle_endtag — otherwise non-div
+                # tags would leave stale ancestors on the stack and a
+                # fork-point OUTSIDE .children could be miscounted as inside.
+                if tag != "div":
+                    return
                 classes = set((dict(attrs).get("class") or "").split())
-                if tag == "div" and "fork-point" in classes:
+                if "fork-point" in classes:
                     self.fork_total += 1
                     if any("children" in c for c in self.classes_stack):
                         self.fork_inside_children += 1

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -627,6 +627,54 @@ class TestWithinSessionForkRealData:
         total_in_daglines = sum(len(dl.uuids) for dl in tree.sessions.values())
         assert total_in_daglines == len(tree.nodes)
 
+    def test_fork_point_rendered_inside_children_container(self) -> None:
+        """Every ``.fork-point`` marker must render INSIDE a ``.children``
+        container so it folds together with the subtree (CodeRabbit on
+        PR #191). With the dissociated nested DOM the fold logic hides a
+        node's ``.children``; a fork-point left as a *sibling* of
+        ``.children`` would stay visible when the node is folded —
+        orphaned branch UI. Walk the rendered DOM and assert each
+        fork-point has a ``.children`` ancestor.
+        """
+        from pathlib import Path
+        from html.parser import HTMLParser
+        from claude_code_log.converter import load_transcript
+        from claude_code_log.html.renderer import generate_html
+
+        fixture = Path(__file__).parent / "test_data" / "dag_within_fork.jsonl"
+        entries = load_transcript(fixture)
+        html = generate_html(entries)
+
+        class ForkWalker(HTMLParser):
+            def __init__(self) -> None:
+                super().__init__()
+                self.classes_stack: list[set[str]] = []
+                self.fork_total = 0
+                self.fork_inside_children = 0
+
+            def handle_starttag(self, tag, attrs):
+                classes = set((dict(attrs).get("class") or "").split())
+                if tag == "div" and "fork-point" in classes:
+                    self.fork_total += 1
+                    if any("children" in c for c in self.classes_stack):
+                        self.fork_inside_children += 1
+                self.classes_stack.append(classes)
+
+            def handle_endtag(self, tag):
+                if tag == "div" and self.classes_stack:
+                    self.classes_stack.pop()
+
+        walker = ForkWalker()
+        walker.feed(html)
+
+        # The fixture has a within-session fork → at least one fork-point.
+        assert walker.fork_total >= 1, "expected dag_within_fork to render a fork-point"
+        # Every fork-point must be nested inside a .children container.
+        assert walker.fork_inside_children == walker.fork_total, (
+            f"{walker.fork_total - walker.fork_inside_children} fork-point(s) "
+            f"rendered OUTSIDE a .children container (would orphan on fold)"
+        )
+
 
 # =============================================================================
 # Test: Agent transcript DAG integration

--- a/test/test_integration_realistic.py
+++ b/test/test_integration_realistic.py
@@ -1812,29 +1812,51 @@ class TestExperimentsWorktreesTeammates:
     ) -> None:
         """Each subagent's sidechain content must nest under its OWN
         Task/Agent tool_result, not collapse under whichever rendered
-        last. Pre-relocation, all sidechain ``ancestry`` ended in the
-        same tool_result d-id; post-relocation each agent has a distinct
-        anchor.
+        last. With nested-DOM rendering, every ``assistant sidechain``
+        card lives inside the ``.children`` container of its anchoring
+        tool_result; pre-relocation they all shared a single anchor.
+        Walk each sidechain card up to its nearest enclosing
+        ``.message.tool_result`` and assert ≥6 distinct anchors (one per
+        subagent). Pre-fix the count was 1.
         """
-        import re
+        from html.parser import HTMLParser
 
         project = self._project_dir(temp_projects_copy)
         convert_jsonl_to_html(project)
         html = (project / "combined_transcripts.html").read_text(encoding="utf-8")
 
-        # Every `assistant sidechain` row carries an ancestry tail like
-        # `d-0 d-1 d-26 d-<anchor>`. Collect the immediate parent (last
-        # d-id before message_index) — there should be at least 6
-        # distinct values, one per subagent. Pre-fix the count was 1.
-        pattern = re.compile(
-            r"message assistant sidechain ((?:d-\d+ ?)+)' data-message-id"
-        )
-        anchors: set[str] = set()
-        for match in pattern.finditer(html):
-            ancestry = match.group(1).strip().split()
-            anchors.add(ancestry[-1])  # immediate parent
-        assert len(anchors) >= 6, (
-            f"expected ≥6 distinct anchors for the 6 subagents, got {anchors}"
+        # Walk the DOM with a stack of open <div>s, tracking each div's
+        # class list + data-message-id. For every `.message.assistant.
+        # sidechain` card, find the nearest enclosing `.message.tool_result`
+        # on the stack and record its id. Distinct ids = distinct anchors.
+        class AnchorWalker(HTMLParser):
+            def __init__(self) -> None:
+                super().__init__()
+                self.stack: list[tuple[set[str], str | None]] = []
+                self.anchors: set[str] = set()
+
+            def handle_starttag(self, tag, attrs):
+                if tag != "div":
+                    return
+                ad = dict(attrs)
+                classes = set((ad.get("class") or "").split())
+                mid = ad.get("data-message-id")
+                if {"message", "assistant", "sidechain"} <= classes:
+                    for cls, anchor_id in reversed(self.stack):
+                        if "message" in cls and "tool_result" in cls and anchor_id:
+                            self.anchors.add(anchor_id)
+                            break
+                self.stack.append((classes, mid))
+
+            def handle_endtag(self, tag):
+                if tag == "div" and self.stack:
+                    self.stack.pop()
+
+        walker = AnchorWalker()
+        walker.feed(html)
+        assert len(walker.anchors) >= 6, (
+            f"expected ≥6 distinct tool_result anchors for the 6 subagents, "
+            f"got {walker.anchors}"
         )
 
     def test_no_subagent_collapse_markup(self, temp_projects_copy: Path) -> None:

--- a/test/test_integration_realistic.py
+++ b/test/test_integration_realistic.py
@@ -1812,12 +1812,14 @@ class TestExperimentsWorktreesTeammates:
     ) -> None:
         """Each subagent's sidechain content must nest under its OWN
         Task/Agent tool_result, not collapse under whichever rendered
-        last. With nested-DOM rendering, every ``assistant sidechain``
-        card lives inside the ``.children`` container of its anchoring
-        tool_result; pre-relocation they all shared a single anchor.
-        Walk each sidechain card up to its nearest enclosing
-        ``.message.tool_result`` and assert ≥6 distinct anchors (one per
-        subagent). Pre-fix the count was 1.
+        last. With the dissociated nested-DOM (issue #174), each message
+        renders as ``.message-node > [.message card] + [.children]`` — so a
+        sidechain card is NOT a DOM descendant of its anchoring
+        tool_result; the anchor card is a *sibling* of the ``.children``
+        container that (transitively) holds the sidechain. Resolve each
+        ``assistant sidechain`` card to the tool_result card of its nearest
+        enclosing ``.message-node`` and assert ≥6 distinct anchors (one per
+        subagent). Pre-relocation they all shared a single anchor (count 1).
         """
         from html.parser import HTMLParser
 
@@ -1825,14 +1827,18 @@ class TestExperimentsWorktreesTeammates:
         convert_jsonl_to_html(project)
         html = (project / "combined_transcripts.html").read_text(encoding="utf-8")
 
-        # Walk the DOM with a stack of open <div>s, tracking each div's
-        # class list + data-message-id. For every `.message.assistant.
-        # sidechain` card, find the nearest enclosing `.message.tool_result`
-        # on the stack and record its id. Distinct ids = distinct anchors.
+        # Walk the DOM with a stack of open <div>s. Each ``.message-node``
+        # frame records the card (class list + id) found directly inside it.
+        # For every ``.message.assistant.sidechain`` card, scan enclosing
+        # message-node frames for the nearest whose card is a tool_result —
+        # that is its anchor. (Its own node's card is the sidechain itself,
+        # never a tool_result, so it's skipped naturally.) Distinct anchor
+        # ids = distinct anchors.
         class AnchorWalker(HTMLParser):
             def __init__(self) -> None:
                 super().__init__()
-                self.stack: list[tuple[set[str], str | None]] = []
+                # frame: {is_node, card_classes, card_id}
+                self.stack: list[dict[str, object]] = []
                 self.anchors: set[str] = set()
 
             def handle_starttag(self, tag, attrs):
@@ -1841,12 +1847,31 @@ class TestExperimentsWorktreesTeammates:
                 ad = dict(attrs)
                 classes = set((ad.get("class") or "").split())
                 mid = ad.get("data-message-id")
-                if {"message", "assistant", "sidechain"} <= classes:
-                    for cls, anchor_id in reversed(self.stack):
-                        if "message" in cls and "tool_result" in cls and anchor_id:
-                            self.anchors.add(anchor_id)
+                is_node = "message-node" in classes
+                if "message" in classes and not is_node:
+                    # A message card: attach to its nearest message-node frame.
+                    for frame in reversed(self.stack):
+                        if frame["is_node"]:
+                            frame["card_classes"] = classes
+                            frame["card_id"] = mid
                             break
-                self.stack.append((classes, mid))
+                    if {"message", "assistant", "sidechain"} <= classes:
+                        for frame in reversed(self.stack):
+                            if not frame["is_node"]:
+                                continue
+                            cc = frame["card_classes"]
+                            anchor_id = frame["card_id"]
+                            if (
+                                isinstance(cc, set)
+                                and "tool_result" in cc
+                                and "message" in cc
+                                and isinstance(anchor_id, str)
+                            ):
+                                self.anchors.add(anchor_id)
+                                break
+                self.stack.append(
+                    {"is_node": is_node, "card_classes": None, "card_id": None}
+                )
 
             def handle_endtag(self, tag):
                 if tag == "div" and self.stack:

--- a/test/test_nested_dom_browser.py
+++ b/test/test_nested_dom_browser.py
@@ -1,0 +1,145 @@
+"""Live-browser tests for the dissociated nested-DOM (issue #174) and the
+CodeRabbit follow-ups on PR #191:
+
+- A ``.filtered-hidden`` parent card hides only its OWN row, never its
+  ``.children`` (which are siblings, not descendants). This is what makes
+  ``updateVisibleCounts()``'s ``:not(.filtered-hidden)`` count correct: a
+  child of a filtered-out parent is genuinely visible AND counted, with no
+  cascade mismatch (CR comment 1b).
+- Folding a node hides the fork-point marker too, because the template
+  renders it INSIDE ``.children`` (CR comment 2 — fork-point fold).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.html.renderer import generate_html
+
+TEAMMATES = (
+    Path(__file__).parent
+    / "test_data"
+    / "teammates"
+    / "ef000000-0000-4000-8000-000000000001.jsonl"
+)
+
+
+def _render(tmp_path: Path) -> str:
+    """Render the teammates fixture (deeply nested: user → assistant/system
+    children) to an HTML file and return a ``file://`` URL."""
+    html = generate_html(load_transcript(TEAMMATES))
+    out = tmp_path / "nested.html"
+    out.write_text(html, encoding="utf-8")
+    return f"file://{out}"
+
+
+class TestFilteredParentDoesNotCascade:
+    """CR 1b: a filtered-out parent must not hide — nor cause overcounting
+    of — its children, which live in a sibling ``.children`` container."""
+
+    @pytest.mark.browser
+    def test_filtered_parent_keeps_children_visible_and_counted(
+        self, page: Page, tmp_path: Path
+    ) -> None:
+        page.goto(_render(tmp_path))
+        page.wait_for_timeout(300)
+
+        result = page.evaluate(
+            """() => {
+                // Find a card that has a .children sibling holding >=1 other card.
+                const cards = Array.from(document.querySelectorAll('.message[data-message-id]'));
+                let parent = null, childCard = null;
+                for (const c of cards) {
+                    const cc = c.parentElement &&
+                        c.parentElement.querySelector(':scope > .children');
+                    const inner = cc && cc.querySelector('.message[data-message-id]');
+                    if (inner) { parent = c; childCard = inner; break; }
+                }
+                if (!parent) return { error: 'no parent-with-children found' };
+
+                // Simulate the filter hiding the parent card (applyFilter adds
+                // .filtered-hidden to the .message card by its type).
+                parent.classList.add('filtered-hidden');
+
+                // The count selector used by updateVisibleCounts():
+                const countedAsVisible = document
+                    .querySelector(`.message[data-message-id="${childCard.getAttribute('data-message-id')}"]:not(.filtered-hidden)`) !== null;
+
+                return {
+                    parentDisplay: getComputedStyle(parent).display,         // none
+                    childDisplay: getComputedStyle(childCard).display,        // not none
+                    childCountedAsVisible: countedAsVisible,                  // true
+                    childActuallyVisible: getComputedStyle(childCard).display !== 'none',
+                };
+            }"""
+        )
+
+        assert "error" not in result, result
+        # Parent's own row is hidden ...
+        assert result["parentDisplay"] == "none"
+        # ... but its child (a sibling under .children) stays visible ...
+        assert result["childActuallyVisible"] is True
+        # ... and the count selector's "counted visible" matches reality
+        # (no cascade overcount — CR 1b).
+        assert result["childCountedAsVisible"] == result["childActuallyVisible"]
+
+
+class TestFoldHidesForkPoint:
+    """CR 2: a fork-point rendered inside ``.children`` folds away with the
+    subtree instead of orphaning."""
+
+    @pytest.mark.browser
+    def test_folding_hides_fork_point_inside_children(
+        self, page: Page, tmp_path: Path
+    ) -> None:
+        page.goto(_render(tmp_path))
+        page.wait_for_timeout(300)
+
+        # Real within-session fork nodes have no children (the branches are
+        # separate top-level nodes), so no fixture yields a foldable node that
+        # also owns a fork-point. Synthesize that co-occurrence by injecting a
+        # fork-point into a foldable node's .children — exactly where the
+        # template places it — then fold and assert it hides.
+        result = page.evaluate(
+            """() => {
+                // Find a node that is currently EXPANDED (its .children is
+                // visible and its fold-one section is not folded), so a single
+                // click deterministically folds it.
+                const sections = Array.from(
+                    document.querySelectorAll('.fold-bar-section.fold-one-level'));
+                for (const sec of sections) {
+                    if (sec.classList.contains('folded')) continue;
+                    const id = sec.getAttribute('data-target');
+                    const card = document.querySelector(
+                        `.message[data-message-id="${id}"]`);
+                    const cc = card && card.parentElement.querySelector(':scope > .children');
+                    if (!cc || getComputedStyle(cc).display === 'none') continue;
+
+                    // Inject a fork-point INSIDE .children (mirrors the template,
+                    // which renders the marker there so it folds with the subtree).
+                    const fp = document.createElement('div');
+                    fp.className = 'fork-point';
+                    fp.id = 'injected-fork-point';
+                    cc.appendChild(fp);
+
+                    // checkVisibility() accounts for ANCESTOR display:none
+                    // (getComputedStyle(fp).display would still report the
+                    // element's own 'block' even inside a hidden container).
+                    const before = fp.checkVisibility();          // true
+                    sec.click();                                  // fold the subtree
+                    const after = fp.checkVisibility();           // false
+                    return { before, after, ccAfter: getComputedStyle(cc).display };
+                }
+                return { error: 'no expanded foldable node found' };
+            }"""
+        )
+
+        assert "error" not in result, result
+        assert result["before"] is True
+        # Folding the node hid its .children, taking the fork-point with it.
+        assert result["ccAfter"] == "none"
+        assert result["after"] is False

--- a/test/test_template_rendering.py
+++ b/test/test_template_rendering.py
@@ -324,5 +324,65 @@ class TestTemplateRendering:
             )  # Allow for the markdown script and search script
 
 
+class TestNestedDomSkipsEmptyLeaves:
+    """Pinning test for the nested-DOM ``should_render`` skip (PR0, #174).
+
+    The flat ``_flatten_preorder`` renderer dropped leaf messages that
+    formatted to nothing (e.g. TaskCreate/TaskUpdate tool_results whose
+    output formatter returns ``""``) so they didn't show as bare,
+    timestamp-only cards. The nested-DOM rewrite moved that decision onto
+    ``TemplateMessage.should_render`` (computed in
+    ``HtmlRenderer._annotate_tree_for_render``) which the recursive
+    ``render_message`` macro must honour.
+
+    Regression guard: if the macro ever renders unconditionally again
+    (e.g. ``{% elif message.should_render %}`` reverted to ``{% else %}``),
+    these empty-formatting tool_results reappear as empty cards and this
+    test fails.
+    """
+
+    def test_empty_formatting_tool_results_emit_no_card(self):
+        """``task_id_linking.jsonl`` contains TaskCreate/TaskUpdate
+        tool_results that format to empty HTML. Their message cards
+        (``id='msg-d-<idx>'``) must be absent from the rendered output."""
+        from claude_code_log.html.renderer import HtmlRenderer
+        from claude_code_log.renderer import generate_template_messages
+
+        test_file = Path(__file__).parent / "test_data" / "task_id_linking.jsonl"
+        messages = load_transcript(test_file)
+
+        # Identify the nodes the renderer marks should_render=False by
+        # running the same annotation the HTML path uses.
+        roots, _nav, _ctx = generate_template_messages(messages)
+        renderer = HtmlRenderer(image_export_mode="placeholder")
+        renderer._annotate_tree_for_render(roots)
+
+        suppressed_ids: list[str] = []
+
+        def collect(node):
+            if not node.should_render and node.message_id:
+                suppressed_ids.append(node.message_id)
+            for child in node.children:
+                collect(child)
+
+        for root in roots:
+            collect(root)
+
+        # The fixture must actually exercise the skip, else the guard is
+        # vacuous.
+        assert suppressed_ids, (
+            "fixture no longer contains empty-formatting tool_results; "
+            "pick another fixture that does so this guard stays meaningful"
+        )
+
+        html = generate_html(messages, "Task ID Linking")
+
+        for mid in suppressed_ids:
+            assert f"id='msg-{mid}'" not in html, (
+                f"empty-formatting node {mid} rendered a card — the "
+                f"should_render skip regressed in the template macro"
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_user_renderer.py
+++ b/test/test_user_renderer.py
@@ -475,9 +475,16 @@ class TestRegularUserMessageRendering:
             messages = load_transcript(test_file_path)
             html = generate_html(messages, "Test Regular")
 
-            # Should have user class without special modifiers (class includes session ID)
+            # Should have user class without special modifiers. With
+            # nested-DOM rendering the message div no longer carries d-N
+            # ancestry classes, so the class string ends right after the
+            # type ("user") — match the bare close or a trailing modifier.
             assert "Hello, can you help me with Python?" in html
-            # Check that it's a user message (class includes session ID suffix)
-            assert "class='message user " in html or 'class="message user ' in html
+            assert (
+                "class='message user'" in html
+                or "class='message user " in html
+                or 'class="message user"' in html
+                or 'class="message user ' in html
+            )
         finally:
             test_file_path.unlink()


### PR DESCRIPTION
## What

Convert HTML rendering from a flat message list + `d-N` ancestry CSS
classes to **truly nested DOM** (a recursive Jinja macro over
`message.children`), as a **behaviour-preserving pure refactor**.

This is **PR0** of the dynamic-workflow support work (#174): it lands the
nested-DOM rendering on its own, before any workflow parsing/rendering is
added on top. Nested rendering is a long-standing item in
`work/rendering-next.md` §1; the deeper nesting required to render
dynamic-workflow transcripts is the concrete use case that motivates it.

## Behaviour preserved

No change to **which** messages render, their **content**, their
**order**, or their element **ids** (`id='msg-d-N'` is kept, so deep
links still resolve). Only the DOM **structure** and the fold/unfold
**mechanism** change.

- **renderer.py**: `TemplateMessage` gains transient per-render fields
  (`rendered_title`/`rendered_html`/`rendered_timestamp`/`should_render`).
  The tree *computation* is untouched (`_build_message_hierarchy`,
  `_mark_messages_with_children`, `_build_message_tree`,
  `_relocate_subagent_blocks`, and the 0–5 `_get_message_hierarchy_level`
  table all stay).
- **html/renderer.py**: `_flatten_preorder` → `_annotate_tree_for_render`
  — same pre-order walk + skip-empty/stranded-pair cleanup, but it
  annotates each node and returns the roots; `generate()` passes `roots=`.
- **transcript.html**: flat loop → recursive `render_message` macro with
  nested `<div class='children'>`; dropped `d-N` class emission. The five
  `d-N` JS fold consumers now traverse the DOM; fold state machine
  (▼/▶/▼▼/▶▶ + tooltips) is behaviour-identical.

## Tests

The two `d-N` pinning tests are re-expressed against nested DOM (spirit
kept), `test_subagents_relocated_under_their_anchors` using a stdlib
`HTMLParser` (no new dependency). Snapshots regenerated serially (`-n0`)
— structure-only diff (d-N removed, children wrappers added).

`just ci` green (format, lint, pyright, ty, unit, browser, tui).
The timeline component needs no change (navigates by `data-message-id` +
`scrollIntoView`, not `d-N`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transcript rendering now produces a true nested DOM preserving message ancestry, uses per-node render annotations to suppress empty messages, and updates folding/unfolding and anchor navigation to operate on each message’s immediate children. Added a structural wrapper so nested layout doesn’t alter card visuals.

* **Tests**
  * Multiple integration, regression, unit, and browser tests added/updated to verify nested DOM structure, anchor placement, folding behavior, suppressed empty nodes, and relaxed class assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->