### PR TITLE
Render Workflow tool-input (JS) + async-result JSON bodies (#174 PR2)

### DIFF
--- a/claude_code_log/factories/tool_factory.py
+++ b/claude_code_log/factories/tool_factory.py
@@ -38,6 +38,7 @@ from ..models import (
     TaskListInput,
     TaskOutputInput,
     TaskStopInput,
+    WorkflowToolInput,
     TaskUpdateInput,
     TeamCreateInput,
     TeamDeleteInput,
@@ -134,6 +135,8 @@ TOOL_INPUT_MODELS: dict[str, type[BaseModel]] = {
     # TaskStop kills a background task. Same ``task_id`` shape /
     # id space as TaskOutput (PR #158 follow-up).
     "TaskStop": TaskStopInput,
+    # Dynamic Workflow orchestrator (issue #174): input.script is JS.
+    "Workflow": WorkflowToolInput,
 }
 
 

--- a/claude_code_log/html/async_formatter.py
+++ b/claude_code_log/html/async_formatter.py
@@ -22,7 +22,7 @@ from ..models import (
     TaskOutputInput,
     TaskOutputResult,
 )
-from .utils import escape_html, render_markdown_collapsible
+from .utils import escape_html, render_async_result_body
 
 
 def _row(label: str, value_html: str) -> str:
@@ -170,6 +170,6 @@ def format_task_notification_content(content: TaskNotificationMessage) -> str:
         )
     if content.result_text and not content.result_is_duplicate:
         parts.append(
-            render_markdown_collapsible(content.result_text, "task-notification-result")
+            render_async_result_body(content.result_text, "task-notification-result")
         )
     return "".join(parts)

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -57,6 +57,7 @@ from ..models import (
     SkillInput,
     WebSearchInput,
     WebFetchInput,
+    WorkflowToolInput,
     MonitorInput,
     MonitorOutput,
     ScheduleWakeupInput,
@@ -168,6 +169,7 @@ from .tool_formatters import (
     format_websearch_input,
     format_websearch_output,
     format_webfetch_input,
+    format_workflow_input,
     format_webfetch_output,
     format_monitor_input,
     format_monitor_output,
@@ -810,6 +812,12 @@ class HtmlRenderer(Renderer):
     def format_WebFetchInput(self, input: WebFetchInput, _: TemplateMessage) -> str:
         """Format → prompt text if long, empty if shown in title."""
         return format_webfetch_input(input)
+
+    def format_WorkflowToolInput(
+        self, input: WorkflowToolInput, _: TemplateMessage
+    ) -> str:
+        """Format → meta header (name/description/phases) + highlighted JS script."""
+        return format_workflow_input(input)
 
     def format_WebFetchOutput(self, output: WebFetchOutput, _: TemplateMessage) -> str:
         """Format → collapsible markdown with metadata badge."""

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -1304,3 +1304,43 @@ details summary {
         margin-right: 2%;
     }
 }
+
+/* Workflow tool-input (issue #174) — meta header above the highlighted JS
+   orchestrator. The script body reuses the standard Pygments code styling
+   via render_file_content_collapsible. */
+.workflow-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px 10px;
+    margin-bottom: 8px;
+}
+
+.workflow-name {
+    font-weight: 600;
+    color: var(--tool-use-color);
+}
+
+.workflow-description {
+    color: var(--text-muted);
+    font-size: 0.9em;
+}
+
+.workflow-phases {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.workflow-phase-pill {
+    font-size: 0.78em;
+    padding: 1px 8px;
+    border-radius: 10px;
+    background-color: var(--highlight-dimmed);
+    border: 1px solid #00000011;
+    color: var(--text-secondary);
+}
+
+.workflow-script {
+    margin-top: 4px;
+}

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -23,6 +23,7 @@ from typing import Any, Optional, cast
 from .utils import (
     escape_html,
     render_collapsible_code,
+    render_async_result_body,
     render_file_content_collapsible,
     render_markdown_collapsible,
     render_markdown_inline,
@@ -63,6 +64,7 @@ from ..models import (
     WebSearchOutput,
     WebFetchInput,
     WebFetchOutput,
+    WorkflowToolInput,
     WriteInput,
     WriteOutput,
 )
@@ -533,7 +535,7 @@ def format_task_output(output: TaskOutput) -> str:
             "</div>"
         )
         parts.append(
-            render_markdown_collapsible(output.async_final_answer, "task-async-answer")
+            render_async_result_body(output.async_final_answer, "task-async-answer")
         )
     return "".join(parts)
 
@@ -1159,6 +1161,76 @@ def format_tool_result_content_raw(tool_result: ToolResultContent) -> str:
     """
 
 
+# -- Workflow tool input (issue #174) -----------------------------------------
+
+_WF_META_RE = re.compile(r"meta\s*=\s*\{(.*?)\n\}", re.DOTALL)
+_WF_NAME_RE = re.compile(r"\bname\s*:\s*['\"]([^'\"]*)['\"]")
+_WF_DESC_RE = re.compile(r"\bdescription\s*:\s*['\"]([^'\"]*)['\"]")
+_WF_PHASES_RE = re.compile(r"phases\s*:\s*\[(.*?)\]", re.DOTALL)
+_WF_TITLE_RE = re.compile(r"title\s*:\s*['\"]([^'\"]+)['\"]")
+
+
+def _parse_workflow_meta(script: str) -> tuple[str, str, list[str]]:
+    """Best-effort extraction of ``(name, description, phase_titles)`` from a
+    Workflow script's ``export const meta = {...}`` block.
+
+    Returns empty values when the block (or a field) isn't found — this is
+    purely a display aid, scoped to the meta block so it can't pick up
+    ``name:``/``title:`` occurrences elsewhere in the orchestrator body.
+    """
+    block_m = _WF_META_RE.search(script)
+    if not block_m:
+        return "", "", []
+    block = block_m.group(1)
+    name_m = _WF_NAME_RE.search(block)
+    desc_m = _WF_DESC_RE.search(block)
+    phases_m = _WF_PHASES_RE.search(block)
+    phases = _WF_TITLE_RE.findall(phases_m.group(1)) if phases_m else []
+    return (
+        name_m.group(1) if name_m else "",
+        desc_m.group(1) if desc_m else "",
+        phases,
+    )
+
+
+def format_workflow_input(workflow_input: WorkflowToolInput) -> str:
+    """Format a ``Workflow`` tool_use (issue #174): a header from the script's
+    ``meta`` block (name / description / phase pills) above the JavaScript
+    orchestrator source, syntax-highlighted and collapsible when long."""
+    script = workflow_input.script or ""
+    name, description, phases = _parse_workflow_meta(script)
+
+    header_parts: list[str] = []
+    if name:
+        header_parts.append(f"<span class='workflow-name'>{escape_html(name)}</span>")
+    if description:
+        header_parts.append(
+            f"<span class='workflow-description'>{escape_html(description)}</span>"
+        )
+    if phases:
+        pills = "".join(
+            f"<span class='workflow-phase-pill'>{escape_html(p)}</span>" for p in phases
+        )
+        header_parts.append(f"<span class='workflow-phases'>{pills}</span>")
+    header = (
+        f"<div class='workflow-meta'>{''.join(header_parts)}</div>"
+        if header_parts
+        else ""
+    )
+
+    if not script.strip():
+        return header
+
+    body = render_file_content_collapsible(
+        script,
+        "workflow.js",
+        "workflow-script",
+        line_threshold=12,
+        preview_line_count=6,
+    )
+    return f"{header}{body}"
+
+
 # -- Public Exports -----------------------------------------------------------
 
 __all__ = [
@@ -1176,6 +1248,7 @@ __all__ = [
     "format_grep_input",
     "format_websearch_input",
     "format_webfetch_input",
+    "format_workflow_input",
     "format_monitor_input",
     "format_schedulewakeup_input",
     "format_croncreate_input",

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -29,6 +29,7 @@ from .utils import (
     render_markdown_inline,
 )
 from ..utils import strip_error_tags
+from ..workflow import parse_workflow_meta
 from ..models import (
     AskUserQuestionInput,
     AskUserQuestionItem,
@@ -1163,42 +1164,13 @@ def format_tool_result_content_raw(tool_result: ToolResultContent) -> str:
 
 # -- Workflow tool input (issue #174) -----------------------------------------
 
-_WF_META_RE = re.compile(r"meta\s*=\s*\{(.*?)\n\}", re.DOTALL)
-_WF_NAME_RE = re.compile(r"\bname\s*:\s*['\"]([^'\"]*)['\"]")
-_WF_DESC_RE = re.compile(r"\bdescription\s*:\s*['\"]([^'\"]*)['\"]")
-_WF_PHASES_RE = re.compile(r"phases\s*:\s*\[(.*?)\]", re.DOTALL)
-_WF_TITLE_RE = re.compile(r"title\s*:\s*['\"]([^'\"]+)['\"]")
-
-
-def _parse_workflow_meta(script: str) -> tuple[str, str, list[str]]:
-    """Best-effort extraction of ``(name, description, phase_titles)`` from a
-    Workflow script's ``export const meta = {...}`` block.
-
-    Returns empty values when the block (or a field) isn't found — this is
-    purely a display aid, scoped to the meta block so it can't pick up
-    ``name:``/``title:`` occurrences elsewhere in the orchestrator body.
-    """
-    block_m = _WF_META_RE.search(script)
-    if not block_m:
-        return "", "", []
-    block = block_m.group(1)
-    name_m = _WF_NAME_RE.search(block)
-    desc_m = _WF_DESC_RE.search(block)
-    phases_m = _WF_PHASES_RE.search(block)
-    phases = _WF_TITLE_RE.findall(phases_m.group(1)) if phases_m else []
-    return (
-        name_m.group(1) if name_m else "",
-        desc_m.group(1) if desc_m else "",
-        phases,
-    )
-
 
 def format_workflow_input(workflow_input: WorkflowToolInput) -> str:
     """Format a ``Workflow`` tool_use (issue #174): a header from the script's
     ``meta`` block (name / description / phase pills) above the JavaScript
     orchestrator source, syntax-highlighted and collapsible when long."""
     script = workflow_input.script or ""
-    name, description, phases = _parse_workflow_meta(script)
+    name, description, phases = parse_workflow_meta(script)
 
     header_parts: list[str] = []
     if name:

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -15,6 +15,7 @@ HTML-specific output.
 
 import functools
 import html
+import json
 import re
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
@@ -587,6 +588,36 @@ def render_file_content_collapsible(
 
     html_parts.append("</div>")
     return "".join(html_parts)
+
+
+def render_async_result_body(text: str, css_class: str) -> str:
+    """Render an async-result body, JSON-aware (issue #174 D4).
+
+    A JSON-shaped payload — ``lstrip()`` starts with ``{"`` per cboos's
+    heuristic, and so possibly truncated — is pretty-printed when it parses
+    and Pygments-highlighted as JSON (collapsible when long); everything
+    else (plain markdown answers from non-workflow async agents) falls back
+    to the existing markdown rendering, so this is a safe no-op for them.
+
+    (Spilling to the full untruncated ``tool-results/<taskId>.txt`` is a
+    separate enhancement — it needs the taskId plumbed to this layer — and
+    is deferred to a follow-up.)
+    """
+    stripped = (text or "").lstrip()
+    if stripped.startswith('{"'):
+        rendered = text
+        try:
+            rendered = json.dumps(json.loads(text), indent=2, ensure_ascii=False)
+        except (json.JSONDecodeError, ValueError):
+            pass  # truncated / variant payload — highlight the raw text as-is
+        return render_file_content_collapsible(
+            rendered,
+            "result.json",
+            css_class,
+            line_threshold=10,
+            preview_line_count=6,
+        )
+    return render_markdown_collapsible(text, css_class)
 
 
 # -- Template Environment -----------------------------------------------------

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -1047,13 +1047,18 @@ class MarkdownRenderer(Renderer):
 
         parts: list[str] = []
         header_bits: list[str] = []
+        # Neutralize raw HTML tags in script-derived fields before injecting
+        # into Markdown (CR #205) — mirrors the file's _protect_html_tags
+        # posture so a permissive viewer can't interpret e.g. a <script> in a
+        # workflow name/description/phase. (The script body itself is fenced.)
         if name:
-            header_bits.append(f"**{name}**")
+            header_bits.append(f"**{_protect_html_tags(name)}**")
         if description:
-            header_bits.append(description)
+            header_bits.append(_protect_html_tags(description))
         header = " — ".join(header_bits)
         if phases:
-            phase_text = "_(phases: " + ", ".join(phases) + ")_"
+            safe_phases = ", ".join(_protect_html_tags(p) for p in phases)
+            phase_text = f"_(phases: {safe_phases})_"
             header = f"{header} {phase_text}" if header else phase_text
         if header:
             parts.append(header)

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -64,6 +64,7 @@ from ..models import (
     SkillInput,
     WebSearchInput,
     WebFetchInput,
+    WorkflowToolInput,
     MonitorInput,
     MonitorOutput,
     ScheduleWakeupInput,
@@ -1027,6 +1028,38 @@ class MarkdownRenderer(Renderer):
         if len(input.prompt) > 100:
             return self._code_fence(input.prompt)
         return ""
+
+    def format_WorkflowToolInput(
+        self, input: WorkflowToolInput, _: TemplateMessage
+    ) -> str:
+        """Format → optional one-line meta header + the JS script in a fenced
+        ```js block (issue #174).
+
+        Registering ``Workflow`` in TOOL_INPUT_MODELS is format-neutral, so
+        this method is required for parity — without it the Markdown renderer
+        would emit nothing for the script (a regression from the pre-PR
+        ToolUseContent ``**script:**`` fallback).
+        """
+        from ..workflow import parse_workflow_meta
+
+        script = input.script or ""
+        name, description, phases = parse_workflow_meta(script)
+
+        parts: list[str] = []
+        header_bits: list[str] = []
+        if name:
+            header_bits.append(f"**{name}**")
+        if description:
+            header_bits.append(description)
+        header = " — ".join(header_bits)
+        if phases:
+            phase_text = "_(phases: " + ", ".join(phases) + ")_"
+            header = f"{header} {phase_text}" if header else phase_text
+        if header:
+            parts.append(header)
+        if script.strip():
+            parts.append(self._code_fence(script, "js"))
+        return "\n\n".join(parts)
 
     def format_MonitorInput(self, input: MonitorInput, _: TemplateMessage) -> str:
         """Format → bullet list of fields with the command in a fenced block.

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -1545,6 +1545,20 @@ class TaskStopInput(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class WorkflowToolInput(BaseModel):
+    """Input parameters for the dynamic ``Workflow`` tool (issue #174).
+
+    A Workflow tool_use carries a single field: ``script``, the JavaScript
+    orchestrator source. Its ``export const meta = {...}`` block (name /
+    description / phases) is surfaced as a header and the script body is
+    syntax-highlighted as JavaScript by the formatter.
+    """
+
+    script: str = ""
+
+    model_config = {"extra": "allow"}
+
+
 # Union of all typed tool inputs
 ToolInput = Union[
     BashInput,
@@ -1574,6 +1588,7 @@ ToolInput = Union[
     SendMessageInput,
     TaskOutputInput,
     TaskStopInput,
+    WorkflowToolInput,
     ToolUseContent,  # Generic fallback when no specialized parser
 ]
 

--- a/claude_code_log/workflow.py
+++ b/claude_code_log/workflow.py
@@ -31,7 +31,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
 
-_WF_META_RE = re.compile(r"meta\s*=\s*\{(.*?)\n\}", re.DOTALL)
+_WF_META_RE = re.compile(
+    r"export\s+(?:const|let|var)\s+meta\s*=\s*\{(.*?)\n\}", re.DOTALL
+)
 _WF_NAME_RE = re.compile(r"\bname\s*:\s*['\"]([^'\"]*)['\"]")
 _WF_DESC_RE = re.compile(r"\bdescription\s*:\s*['\"]([^'\"]*)['\"]")
 _WF_PHASES_KEY_RE = re.compile(r"\bphases\s*:")
@@ -43,14 +45,15 @@ def parse_workflow_meta(script: str) -> tuple[str, str, list[str]]:
     script's ``export const meta = {...}`` block — a display aid shared by
     the HTML and Markdown renderers (issue #174).
 
-    Assumes the canonical top-level form the Workflow tool mandates: a
-    column-0 ``export const meta = { ... \\n}`` (the closing-brace anchor is
-    at column 0; an indented close yields no header). All lookups are scoped
-    to the meta-block slice, so they can't pick up ``name:``/``title:``
-    elsewhere in the orchestrator body. Phase titles are collected from every
-    ``title:`` *after* the ``phases:`` key, so a ``detail`` string containing
-    ``]`` doesn't truncate the list. Returns empty values when the block or a
-    field isn't found.
+    Matches only the **exported** declaration the Workflow tool mandates —
+    ``export const meta = { ... \\n}`` (also ``let``/``var``) — so an
+    unrelated local ``meta = {...}`` elsewhere in the orchestrator can't be
+    mis-parsed as the header. The closing-brace anchor is at column 0 (an
+    indented close yields no header). All field lookups are scoped to the
+    matched block, so they can't pick up ``name:``/``title:`` elsewhere in
+    the body. Phase titles are collected from every ``title:`` *after* the
+    ``phases:`` key, so a ``detail`` string containing ``]`` doesn't truncate
+    the list. Returns empty values when the block or a field isn't found.
     """
     block_m = _WF_META_RE.search(script)
     if not block_m:

--- a/claude_code_log/workflow.py
+++ b/claude_code_log/workflow.py
@@ -26,9 +26,48 @@ import with ``converter``.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
+
+_WF_META_RE = re.compile(r"meta\s*=\s*\{(.*?)\n\}", re.DOTALL)
+_WF_NAME_RE = re.compile(r"\bname\s*:\s*['\"]([^'\"]*)['\"]")
+_WF_DESC_RE = re.compile(r"\bdescription\s*:\s*['\"]([^'\"]*)['\"]")
+_WF_PHASES_KEY_RE = re.compile(r"\bphases\s*:")
+_WF_TITLE_RE = re.compile(r"title\s*:\s*['\"]([^'\"]+)['\"]")
+
+
+def parse_workflow_meta(script: str) -> tuple[str, str, list[str]]:
+    """Best-effort ``(name, description, phase_titles)`` from a Workflow
+    script's ``export const meta = {...}`` block — a display aid shared by
+    the HTML and Markdown renderers (issue #174).
+
+    Assumes the canonical top-level form the Workflow tool mandates: a
+    column-0 ``export const meta = { ... \\n}`` (the closing-brace anchor is
+    at column 0; an indented close yields no header). All lookups are scoped
+    to the meta-block slice, so they can't pick up ``name:``/``title:``
+    elsewhere in the orchestrator body. Phase titles are collected from every
+    ``title:`` *after* the ``phases:`` key, so a ``detail`` string containing
+    ``]`` doesn't truncate the list. Returns empty values when the block or a
+    field isn't found.
+    """
+    block_m = _WF_META_RE.search(script)
+    if not block_m:
+        return "", "", []
+    block = block_m.group(1)
+    name_m = _WF_NAME_RE.search(block)
+    desc_m = _WF_DESC_RE.search(block)
+    phases: list[str] = []
+    phases_key = _WF_PHASES_KEY_RE.search(block)
+    if phases_key:
+        phases = _WF_TITLE_RE.findall(block[phases_key.end() :])
+    return (
+        name_m.group(1) if name_m else "",
+        desc_m.group(1) if desc_m else "",
+        phases,
+    )
+
 
 if TYPE_CHECKING:
     from claude_code_log.models import TranscriptEntry

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -1658,6 +1658,46 @@
           margin-right: 2%;
       }
   }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -7480,6 +7520,46 @@
           margin-left: 6%;
           margin-right: 2%;
       }
+  }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
   }
   /* Session navigation styles */
   .navigation {
@@ -15386,6 +15466,46 @@
           margin-right: 2%;
       }
   }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -21323,6 +21443,46 @@
           margin-left: 6%;
           margin-right: 2%;
       }
+  }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
   }
   /* Session navigation styles */
   .navigation {
@@ -27529,6 +27689,46 @@
           margin-right: 2%;
       }
   }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -33578,6 +33778,46 @@
           margin-left: 6%;
           margin-right: 2%;
       }
+  }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
   }
   /* Session navigation styles */
   .navigation {
@@ -39689,6 +39929,46 @@
           margin-left: 6%;
           margin-right: 2%;
       }
+  }
+  
+  /* Workflow tool-input (issue #174) — meta header above the highlighted JS
+     orchestrator. The script body reuses the standard Pygments code styling
+     via render_file_content_collapsible. */
+  .workflow-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 6px 10px;
+      margin-bottom: 8px;
+  }
+  
+  .workflow-name {
+      font-weight: 600;
+      color: var(--tool-use-color);
+  }
+  
+  .workflow-description {
+      color: var(--text-muted);
+      font-size: 0.9em;
+  }
+  
+  .workflow-phases {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 4px;
+  }
+  
+  .workflow-phase-pill {
+      font-size: 0.78em;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background-color: var(--highlight-dimmed);
+      border: 1px solid #00000011;
+      color: var(--text-secondary);
+  }
+  
+  .workflow-script {
+      margin-top: 4px;
   }
   /* Session navigation styles */
   .navigation {

--- a/test/test_workflow_rendering.py
+++ b/test/test_workflow_rendering.py
@@ -133,3 +133,45 @@ class TestWorkflowMetaParsing:
 
     def test_no_meta_block_returns_empty(self) -> None:
         assert parse_workflow_meta("const x = 1\nawait agent('hi')\n") == ("", "", [])
+
+    def test_decoy_local_meta_ignored_for_exported_block(self) -> None:
+        # CR #205: only the EXPORTED `meta` declaration is the header source;
+        # a non-export local `meta = {...}` before it must not be mis-parsed.
+        script = (
+            "const meta = { name: 'DECOY', description: 'local' }\n"
+            "export const meta = {\n"
+            "  name: 'real-wf',\n"
+            "  description: 'the real one',\n"
+            "  phases: [{ title: 'Map' }],\n"
+            "}\n"
+        )
+        assert parse_workflow_meta(script) == ("real-wf", "the real one", ["Map"])
+
+
+class TestWorkflowMarkdownEscaping:
+    """CR #205 (Major): script-derived meta fields must be HTML-tag-neutralized
+    before injection into the Markdown header (the script body itself is fenced
+    and safe)."""
+
+    def test_header_neutralizes_html_tags(self) -> None:
+        from claude_code_log.models import WorkflowToolInput
+
+        script = (
+            "export const meta = {\n"
+            "  name: 'pwn <script>alert(1)</script>',\n"
+            "  description: 'd <img src=x onerror=alert(2)>',\n"
+            "  phases: [{ title: 'P <b>x</b>' }],\n"
+            "}\n"
+        )
+        out = MarkdownRenderer().format_WorkflowToolInput(
+            WorkflowToolInput(script=script),
+            None,  # type: ignore[arg-type]  # message is unused by this formatter
+        )
+        # Inspect only the header (everything before the fenced script, where
+        # the raw tags legitimately appear inside a code block).
+        header = out.split("```")[0]
+        assert "<script>" not in header
+        assert "<img" not in header
+        assert "<b>" not in header
+        # Neutralized text still readable in the header.
+        assert "alert(1)" in header

--- a/test/test_workflow_rendering.py
+++ b/test/test_workflow_rendering.py
@@ -1,0 +1,86 @@
+"""Tests for Workflow tool-input + async-result-body rendering (#174 PR2).
+
+D3: a ``Workflow`` tool_use renders a meta header (name/description/phase
+pills) above its JavaScript orchestrator, syntax-highlighted — not the raw
+ToolUseContent fallback.
+D4: a JSON-shaped async-result body is pretty-printed + highlighted as JSON;
+non-JSON (markdown) bodies fall back to the existing markdown rendering.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.html.utils import render_async_result_body
+
+TRUNK = (
+    Path(__file__).parent
+    / "test_data"
+    / "workflow_basic"
+    / "11110000-0000-4000-8000-000000000001.jsonl"
+)
+
+
+class TestWorkflowToolInputRendering:
+    """D3 — Workflow tool_use → meta header + highlighted JS."""
+
+    def _html(self) -> str:
+        return generate_html(load_transcript(TRUNK))
+
+    def test_meta_header_from_script_meta_block(self) -> None:
+        html = self._html()
+        assert "workflow-meta" in html
+        assert "workflow-name" in html and "demo-review" in html
+        # description surfaced from the script's meta block
+        assert "Review changed files across dimensions" in html
+
+    def test_both_phase_pills_rendered(self) -> None:
+        html = self._html()
+        assert html.count("workflow-phase-pill") >= 2  # Map + Synthesize
+
+    def test_script_highlighted_as_javascript(self) -> None:
+        html = self._html()
+        # Target the rendered div, not the `.workflow-script` CSS rule in <head>.
+        idx = html.find("class='workflow-script'")
+        assert idx != -1, "expected a rendered workflow-script block"
+        segment = html[idx : idx + 600]
+        # render_file_content_collapsible emits a Pygments highlight table
+        assert "highlight" in segment
+
+    def test_specialized_path_not_raw_fallback(self) -> None:
+        # The generic fallback would dump input as a params table / raw JSON
+        # with no meta header or highlighted script; the specialized renderer
+        # produces both.
+        html = self._html()
+        assert "workflow-meta" in html and "workflow-script" in html
+
+
+class TestAsyncResultBodyJson:
+    """D4 — JSON-aware async-result body rendering."""
+
+    def test_json_body_pretty_printed_and_highlighted(self) -> None:
+        out = render_async_result_body(
+            '{"plan": "Land parsing first.", "areaCount": 2}', "task-async-answer"
+        )
+        assert "highlight" in out  # Pygments-highlighted
+        assert "task-async-answer" in out  # wrapper css class preserved
+        assert out.count("\n") > 2  # pretty-printed (indented, multi-line)
+
+    def test_truncated_json_highlights_without_crashing(self) -> None:
+        # Real async previews are often truncated mid-value; still starts with
+        # {" so it's treated as JSON and highlighted best-effort.
+        out = render_async_result_body('{"plan": "Lan', "x")
+        assert "highlight" in out
+
+    def test_markdown_body_uses_markdown_path(self) -> None:
+        out = render_async_result_body("## Plan\n\nLand it first.", "x")
+        # markdown path → no Pygments code-highlight table
+        assert 'class="highlight"' not in out
+        assert "Plan" in out
+
+    def test_non_json_brace_text_is_not_treated_as_json(self) -> None:
+        # Heuristic is specifically `{"` — a lone "{" (e.g. prose) is markdown.
+        out = render_async_result_body("{ not really json", "x")
+        assert 'class="highlight"' not in out

--- a/test/test_workflow_rendering.py
+++ b/test/test_workflow_rendering.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from claude_code_log.converter import load_transcript
 from claude_code_log.html.renderer import generate_html
 from claude_code_log.html.utils import render_async_result_body
+from claude_code_log.markdown.renderer import MarkdownRenderer
+from claude_code_log.workflow import parse_workflow_meta
 
 TRUNK = (
     Path(__file__).parent
@@ -84,3 +86,50 @@ class TestAsyncResultBodyJson:
         # Heuristic is specifically `{"` — a lone "{" (e.g. prose) is markdown.
         out = render_async_result_body("{ not really json", "x")
         assert 'class="highlight"' not in out
+
+
+class TestWorkflowToolInputMarkdown:
+    """D3 parity for the Markdown renderer — registering Workflow in
+    TOOL_INPUT_MODELS is format-neutral, so the script must NOT vanish from
+    Markdown output (regression guard, monk PR2 review)."""
+
+    def _md(self) -> str:
+        return MarkdownRenderer().generate(load_transcript(TRUNK))
+
+    def test_script_present_in_markdown(self) -> None:
+        md = self._md()
+        # The script body (and its meta) must render, not disappear.
+        assert "demo-review" in md
+        assert "export const meta" in md
+        assert "```js" in md  # fenced as JavaScript
+
+    def test_meta_header_in_markdown(self) -> None:
+        md = self._md()
+        assert "Review changed files across dimensions" in md  # description
+        assert "Map" in md and "Synthesize" in md  # phase titles
+
+
+class TestWorkflowMetaParsing:
+    """Unit tests for the shared meta parser (issue #174)."""
+
+    def test_name_description_phases(self) -> None:
+        script = (
+            "export const meta = {\n"
+            "  name: 'demo',\n"
+            "  description: 'A demo',\n"
+            "  phases: [{ title: 'Map' }, { title: 'Synthesize' }],\n"
+            "}\n"
+        )
+        assert parse_workflow_meta(script) == ("demo", "A demo", ["Map", "Synthesize"])
+
+    def test_bracket_in_phase_detail_does_not_truncate_phases(self) -> None:
+        # N1 regression: a ']' inside a phase detail must not cut the list short.
+        script = (
+            "export const meta = {\n"
+            "  phases: [{ title: 'Scan', detail: 'grep [logs]' }, { title: 'Fix' }],\n"
+            "}\n"
+        )
+        assert parse_workflow_meta(script)[2] == ["Scan", "Fix"]
+
+    def test_no_meta_block_returns_empty(self) -> None:
+        assert parse_workflow_meta("const x = 1\nawait agent('hi')\n") == ("", "", [])

--- a/work/dynamic-workflow-support.md
+++ b/work/dynamic-workflow-support.md
@@ -1,7 +1,12 @@
 # Plan: support dynamic-workflow transcripts (issue #174)
 
-**Status:** draft for greenlight — *no implementation yet*.
-**Branch:** `dev/dynamic-workflow-support` (off `main`).
+**Status:** greenlit & in progress — PR0 (nested DOM, #191) and PR1
+(parsing/models, #203) have landed; PR2 (tool-input + async-body rendering)
+is underway. *The §1–§9 narrative below was written 2026-05-31 and describes
+the pre-implementation baseline as of that date; it is kept as the design
+record rather than rewritten per landed PR.*
+**Branch (original plan):** `dev/dynamic-workflow-support` (off `main`);
+implementation lands as the per-PR branches in the §9 sequence.
 **Scope:** parse & render Claude Code *dynamic Workflow* runs so a
 workflow tool_use no longer collapses to a single async-launch card +
 final-answer blob, but shows its phases and the dozens of sub-agents
@@ -119,8 +124,11 @@ v1, though the recursive loader handles it for free if it ever appears).
 
 ## 2. What the code does today (and where it breaks)
 
-`grep -rni workflow claude_code_log/` → **0 hits.** No workflow handling
-exists. Concretely:
+*As of 2026-05-31 (pre-implementation baseline):* `grep -rni workflow
+claude_code_log/` → **0 hits**; no workflow handling existed. (PR1 / #203
+has since added `claude_code_log/workflow.py`, which parses runs into
+`WorkflowRun` models but does not yet render them.) The gaps this plan
+addresses were, concretely:
 
 1. **The Workflow tool_use** (`name:"Workflow"`, `input.script` = JS)
    falls through `create_tool_input` to the raw `ToolUseContent`


### PR DESCRIPTION
The first **visible** slice of dynamic-Workflow support (#174), building on
the nested-DOM groundwork (#191) and the parser (#203). Renders Workflow
tool data that PR1 only parsed. No tree-splicing of `WorkflowRun` yet — that
is PR3.

## D3 — Workflow tool-input (JS)

A `Workflow` tool_use previously fell through to the raw `ToolUseContent`
blob. Now:
- A `WorkflowToolInput` model (just `script`) is registered in
  `TOOL_INPUT_MODELS`.
- The script's `export const meta = {...}` block (name / description /
  phases) is surfaced as a header — a best-effort parse scoped to the meta
  block (`parse_workflow_meta`, shared by both renderers).
- The JavaScript body is Pygments-highlighted and collapsible (HTML) /
  fenced ` ```js ` (Markdown).

## D4 — async-result body (JSON-aware)

`render_async_result_body` detects a JSON-shaped payload (`lstrip()` starts
with `{"`, per the agreed heuristic — possibly truncated), pretty-prints it
when parseable, and Pygments-highlights it as JSON. Non-JSON (markdown)
answers fall back to the existing markdown rendering unchanged, so it is a
safe no-op for them. Wired into both async render sites (the
`<task-notification>` card and the launch-card folded answer).

Spilling to the full untruncated `tool-results/<taskId>.txt` is deferred (it
needs the taskId plumbed to the formatter layer) and noted in the helper.

## Notes

- Registering `Workflow` is format-neutral, so **both** the HTML and Markdown
  renderers get a `format_WorkflowToolInput` (the Markdown one avoids a
  regression where the script would otherwise render empty).
- Snapshot change is the inlined workflow CSS block only — no existing
  fixture has a Workflow tool_use or a JSON-shaped async body.
- Also includes a small doc tidy: timestamps the plan's pre-implementation
  baseline as historical.

Tests: `test_workflow_rendering.py` — HTML + Markdown tool-input rendering,
the JSON/markdown async-body heuristic (incl. truncated JSON), and the meta
parser (incl. a `]`-in-detail case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Render Workflow tool inputs with metadata (name, description, phase pills) and show workflow scripts with JS syntax highlighting in HTML and Markdown.
  * Async result rendering now detects JSON, pretty-prints and highlights it, or falls back to markdown rendering for prose; task-notification results use the new async rendering path.
* **Styles**
  * Added CSS to style workflow metadata, phase pills, and script container.
* **Tests**
  * Added tests for workflow rendering, async-result formatting, and metadata parsing.
* **Documentation**
  * Updated implementation status and notes for dynamic workflow support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->