### PR TITLE
Exclude docs/ from ty type-checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,14 @@ markers = [
 # Use custom stubs for untyped libraries
 extra-paths = ["stubs"]
 
+[tool.ty.src]
+# docs/gen_pages.py is a build-time mkdocs-gen-files script: it imports
+# `mkdocs_gen_files` (a docs-only dependency) and the standalone helpers in
+# scripts/ via sys.path manipulation, neither of which ty can resolve in the
+# default environment. It is not part of the type-checked source (pyright only
+# `include`s claude_code_log), so exclude it here to match that intent.
+exclude = ["docs"]
+
 [tool.pyright]
 # Pyright configuration with strict settings
 include = ["claude_code_log"]           # TODO: , "test"


### PR DESCRIPTION
## Problem

The local `just ci` `uv run ty check` step fails with four
`unresolved-import` errors in `docs/gen_pages.py`:

```
error[unresolved-import]: Cannot resolve imported module `mkdocs_gen_files`
error[unresolved-import]: Cannot resolve imported module `generate_tui_docs`
error[unresolved-import]: Cannot resolve imported module `generate_tui_screenshots`
error[unresolved-import]: Cannot resolve imported module `generate_example_output`
```

`docs/gen_pages.py` is a build-time `mkdocs-gen-files` script: it imports
`mkdocs_gen_files` (a docs-only dependency) and the standalone `scripts/`
helpers via `sys.path` manipulation. ty cannot resolve these in the
default environment.

This only breaks the **local** `just ci` ty step — GitHub CI uses pyright,
which passes because it `include`s `claude_code_log` exclusively and never
looks at `docs/`. The pre-existing `[tool.hatch.build]` `exclude` covers
`/docs` only for packaging, not for ty.

## Fix

Add a `[tool.ty.src]` section excluding `docs/`, mirroring the intent of
the pyright `include` scope. Minimal, config-only change.

After this, `uv run ty check` exits 0 (only pre-existing warnings remain),
and the full `just ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project configuration so documentation-generation code is excluded from automated type checking, preventing build-time docs tooling from being treated as application source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->