### PR TITLE
Relax Textual constraint from `==` to `>=`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "mistune>=3.1.4",
     "toml>=0.10.2",
-    "textual==6.5.0",
+    "textual>=6.5.0",
     "packaging>=25.0",
     "gitpython>=3.1.45",
     "pygments>=2.19.2",

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pygments", specifier = ">=2.19.2" },
-    { name = "textual", specifier = "==6.5.0" },
+    { name = "textual", specifier = ">=6.5.0" },
     { name = "toml", specifier = ">=0.10.2" },
 ]
 


### PR DESCRIPTION
It's unclear why #40 changed this from `>=` to `==` in the first place, rather than just updating the version in `uv.lock`.

As far as I can tell, the only [breaking changes since Textual 6.5.0](https://github.com/Textualize/textual/blob/v8.2.7/CHANGELOG.md#800---2026-02-16) were the following two, neither of which affect this tool:

> ## [8.0.0](https://github.com/Textualize/textual/compare/v7.5.0...v8.0.0) - 2026-02-16

> ### Changed

> - It is no longer a NOOP and warning to dismiss a non-active screen. The dismiss will still work, but the screen may not update if the current mode is not active. https://github.com/Textualize/textual/pull/6362

> - Breaking change: Changed `Select.BLANK` to `Select.NULL` to avoid clash with newer `Widget.BLANK` Classvar https://github.com/Textualize/textual/pull/6374

Relaxing this constraint will make it easier to package this tool in Nixpkgs, since without it, `pythonRelaxDeps = [ "textual" ]` is required because [the Textual version in Nixpkgs is currently 8.2.7](https://github.com/NixOS/nixpkgs/blob/3caf5331bedfa6ec900320521224003c49e0fe7d/pkgs/development/python-modules/textual/default.nix#L40).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraint to allow newer compatible versions of a core library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->