### PR TITLE
Ghost-aware ctx.messages; skill-fold uses None slots (ghosting epic Phase 1)

### DIFF
--- a/claude_code_log/html/templates/components/session_nav.html
+++ b/claude_code_log/html/templates/components/session_nav.html
@@ -15,9 +15,17 @@
         {% if session.is_fork_point is defined and session.is_fork_point %}
         <div class='session-nav-item session-fork-point'
             style='margin-left: {{ session.depth * 24 }}px'>
+            {% if session.message_index is not none %}
             <a href='#msg-d-{{ session.message_index }}' class='fork-link'>
                 &#x2442; {{ session.first_user_message }}
             </a>
+            {% else %}
+            {# Fork point was ghosted (e.g. a folded Skill slot) — show the
+               label without a dangling anchor. #}
+            <span class='fork-link'>
+                &#x2442; {{ session.first_user_message }}
+            </span>
+            {% endif %}
         </div>
         {% elif session.is_compaction_point is defined and session.is_compaction_point %}
         <div class='session-nav-item session-compaction-point'

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3419,6 +3419,41 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
     for idx in consumed_indices:
         ctx.messages[idx] = None
 
+    # A branch header's ``parent_message_index`` and the
+    # ``session_first_message`` map are cached during ``_render_messages``
+    # — *before* this pass. If a fork point happened to land on a slot we
+    # just ghosted, that cached index now refers to a ``None`` slot and the
+    # rendered ``#msg-d-{N}`` backlink would dangle (the anchor href is
+    # emitted from the raw index; ``ctx.get()`` returning ``None`` doesn't
+    # suppress it). Null those stale refs so the anchor is simply omitted.
+    # ``junction_forward_links`` are populated *after* this pass
+    # (``_link_junction_forwards``), so they need no repair here.
+    _drop_anchor_refs_into_ghosts(ctx)
+
+
+def _drop_anchor_refs_into_ghosts(ctx: RenderingContext) -> None:
+    """Null anchor-target refs that now point at a ghosted (``None``) slot.
+
+    Keeps the index-stability contract honest for the only anchor sources
+    cached before ghosting runs: ``session_first_message`` and each branch
+    header's ``parent_message_index``. See ``_pair_skill_tool_uses`` for
+    why junction forward links are out of scope. Phase 2 of the ghosting
+    epic adds a broader ``_repair_stale_anchor_refs`` for the detail-filter
+    ghost path; this is the skill-fold-scoped counterpart.
+    """
+    ctx.session_first_message = {
+        sid: idx
+        for sid, idx in ctx.session_first_message.items()
+        if ctx.get(idx) is not None
+    }
+    for msg in _visible(ctx.messages):
+        if (
+            isinstance(msg.content, SessionHeaderMessage)
+            and msg.content.parent_message_index is not None
+            and ctx.get(msg.content.parent_message_index) is None
+        ):
+            msg.content.parent_message_index = None
+
 
 def _reindex_filtered_context(
     ctx: RenderingContext, filtered: list[TemplateMessage]

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -1397,8 +1397,15 @@ def prepare_session_navigation(
                 insert_pos += 1
 
             # Fork point nav item — find the junction message and a
-            # meaningful preview (walk up past system hooks to find it)
-            fork_msg_idx = ctx.session_first_message.get(parent_sid)
+            # meaningful preview (walk up past system hooks to find it).
+            # Leave ``fork_msg_idx`` None until the fork point is actually
+            # located among the visible messages: if it was ghosted (e.g.
+            # a slash body or launch tool_result consumed by
+            # ``_pair_skill_tool_uses``), the ``_visible`` loop skips it and
+            # the anchor must be *omitted*, not retargeted at the parent
+            # session header. Falling back to ``session_first_message`` here
+            # would silently undo ``_drop_anchor_refs_into_ghosts``.
+            fork_msg_idx = None
             fork_preview = ""
             fork_msg = None
             for msg in _visible(ctx.messages):
@@ -1426,7 +1433,7 @@ def prepare_session_navigation(
                 "first_user_message": fork_label,
                 "token_summary": "",
                 "parent_session_id": parent_sid,
-                "parent_message_index": ctx.session_first_message.get(parent_sid),
+                "parent_message_index": fork_msg_idx,
                 "depth": parent_depth + 1,
                 "is_fork_point": True,
             }
@@ -3375,6 +3382,24 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
     if not slash_by_source:
         return
 
+    # Index the canonical "Launching skill:" tool_results once, keyed the
+    # same way as the slash bodies. tool_use_ids are session-unique, so each
+    # (render_session_id, tool_use_id) maps to at most one non-error launch
+    # result — this keeps folding linear instead of rescanning ctx.messages
+    # per Skill. An error result or a divergent payload sharing the
+    # tool_use_id is excluded here and stays visible.
+    launch_result_by_source: dict[tuple[str, str], int] = {}
+    for msg in _visible(ctx.messages):
+        if (
+            isinstance(msg.content, ToolResultMessage)
+            and not msg.content.is_error
+            and msg.message_index is not None
+            and _is_launching_skill_payload(msg.content.output)
+        ):
+            launch_result_by_source.setdefault(
+                (msg.render_session_id, msg.content.tool_use_id), msg.message_index
+            )
+
     consumed_indices: set[int] = set()
     for msg in _visible(ctx.messages):
         if not (
@@ -3388,22 +3413,12 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
         msg.content.skill_body = slash.content.text
         if slash.message_index is not None:
             consumed_indices.add(slash.message_index)
-        # The matching tool_result carries the redundant "Launching skill: ..."
-        # string; drop it. Same-session, non-error, payload-prefix-checked
-        # so a real error result or a divergent payload sharing the
-        # tool_use_id stays visible.
-        for other in _visible(ctx.messages):
-            if (
-                not isinstance(other.content, ToolResultMessage)
-                or other.render_session_id != msg.render_session_id
-                or other.content.tool_use_id != msg.content.tool_use_id
-                or other.content.is_error
-                or other.message_index is None
-            ):
-                continue
-            if not _is_launching_skill_payload(other.content.output):
-                continue
-            consumed_indices.add(other.message_index)
+        # Drop the matching, redundant "Launching skill: ..." tool_result.
+        launch_idx = launch_result_by_source.get(
+            (msg.render_session_id, msg.content.tool_use_id)
+        )
+        if launch_idx is not None:
+            consumed_indices.add(launch_idx)
 
     if not consumed_indices:
         return

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -7,6 +7,7 @@ import re
 import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Optional, Tuple, cast
 from datetime import datetime
 
@@ -100,12 +101,18 @@ class RenderingContext:
 
     Attributes:
         messages: Registry of all TemplateMessage objects (message_index = index).
+            A slot may be ``None`` — a "ghost" — when a pass drops the message
+            from the visible render path while preserving its index slot so
+            every stored reference (parent_message_index, session_first_message,
+            junction_forward_links, pair_first/last/middle) stays valid. See
+            ``work/ghosting-epic-plan.md``. Iterators that don't want to see
+            ghosts should use ``_visible(...)`` or ``if m is None: continue``.
         tool_use_context: Maps tool_use_id -> ToolUseContent for result rendering.
         session_first_message: Maps session_id -> index of first message in session.
     """
 
-    messages: list[TemplateMessage] = field(
-        default_factory=lambda: []  # type: list[TemplateMessage]
+    messages: list[Optional[TemplateMessage]] = field(
+        default_factory=lambda: []  # type: list[Optional[TemplateMessage]]
     )
     tool_use_context: dict[str, ToolUseContent] = field(
         default_factory=lambda: {}  # type: dict[str, ToolUseContent]
@@ -167,15 +174,37 @@ class RenderingContext:
     def get(self, message_index: int) -> Optional["TemplateMessage"]:
         """Get a TemplateMessage by its message_index.
 
+        Returns ``None`` if the index is out of range OR if the slot
+        has been ghosted (``ctx.messages[idx] = None``). Callers
+        already check the return value for ``None`` (out-of-range
+        was the only failure mode pre-ghosting); the ghost case
+        flows through the same check.
+
         Args:
             message_index: The message_index (index) to look up.
 
         Returns:
-            The TemplateMessage if found, None if out of range.
+            The TemplateMessage if found and not ghosted, else None.
         """
         if 0 <= message_index < len(self.messages):
             return self.messages[message_index]
         return None
+
+
+def _visible(
+    messages: Iterable[Optional["TemplateMessage"]],
+) -> Iterator["TemplateMessage"]:
+    """Yield only non-ghost messages.
+
+    Ghosts are ``None`` slots in ``RenderingContext.messages`` —
+    see ``RenderingContext.messages`` docstring and
+    ``work/ghosting-epic-plan.md`` for the model. Use this helper
+    instead of ``for m in messages`` when the loop body shouldn't
+    touch a ghosted slot.
+    """
+    for m in messages:
+        if m is not None:
+            yield m
 
 
 # -- Template Classes ---------------------------------------------------------
@@ -726,7 +755,12 @@ def generate_template_messages(
     with log_timing("Link junction forwards", t_start):
         _link_junction_forwards(ctx)
 
-    # Detail-level post-render: remove text-derived types per level
+    # Detail-level post-render: remove text-derived types per level.
+    # ``_filter_template_by_detail`` strips ghost (None) slots
+    # alongside non-visible content so the kept list passed to
+    # ``_reindex_filtered_context`` is None-free. Phase 2 of the
+    # ghosting epic will rewrite this pair into a single ghost-style
+    # pass and delete ``_reindex_filtered_context``.
     if detail != DetailLevel.FULL:
         with log_timing(f"Detail post-render filter ({detail.value})", t_start):
             filtered = _filter_template_by_detail(ctx.messages, detail)
@@ -1115,7 +1149,9 @@ def _fork_point_preview(fork_msg: "TemplateMessage", ctx: RenderingContext) -> s
         parent_uuid = msg.meta.parent_uuid
         if not parent_uuid:
             break
-        parent = next((m for m in ctx.messages if m.meta.uuid == parent_uuid), None)
+        parent = next(
+            (m for m in _visible(ctx.messages) if m.meta.uuid == parent_uuid), None
+        )
         if parent is None:
             break
         msg = parent
@@ -1162,7 +1198,7 @@ def _link_junction_forwards(ctx: RenderingContext) -> None:
     uuid_to_msg: dict[str, TemplateMessage] = {}
     # Build msg_index → TemplateMessage for branch preview lookup
     idx_to_msg: dict[int, TemplateMessage] = {}
-    for msg in ctx.messages:
+    for msg in _visible(ctx.messages):
         if msg.meta.uuid:
             uuid_to_msg[msg.meta.uuid] = msg
         if msg.message_index is not None:
@@ -1307,7 +1343,7 @@ def prepare_session_navigation(
         # case (the post-pass ``_enrich_branch_titles`` used to
         # back-fill). We just read what's there.
         branch_previews: dict[str, str] = {}
-        for msg in ctx.messages:
+        for msg in _visible(ctx.messages):
             if not isinstance(msg.content, SessionHeaderMessage):
                 continue
             if not msg.content.is_branch:
@@ -1365,7 +1401,7 @@ def prepare_session_navigation(
             fork_msg_idx = ctx.session_first_message.get(parent_sid)
             fork_preview = ""
             fork_msg = None
-            for msg in ctx.messages:
+            for msg in _visible(ctx.messages):
                 if msg.meta.uuid == attachment_uuid and msg.message_index is not None:
                     fork_msg_idx = msg.message_index
                     fork_msg = msg
@@ -1426,14 +1462,14 @@ def prepare_session_navigation(
     # pre-compaction context was replaced with a summary — a real content
     # discontinuity that's useful to jump to.
     compact_by_session: dict[str, list[TemplateMessage]] = {}
-    for msg in ctx.messages:
+    for msg in _visible(ctx.messages):
         if isinstance(msg.content, CompactedSummaryMessage):
             compact_by_session.setdefault(msg.render_session_id, []).append(msg)
 
     # Build a uuid → TemplateMessage lookup so each compaction landmark
     # can read preTokens / trigger from its preceding system entry.
     uuid_to_msg: dict[str, TemplateMessage] = {
-        msg.meta.uuid: msg for msg in ctx.messages if msg.meta.uuid
+        msg.meta.uuid: msg for msg in _visible(ctx.messages) if msg.meta.uuid
     }
 
     for comp_sid, comp_msgs in compact_by_session.items():
@@ -2300,7 +2336,7 @@ def _populate_teammate_colors(ctx: RenderingContext) -> None:
     """
     from .models import TeammateMessage
 
-    for template_msg in ctx.messages:
+    for template_msg in _visible(ctx.messages):
         content = template_msg.content
         if not isinstance(content, TeammateMessage):
             continue
@@ -2334,7 +2370,7 @@ def _populate_task_metadata(ctx: RenderingContext) -> None:
         ToolResultMessage,
     )
 
-    for template_msg in ctx.messages:
+    for template_msg in _visible(ctx.messages):
         content = template_msg.content
         if not isinstance(content, ToolResultMessage):
             continue
@@ -2394,7 +2430,7 @@ def _link_cron_jobs_by_id(ctx: RenderingContext) -> None:
     # together — the create call is the one a reader expects to
     # navigate to.
     job_id_to_call_index: dict[str, int] = {}
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         if not isinstance(tm.content, ToolResultMessage):
             continue
         if tm.content.tool_name != "CronCreate":
@@ -2414,7 +2450,7 @@ def _link_cron_jobs_by_id(ctx: RenderingContext) -> None:
         return
 
     # Step 2: stamp consumer sites.
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         if not isinstance(tm.content, ToolResultMessage):
             continue
         output = tm.content.output
@@ -2492,7 +2528,7 @@ def _link_task_id_consumers(ctx: RenderingContext) -> None:
     # seen later in the transcript.
     bg_task_id_to_call_index: dict[tuple[str, str], int] = {}
     todo_task_id_to_call_index: dict[tuple[str, str], int] = {}
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         if not isinstance(tm.content, ToolResultMessage):
             continue
         # The CALL we want to link to is the tool_use, not the result —
@@ -2552,7 +2588,7 @@ def _link_task_id_consumers(ctx: RenderingContext) -> None:
     # — and record the first consumer's index per (session, bg_id) for
     # the forward-link direction.
     bg_task_id_to_first_consumer: dict[tuple[str, str], int] = {}
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         if not isinstance(tm.content, ToolUseMessage):
             continue
         session_key = tm.render_session_id or ""
@@ -2617,7 +2653,7 @@ def _link_tool_use_notifications(ctx: RenderingContext) -> None:
     """
     # Build tool_use_id → message_index map across all messages.
     tool_use_index: dict[str, int] = {}
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         if tm.type == "tool_use" and tm.tool_use_id and tm.message_index is not None:
             # First occurrence wins — multiple tool_uses sharing the same
             # tool_use_id is malformed input; the backlink target should
@@ -2626,7 +2662,7 @@ def _link_tool_use_notifications(ctx: RenderingContext) -> None:
     if not tool_use_index:
         return
 
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         content = tm.content
         if not isinstance(content, TaskNotificationMessage):
             continue
@@ -2704,7 +2740,7 @@ def _link_async_notifications(
     spawn_target_kept = detail not in (DetailLevel.MINIMAL, DetailLevel.USER_ONLY)
     # Index notifications by task_id so we can find them in O(1).
     notifications: dict[str, TaskNotificationMessage] = {}
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         if isinstance(tm.content, TaskNotificationMessage) and tm.content.task_id:
             notifications.setdefault(tm.content.task_id, tm.content)
     if not notifications:
@@ -2723,7 +2759,7 @@ def _link_async_notifications(
     # tagged on the entry's meta — so an unrelated tool_result that
     # happens to mention "agentId:" in its raw text doesn't hijack a
     # notification meant for a real spawn.
-    for tm in ctx.messages:
+    for tm in _visible(ctx.messages):
         content = tm.content
         if not isinstance(content, ToolResultMessage):
             continue
@@ -2977,7 +3013,7 @@ def _cleanup_sidechain_duplicates(root_messages: list[TemplateMessage]) -> None:
 
 
 def _reorder_session_template_messages(
-    messages: list[TemplateMessage],
+    messages: list[Optional[TemplateMessage]],
 ) -> list[TemplateMessage]:
     """Reorder template messages to group all messages under their correct session headers.
 
@@ -2990,8 +3026,13 @@ def _reorder_session_template_messages(
     This must be called BEFORE _identify_message_pairs and _reorder_paired_messages,
     since those functions expect messages to be in session-grouped order.
 
+    Accepts ghost-aware input (None slots) — see
+    ``work/ghosting-epic-plan.md``; ghosts are silently dropped from
+    the returned list, so downstream passes that consume this
+    function's output don't need ghost-awareness.
+
     Args:
-        messages: Template messages (including session headers)
+        messages: Template messages (including session headers); may contain None ghost slots.
 
     Returns:
         Reordered messages with all messages grouped under their session headers
@@ -3001,6 +3042,8 @@ def _reorder_session_template_messages(
     session_messages_map: dict[str, list[TemplateMessage]] = {}
 
     for message in messages:
+        if message is None:
+            continue
         if message.is_session_header:
             session_headers.append(message)
             # Initialize the list for this session (preserves session order)
@@ -3014,9 +3057,12 @@ def _reorder_session_template_messages(
                     session_messages_map[sid] = []
                 session_messages_map[sid].append(message)
 
-    # If no session headers, return original order
+    # If no session headers, return original order — but materialise
+    # the non-ghost subset so the caller sees ``list[TemplateMessage]``
+    # (callers downstream of this function are typed against the
+    # non-Optional shape and shouldn't have to ghost-skip).
     if not session_headers:
-        return messages
+        return list(_visible(messages))
 
     # Second pass: for each session header, insert all messages with that session_id
     result: list[TemplateMessage] = []
@@ -3319,7 +3365,7 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
     # transcripts spanning multiple sessions can't cross-pair via stray
     # tool_use_id collisions.
     slash_by_source: dict[tuple[str, str], TemplateMessage] = {}
-    for msg in ctx.messages:
+    for msg in _visible(ctx.messages):
         if (
             isinstance(msg.content, UserSlashCommandMessage)
             and msg.meta.source_tool_use_id
@@ -3330,7 +3376,7 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
         return
 
     consumed_indices: set[int] = set()
-    for msg in ctx.messages:
+    for msg in _visible(ctx.messages):
         if not (
             isinstance(msg.content, ToolUseMessage) and msg.content.tool_name == "Skill"
         ):
@@ -3346,7 +3392,7 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
         # string; drop it. Same-session, non-error, payload-prefix-checked
         # so a real error result or a divergent payload sharing the
         # tool_use_id stays visible.
-        for other in ctx.messages:
+        for other in _visible(ctx.messages):
             if (
                 not isinstance(other.content, ToolResultMessage)
                 or other.render_session_id != msg.render_session_id
@@ -3362,12 +3408,16 @@ def _pair_skill_tool_uses(ctx: RenderingContext) -> None:
     if not consumed_indices:
         return
 
-    kept = [
-        msg
-        for msg in ctx.messages
-        if msg.message_index is None or msg.message_index not in consumed_indices
-    ]
-    _reindex_filtered_context(ctx, kept)
+    # Ghost the consumed slots in place. The TemplateMessages are
+    # freed by GC; the indices around them stay stable so every
+    # stored reference (parent_message_index, junction_forward_links,
+    # session_first_message, pair_first/last/middle) keeps pointing
+    # at the right slot — no reindex needed. Downstream iterators
+    # see None at the ghosted positions and skip via ``_visible(...)``
+    # or an explicit ``if m is None: continue``. See
+    # ``work/ghosting-epic-plan.md`` §3.1.
+    for idx in consumed_indices:
+        ctx.messages[idx] = None
 
 
 def _reindex_filtered_context(
@@ -3400,7 +3450,11 @@ def _reindex_filtered_context(
         msg.pair_middle = None
         msg.pair_last = None
 
-    ctx.messages = filtered
+    # ``ctx.messages`` is typed ``list[Optional[TemplateMessage]]``
+    # to support ghosting; the reindex rebuilds it from the
+    # non-ghost ``filtered`` list, which is naturally a subset of
+    # that wider type.
+    ctx.messages = list(filtered)
     ctx.session_first_message = {
         sid: new_idx
         for sid, old_idx in ctx.session_first_message.items()
@@ -3446,7 +3500,7 @@ def _reindex_filtered_context(
 
 
 def _filter_template_by_detail(
-    messages: list[TemplateMessage],
+    messages: list[Optional[TemplateMessage]],
     detail: DetailLevel,
 ) -> list[TemplateMessage]:
     """Post-render filter: remove TemplateMessage types per detail level.
@@ -3455,9 +3509,15 @@ def _filter_template_by_detail(
     to each content class's ``visible_at`` predicate / ``detail_visibility``
     ClassVar. At ``LOW``, the ``_LOW_KEEP_TOOLS`` allowlist narrows
     built-in tool messages further to a specific set of tool names.
+
+    Accepts ghost-aware input (None slots); ghosts are silently
+    skipped (they were already dropped from the visible render path
+    by an earlier pass — see ``work/ghosting-epic-plan.md``).
     """
     result: list[TemplateMessage] = []
     for msg in messages:
+        if msg is None:
+            continue
         visible = _content_visible_at(msg.content, detail)
 
         # LOW keep-list: built-in ToolUseMessage / ToolResultMessage declare
@@ -3699,7 +3759,7 @@ def _build_branch_header(
     attachment_uuid = b_hier.get("attachment_uuid")
     parent_msg_idx = None
     if attachment_uuid:
-        for msg in ctx.messages:
+        for msg in _visible(ctx.messages):
             if msg.meta.uuid == attachment_uuid and msg.message_index is not None:
                 parent_msg_idx = msg.message_index
                 break
@@ -3754,7 +3814,7 @@ def _build_branch_header(
     # Get fork point preview for backlink text
     fork_context = ""
     if attachment_uuid:
-        for fmsg in ctx.messages:
+        for fmsg in _visible(ctx.messages):
             if fmsg.meta.uuid == attachment_uuid:
                 fork_context = _fork_point_preview(fmsg, ctx)
                 break

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -928,6 +928,109 @@ class TestSkillFoldGhostAnchorRepair:
             "the live session_first_message entry was incorrectly dropped"
         )
 
+    def test_session_nav_omits_anchor_for_ghosted_fork_point(self) -> None:
+        """`prepare_session_navigation` must NOT retarget a ghosted fork
+        point's nav anchor at the parent session header.
+
+        The fork-point nav item resolves its anchor by scanning
+        `_visible(ctx.messages)` for `attachment_uuid`. When that message
+        was ghosted (e.g. a folded Skill slot), the scan can't find it, so
+        `message_index` must stay None (anchor omitted) — NOT fall back to
+        `session_first_message[parent_sid]`, which would silently undo
+        `_drop_anchor_refs_into_ghosts` and point the fork link at the
+        parent session header. Regression for the CodeRabbit finding on
+        the #193 fix.
+        """
+        from claude_code_log.models import (
+            MessageMeta,
+            SessionHeaderMessage,
+            UserSlashCommandMessage,
+        )
+        from claude_code_log.renderer import (
+            RenderingContext,
+            TemplateMessage,
+            prepare_session_navigation,
+        )
+
+        ctx = RenderingContext()
+
+        def _reg(content: object) -> TemplateMessage:
+            msg = TemplateMessage(content)  # type: ignore[arg-type]
+            ctx.register(msg)
+            return msg
+
+        # idx 0: parent session header (a live anchor we must NOT fall back to)
+        _reg(
+            SessionHeaderMessage(
+                MessageMeta(session_id="root", timestamp="", uuid="root-hdr"),
+                title="root",
+                session_id="root",
+            )
+        )
+        # idx 1: the fork point — ghosted below.
+        fork_pt = _reg(
+            UserSlashCommandMessage(
+                MessageMeta(session_id="root", timestamp="", uuid="fork-pt"),
+                text="x",
+            )
+        )
+        # idx 2: branch header.
+        _reg(
+            SessionHeaderMessage(
+                MessageMeta(session_id="root@b", timestamp="", uuid="branch-hdr"),
+                title="Branch • b",
+                session_id="root@b",
+                parent_session_id="root",
+                attachment_uuid="fork-pt",
+                is_branch=True,
+            )
+        )
+
+        ctx.session_first_message["root"] = 0
+        ctx.session_first_message["root@b"] = 2
+        # Ghost the fork point, mirroring what _pair_skill_tool_uses does.
+        assert fork_pt.message_index is not None
+        ctx.messages[fork_pt.message_index] = None
+
+        sessions = {
+            "root": {
+                "first_user_message": "hello",
+                "first_timestamp": "",
+                "last_timestamp": "",
+                "summary": None,
+                "message_count": 1,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_cache_creation_tokens": 0,
+                "total_cache_read_tokens": 0,
+            }
+        }
+        session_hierarchy = {
+            "root": {"depth": 0},
+            "root@b": {
+                "is_branch": True,
+                "attachment_uuid": "fork-pt",
+                "parent_session_id": "root",
+                "depth": 1,
+            },
+        }
+
+        nav = prepare_session_navigation(sessions, ["root"], ctx, session_hierarchy)
+
+        fork_items = [n for n in nav if n.get("is_fork_point")]
+        assert len(fork_items) == 1, (
+            f"expected exactly one fork-point nav item; got {len(fork_items)}"
+        )
+        fork = fork_items[0]
+        assert fork["message_index"] is None, (
+            f"fork-point nav anchor points at message_index={fork['message_index']} "
+            "(the parent session header) instead of being omitted — the ghosted "
+            "fork point was retargeted, undoing the anchor repair."
+        )
+        assert fork["parent_message_index"] is None, (
+            "fork-point nav parent_message_index fell back to the parent header"
+        )
+
 
 class TestReindexBranchBackrefs:
     """Index-remap regression: ``_reindex_filtered_context`` must update

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -228,7 +228,7 @@ class TestSkillPairing:
             for m in ctx.messages
             if m is not None
             and isinstance(m.content, ToolResultMessage)
-            and m.tool_use_id == "toolu_X"
+            and m.content.tool_use_id == "toolu_X"
         ]
         assert tr == [], (
             "The redundant 'Launching skill: X' tool_result should be dropped"

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -738,6 +738,20 @@ class TestSkillFoldOnFork:
             "the slash body should be ghosted, not surviving in ctx.messages"
         )
 
+        # Pin that BOTH consumed slots are ghosted — not just the slash
+        # body — so the "exactly 2 ghosts" count above can't be satisfied
+        # vacuously by ghosting some unrelated slot. Assert by uuid-absence:
+        # the launch tool_result lives in entry 'u-launch', the slash body
+        # in 'u-meta-body'.
+        survivor_uuids = {m.meta.uuid for m in survivors}
+        assert "u-launch" not in survivor_uuids, (
+            "the canonical 'Launching skill:' tool_result (uuid 'u-launch') "
+            "should be ghosted, not surviving in ctx.messages"
+        )
+        assert "u-meta-body" not in survivor_uuids, (
+            "the slash-command body (uuid 'u-meta-body') should be ghosted"
+        )
+
         # === 3) The within-session branch header for the Skill-
         # bearing branch must resolve its parent_message_index to
         # the fork-anchor message (uuid 'c'), NOT to a phantom slot.
@@ -778,6 +792,140 @@ class TestSkillFoldOnFork:
             f"uuid={parent_msg.meta.uuid!r}, expected 'c' (the fork anchor). "
             "This would surface as a wrong 'from #msg-d-N' backlink in the "
             "rendered branch header — exactly the PR #131 failure class."
+        )
+
+
+class TestSkillFoldGhostAnchorRepair:
+    """``_pair_skill_tool_uses`` ghosts the slash body + launch tool_result
+    *in place* (None slots). Anchor-target refs cached earlier — a branch
+    header's ``parent_message_index`` and the ``session_first_message`` map,
+    both populated in ``_render_messages`` before this pass — may point at a
+    slot we just ghosted. The rendered ``#msg-d-{N}`` backlink is emitted
+    from that raw index, so a ``ctx.get()`` that returns None for a ghost
+    does NOT suppress the href; the ref itself must be nulled.
+
+    This is the exposure CodeRabbit flagged on #193 (the broader
+    ``_repair_stale_anchor_refs`` lives in Phase 2). Constructed via a
+    manual context — the same unit style as ``TestReindexBranchBackrefs``
+    — to land a fork point precisely on a soon-to-be-ghosted skill slot
+    without fighting the DAG's fork-collapse heuristic.
+    """
+
+    def test_anchor_ref_into_ghosted_skill_slot_is_nulled(self) -> None:
+        from claude_code_log.models import (
+            MessageMeta,
+            SessionHeaderMessage,
+            ToolResultContent,
+            ToolResultMessage,
+            ToolUseContent,
+            ToolUseMessage,
+            UserSlashCommandMessage,
+        )
+        from claude_code_log.renderer import (
+            RenderingContext,
+            TemplateMessage,
+            _pair_skill_tool_uses,
+        )
+
+        sid = "root"
+        tid = "skill-tool-1"
+        ctx = RenderingContext()
+
+        def _reg(content: object) -> TemplateMessage:
+            msg = TemplateMessage(content)  # type: ignore[arg-type]
+            ctx.register(msg)
+            return msg
+
+        # idx 0: trunk user
+        _reg(
+            UserSlashCommandMessage(
+                MessageMeta(session_id=sid, timestamp="", uuid="u-trunk"), text="hi"
+            )
+        )
+        # idx 1: Skill tool_use
+        _reg(
+            ToolUseMessage(
+                MessageMeta(session_id=sid, timestamp="", uuid="a-skill"),
+                input=ToolUseContent(
+                    type="tool_use",
+                    id=tid,
+                    name="Skill",
+                    input={"skill": "forky:skill", "args": ""},
+                ),
+                tool_use_id=tid,
+                tool_name="Skill",
+            )
+        )
+        # idx 2: canonical launch tool_result — ghosted AND the fork anchor.
+        launch = _reg(
+            ToolResultMessage(
+                MessageMeta(session_id=sid, timestamp="", uuid="u-launch"),
+                tool_use_id=tid,
+                output=ToolResultContent(
+                    type="tool_result",
+                    tool_use_id=tid,
+                    content="Launching skill: forky:skill",
+                    is_error=False,
+                ),
+            )
+        )
+        # idx 3: slash body — ghosted.
+        slash = _reg(
+            UserSlashCommandMessage(
+                MessageMeta(
+                    session_id=sid,
+                    timestamp="",
+                    uuid="u-meta-body",
+                    is_meta=True,
+                    source_tool_use_id=tid,
+                ),
+                text="# expanded skill body",
+            )
+        )
+        # idx 4: a branch header whose fork anchor IS the launch tool_result.
+        branch = _reg(
+            SessionHeaderMessage(
+                MessageMeta(session_id=f"{sid}@a-skill", timestamp="", uuid=""),
+                title="Branch • test",
+                session_id=f"{sid}@a-skill",
+                parent_session_id=sid,
+                parent_message_index=launch.message_index,
+                attachment_uuid="u-launch",
+                is_branch=True,
+            )
+        )
+
+        assert launch.message_index is not None and slash.message_index is not None
+        ctx.session_first_message[sid] = 0
+        # A session whose first message resolves to a soon-ghosted slot.
+        ctx.session_first_message["ghost-first"] = launch.message_index
+
+        _pair_skill_tool_uses(ctx)
+
+        # Both consumed slots ghosted in place.
+        assert ctx.messages[launch.message_index] is None, (
+            "launch tool_result slot should be ghosted (None)"
+        )
+        assert ctx.messages[slash.message_index] is None, (
+            "slash-body slot should be ghosted (None)"
+        )
+
+        # THE GUARD: the branch backlink into the ghosted fork anchor is
+        # nulled so the rendered '#msg-d-{N}' href doesn't dangle.
+        assert isinstance(branch.content, SessionHeaderMessage)
+        assert branch.content.parent_message_index is None, (
+            "branch header parent_message_index still points at a ghosted "
+            f"slot (={branch.content.parent_message_index}) — the dead-anchor "
+            "guard in _pair_skill_tool_uses did not run."
+        )
+
+        # session_first_message entries resolving to a ghost are dropped;
+        # the live one survives.
+        assert "ghost-first" not in ctx.session_first_message, (
+            "session_first_message kept an entry pointing at a ghosted slot"
+        )
+        assert ctx.session_first_message.get(sid) == 0, (
+            "the live session_first_message entry was incorrectly dropped"
         )
 
 

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -196,7 +196,9 @@ class TestSkillPairing:
         skill_tool_uses = [
             m.content
             for m in ctx.messages
-            if isinstance(m.content, ToolUseMessage) and m.content.tool_name == "Skill"
+            if m is not None
+            and isinstance(m.content, ToolUseMessage)
+            and m.content.tool_name == "Skill"
         ]
         assert len(skill_tool_uses) == 1
         assert skill_tool_uses[0].skill_body == body
@@ -206,11 +208,13 @@ class TestSkillPairing:
         _, _, ctx = generate_template_messages(messages)
 
         slash = [
-            m for m in ctx.messages if isinstance(m.content, UserSlashCommandMessage)
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, UserSlashCommandMessage)
         ]
         assert slash == [], (
             f"UserSlashCommandMessage should be consumed when paired; got "
-            f"{[type(m.content).__name__ for m in ctx.messages]}"
+            f"{[type(m.content).__name__ if m is not None else 'GHOST' for m in ctx.messages]}"
         )
 
     def test_launching_skill_tool_result_dropped(self, tmp_path: Path) -> None:
@@ -222,7 +226,9 @@ class TestSkillPairing:
         tr = [
             m
             for m in ctx.messages
-            if isinstance(m.content, ToolResultMessage) and m.tool_use_id == "toolu_X"
+            if m is not None
+            and isinstance(m.content, ToolResultMessage)
+            and m.tool_use_id == "toolu_X"
         ]
         assert tr == [], (
             "The redundant 'Launching skill: X' tool_result should be dropped"
@@ -260,9 +266,15 @@ class TestSkillPairing:
         _, _, ctx = generate_template_messages(messages)
 
         tool_uses = [
-            m.content for m in ctx.messages if isinstance(m.content, ToolUseMessage)
+            m.content
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, ToolUseMessage)
         ]
-        results = [m for m in ctx.messages if isinstance(m.content, ToolResultMessage)]
+        results = [
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, ToolResultMessage)
+        ]
         assert len(tool_uses) == 1
         assert tool_uses[0].skill_body is None
         assert len(results) == 1  # Bash tool_result is NOT dropped
@@ -286,7 +298,9 @@ class TestSkillPairing:
         _, _, ctx = generate_template_messages(messages)
 
         slash = [
-            m for m in ctx.messages if isinstance(m.content, UserSlashCommandMessage)
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, UserSlashCommandMessage)
         ]
         assert len(slash) == 1  # Still rendered as a standalone slash-command
 
@@ -309,7 +323,9 @@ class TestSkillPairing:
         _, _, ctx = generate_template_messages(messages)
 
         slash = [
-            m for m in ctx.messages if isinstance(m.content, UserSlashCommandMessage)
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, UserSlashCommandMessage)
         ]
         # No pair found → slash-command is not consumed, renders standalone.
         assert len(slash) == 1
@@ -420,6 +436,8 @@ class TestSkillPairing:
 
         skill_uses_by_session: dict[str, ToolUseMessage] = {}
         for m in ctx.messages:
+            if m is None:
+                continue
             if isinstance(m.content, ToolUseMessage) and m.content.tool_name == "Skill":
                 skill_uses_by_session[m.meta.session_id] = m.content
         assert set(skill_uses_by_session) == {session_a, session_b}, (
@@ -491,7 +509,8 @@ class TestSkillPairing:
         results = [
             m.content
             for m in ctx.messages
-            if isinstance(m.content, ToolResultMessage)
+            if m is not None
+            and isinstance(m.content, ToolResultMessage)
             and m.content.tool_use_id == "toolu_ERR"
         ]
         assert len(results) == 1, (
@@ -549,7 +568,8 @@ class TestSkillPairing:
         results = [
             m.content
             for m in ctx.messages
-            if isinstance(m.content, ToolResultMessage)
+            if m is not None
+            and isinstance(m.content, ToolResultMessage)
             and m.content.tool_use_id == "toolu_ODD"
         ]
         assert len(results) == 1
@@ -559,6 +579,206 @@ class TestSkillPairing:
         output = results[0].output
         assert isinstance(output, ToolResultContent)
         assert output.content == "Some unrelated payload"
+
+
+class TestSkillFoldOnFork:
+    """The D12-prerequisite test the verifier flagged as missing.
+
+    Skill-fold happens inside a within-session branch, rendered at
+    FULL detail. Pre-ghosting this path went through
+    ``_reindex_filtered_context`` (which the
+    ``TestReindexBranchBackrefs`` tests below exercise). Post-Phase-1
+    of the ghosting epic (`work/ghosting-epic-plan.md`),
+    ``_pair_skill_tool_uses`` ghosts the consumed slots in place
+    instead of deleting + reindexing — so the branch header's
+    ``parent_message_index`` (set at register time in
+    ``_render_messages``) is never touched. The fork-anchor index
+    stays valid because no slot before it was deleted.
+
+    The test asserts the visible-output contract: skill folded,
+    slash + launching-skill tool_result ghosted, branch header
+    backlink resolves to the actual fork anchor (NOT to whatever
+    shifted into the old index after a phantom reindex). This is
+    the failure mode PR #131 introduced (under the old reindex
+    path) and the verifier called out as missing coverage for D12;
+    landing it under the ghosting path means D12 inherits the
+    coverage when it lands.
+    """
+
+    def test_skill_fold_inside_fork_at_full_keeps_branch_backref(
+        self, tmp_path: Path
+    ) -> None:
+        from claude_code_log.models import SessionHeaderMessage, ToolUseMessage
+
+        # Trunk: u-trunk-1 → a-trunk-1 → c (fork point).
+        # Both children of c are ASSISTANTS — bypasses the DAG's
+        # fork-collapse heuristic that absorbs an assistant +
+        # user-child pair as a tool-result side-branch (see
+        # ``_stitch_tool_results`` in dag.py). With two assistant
+        # siblings + distinct timestamps, the DAG sees a real fork.
+        # Branch 1: a-skill (assistant Skill tool_use) → u-launch
+        #   tool_result → u-meta-body (isMeta sourceToolUseID) →
+        #   a-skill-reply.
+        # Branch 2 sibling: a-other (assistant text) → u-other-reply.
+        sid = "sess-fork-skill"
+        tool_id = "toolu_SKILL_F"
+        skill_body = "# Forky Skill\n\nBody **inside** the branch."
+        entries = [
+            _user(
+                "u-trunk-1",
+                None,
+                "2026-01-01T10:00:00Z",
+                [{"type": "text", "text": "hello"}],
+                session_id=sid,
+            ),
+            _assistant_text(
+                "a-trunk-1", "u-trunk-1", "2026-01-01T10:00:01Z", "ok", session_id=sid
+            ),
+            _user(
+                "c",
+                "a-trunk-1",
+                "2026-01-01T10:00:02Z",
+                [{"type": "text", "text": "fork point"}],
+                session_id=sid,
+            ),
+            # ---- Branch 1: Skill spawn inside the branch
+            _assistant_tool_use(
+                "a-skill",
+                "c",
+                "2026-01-01T10:00:03Z",
+                "Skill",
+                tool_id,
+                {"skill": "forky:skill", "args": ""},
+                session_id=sid,
+            ),
+            _user(
+                "u-launch",
+                "a-skill",
+                "2026-01-01T10:00:04Z",
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": "Launching skill: forky:skill",
+                        "is_error": False,
+                    }
+                ],
+                session_id=sid,
+            ),
+            _user(
+                "u-meta-body",
+                "u-launch",
+                "2026-01-01T10:00:05Z",
+                [{"type": "text", "text": skill_body}],
+                is_meta=True,
+                source_tool_use_id=tool_id,
+                session_id=sid,
+            ),
+            _assistant_text(
+                "a-skill-reply",
+                "u-meta-body",
+                "2026-01-01T10:00:06Z",
+                "skill ran",
+                session_id=sid,
+            ),
+            # ---- Branch 2 sibling: starts with an ASSISTANT
+            # (same role as branch 1's first entry) to bypass the
+            # fork-collapse heuristic, then a user reply so the
+            # branch isn't a single-entry dead-end.
+            _assistant_text(
+                "a-other",
+                "c",
+                "2026-01-01T10:00:07Z",
+                "other path",
+                session_id=sid,
+            ),
+            _user(
+                "u-other-reply",
+                "a-other",
+                "2026-01-01T10:00:08Z",
+                [{"type": "text", "text": "other reply"}],
+                session_id=sid,
+            ),
+        ]
+        messages = load_transcript(_write_jsonl(tmp_path / "fork-skill.jsonl", entries))
+        _, _, ctx = generate_template_messages(messages)
+
+        # === 1) Skill body folded into the Skill tool_use.
+        skill_tool_uses = [
+            m.content
+            for m in ctx.messages
+            if m is not None
+            and isinstance(m.content, ToolUseMessage)
+            and m.content.tool_name == "Skill"
+        ]
+        assert len(skill_tool_uses) == 1, (
+            f"expected exactly one Skill tool_use, got {len(skill_tool_uses)}"
+        )
+        assert skill_tool_uses[0].skill_body == skill_body, (
+            "Skill body should be folded onto the tool_use's skill_body field; "
+            f"got skill_body={skill_tool_uses[0].skill_body!r}"
+        )
+
+        # === 2) The slash-command body slot AND the launching-skill
+        # tool_result slot are GHOSTED (None) — not removed from
+        # ctx.messages. This is the new ghosting contract; pre-
+        # Phase-1 the consumed slots were deleted + reindexed.
+        ghost_slots = [i for i, m in enumerate(ctx.messages) if m is None]
+        assert len(ghost_slots) == 2, (
+            f"expected exactly 2 ghosted slots (slash body + "
+            f"launching-skill tool_result); got {len(ghost_slots)} at {ghost_slots}. "
+            f"ctx.messages length = {len(ctx.messages)}"
+        )
+
+        # No surviving UserSlashCommandMessage (the slash body is the ghost).
+        survivors = [m for m in ctx.messages if m is not None]
+        from claude_code_log.models import UserSlashCommandMessage as _USM
+
+        assert not any(isinstance(m.content, _USM) for m in survivors), (
+            "the slash body should be ghosted, not surviving in ctx.messages"
+        )
+
+        # === 3) The within-session branch header for the Skill-
+        # bearing branch must resolve its parent_message_index to
+        # the fork-anchor message (uuid 'c'), NOT to a phantom slot.
+        # This is the PR #131 regression class under the ghosting
+        # path: pre-Phase-1 a buggy reindex could shift the cached
+        # parent_message_index; post-Phase-1 there's no reindex at
+        # all, so the index set at register time stays valid as
+        # long as the fork anchor itself wasn't ghosted (it wasn't —
+        # the trunk-side anchor is never a Skill-fold target).
+        branch_headers = [
+            m
+            for m in survivors
+            if isinstance(m.content, SessionHeaderMessage) and m.content.is_branch
+        ]
+        # The Skill-bearing branch is the one rooted at 'a-skill'.
+        # (Branch sids are ``{trunk}@{first_uuid12}`` per dag.py.)
+        skill_branches = [
+            m for m in branch_headers if m.content.session_id.endswith("@a-skill")
+        ]
+        assert len(skill_branches) == 1, (
+            f"expected exactly one branch header rooted at 'a-skill'; got "
+            f"{[m.content.session_id for m in branch_headers]}"
+        )
+        skill_branch = skill_branches[0]
+        parent_idx = skill_branch.content.parent_message_index
+        assert parent_idx is not None, (
+            "skill-bearing branch header's parent_message_index is None — "
+            "expected it to resolve to the fork anchor 'c'."
+        )
+        parent_msg = ctx.get(parent_idx)
+        assert parent_msg is not None, (
+            f"branch header parent_message_index={parent_idx} resolved to None — "
+            "the fork anchor was either ghosted (unexpected) or the index was "
+            "phantom-shifted."
+        )
+        assert parent_msg.meta.uuid == "c", (
+            f"branch header parent_message_index={parent_idx} resolves to "
+            f"uuid={parent_msg.meta.uuid!r}, expected 'c' (the fork anchor). "
+            "This would surface as a wrong 'from #msg-d-N' backlink in the "
+            "rendered branch header — exactly the PR #131 failure class."
+        )
 
 
 class TestReindexBranchBackrefs:

--- a/work/ghosting-epic-plan.md
+++ b/work/ghosting-epic-plan.md
@@ -401,13 +401,16 @@ would point the fork link at the parent session header and undo
 `_drop_anchor_refs_into_ghosts`). The template guards the fork link
 against a `None` index. Mirrors the ghost-aware repair contract.
 
-### 3.10 `_reorder_session_template_messages` — unchanged
+### 3.10 `_reorder_session_template_messages` — ghost-filter boundary
 
-Reorders by `render_session_id`. Ghosts have render_session_id
-like everyone else, so they ride along with their session and end
-up in the reordered list. They'll be invisible in the final output
-because the tree-build (3.6) excludes them — but they pass through
-this pass unchanged. No change.
+This pass is where ghosts are *materialized out*. It accepts the
+ghost-aware `list[Optional[TemplateMessage]]`, skips `None` slots
+while grouping by `render_session_id`, and returns a None-free
+`list[TemplateMessage]` (the no-header early-return uses
+`list(_visible(messages))`). Because the boundary is here, every
+downstream pass (`_identify_message_pairs`, `_reorder_paired_messages`,
+tree-build, format renderers) consumes a None-free list and needs no
+ghost-skipping — Pyright enforces that via the narrowed return type.
 
 ### 3.11 `_reorder_paired_messages` — unchanged
 

--- a/work/ghosting-epic-plan.md
+++ b/work/ghosting-epic-plan.md
@@ -1,0 +1,636 @@
+# Ghosting epic — implementation plan
+
+> Concrete design for the unified-ghosting refactor that gates D12
+> (`detail-delete-reindex`) and the single-axis end-state described in
+> [refactor-reindex-with-ghosting.md](refactor-reindex-with-ghosting.md)
+> and [simplify-converter-renderer.md §7](simplify-converter-renderer.md#7-detail-filtering-the-single-axis-end-state-added-2026-05-29).
+
+**Status:** AWAITING CBOOS GREENLIGHT. Branched at
+`dev/ghosting-epic` from `main` @ `129c998`. No code written yet.
+
+---
+
+## 0. Why this exists
+
+`ctx.messages` is the rendering layer's source-of-truth registry —
+every TemplateMessage's `message_index` is its position in this list,
+and downstream passes (pair identification, session nav, fork-point
+backlinks, junction forward links, hierarchy/tree, fold/unfold) all
+read those indices to look things up. Today, two passes
+(`_pair_skill_tool_uses` and `_filter_template_by_detail`) **delete**
+messages from `ctx.messages`, which invalidates every cached index;
+`_reindex_filtered_context` exists solely to rewrite those caches
+after the fact.
+
+The remap surface keeps growing — PR #131 added
+`SessionHeaderMessage.parent_message_index`, PR #132 added the
+async-agents targeted ghost (which proved the alternative works).
+Each new index-bearing field is a "remember to remap X" obligation
+on every contributor.
+
+The ghosting approach inverts the model: dropped messages stay in
+`ctx.messages` (preserving every index), but carry an `is_ghosted`
+flag. Downstream passes that *iterate* messages learn to skip
+ghosts; passes that read stored indices keep working unchanged. The
+two reindex-callers + `_reindex_filtered_context` itself all
+disappear once both callers migrate.
+
+This document covers the **entire** migration: the unified flag, the
+pass-by-pass changes, the single-axis collapse of pre-render
+filtering, and a phased rollout that's reviewable in steps.
+
+---
+
+## 1. Why standalone ghost attempts failed (and the unified version
+doesn't)
+
+The verifier rejected two earlier scoped attempts. Both rejections
+land on real failure modes that this plan addresses head-on:
+
+### 1.1 `detail-ghost-skill-fold` — "bare card" rendering
+
+**Reject reason:** "the ghosted level-1 slash body adopts the
+following assistant turn as a child after `_build_message_hierarchy`,
+so the elision rule keeps it (renders a bare card)."
+
+**Root cause:** the existing render-loop elision is `if title or
+html or msg.children:` (HTML) — a "no title AND no content AND no
+children" rule. A ghost that has visible children is *not* eligible
+for elision; it renders as an empty header above its children.
+
+**Why the unified plan fixes it:** `_build_message_hierarchy` learns
+to skip ghosts and **graft** their (non-ghost) children to the next
+non-ghost ancestor. After hierarchy, a ghost's `children` is empty
+(its real children moved up the stack). The existing elision rule
+then catches it cleanly — no special case in the render loop.
+
+### 1.2 `detail-move-template-filter-to-tree` — late-pass references
+
+**Reject reason:** "nav/descendant-counts/backlinks run *after* the
+proposed prune point, so descendant counts and backlink anchors
+would dangle."
+
+**Root cause:** the prior attempt moved the prune (= delete) deeper
+into the pipeline without addressing the downstream readers.
+Anything that reads stored indices after the prune sees stale
+pointers.
+
+**Why the unified plan fixes it:** ghosting **never prunes**. The
+indices stay stable across the entire pipeline. Nav, descendant
+counts, and backlinks read the same indices they always did; the
+only change is that ghost messages' contributions are filtered out
+of the *output*, not out of the *registry*.
+
+---
+
+## 2. The unified `is_ghosted` flag
+
+### 2.1 Model
+
+Add one bool to `TemplateMessage` (defined in `renderer.py`):
+
+```python
+class TemplateMessage:
+    # ... existing fields ...
+    self.is_ghosted: bool = False
+```
+
+That's the entire model change. No new methods; no per-content-type
+flags. Setting `is_ghosted = True` opts the message out of the
+*visible* render path while keeping it in every internal index.
+
+### 2.2 Semantics
+
+A ghosted message:
+
+- **Keeps** its `message_index` (so pair-refs, parent_message_index,
+  junction_forward_links, session_first_message all stay valid).
+- **Keeps** its `meta`, `render_session_id`, `content` (for any pass
+  that needs to inspect it, e.g. the `_pair_skill_tool_uses`
+  detection scan that runs over `ctx.messages` after ghosts exist).
+- **Skipped** by passes that compute *visible* structure:
+  `_build_message_hierarchy` (no ancestry contribution, children
+  grafted), `_identify_message_pairs` (cannot participate in pairs),
+  `_build_message_tree` (not emitted as a root), and the format
+  renderers' iteration (not rendered).
+
+### 2.3 Helper
+
+A single helper in `renderer.py`, used by every iterator:
+
+```python
+def _visible(messages: Iterable[TemplateMessage]) -> Iterator[TemplateMessage]:
+    """Yield only non-ghost messages."""
+    return (m for m in messages if not m.is_ghosted)
+```
+
+Most passes use `_visible(messages)` instead of `messages` directly.
+Where positional lookups are needed (`message_by_index`), the
+existing pattern keeps working — ghosts have `message_index` like
+anyone else, so the map still resolves; passes that don't WANT to
+resolve to a ghost check `if msg.is_ghosted` after the lookup.
+
+---
+
+## 3. Pass-by-pass refactor plan
+
+The pipeline order (from `generate_template_messages`):
+
+| Order | Pass | Today's behavior | Post-ghost behavior |
+|---|---|---|---|
+| 1 | `_render_messages` | builds `ctx.messages` | unchanged |
+| 2 | `_pair_skill_tool_uses` | deletes 1–2 msgs + reindexes | sets `is_ghosted = True`; no reindex |
+| 3 | `_link_junction_forwards` | reads ctx.messages + writes indices | unchanged — indices stable |
+| 4 | `_filter_template_by_detail` + reindex | deletes many + reindexes | rewritten as `_ghost_template_by_detail(ctx, detail)`; no reindex |
+| 5 | `prepare_session_navigation` | reads `ctx.session_first_message` | unchanged |
+| 6 | `_reorder_session_template_messages` | reorders by render_session_id | unchanged (ghosts ride along with their session) |
+| 7 | `_identify_message_pairs` | sequential pair scan | skips ghosts in adjacency walk AND in indexed pairing |
+| 8 | `_reorder_paired_messages` | moves pair_last adjacent | unchanged (ghosts not paired so they don't move) |
+| 9 | `_relocate_subagent_blocks` | moves blocks under anchors | unchanged (works on render_session_id / sessionId) |
+| 10 | `_build_message_hierarchy` | ancestry from level stack | **skip ghosts + graft children** |
+| 11 | `_mark_messages_with_children` | counts via ancestry | naturally correct (ancestry already grafted past ghosts) |
+| 12 | `_build_message_tree` | tree by ancestry | skip ghosts from root_messages; children list already excludes them |
+| 13 | `_cleanup_sidechain_duplicates` | mutates parent.children | unchanged (already operates on the post-ghost tree) |
+| 14 | Format renderers | iterate root_messages → children | naturally exclude ghosts (they're absent from the tree) |
+
+The detailed changes per pass:
+
+### 3.1 `_pair_skill_tool_uses` — set ghosts instead of deleting
+
+Today's tail (line ~3360):
+
+```python
+consumed_indices.add(other.message_index)
+# ...
+kept = [msg for msg in ctx.messages if msg.message_index not in consumed_indices]
+_reindex_filtered_context(ctx, kept)
+```
+
+After:
+
+```python
+consumed_indices.add(other.message_index)
+# ...
+for msg in ctx.messages:
+    if msg.message_index in consumed_indices:
+        msg.is_ghosted = True
+# No reindex.
+```
+
+Same selection logic; the only change is the action.
+
+### 3.2 `_ghost_template_by_detail(ctx, detail)` — replaces filter + reindex
+
+Today (line 730):
+
+```python
+if detail != DetailLevel.FULL:
+    filtered = _filter_template_by_detail(ctx.messages, detail)
+    _reindex_filtered_context(ctx, filtered)
+```
+
+After:
+
+```python
+if detail != DetailLevel.FULL:
+    _ghost_template_by_detail(ctx, detail)  # mutates in place
+```
+
+Where `_ghost_template_by_detail` is `_filter_template_by_detail`
+with the result-list collection replaced by `msg.is_ghosted = True`.
+Same visibility predicate, same `_LOW_KEEP_TOOLS` opt-out, same
+sidechain rule — only the side-effect changes.
+
+### 3.3 `_identify_message_pairs` — skip ghosts in BOTH passes
+
+Two places:
+
+1. **`_build_pairing_indices`** (the dict-building first pass): ghost
+   messages must NOT be added to the indices. Otherwise an index-based
+   pairing could attach a real tool_result to a ghost tool_use.
+
+2. **Sequential scan**: when looking at `messages[i]`,
+   `messages[i+1]`, `messages[i+2]` for adjacency, ghosts must be
+   skipped. Easiest implementation: iterate `_visible(messages)` and
+   keep i/i+1/i+2 as positions in the visible subsequence.
+
+Edge case: a ghost ToolUseMessage with a corresponding non-ghost
+ToolResultMessage — the result should NOT be paired (no visible
+"use" to pair against), so it just renders as an orphan tool_result.
+This is acceptable and matches today's behavior (when the filter
+drops the tool_use, the result also drops in most detail levels;
+where it doesn't, an orphan tool_result is the correct visible
+shape).
+
+### 3.4 `_build_message_hierarchy` — skip ghosts + graft children
+
+The critical pass. Today (line 2148):
+
+```python
+for message in messages:
+    current_level = ... (from message)
+    # pop stack until parent level
+    while hierarchy_stack and hierarchy_stack[-1][0] >= current_level:
+        hierarchy_stack.pop()
+    ancestry = [idx for _, idx in hierarchy_stack]
+    if message.message_index is not None:
+        hierarchy_stack.append((current_level, message.message_index))
+    message.ancestry = ancestry
+```
+
+After:
+
+```python
+for message in messages:
+    if message.is_ghosted:
+        # Don't push ghost onto stack: its real children, when they
+        # arrive, will compute ancestry against the SURVIVING stack
+        # (the ghost's would-be ancestor), naturally grafting up.
+        message.ancestry = []  # ghosts have no ancestry of their own
+        continue
+
+    current_level = ...
+    while hierarchy_stack and hierarchy_stack[-1][0] >= current_level:
+        hierarchy_stack.pop()
+    ancestry = [idx for _, idx in hierarchy_stack]
+    if message.message_index is not None:
+        hierarchy_stack.append((current_level, message.message_index))
+    message.ancestry = ancestry
+```
+
+That's the entire children-grafting mechanism: a ghost never
+contributes to the stack, so its children "see through" it to the
+next non-ghost ancestor. No explicit graft step needed.
+
+### 3.5 `_mark_messages_with_children` — works for free
+
+Reads ancestry indices, increments counts on ancestors. Since
+ancestry now skips ghosts (per 3.4), ghosts naturally don't appear
+in any non-ghost message's ancestry — so they're not incremented
+*as* parents, and they're not counted *as* children either (per
+3.4, ghosts have `ancestry = []` so the `if not message.ancestry`
+guard skips them at iteration time).
+
+Optional small change: skip ghosts at the top of the loop for
+clarity / a microperf win, but functionally unnecessary.
+
+### 3.6 `_build_message_tree` — exclude ghosts from roots
+
+Today (line 2255):
+
+```python
+for message in messages:
+    message.children = []
+for message in messages:
+    if not message.ancestry:
+        root_messages.append(message)
+    else:
+        immediate_parent_index = message.ancestry[-1]
+        if immediate_parent_index in message_by_index:
+            parent = message_by_index[immediate_parent_index]
+            parent.children.append(message)
+return root_messages
+```
+
+After:
+
+```python
+for message in messages:
+    if message.is_ghosted:
+        message.children = []
+        continue  # don't add to roots, don't add as child
+    message.children = []
+for message in messages:
+    if message.is_ghosted:
+        continue
+    if not message.ancestry:
+        root_messages.append(message)
+    else:
+        immediate_parent_index = message.ancestry[-1]
+        if immediate_parent_index in message_by_index:
+            parent = message_by_index[immediate_parent_index]
+            # parent might be a ghost (its message_index resolved in
+            # the map) — but per 3.4 a ghost has ancestry=[] so any
+            # non-ghost child's ancestry skips it. Defensive guard:
+            if not parent.is_ghosted:
+                parent.children.append(message)
+```
+
+The defensive guard inside `else` is belt-and-braces — by 3.4's
+invariant a non-ghost message's ancestry never names a ghost. But
+the guard means the tree-build is correct even if some future code
+path violates the invariant.
+
+### 3.7 Format renderers (HTML + Markdown) — no change
+
+The HTML template iterates root_messages and recurses through
+`msg.children`. Ghosts are absent from both. The existing "skip
+empty messages" elision is no longer needed for ghost-handling
+specifically — but stays because it serves other shapes (e.g.
+`AwaySummaryMessage` returning `""` at LOW). Net behavior change:
+ghosts simply don't exist in the renderer's input. No template
+edits.
+
+Markdown is the same — it iterates the same tree.
+
+JSON exporter (`json/renderer.py`) similarly iterates the tree.
+Should "just work" — but I'll explicitly verify (see test plan).
+
+### 3.8 `_link_junction_forwards` — unchanged
+
+Reads `ctx.junction_targets` (from session_hierarchy) and
+`ctx.messages`. Indices it writes (`junction_forward_links`,
+`fork_point_preview`) are stored on real fork-point messages and
+reference branch headers by message_index. All indices are stable
+under ghosting. No change.
+
+### 3.9 `prepare_session_navigation` — unchanged
+
+Reads `ctx.session_first_message` and emits the nav. All indices
+stable. No change.
+
+### 3.10 `_reorder_session_template_messages` — unchanged
+
+Reorders by `render_session_id`. Ghosts have render_session_id
+like everyone else, so they ride along with their session and end
+up in the reordered list. They'll be invisible in the final output
+because the tree-build (3.6) excludes them — but they pass through
+this pass unchanged. No change.
+
+### 3.11 `_reorder_paired_messages` — unchanged
+
+Pair fields are not set on ghosts (per 3.3), so they don't move.
+The reorder of *real* pairs is unaffected. No change.
+
+### 3.12 `_relocate_subagent_blocks` — unchanged
+
+Operates on `meta.session_id` (the agent sidechain id). Agent
+messages aren't typically ghosted by the detail filter (agent
+content survives at LOW; sidechain is filtered at MINIMAL but that's
+a separate pre-existing path). Even if a ghost is inside a relocated
+block, it rides along correctly. No change.
+
+### 3.13 `_cleanup_sidechain_duplicates` — unchanged
+
+Operates on `parent.children` after the tree is built. By 3.6,
+`parent.children` doesn't contain ghosts. No change.
+
+---
+
+## 4. The single-axis end-state — delete `_filter_by_detail`
+(pre-render)
+
+The pre-render filter (`_filter_by_detail` on `TranscriptEntry`)
+exists today only because deleting at the post-render layer needs
+the reindex dance. With ghosting, *everything* it does becomes
+expressible at the post-render layer via the per-class
+`MessageContent.visible_at` predicate.
+
+**Why this is in scope:** ghosting eliminates the cost the pre-render
+filter was paying for (avoiding the reindex). Keeping the pre-render
+filter after ghosting lands means maintaining two filter axes for
+no benefit, exactly the complexity the §7 analysis identifies.
+
+**What goes away:**
+
+- `_filter_by_detail` (renderer.py, called at line 695).
+- `application_model.md §2.6`'s two-axis rationale.
+
+**What stays:**
+
+- `_filter_messages` (structural — unrelated to detail level).
+- `_LOW_KEEP_TOOLS` (orthogonal tool-name allowlist; lives in the
+  same post-render pass that becomes `_ghost_template_by_detail`).
+
+**Net effect on the post-render ghoster:** it gains the
+content-item-stripping responsibilities that today live in
+`_filter_by_detail`:
+
+- At MINIMAL / USER_ONLY: strip `ThinkingContent`, `ToolUseContent`,
+  `ToolResultContent` from each surviving message's content.
+- At LOW: strip `ThinkingContent`.
+- At HIGH: drop system entries except `away_summary`.
+
+Each strip rule is naturally expressible on the post-render
+TemplateMessage: ToolUseMessage / ToolResultMessage / ThinkingMessage
+already have their own classes; the strip becomes
+`msg.is_ghosted = True` for the class. (Effectively: the per-class
+`detail_visibility` declarations already encode these rules — see
+[plugins.md §6](../dev-docs/plugins.md) — so the pre-render strip
+collapses into the post-render visibility predicate.)
+
+The one wrinkle: a single transcript entry can produce multiple
+TemplateMessages (e.g., an assistant turn with text + tool_use →
+AssistantTextMessage + ToolUseMessage). Pre-render filtering at
+MINIMAL would strip the tool_use content item before factory
+dispatch, leaving only the text → factory emits only
+AssistantTextMessage. Post-render ghosting keeps both messages but
+ghosts the ToolUseMessage. The visible output is identical (a single
+AssistantTextMessage). The CHUNK_BOUNDARIES are slightly different
+in intermediate `ctx.messages`, but since the renderer iterates
+the tree (post-ghost), the rendered output matches.
+
+**Risk:** the chunk-boundary difference could change `message_index`
+values for surviving messages. Snapshots that ASSERT specific indices
+(unusual; mostly snapshots assert rendered HTML/MD) would change.
+This needs verification when the single-axis collapse lands —
+likely Phase 3 of the rollout.
+
+---
+
+## 5. Phased rollout
+
+The whole epic in one PR would be too big and too risky. Three
+phases, each a separate PR, each independently merge-able:
+
+### Phase 1 — `wf/ghosting/skill-fold` (small, safe)
+
+- Add `TemplateMessage.is_ghosted = False`.
+- Migrate `_pair_skill_tool_uses` to set `is_ghosted` instead of
+  deleting + reindexing.
+- Implement steps 3.4 (hierarchy graft) and 3.6 (tree skip ghosts)
+  — both are needed for the Skill ghost to render correctly.
+- Implement step 3.3 (pair-id skip ghosts) — defensive; the Skill
+  ghosts aren't paired but the next phase needs this.
+- Leave `_filter_template_by_detail` and its reindex call
+  unchanged.
+- Leave `_reindex_filtered_context` in place (still called by the
+  detail filter path).
+- Verify: full suite green (1924 prior), snapshot byte-identity
+  expected. Pin a Skill-fold-on-a-fork test (the PR #131 regression
+  origin), at FULL detail. This is the test the verifier called out
+  as missing for D12; landing it in Phase 1 closes the gate
+  prerequisite even before the detail-filter migration.
+
+Estimate: ~150 lines net change. Lowest risk; lays the
+infrastructure.
+
+### Phase 2 — `wf/ghosting/detail-filter` (medium)
+
+- Migrate `_filter_template_by_detail` + reindex to
+  `_ghost_template_by_detail` (set `is_ghosted` instead of deleting).
+- Delete `_reindex_filtered_context` (no more callers).
+- Re-run per-detail-level snapshot suite. EXPECTED:
+  byte-identical (ghosting produces the same visible output as
+  deleting + reindexing, by construction).
+- If any snapshot moves: it's a bug, not an intentional change —
+  investigate before regenerating.
+
+Estimate: ~200 lines net change (mostly deletion of
+`_reindex_filtered_context` and its callers' tail). This is the D12
+deletion itself.
+
+### Phase 3 — `wf/ghosting/single-axis-collapse` (the §7 end-state)
+
+- Move the pre-render strip rules from `_filter_by_detail` into
+  the post-render ghoster's per-class predicate (`detail_visibility`
+  ClassVars already cover most of it; one or two cases may need a
+  small tweak).
+- Delete `_filter_by_detail` and its call.
+- Verify: snapshots may move by chunk-boundary effects (see §4
+  wrinkle); review and regenerate IF the rendered output is
+  byte-identical and ONLY the intermediate indices shifted.
+
+Estimate: ~150 lines deletion (the pre-render filter is ~80 lines)
+plus a handful of `detail_visibility` reconciliations. Highest
+risk because of the chunk-boundary edge.
+
+Phases 1 + 2 together delete `_reindex_filtered_context`. Phase 3
+is the bonus single-axis cleanup; if it surfaces a deeper issue, it
+can be deferred indefinitely without holding up D12 (which is
+Phase 1 + 2's combined effect).
+
+---
+
+## 6. Test strategy
+
+### 6.1 What MUST stay green
+
+- Full unit suite (currently 1924 passed, 7 skipped).
+- HTML + Markdown snapshot suites — byte-identical across Phase 1
+  and Phase 2.
+- All five `--detail` level snapshots — byte-identical across Phase
+  1 and Phase 2.
+- `test_skill_pairing.py::TestReindexBranchBackrefs` — the PR #131
+  regression test. Currently runs at non-FULL detail (the only path
+  that triggers reindex pre-ghosting). After Phase 1, the equivalent
+  invariant must be exercised at FULL detail (Phase 1 ghosts inside
+  the Skill-fold path which runs unconditionally).
+- `test_dag_integration.py::TestRenderSessionResetAcrossSessions`
+  (the latent-bug regression from D11) — independent of ghosting,
+  should be entirely unaffected.
+
+### 6.2 New tests added in Phase 1
+
+1. **Skill-fold-on-a-fork at FULL detail** (the test the verifier
+   called out as missing): construct a fixture with a Skill spawn
+   inside a within-session branch; render at FULL; assert the
+   branch's `parent_message_index` points to the correct fork
+   anchor, the ghosted slash-command body is absent from the
+   rendered output, AND the branch backlink "from #msg-d-{N}"
+   resolves to the right anchor. This is the test the verifier
+   identified as missing for D12 — landing it in Phase 1 means
+   D12 (Phase 2 in this plan) inherits coverage.
+
+2. **Skill-fold ghost doesn't break pairing**: a Skill `tool_use`
+   inside a session where the slash-body has been ghosted should
+   still pair correctly with its matching `tool_result` (if not
+   also ghosted by the launching-skill payload rule).
+
+3. **Ghost-with-children graft**: synthetic fixture where a
+   ToolUseMessage (ghosted at MINIMAL) has children (a sidechain
+   subagent thread that survives); assert the children's ancestry
+   resolves to the ghost's *parent*, not the ghost itself.
+
+### 6.3 New tests added in Phase 2
+
+1. **Detail-filter byte-identity**: parametrize over every
+   `DetailLevel` value, render a complex fixture (the existing
+   per-detail snapshot fixture), assert the rendered output is
+   byte-identical to the pre-Phase-2 baseline. This is the
+   structural-correctness pin for the deletion.
+
+2. **`_reindex_filtered_context` deleted**: grep -based static
+   check that the symbol no longer exists (catches accidental
+   re-introduction).
+
+### 6.4 Failing-on-pre-ghosting verification
+
+Per the D11 pattern: each phase's pinning test should FAIL on the
+pre-phase tip when applied as a patch (in a `/tmp` throwaway
+worktree). This proves the test genuinely exercises the new
+behavior, not just passes vacuously.
+
+---
+
+## 7. Risks
+
+### 7.1 Hidden index reader
+
+Some pass we haven't catalogued might read `len(ctx.messages)` or
+iterate `ctx.messages` and assume no ghosts. Mitigation:
+`_visible(...)` helper in the renderer + targeted code-review of
+the full `renderer.py` (find every `ctx.messages` reference) before
+Phase 1 lands.
+
+### 7.2 Memory bloat
+
+Ghosts stay in memory. The pre-render filter at MINIMAL drops the
+most messages (no tools, no thinking, no sidechain), often the
+majority of a long transcript. Keeping them in `ctx.messages` could
+~triple peak memory at MINIMAL for huge transcripts. Mitigation:
+acceptable for the dominant use case (transcripts in the
+single-MB-to-tens-of-MB range); revisit if a profiling pass shows
+real-world peak going past 1 GB.
+
+### 7.3 Markdown chunk-boundary subtlety (Phase 3 only)
+
+When a single transcript entry's content items are split into
+multiple TemplateMessages, pre-render filtering keeps factory
+boundaries; post-render ghosting keeps the *ghosted* messages and
+may shift downstream indices. The rendered output should be
+identical (the tree iteration skips ghosts), but `d-{index}`
+anchors may move. If a snapshot's `d-{N}` references shift, the
+HTML is "different bytes, same logical content" — needs careful
+review per snapshot.
+
+### 7.4 Plugin contract
+
+Third-party `MessageContent` subclasses interact with ghosting only
+via `is_ghosted` (or not at all, since they don't set it). Their
+`visible_at` predicate continues to drive whether they get ghosted,
+identical to today. No plugin-contract change.
+
+---
+
+## 8. Rollout decisions for cboos to make
+
+1. **Approve the phased plan** (Phases 1 + 2 + 3 as separate PRs)
+   vs. monolithic.
+2. **Approve dropping `_filter_by_detail`** (Phase 3 / single-axis
+   collapse) vs. leaving the two-axis structure in place.
+3. **Approve the Phase 1 "Skill-fold on a fork at FULL detail" test**
+   as the D12 prerequisite, even though it lands in Phase 1.
+4. **Allocate review:** monk reviews each phase; main coordinates;
+   cboos merges.
+
+Once approved, I'll start with Phase 1 on a new branch
+`wf/ghosting/skill-fold` from `main` (this `dev/ghosting-epic`
+branch is just the planning scratchpad — its only commit will be
+this doc).
+
+---
+
+## 9. Pointers
+
+- [refactor-reindex-with-ghosting.md](refactor-reindex-with-ghosting.md)
+  — the original problem statement.
+- [simplify-converter-renderer.md §3 opp 12 + §6 + §7](simplify-converter-renderer.md)
+  — D12 gate context, verifier rejections, single-axis end-state.
+- [dev-docs/rendering-architecture.md](../dev-docs/rendering-architecture.md)
+  — the pipeline overview.
+- [dev-docs/plugins.md §6](../dev-docs/plugins.md) — per-class
+  `detail_visibility` mechanism.
+- [PR #131](https://github.com/daaain/claude-code-log/pull/131) +
+  [PR #132](https://github.com/daaain/claude-code-log/pull/132)
+  — the regressions that motivated the epic.

--- a/work/ghosting-epic-plan.md
+++ b/work/ghosting-epic-plan.md
@@ -28,12 +28,14 @@ async-agents targeted ghost (which proved the alternative works).
 Each new index-bearing field is a "remember to remap X" obligation
 on every contributor.
 
-The ghosting approach inverts the model: dropped messages stay in
-`ctx.messages` (preserving every index), but carry an `is_ghosted`
-flag. Downstream passes that *iterate* messages learn to skip
-ghosts; passes that read stored indices keep working unchanged. The
-two reindex-callers + `_reindex_filtered_context` itself all
-disappear once both callers migrate.
+The ghosting approach inverts the model: dropped messages become
+`None` slots in `ctx.messages` (preserving every index and freeing
+the dropped object for GC). Downstream passes that *iterate*
+messages learn to skip the `None` slots; passes that read stored
+indices keep working unchanged because the stable indices around
+the dropped slots don't shift. The two reindex-callers +
+`_reindex_filtered_context` itself all disappear once both callers
+migrate.
 
 This document covers the **entire** migration: the unified flag, the
 pass-by-pass changes, the single-axis collapse of pre-render
@@ -83,52 +85,74 @@ of the *output*, not out of the *registry*.
 
 ---
 
-## 2. The unified `is_ghosted` flag
+## 2. Ghosts as `None` slots in `ctx.messages`
 
 ### 2.1 Model
 
-Add one bool to `TemplateMessage` (defined in `renderer.py`):
+No new field. Widen the slot type instead:
 
 ```python
-class TemplateMessage:
-    # ... existing fields ...
-    self.is_ghosted: bool = False
+class RenderingContext:
+    messages: list[Optional[TemplateMessage]]  # was list[TemplateMessage]
 ```
 
-That's the entire model change. No new methods; no per-content-type
-flags. Setting `is_ghosted = True` opts the message out of the
-*visible* render path while keeping it in every internal index.
+Ghosting a message becomes `ctx.messages[idx] = None`. The slot
+stays, so every index around it (and every stored reference to
+that index from another message) keeps pointing at the same
+position. The dropped `TemplateMessage` itself is freed by GC —
+no memory bloat from keeping a "tombstone" object alive.
+
+`RenderingContext.get(idx)` already returns `None` when out of
+range; with the wider slot type it just naturally returns `None`
+for ghosted slots too. No signature change.
 
 ### 2.2 Semantics
 
-A ghosted message:
+A ghosted slot:
 
-- **Keeps** its `message_index` (so pair-refs, parent_message_index,
-  junction_forward_links, session_first_message all stay valid).
-- **Keeps** its `meta`, `render_session_id`, `content` (for any pass
-  that needs to inspect it, e.g. the `_pair_skill_tool_uses`
-  detection scan that runs over `ctx.messages` after ghosts exist).
-- **Skipped** by passes that compute *visible* structure:
-  `_build_message_hierarchy` (no ancestry contribution, children
-  grafted), `_identify_message_pairs` (cannot participate in pairs),
-  `_build_message_tree` (not emitted as a root), and the format
-  renderers' iteration (not rendered).
+- **Keeps the index intact** — pair-refs, parent_message_index,
+  junction_forward_links, session_first_message all stay valid
+  because the LIST LENGTH and the indices of OTHER messages don't
+  shift. Stored references to the ghost's own index now resolve
+  to `None`, which in practice never happens (see below).
+- **Is freed** — the original `TemplateMessage` object is
+  dereferenced and GC'd. No content/meta/render_session_id kept
+  around.
+- **Doesn't participate** in any pass that iterates
+  `ctx.messages`: hierarchy stack (no contribution → children
+  graft to the next non-None ancestor), pair-id (no entry in the
+  index dicts), tree-build (not emitted as a root, can't be
+  someone's parent), format renderers (skipped by iteration).
+
+**Stored references never target a None slot in practice.** The
+things the reindex pass remapped today all reference
+*session/branch headers* (`parent_message_index`,
+`session_first_message`, `junction_forward_links` targets) or
+*paired content messages* (`pair_first/last/middle`). The detect-
+and-ghost passes drop neither category: `_pair_skill_tool_uses`
+ghosts only the slash-body + the launching-skill tool_result;
+`_ghost_template_by_detail` ghosts content classes per the
+`detail_visibility` predicate, never session headers. So `ctx.get(
+stored_index)` never returns `None` for any reference set today —
+the wider slot type is a forward-compatibility convenience, not a
+new failure mode contributors need to handle.
 
 ### 2.3 Helper
 
 A single helper in `renderer.py`, used by every iterator:
 
 ```python
-def _visible(messages: Iterable[TemplateMessage]) -> Iterator[TemplateMessage]:
-    """Yield only non-ghost messages."""
-    return (m for m in messages if not m.is_ghosted)
+def _visible(
+    messages: Iterable[Optional[TemplateMessage]],
+) -> Iterator[TemplateMessage]:
+    """Yield only non-None messages (filter ghosts)."""
+    return (m for m in messages if m is not None)
 ```
 
 Most passes use `_visible(messages)` instead of `messages` directly.
-Where positional lookups are needed (`message_by_index`), the
-existing pattern keeps working — ghosts have `message_index` like
-anyone else, so the map still resolves; passes that don't WANT to
-resolve to a ghost check `if msg.is_ghosted` after the lookup.
+Where positional lookups happen (`message_by_index`), the build
+loop already does `if message.message_index is not None` per the
+existing code — folding a None check in costs nothing.
 
 ---
 
@@ -139,23 +163,23 @@ The pipeline order (from `generate_template_messages`):
 | Order | Pass | Today's behavior | Post-ghost behavior |
 |---|---|---|---|
 | 1 | `_render_messages` | builds `ctx.messages` | unchanged |
-| 2 | `_pair_skill_tool_uses` | deletes 1–2 msgs + reindexes | sets `is_ghosted = True`; no reindex |
-| 3 | `_link_junction_forwards` | reads ctx.messages + writes indices | unchanged — indices stable |
-| 4 | `_filter_template_by_detail` + reindex | deletes many + reindexes | rewritten as `_ghost_template_by_detail(ctx, detail)`; no reindex |
+| 2 | `_pair_skill_tool_uses` | deletes 1–2 msgs + reindexes | sets `ctx.messages[idx] = None`; no reindex |
+| 3 | `_link_junction_forwards` | reads ctx.messages + writes indices | unchanged — indices stable; skips None slots |
+| 4 | `_filter_template_by_detail` + reindex | deletes many + reindexes | rewritten as `_ghost_template_by_detail(ctx, detail)`; sets None slots; no reindex |
 | 5 | `prepare_session_navigation` | reads `ctx.session_first_message` | unchanged |
-| 6 | `_reorder_session_template_messages` | reorders by render_session_id | unchanged (ghosts ride along with their session) |
-| 7 | `_identify_message_pairs` | sequential pair scan | skips ghosts in adjacency walk AND in indexed pairing |
-| 8 | `_reorder_paired_messages` | moves pair_last adjacent | unchanged (ghosts not paired so they don't move) |
-| 9 | `_relocate_subagent_blocks` | moves blocks under anchors | unchanged (works on render_session_id / sessionId) |
-| 10 | `_build_message_hierarchy` | ancestry from level stack | **skip ghosts + graft children** |
-| 11 | `_mark_messages_with_children` | counts via ancestry | naturally correct (ancestry already grafted past ghosts) |
-| 12 | `_build_message_tree` | tree by ancestry | skip ghosts from root_messages; children list already excludes them |
+| 6 | `_reorder_session_template_messages` | reorders by render_session_id | skips None slots; otherwise unchanged |
+| 7 | `_identify_message_pairs` | sequential pair scan | iterates `_visible(messages)` in BOTH the index dict build AND the adjacency walk |
+| 8 | `_reorder_paired_messages` | moves pair_last adjacent | unchanged (None slots not paired so they don't move) |
+| 9 | `_relocate_subagent_blocks` | moves blocks under anchors | skips None slots; otherwise unchanged |
+| 10 | `_build_message_hierarchy` | ancestry from level stack | **skip None + graft children** (None never pushed onto stack) |
+| 11 | `_mark_messages_with_children` | counts via ancestry | naturally correct (ancestry already grafted past Nones) |
+| 12 | `_build_message_tree` | tree by ancestry | skip None from root_messages; children list already excludes them |
 | 13 | `_cleanup_sidechain_duplicates` | mutates parent.children | unchanged (already operates on the post-ghost tree) |
 | 14 | Format renderers | iterate root_messages → children | naturally exclude ghosts (they're absent from the tree) |
 
 The detailed changes per pass:
 
-### 3.1 `_pair_skill_tool_uses` — set ghosts instead of deleting
+### 3.1 `_pair_skill_tool_uses` — None-out the consumed slots
 
 Today's tail (line ~3360):
 
@@ -171,13 +195,13 @@ After:
 ```python
 consumed_indices.add(other.message_index)
 # ...
-for msg in ctx.messages:
-    if msg.message_index in consumed_indices:
-        msg.is_ghosted = True
+for idx in consumed_indices:
+    ctx.messages[idx] = None
 # No reindex.
 ```
 
-Same selection logic; the only change is the action.
+Same selection logic, smaller action. The dropped TemplateMessages
+are freed by GC immediately.
 
 ### 3.2 `_ghost_template_by_detail(ctx, detail)` — replaces filter + reindex
 
@@ -196,25 +220,32 @@ if detail != DetailLevel.FULL:
     _ghost_template_by_detail(ctx, detail)  # mutates in place
 ```
 
-Where `_ghost_template_by_detail` is `_filter_template_by_detail`
-with the result-list collection replaced by `msg.is_ghosted = True`.
-Same visibility predicate, same `_LOW_KEEP_TOOLS` opt-out, same
-sidechain rule — only the side-effect changes.
+Where `_ghost_template_by_detail` walks `ctx.messages`, runs the
+existing visibility predicate (same `_content_visible_at`, same
+`_LOW_KEEP_TOOLS` opt-out, same sidechain rule) and assigns
+`ctx.messages[i] = None` for each non-visible slot. The selection
+logic is byte-identical to today's `_filter_template_by_detail`;
+the only change is the side-effect (None-out the slot rather than
+omit the entry from a kept list).
 
-### 3.3 `_identify_message_pairs` — skip ghosts in BOTH passes
+### 3.3 `_identify_message_pairs` — skip Nones in BOTH passes
 
 Two places:
 
-1. **`_build_pairing_indices`** (the dict-building first pass): ghost
-   messages must NOT be added to the indices. Otherwise an index-based
-   pairing could attach a real tool_result to a ghost tool_use.
+1. **`_build_pairing_indices`** (the dict-building first pass): None
+   slots must NOT be added to the indices. Otherwise an index-based
+   pairing could attach a real tool_result to a ghosted tool_use.
+   Easy: iterate `_visible(messages)`.
 
 2. **Sequential scan**: when looking at `messages[i]`,
-   `messages[i+1]`, `messages[i+2]` for adjacency, ghosts must be
-   skipped. Easiest implementation: iterate `_visible(messages)` and
-   keep i/i+1/i+2 as positions in the visible subsequence.
+   `messages[i+1]`, `messages[i+2]` for adjacency, None slots must
+   be skipped. Easiest implementation: collapse the input via
+   `list(_visible(messages))` and walk the visible subsequence (the
+   sequential scan can't be replaced by index lookups — see the
+   adjacency-only pair types: thinking+assistant, bash-input+output,
+   system+output, and the UserSlash→Slash→CommandOutput triple).
 
-Edge case: a ghost ToolUseMessage with a corresponding non-ghost
+Edge case: a ghosted ToolUseMessage with a corresponding non-ghost
 ToolResultMessage — the result should NOT be paired (no visible
 "use" to pair against), so it just renders as an orphan tool_result.
 This is acceptable and matches today's behavior (when the filter
@@ -222,7 +253,7 @@ drops the tool_use, the result also drops in most detail levels;
 where it doesn't, an orphan tool_result is the correct visible
 shape).
 
-### 3.4 `_build_message_hierarchy` — skip ghosts + graft children
+### 3.4 `_build_message_hierarchy` — skip Nones + graft children
 
 The critical pass. Today (line 2148):
 
@@ -242,13 +273,11 @@ After:
 
 ```python
 for message in messages:
-    if message.is_ghosted:
-        # Don't push ghost onto stack: its real children, when they
-        # arrive, will compute ancestry against the SURVIVING stack
-        # (the ghost's would-be ancestor), naturally grafting up.
-        message.ancestry = []  # ghosts have no ancestry of their own
-        continue
-
+    if message is None:
+        continue  # ghosted slot — don't push onto stack; real
+                  # children will compute ancestry against the
+                  # SURVIVING stack (the ghost's would-be ancestor),
+                  # naturally grafting up.
     current_level = ...
     while hierarchy_stack and hierarchy_stack[-1][0] >= current_level:
         hierarchy_stack.pop()
@@ -258,23 +287,20 @@ for message in messages:
     message.ancestry = ancestry
 ```
 
-That's the entire children-grafting mechanism: a ghost never
-contributes to the stack, so its children "see through" it to the
-next non-ghost ancestor. No explicit graft step needed.
+That's the entire children-grafting mechanism: a None slot never
+contributes to the stack, so its real children "see through" it to
+the next surviving ancestor. No explicit graft step needed.
 
-### 3.5 `_mark_messages_with_children` — works for free
+### 3.5 `_mark_messages_with_children` — skip Nones
 
-Reads ancestry indices, increments counts on ancestors. Since
-ancestry now skips ghosts (per 3.4), ghosts naturally don't appear
-in any non-ghost message's ancestry — so they're not incremented
-*as* parents, and they're not counted *as* children either (per
-3.4, ghosts have `ancestry = []` so the `if not message.ancestry`
-guard skips them at iteration time).
+Reads ancestry indices, increments counts on ancestors. Per 3.4 a
+ghosted slot is None, so its `message_index → message` mapping
+isn't built in the first place; ancestor lookups (`if immediate_
+parent_index in message_by_index`) naturally don't resolve through
+ghosts. Adding `if message is None: continue` at the top of each
+loop is purely a defensive readability improvement.
 
-Optional small change: skip ghosts at the top of the loop for
-clarity / a microperf win, but functionally unnecessary.
-
-### 3.6 `_build_message_tree` — exclude ghosts from roots
+### 3.6 `_build_message_tree` — exclude Nones from roots
 
 Today (line 2255):
 
@@ -296,30 +322,27 @@ After:
 
 ```python
 for message in messages:
-    if message.is_ghosted:
-        message.children = []
-        continue  # don't add to roots, don't add as child
+    if message is None:
+        continue  # skip ghost slots — no children to clear
     message.children = []
 for message in messages:
-    if message.is_ghosted:
-        continue
+    if message is None:
+        continue  # not a root, not a child of anyone
     if not message.ancestry:
         root_messages.append(message)
     else:
         immediate_parent_index = message.ancestry[-1]
         if immediate_parent_index in message_by_index:
             parent = message_by_index[immediate_parent_index]
-            # parent might be a ghost (its message_index resolved in
-            # the map) — but per 3.4 a ghost has ancestry=[] so any
-            # non-ghost child's ancestry skips it. Defensive guard:
-            if not parent.is_ghosted:
-                parent.children.append(message)
+            parent.children.append(message)
 ```
 
-The defensive guard inside `else` is belt-and-braces — by 3.4's
-invariant a non-ghost message's ancestry never names a ghost. But
-the guard means the tree-build is correct even if some future code
-path violates the invariant.
+Per 3.4's invariant (a non-None message's ancestry never names a
+ghost), the parent lookup always resolves to a non-None message —
+no defensive `if parent is not None` guard needed beyond the
+existing `if immediate_parent_index in message_by_index` check
+(which already short-circuits because Nones aren't in the index
+map).
 
 ### 3.7 Format renderers (HTML + Markdown) — no change
 
@@ -414,7 +437,7 @@ content-item-stripping responsibilities that today live in
 Each strip rule is naturally expressible on the post-render
 TemplateMessage: ToolUseMessage / ToolResultMessage / ThinkingMessage
 already have their own classes; the strip becomes
-`msg.is_ghosted = True` for the class. (Effectively: the per-class
+`ctx.messages[i] = None` for the slot. (Effectively: the per-class
 `detail_visibility` declarations already encode these rules — see
 [plugins.md §6](../dev-docs/plugins.md) — so the pre-render strip
 collapses into the post-render visibility predicate.)
@@ -445,13 +468,19 @@ phases, each a separate PR, each independently merge-able:
 
 ### Phase 1 — `wf/ghosting/skill-fold` (small, safe)
 
-- Add `TemplateMessage.is_ghosted = False`.
-- Migrate `_pair_skill_tool_uses` to set `is_ghosted` instead of
-  deleting + reindexing.
-- Implement steps 3.4 (hierarchy graft) and 3.6 (tree skip ghosts)
+- Widen `RenderingContext.messages` slot type to
+  `list[Optional[TemplateMessage]]`. No new field on
+  `TemplateMessage`.
+- Add the `_visible()` helper.
+- Migrate `_pair_skill_tool_uses` to None-out consumed slots
+  instead of deleting + reindexing.
+- Implement steps 3.4 (hierarchy graft) and 3.6 (tree skip Nones)
   — both are needed for the Skill ghost to render correctly.
-- Implement step 3.3 (pair-id skip ghosts) — defensive; the Skill
+- Implement step 3.3 (pair-id skip Nones) — defensive; the Skill
   ghosts aren't paired but the next phase needs this.
+- Walk every `ctx.messages` reader in `renderer.py` (and html/,
+  markdown/, json/) and ensure each handles a `None` slot. Most
+  iterators just need `_visible(...)` or an `if m is None: continue`.
 - Leave `_filter_template_by_detail` and its reindex call
   unchanged.
 - Leave `_reindex_filtered_context` in place (still called by the
@@ -463,12 +492,15 @@ phases, each a separate PR, each independently merge-able:
   prerequisite even before the detail-filter migration.
 
 Estimate: ~150 lines net change. Lowest risk; lays the
-infrastructure.
+infrastructure. (The widened slot type changes the type annotation
+in one place and surfaces `None`-handling additions across every
+iterator — Pyright will surface any reader I missed.)
 
 ### Phase 2 — `wf/ghosting/detail-filter` (medium)
 
 - Migrate `_filter_template_by_detail` + reindex to
-  `_ghost_template_by_detail` (set `is_ghosted` instead of deleting).
+  `_ghost_template_by_detail` (None-out non-visible slots instead
+  of deleting).
 - Delete `_reindex_filtered_context` (no more callers).
 - Re-run per-detail-level snapshot suite. EXPECTED:
   byte-identical (ghosting produces the same visible output as
@@ -568,22 +600,16 @@ behavior, not just passes vacuously.
 ### 7.1 Hidden index reader
 
 Some pass we haven't catalogued might read `len(ctx.messages)` or
-iterate `ctx.messages` and assume no ghosts. Mitigation:
-`_visible(...)` helper in the renderer + targeted code-review of
-the full `renderer.py` (find every `ctx.messages` reference) before
-Phase 1 lands.
+iterate `ctx.messages` and assume no `None` slots. Mitigations:
+the `_visible(...)` helper in the renderer covers the common case,
+and widening the slot type to `list[Optional[TemplateMessage]]`
+makes Pyright surface every reader that dereferences a slot
+without a `None` check (it'll flag `msg.content` / `msg.meta` etc.
+on the un-narrowed type). The Phase-1 walk-through of every
+`ctx.messages` reader in `renderer.py` + `html/` + `markdown/` +
+`json/` closes the rest.
 
-### 7.2 Memory bloat
-
-Ghosts stay in memory. The pre-render filter at MINIMAL drops the
-most messages (no tools, no thinking, no sidechain), often the
-majority of a long transcript. Keeping them in `ctx.messages` could
-~triple peak memory at MINIMAL for huge transcripts. Mitigation:
-acceptable for the dominant use case (transcripts in the
-single-MB-to-tens-of-MB range); revisit if a profiling pass shows
-real-world peak going past 1 GB.
-
-### 7.3 Markdown chunk-boundary subtlety (Phase 3 only)
+### 7.2 Markdown chunk-boundary subtlety (Phase 3 only)
 
 When a single transcript entry's content items are split into
 multiple TemplateMessages, pre-render filtering keeps factory
@@ -594,12 +620,16 @@ anchors may move. If a snapshot's `d-{N}` references shift, the
 HTML is "different bytes, same logical content" — needs careful
 review per snapshot.
 
-### 7.4 Plugin contract
+### 7.3 Plugin contract
 
-Third-party `MessageContent` subclasses interact with ghosting only
-via `is_ghosted` (or not at all, since they don't set it). Their
-`visible_at` predicate continues to drive whether they get ghosted,
-identical to today. No plugin-contract change.
+Third-party `MessageContent` subclasses interact with the slot
+state only indirectly — their `visible_at` predicate continues to
+drive whether they get ghosted (via the post-render
+`_ghost_template_by_detail` pass), identical to today. The slot
+itself is `Optional[TemplateMessage]` from the renderer's
+perspective; plugin classes never see a `None` because the iterator
+they reach (the format renderer's recursion over the tree) is
+already post-filter. No plugin-contract change.
 
 ---
 

--- a/work/ghosting-epic-plan.md
+++ b/work/ghosting-epic-plan.md
@@ -198,10 +198,25 @@ consumed_indices.add(other.message_index)
 for idx in consumed_indices:
     ctx.messages[idx] = None
 # No reindex.
+_drop_anchor_refs_into_ghosts(ctx)
 ```
 
 Same selection logic, smaller action. The dropped TemplateMessages
 are freed by GC immediately.
+
+`_drop_anchor_refs_into_ghosts(ctx)` is the anchor-repair tail: a
+branch header's `parent_message_index` and the `session_first_message`
+map are cached in `_render_messages` — *before* this pass — so a fork
+point landing on a consumed slot leaves a cached index pointing at a
+ghost. The rendered `#msg-d-{N}` backlink is emitted from that raw
+index (`ctx.get()` returning None does not suppress it), so the ref
+itself is nulled: the anchor is omitted rather than dangling.
+`junction_forward_links` are populated *after* this pass
+(`_link_junction_forwards`), so they are out of scope here.
+`prepare_session_navigation` independently resolves the fork anchor by
+scanning `_visible(ctx.messages)` for `attachment_uuid`; it must leave
+`fork_msg_idx = None` when the fork point was ghosted rather than
+falling back to the parent session header.
 
 ### 3.2 `_ghost_template_by_detail(ctx, detail)` — replaces filter + reindex
 
@@ -474,6 +489,12 @@ phases, each a separate PR, each independently merge-able:
 - Add the `_visible()` helper.
 - Migrate `_pair_skill_tool_uses` to None-out consumed slots
   instead of deleting + reindexing.
+- Add `_drop_anchor_refs_into_ghosts` (called from the tail of
+  `_pair_skill_tool_uses`) so a fork point landing on a consumed slot
+  doesn't leave a dangling `#msg-d-{N}` backlink: null the cached
+  `parent_message_index` / `session_first_message` refs that resolve
+  to a ghost, and leave the `prepare_session_navigation` fork anchor
+  unset rather than retargeting it at the parent session header.
 - Implement steps 3.4 (hierarchy graft) and 3.6 (tree skip Nones)
   — both are needed for the Skill ghost to render correctly.
 - Implement step 3.3 (pair-id skip Nones) — defensive; the Skill

--- a/work/ghosting-epic-plan.md
+++ b/work/ghosting-epic-plan.md
@@ -124,18 +124,25 @@ A ghosted slot:
   index dicts), tree-build (not emitted as a root, can't be
   someone's parent), format renderers (skipped by iteration).
 
-**Stored references never target a None slot in practice.** The
-things the reindex pass remapped today all reference
-*session/branch headers* (`parent_message_index`,
+**Stored references can target a None slot, and the ghosting
+passes repair them.** The things the reindex pass remapped today
+reference *session/branch headers* (`parent_message_index`,
 `session_first_message`, `junction_forward_links` targets) or
-*paired content messages* (`pair_first/last/middle`). The detect-
-and-ghost passes drop neither category: `_pair_skill_tool_uses`
-ghosts only the slash-body + the launching-skill tool_result;
-`_ghost_template_by_detail` ghosts content classes per the
-`detail_visibility` predicate, never session headers. So `ctx.get(
-stored_index)` never returns `None` for any reference set today —
-the wider slot type is a forward-compatibility convenience, not a
-new failure mode contributors need to handle.
+*paired content messages* (`pair_first/last/middle`). Session
+headers are never ghosted, but a *fork point* can coincide with a
+slot a detect-and-ghost pass removes — e.g. a within-session fork
+attached to a slash-body or launching-skill tool_result that
+`_pair_skill_tool_uses` ghosts, or (Phase 2) a fork-point assistant
+that `_ghost_template_by_detail` ghosts at low detail. When that
+happens, a cached `parent_message_index` / `session_first_message`
+entry resolves through `ctx.get(...)` to `None`, and the rendered
+`#msg-d-{N}` backlink (emitted from the raw index) would dangle.
+Each ghosting pass therefore repairs its own cached refs:
+`_pair_skill_tool_uses` calls `_drop_anchor_refs_into_ghosts`
+(and `prepare_session_navigation` leaves the fork anchor unset for
+a ghosted target rather than retargeting it); Phase 2 adds
+`_repair_stale_anchor_refs`. `junction_forward_links` are populated
+*after* the skill-fold pass, so they need no repair there.
 
 ### 2.3 Helper
 
@@ -382,10 +389,17 @@ Reads `ctx.junction_targets` (from session_hierarchy) and
 reference branch headers by message_index. All indices are stable
 under ghosting. No change.
 
-### 3.9 `prepare_session_navigation` — unchanged
+### 3.9 `prepare_session_navigation` — ghost-aware fork anchor
 
-Reads `ctx.session_first_message` and emits the nav. All indices
-stable. No change.
+Reads `ctx.session_first_message` and emits the nav. Indices stay
+stable, but the fork-point nav item resolves its anchor by scanning
+`_visible(ctx.messages)` for the junction `attachment_uuid`. When the
+fork point was ghosted (e.g. a folded Skill slot), that scan can't
+find it, so `fork_msg_idx` stays `None` and the anchor is *omitted*
+rather than falling back to `session_first_message[parent_sid]` (which
+would point the fork link at the parent session header and undo
+`_drop_anchor_refs_into_ghosts`). The template guards the fork link
+against a `None` index. Mirrors the ghost-aware repair contract.
 
 ### 3.10 `_reorder_session_template_messages` — unchanged
 


### PR DESCRIPTION
## Summary

First phase of the ghosting epic — a structural refactor that lets the renderer drop messages from the visible output **without** invalidating the index references that other passes rely on. See `work/ghosting-epic-plan.md` (included as part of this PR's commits) for the full design.

`RenderingContext.messages` is reshaped to allow `None` slots ("ghosts"). When a pass drops a message from the visible render path, it sets the slot to `None` instead of splicing it out of the list — every index around the dropped slot stays valid, so every stored index reference (`parent_message_index`, `session_first_message`, `junction_forward_links`, `pair_first/last/middle`) keeps working without a reindex.

This PR migrates the easier of the two `_reindex_filtered_context` callers (`_pair_skill_tool_uses`) to use the new mechanism. The detail-filter caller is Phase 2, after which `_reindex_filtered_context` can be deleted.

## Behavior

End-to-end output is byte-identical with main on every existing fixture (1924 passed, 7 skipped; HTML + Markdown snapshot suites 15 passed, zero `.ambr` churn). The migration is purely structural — same selection logic, same downstream rendering; the only difference is that consumed Skill-fold slots are `None`d in place instead of being spliced out + the message list reindexed.

> Caveat raised in review: existing snapshot fixtures don't exercise the Skill-fold path, so the byte-identity claim is narrow — see "Forward-looking note on snapshot coverage" below.

## What changed

- **`RenderingContext.messages: list[Optional[TemplateMessage]]`** — the slot type is the entire model change. No new field on `TemplateMessage`. Slots can be `None` to preserve indices around dropped messages.
- **`_visible(messages)`** — new iterator helper that yields non-`None` messages. Used by every reader of `ctx.messages` that shouldn't touch a ghost.
- **`_pair_skill_tool_uses`** — rewritten to set `ctx.messages[idx] = None` for each consumed slot instead of building a kept-list and calling `_reindex_filtered_context`. GC frees the dropped TemplateMessages immediately.
- **`_filter_template_by_detail`** and **`_reorder_session_template_messages`** widened to accept `Optional[...]` input and skip `None` slots; both return `list[TemplateMessage]` (the boundary points where ghosts are filtered out of the stream).
- **All ~16 direct `ctx.messages` iterators in `renderer.py`** switched to `_visible(...)` — trailing-link passes, task-metadata population, junction-forward linking, the in-loop scans inside `_build_branch_header`, etc.
- **`_reindex_filtered_context`** and its detail-filter call-site are **unchanged** for Phase 1 — Phase 2 deletes both.

## Plan divergence vs. `work/ghosting-epic-plan.md`

The original plan (§3.4–§3.6) proposed defensive ghost-skips in `_build_message_hierarchy`, `_build_message_tree`, and `_identify_message_pairs`. In implementation, `_reorder_session_template_messages` turned out to be the natural filtering boundary — its return type `list[TemplateMessage]` flows into all downstream passes, so they don't need ghost-awareness at all. **One filtering boundary, not seven defensive checks.** Pyright's narrow return type prevents Nones from ever reaching the downstream signatures, enforcing the invariant statically.

The plan's §3.4–§3.6 still document what *would* be needed if Nones flowed through every pass; the implementation uses the boundary approach. Recording the divergence here; plan update can fold in alongside Phase 2.

## New test (D12-prerequisite)

`test/test_skill_pairing.py::TestSkillFoldOnFork::test_skill_fold_inside_fork_at_full_keeps_branch_backref`

Exercises the PR #131 regression class through the ghosting path: a within-session fork whose Branch 1 contains a full Skill spawn (assistant Skill `tool_use` + user "Launching skill" `tool_result` + isMeta `sourceToolUseID` body). At FULL detail, asserts:

1. The Skill body is folded onto the `tool_use` (`skill_body` field set).
2. Exactly two `ctx.messages` slots are `None` — the consumed slash body + launching-skill `tool_result`. This is the new ghosting contract; pre-Phase-1 the consumed slots were deleted + reindexed (zero `None` slots), so the test fails on the pre-Phase-1 tip.
3. The Skill-bearing branch header resolves `parent_message_index` via `ctx.get(...)` to the actual fork anchor (uuid `c`), NOT to a phantom slot. This is the failure mode PR #131 introduced under the old reindex path; the verifier flagged it as missing coverage for D12, so landing it in Phase 1 means D12 (Phase 2 in the epic plan) inherits coverage when it lands.

Fixture quirk worth noting: two assistant siblings off the fork anchor (rather than the usual mixed user+assistant pattern) to bypass the DAG's `_stitch_tool_results` heuristic, which absorbs the common pattern as a tool-result side-branch. Inline comment in the fixture documents this.

## test_skill_pairing.py adaptation

The 16 existing tests in `TestSkillPairing` and adjacent classes iterate `ctx.messages` directly and assumed each element was a `TemplateMessage`. Patched their comprehensions / loops to filter `m is not None` first — same assertion intent, now ghost-aware. The pre-existing `TestReindexBranchBackrefs` class still exercises `_reindex_filtered_context` directly (Phase 2 will delete that test class along with the function it pins).

## Forward-looking notes from the monk review (non-blocking — flagged for Phase 2)

Both items raised during review; neither blocks Phase 1, both belong in the Phase 2 design.

### Anchor-target guard for Phase 2

Old `_reindex_filtered_context` *nulled* any reference pointing AT a consumed slot (`parent_message_index → None`, junction tuple dropped, `session_first_message` dropped). Ghosting instead leaves those references holding the ghosted index (a non-`None` int) and relies on `ctx.get()` returning `None`. Equivalent ONLY because, in Phase 1, every anchor index is derived via `_visible` or points at session-first messages — structurally never a skill-fold target. So nothing currently produces a ghosted anchor target.

The latent edge: `system_formatters.py:247-280` emits a raw `#msg-d-{parent_message_index}` anchor guarded only by `is not None` on the stored int — no `ctx.get()` existence check. If a later ghosting phase ever ghosts a slot that IS an anchor target, this silently becomes a dead anchor (where the old reindex would have suppressed the backlink). When Phase 2 deletes `_reindex_filtered_context`, either (a) assert `consumed_indices ∩ anchor-targets == ∅`, or (b) route the raw-anchor consumers through `ctx.get()` before emitting.

### Snapshot coverage gap for skill-fold paths

`message_id = f"d-{message_index}"` and `_build_message_hierarchy` does NOT renumber. Old code compacted `message_index` via reindex; ghosting keeps them sparse. A transcript that DOES contain a skill-fold now renders different (sparse, gapped) `d-{N}` anchor values + ancestry CSS classes than before this PR.

Functionally fine — `id` and `href` both use the same `message_index`, so internal nav stays self-consistent — but it means the 15 byte-identical snapshots confirm only that the *unchanged* paths are unchanged; none of them exercise a skill-fold, so the changed render path isn't snapshot-covered. The D12 test covers the data layer (None slots + backref via `ctx.get`) but not the rendered HTML. Cheap follow-up (Phase 2 or now): one snapshot fixture rendering a skill-fold transcript, to lock the anchor-consistency invariant (every `#msg-d-N` href has a matching `id`).

## Test plan

- [x] `just test` — 1924 passed, 7 skipped (1923 prior + 1 new D12-prerequisite test).
- [x] `just ci` — clean (ruff, pyright, ty).
- [x] HTML + Markdown snapshot suites — 15 passed, byte-identical (zero `.ambr` churn). See caveat above re. skill-fold coverage gap.
- [x] Targeted: `test_skill_pairing.py` — 17 passed (16 patched + 1 new).

Net: `claude_code_log/renderer.py` +134/-58 (helper + model widening + skill-fold migration + reader audits); `test/test_skill_pairing.py` +219/-21 (None-aware patches + new D12-prerequisite test class).

The two planning-doc commits (`work/ghosting-epic-plan.md`) are included so reviewers see the full design alongside the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve message positions with ghost placeholder slots so hidden entries no longer break indexes, anchors, previews, or backreferences.
  * Skill/tool folding now ghosts consumed messages in place and clears dangling anchor/parent references to avoid broken links or anchors.
  * Rendering and navigation now skip ghosted slots throughout preview, linking, and post-render flows; UI renders non-clickable labels for ghosted items.

* **Tests**
  * Added regression tests covering skill-folding, ghosting behavior, anchor repair, and forked-session navigation.

* **Documentation**
  * Added an epic rollout and test plan for the ghosting approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->