### PR TITLE
Add `--version` flag to the CLI

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -521,6 +521,7 @@ def _validate_git_link_template(template: str) -> None:
 
 
 @click.command()
+@click.version_option(version=get_library_version(), prog_name="claude-code-log")
 @click.argument("input_path", type=click.Path(path_type=Path), required=False)
 @click.option(
     "-o",


### PR DESCRIPTION
Supporting `--version` is pretty generally expected, and also would make it easier for my goal of putting this tool into Nixpkgs, since then I'd be able to use `versionCheckHook`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` flag to the CLI, allowing users to query the tool's version from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->