### PR TITLE
Phase 3 of ghosting epic: single-axis collapse — delete pre-render _filter_by_detail

### DIFF
--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -22,14 +22,12 @@ from .models import (
     MessageType,
     TranscriptEntry,
     AiTitleTranscriptEntry,
-    AssistantMessageModel,
     AssistantTranscriptEntry,
     AttachmentTranscriptEntry,
     PassthroughTranscriptEntry,
     SystemTranscriptEntry,
     SummaryTranscriptEntry,
     QueueOperationTranscriptEntry,
-    UserMessageModel,
     UserTranscriptEntry,
     ContentItem,
     TextContent,
@@ -729,10 +727,10 @@ def generate_template_messages(
     with log_timing("Filter messages", t_start):
         filtered_messages = _filter_messages(messages)
 
-    # Detail-level pre-render filter
-    if detail != DetailLevel.FULL:
-        with log_timing(f"Detail filter ({detail.value})", t_start):
-            filtered_messages = _filter_by_detail(filtered_messages, detail)
+    # Detail-level filtering happens entirely post-render via
+    # ``_ghost_template_by_detail`` (single-axis collapse — Phase 3 of the
+    # ghosting epic). The pre-render ``_filter_by_detail`` is gone; the
+    # per-class ``detail_visibility`` predicate now drives all stripping.
 
     # Pass 1: Collect session metadata and token tracking
     with log_timing("Collect session info", t_start):
@@ -955,9 +953,10 @@ def _build_uuid_to_render_sid(
     flipped on each branch-start trigger — a re-derivation of what
     the ``SessionTree`` already knew authoritatively. The loop
     variable carried a latent bug: if a branch's ``first_uuid`` was
-    dropped by ``_filter_by_detail`` at non-FULL detail, the trigger
-    never fired and subsequent branch messages silently inherited
-    the *previous* branch's sid (or ``None``).
+    dropped before rendering (structurally, by ``_filter_messages`` —
+    or, before the single-axis collapse, by the pre-render detail
+    filter), the trigger never fired and subsequent branch messages
+    silently inherited the *previous* branch's sid (or ``None``).
 
     Reading the map up front fixes this — every uuid in a branch
     DAG-line maps to that branch's sid regardless of which entries
@@ -2745,8 +2744,9 @@ def _link_async_notifications(
     - **Sidechain-only dedup:** when the last sub-assistant text
       matches the notification's ``result_text``, drop it from the
       tree. This branch is a no-op at LOW/MINIMAL/USER_ONLY where
-      ``_filter_by_detail`` has already removed sidechain entries —
-      and that's fine, because there's no duplicate left to remove.
+      ``_ghost_template_by_detail`` has ghosted the sidechain entries
+      (so they fall out of the rendered tree) — and that's fine,
+      because there's no duplicate left to remove.
 
     At MINIMAL/USER_ONLY the spawn fold is skipped entirely: the
     Task tool_result is dropped by ``_ghost_template_by_detail``,
@@ -2823,9 +2823,9 @@ def _link_async_notifications(
         # result body, drop the duplicate from the sidechain tree so
         # the answer only appears once (folded into the spawn). This
         # branch is the only piece that needs the sidechain — at
-        # LOW/MINIMAL/USER_ONLY ``_filter_by_detail`` has already
-        # removed sidechain entries, so ``_last_sidechain_assistant``
-        # returns None and we skip this branch.
+        # LOW/MINIMAL/USER_ONLY ``_ghost_template_by_detail`` ghosts the
+        # sidechain entries (excluded from the tree), so
+        # ``_last_sidechain_assistant`` returns None and we skip this branch.
         located = _last_sidechain_assistant(tm)
         if located is None:
             continue
@@ -3235,92 +3235,6 @@ def _content_visible_at(content: "MessageContent", detail: DetailLevel) -> bool:
     automatically through the same predicate.
     """
     return content.visible_at(detail)
-
-
-def _filter_by_detail(
-    messages: list[TranscriptEntry],
-    detail: DetailLevel,
-) -> list[TranscriptEntry]:
-    """Pre-render filter: strip content items per detail level.
-
-    - MINIMAL / USER_ONLY: keep only user/assistant text (no tools,
-      thinking, system). USER_ONLY drops assistant text in the post-
-      render pass so it behaves identically here.
-    - LOW: keep user/assistant text + WebSearch / WebFetch / Task / Agent
-      tools (Agent is the teammates spawn alias for Task).
-    - HIGH: keep user/assistant + all tools/thinking, drop system entries.
-    """
-    from copy import copy
-
-    if detail in (DetailLevel.MINIMAL, DetailLevel.USER_ONLY):
-        strip_types: tuple[type, ...] = (
-            ThinkingContent,
-            ToolUseContent,
-            ToolResultContent,
-        )
-    elif detail == DetailLevel.LOW:
-        strip_types = (ThinkingContent,)
-        # ToolUseContent and ToolResultContent kept for _LOW_KEEP_TOOLS;
-        # others removed in post-render by _ghost_template_by_detail.
-    else:
-        # HIGH: no content-item stripping needed
-        strip_types = ()
-
-    # Queue-operation entries (carrying UserSteeringMessage) pass through
-    # at every non-FULL detail level. Steering is user-authored content
-    # and belongs in any view of the user's side of the conversation —
-    # the post-render exclude chains (_HIGH/_LOW/_MINIMAL/_USER_ONLY)
-    # don't list UserSteeringMessage, so this allowlist is sufficient
-    # to keep it visible everywhere we already keep assistant/user text.
-    allowed_types: tuple[type, ...] = (
-        UserTranscriptEntry,
-        AssistantTranscriptEntry,
-        QueueOperationTranscriptEntry,
-    )
-
-    filtered: list[TranscriptEntry] = []
-    for message in messages:
-        # HIGH/LOW/MINIMAL/USER_ONLY: drop system entries (factory creates SystemMessage)
-        # — except `away_summary` recaps at HIGH detail, which must survive this
-        # pre-render pass to reach the post-render filter that keeps them at HIGH
-        # (see AwaySummaryMessage.detail_visibility in models.py).
-        if not isinstance(message, allowed_types):
-            if (
-                detail == DetailLevel.HIGH
-                and isinstance(message, SystemTranscriptEntry)
-                and message.subtype == "away_summary"
-            ):
-                filtered.append(message)
-            continue
-        # queue-operation entries don't have `.message` or `.isSidechain` —
-        # they are appended verbatim for downstream conversion.
-        if isinstance(message, QueueOperationTranscriptEntry):
-            filtered.append(message)
-            continue
-        # LOW/MINIMAL/USER_ONLY: drop sidechain (subagent) messages entirely
-        if (
-            detail in (DetailLevel.MINIMAL, DetailLevel.LOW, DetailLevel.USER_ONLY)
-            and message.isSidechain
-        ):
-            continue
-        if not strip_types:
-            filtered.append(message)
-            continue
-        text_items: list[ContentItem] = [
-            item
-            for item in message.message.content
-            if not isinstance(item, strip_types)
-        ]
-        if text_items:
-            msg_copy = copy(message)
-            msg_model = copy(message.message)
-            msg_model.content = text_items
-            if isinstance(msg_copy, UserTranscriptEntry):
-                msg_copy.message = cast("UserMessageModel", msg_model)
-            else:
-                msg_copy.message = cast("AssistantMessageModel", msg_model)
-            filtered.append(msg_copy)
-    return filtered
 
 
 _LAUNCHING_SKILL_PREFIX = "Launching skill:"
@@ -3868,7 +3782,7 @@ def _build_branch_header(
         original_session_id=original_sid,
         # Canonical first uuid of the branch DAG-line, NOT the
         # trigger's uuid. Post-D11 the trigger may be a later entry
-        # (the first one to survive ``_filter_by_detail``) rather
+        # (the first one to survive ``_filter_messages``) rather
         # than ``dag_line.uuids[0]`` itself, so reading from the
         # hierarchy keeps the header's ``first_uuid`` field pointing
         # at the canonical entry regardless of filtering.

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -212,23 +212,28 @@ how much of the transcript renders:
   (designed for feeding to downstream agents, e.g. building a
   requirements doc).
 
-Filtering happens in two passes: a *pre-render* pass on `TranscriptEntry`
-that strips content items (e.g., tool_use blocks from assistant turns),
-and a *post-render* pass on `TemplateMessage` that drops whole content
-types created by factories (`BashInputMessage`, `BashOutputMessage`,
-`CommandOutputMessage` at low/minimal). The two-pass shape exists
-because some content is identifiable only after factory dispatch (e.g.,
-distinguishing `BashInputMessage` from the tool_use that produced it).
+Filtering happens in a single *post-render* pass on `TemplateMessage`:
+`_ghost_template_by_detail` sets each non-visible slot in
+`RenderingContext.messages` to `None` ("ghosting"), keyed by the content
+class's `detail_visibility` predicate (plus the `_LOW_KEEP_TOOLS`
+allowlist at `low` and sidechain dropping below `FULL`). Indices stay
+stable — surviving messages keep their `message_index`, so there is no
+reindex; the rendered tree simply skips ghost slots. Earlier revisions
+ran a *second*, pre-render `_filter_by_detail` pass on `TranscriptEntry`
+plus a `_reindex_filtered_context` remap after every deletion; the
+ghosting model collapsed both into this one axis (see
+[`work/ghosting-epic-plan.md`](../work/ghosting-epic-plan.md)).
 
-Important interaction: `_pair_skill_tool_uses` runs **before**
-`_filter_template_by_detail`, and each pass that drops messages calls
-`_reindex_filtered_context` to remap surviving indices (the skill-fold
-pass remaps after dropping the slash-command body and the redundant
-"Launching skill" tool_result; the detail filter remaps after dropping
-content types below `FULL`). The reindex pass also has to update
-cached parent-message references on `SessionHeaderMessage` (see PR
-#131 fix). See [rendering-architecture.md § 5](rendering-architecture.md)
-for the full pass order.
+Important interaction: `_pair_skill_tool_uses` also ghosts in place (the
+slash-command body and the redundant "Launching skill" tool_result).
+Because anchor-target references can be cached before a slot is ghosted —
+a branch header's `parent_message_index`, `session_first_message`
+entries, junction forward-links — each ghosting step sanitizes them
+afterward: `_pair_skill_tool_uses` calls `_drop_anchor_refs_into_ghosts`
+and `_ghost_template_by_detail` calls `_repair_stale_anchor_refs`, so no
+`#msg-d-{N}` backlink dangles (see PR #131 fix). See
+[rendering-architecture.md § 5](rendering-architecture.md) for the full
+pass order.
 
 ### 2.7 Image export
 

--- a/dev-docs/rendering-architecture.md
+++ b/dev-docs/rendering-architecture.md
@@ -218,18 +218,20 @@ In code order, `generate_template_messages`:
 1. **Setup** — filters warmup sessions, then prepares session metadata:
    `prepare_session_summaries` + `prepare_session_ai_titles` (merged),
    `prepare_session_team_names`, and `_extract_session_hierarchy`.
-2. **Pre-render filtering** — `_filter_messages` (structural), then
-   `_filter_by_detail` (entry-level, only below FULL).
+2. **Pre-render filtering** — `_filter_messages` (structural only).
+   Detail-level filtering is no longer a pre-render pass — the
+   single-axis ghosting model moved it entirely to step 5.
 3. **Collect + render** — `_collect_session_info`, then
    `_render_messages` (**Phase 1**: wrappers, session headers,
-   registration), then `_pair_skill_tool_uses` (which calls
-   `_reindex_filtered_context` internally).
+   registration), then `_pair_skill_tool_uses` (which ghosts the
+   consumed slots in place and calls `_drop_anchor_refs_into_ghosts`).
 4. **Junction linking** — junction forward-link population on fork
    points (`_link_junction_forwards`). Branch-header previews are
    computed in step 3 by `_build_branch_header` scanning the
    branch's DAG-line uuids; there's no separate back-fill pass.
-5. **Post-render detail filter** — `_filter_template_by_detail`
-   followed immediately by `_reindex_filtered_context` (only below FULL).
+5. **Post-render detail filter** — `_ghost_template_by_detail` (only
+   below FULL): sets non-visible slots to `None` in place (no reindex),
+   then calls `_repair_stale_anchor_refs`.
 6. **Nav + structure** — `prepare_session_navigation`, then
    `_reorder_session_template_messages`, `_identify_message_pairs`
    (**Phase 2**), `_reorder_paired_messages`,

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -10041,7 +10041,7 @@
       
       
       <div class='message-node'>
-      <div class='message assistant' data-message-id='d-7' id='msg-d-7'>
+      <div class='message assistant' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
               <span>🤖 Assistant</span>
               <div class='header-info'>

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1287,7 +1287,9 @@ class TestRenderSessionResetAcrossSessions:
 
         # b1 and b2 should NOT appear in the rendered messages
         # (sanity: confirms the filter is doing what we expect).
-        rendered_uuids = {m.meta.uuid for m in ctx.messages if m.meta.uuid}
+        rendered_uuids = {
+            m.meta.uuid for m in ctx.messages if m is not None and m.meta.uuid
+        }
         assert "b1" not in rendered_uuids, (
             f"b1 should be filtered out at MINIMAL; got rendered_uuids={rendered_uuids}"
         )
@@ -1295,7 +1297,11 @@ class TestRenderSessionResetAcrossSessions:
 
         # c1 and c2 SHOULD appear and resolve to their respective
         # branch sids — NOT to "s1" (trunk).
-        by_uuid = {m.meta.uuid: m for m in ctx.messages if m.meta.uuid in ("c1", "c2")}
+        by_uuid = {
+            m.meta.uuid: m
+            for m in ctx.messages
+            if m is not None and m.meta.uuid in ("c1", "c2")
+        }
         assert set(by_uuid) == {"c1", "c2"}, (
             f"expected c1+c2 in rendered messages; got {set(by_uuid)}"
         )
@@ -1436,7 +1442,7 @@ class TestRenderSessionResetAcrossSessions:
         # Collect every session header in encounter order.
         header_order: list[tuple[int, str, bool, object]] = []
         for i, m in enumerate(ctx.messages):
-            if isinstance(m.content, SessionHeaderMessage):
+            if m is not None and isinstance(m.content, SessionHeaderMessage):
                 header_order.append(
                     (
                         i,
@@ -1468,16 +1474,21 @@ class TestRenderSessionResetAcrossSessions:
                 f"template_messages will emit it as a root, not nested "
                 "under the trunk. Header order: " + str(header_order)
             )
-            # 3) Branch header's parent_message_index points to a
-            #    REGISTERED message (the trunk header), not None.
-            assert parent_msg_idx is not None, (
-                f"branch header {sid!r} has parent_message_index=None — "
-                "the trunk header wasn't in ctx.session_first_message "
-                "when the branch header was built. Header order: " + str(header_order)
-            )
-            assert parent_msg_idx == trunk_idx, (
-                f"branch header {sid!r}.parent_message_index={parent_msg_idx} "
-                f"should point to trunk header at {trunk_idx}"
+            # 3) Single-axis collapse (Phase 3): the fork anchor a1 is a
+            #    tool-only assistant, ghosted at MINIMAL. Pre-collapse a1 was
+            #    dropped pre-render and the branch backlink fell back to the
+            #    trunk header; now a1 is built-then-ghosted, so the branch's
+            #    parent_message_index points at a1's ghosted slot and the
+            #    anchor-repair pass correctly NULLS it — the "from #msg-d-N"
+            #    backlink is omitted (rendered as plain text via the
+            #    `is not None` guard) rather than mis-targeting the trunk
+            #    header. The D11 invariant under test — trunk header registered
+            #    BEFORE the branch (assertions 1+2) — is unaffected.
+            assert parent_msg_idx is None, (
+                f"branch header {sid!r}.parent_message_index={parent_msg_idx}: "
+                "expected None because its fork anchor (tool-only assistant "
+                "'a1') is ghosted at MINIMAL, so the backlink must be omitted. "
+                "Header order: " + str(header_order)
             )
 
 

--- a/test/test_detail_levels.py
+++ b/test/test_detail_levels.py
@@ -21,15 +21,9 @@ from claude_code_log.converter import convert_jsonl_to, load_transcript
 from claude_code_log.html.renderer import HtmlRenderer
 from claude_code_log.markdown.renderer import MarkdownRenderer
 from claude_code_log.models import (
-    AssistantTranscriptEntry,
     DetailLevel,
-    SystemTranscriptEntry,
-    ThinkingContent,
-    ToolResultContent,
-    ToolUseContent,
-    UserTranscriptEntry,
 )
-from claude_code_log.renderer import _filter_by_detail, generate_template_messages
+from claude_code_log.renderer import generate_template_messages
 
 
 # -- Test data helpers --------------------------------------------------------
@@ -127,129 +121,137 @@ def _write_jsonl(entries: list[dict], path: Path) -> Path:
     return path
 
 
-# -- Unit tests for _filter_compact ------------------------------------------
+# -- Single-axis collapse: the pre-render detail filter is gone --------------
+
+
+def test_pre_render_detail_filter_is_deleted():
+    """``_filter_by_detail`` (and its reindex helper) must stay deleted.
+
+    Single-axis collapse (Phase 3) folded all detail stripping into the
+    post-render ``_ghost_template_by_detail`` pass. Pin the deletion so the
+    pre-render filter can't be reintroduced and quietly recreate the
+    two-axis complexity the ghosting epic removed.
+    """
+    import claude_code_log.renderer as renderer
+
+    assert not hasattr(renderer, "_filter_by_detail"), (
+        "_filter_by_detail was reintroduced — detail filtering must happen "
+        "only post-render via _ghost_template_by_detail (single-axis)."
+    )
+    assert not hasattr(renderer, "_reindex_filtered_context"), (
+        "_reindex_filtered_context was reintroduced — ghosting keeps indices "
+        "stable, so no reindex pass should exist."
+    )
+
+
+# -- MINIMAL detail filtering (end-to-end) -----------------------------------
 
 
 class TestFilterMinimal:
-    """Test the _filter_compact function directly on parsed TranscriptEntry lists."""
+    """MINIMAL detail filtering, end-to-end via ``generate_template_messages``.
+
+    Single-axis collapse (Phase 3) removed the pre-render
+    ``_filter_by_detail``; all stripping now happens post-render in
+    ``_ghost_template_by_detail`` via per-class ``detail_visibility``. These
+    pin the same MINIMAL contract through the public pipeline by asserting on
+    the *visible* (non-ghost) messages, since the stripped content is ghosted
+    (``None`` slot) rather than removed pre-render.
+    """
+
+    def _render_minimal(self, entries, tmp_path):
+        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
+        root_messages, _, ctx = generate_template_messages(
+            messages, detail=DetailLevel.MINIMAL
+        )
+        types: set[str] = set()
+        _collect_types(root_messages, types)
+        visible = [m for m in ctx.messages if m is not None]
+        return types, visible
 
     def test_keeps_user_and_assistant_text(self, tmp_path):
-        """Plain user and assistant messages pass through."""
-        entries = [
-            _user_entry("Hello"),
-            _assistant_entry("Hi there!"),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 2
-        assert isinstance(result[0], UserTranscriptEntry)
-        assert isinstance(result[1], AssistantTranscriptEntry)
+        """Plain user and assistant text remain visible."""
+        types, _ = self._render_minimal(
+            [_user_entry("Hello"), _assistant_entry("Hi there!")], tmp_path
+        )
+        assert "user" in types
+        assert "assistant" in types
 
     def test_removes_system_entries(self, tmp_path):
-        """System entries are dropped entirely."""
-        entries = [
-            _user_entry("Hello"),
-            _system_entry("model changed"),
-            _assistant_entry("Hi"),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 2
-        assert all(not isinstance(m, SystemTranscriptEntry) for m in result)
+        """System entries are not visible at MINIMAL."""
+        types, _ = self._render_minimal(
+            [
+                _user_entry("Hello"),
+                _system_entry("model changed"),
+                _assistant_entry("Hi"),
+            ],
+            tmp_path,
+        )
+        assert "system" not in types
+        assert "user" in types and "assistant" in types
 
     def test_strips_tool_use_from_assistant(self, tmp_path):
-        """Tool use items within assistant entries are stripped."""
-        entries = [
-            _user_entry("Do something"),
-            _assistant_entry(
-                "I'll run a command.",
-                extra_content=[_tool_use_item()],
-            ),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 2
-        # Assistant entry should have text but no tool_use
-        assistant = result[1]
-        assert isinstance(assistant, AssistantTranscriptEntry)
-        for item in assistant.message.content:
-            assert not isinstance(item, ToolUseContent)
+        """An assistant turn with text + tool_use keeps the text, ghosts the tool_use."""
+        types, _ = self._render_minimal(
+            [
+                _user_entry("Do something"),
+                _assistant_entry(
+                    "I'll run a command.", extra_content=[_tool_use_item()]
+                ),
+            ],
+            tmp_path,
+        )
+        assert "tool_use" not in types
+        assert "assistant" in types
 
     def test_strips_tool_result_from_user(self, tmp_path):
-        """Tool result items within user entries are stripped."""
-        entries = [
-            _user_entry(
-                "Here's the result",
-                extra_content=[_tool_result_item()],
-            ),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 1
-        user = result[0]
-        assert isinstance(user, UserTranscriptEntry)
-        for item in user.message.content:
-            assert not isinstance(item, ToolResultContent)
+        """Tool_result content is not visible at MINIMAL."""
+        types, _ = self._render_minimal(
+            [_user_entry("Here's the result", extra_content=[_tool_result_item()])],
+            tmp_path,
+        )
+        assert "tool_result" not in types
 
     def test_strips_thinking_from_assistant(self, tmp_path):
-        """Thinking items within assistant entries are stripped."""
-        entries = [
-            _assistant_entry(
-                "Here's my answer.",
-                extra_content=[_thinking_item()],
-            ),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 1
-        assistant = result[0]
-        assert isinstance(assistant, AssistantTranscriptEntry)
-        for item in assistant.message.content:
-            assert not isinstance(item, ThinkingContent)
+        """Thinking content is not visible at MINIMAL."""
+        types, _ = self._render_minimal(
+            [_assistant_entry("Here's my answer.", extra_content=[_thinking_item()])],
+            tmp_path,
+        )
+        assert "thinking" not in types
+        assert "assistant" in types
 
     def test_drops_assistant_with_only_tool_use(self, tmp_path):
-        """Assistant entries with only tool_use (no text) are dropped entirely."""
-        # Build an entry where the only content is a tool_use (no text at all)
+        """An assistant turn whose only content is a tool_use yields no
+        visible content message — only the session header survives."""
         entry = _assistant_entry("placeholder", extra_content=[_tool_use_item()])
-        # Remove the text item, keeping only tool_use
         entry["message"]["content"] = [_tool_use_item()]
-        messages = load_transcript(_write_jsonl([entry], tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 0
+        _types, visible = self._render_minimal([entry], tmp_path)
+        # No content message from the tool-only assistant; headers are all
+        # that remain.
+        assert visible, "expected at least a session header to survive"
+        assert all(m.is_session_header for m in visible), (
+            "tool-only assistant should produce no visible content at MINIMAL; "
+            f"got {[m.type for m in visible]}"
+        )
 
     def test_removes_sidechain_entries(self, tmp_path):
-        """Sidechain (subagent) entries are dropped."""
+        """Sidechain (subagent) messages are not visible at MINIMAL."""
         sidechain_user = _user_entry("Subagent prompt")
         sidechain_user["isSidechain"] = True
         sidechain_assistant = _assistant_entry("Subagent reply")
         sidechain_assistant["isSidechain"] = True
-        entries = [
-            _user_entry("Main prompt"),
-            sidechain_user,
-            sidechain_assistant,
-            _assistant_entry("Main reply"),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        result = _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(result) == 2
-        for m in result:
-            assert isinstance(m, (UserTranscriptEntry, AssistantTranscriptEntry))
-            assert not m.isSidechain
-
-    def test_does_not_mutate_original(self, tmp_path):
-        """Filtering creates copies, not mutations of the original."""
-        entries = [
-            _assistant_entry(
-                "Some text",
-                extra_content=[_tool_use_item()],
-            ),
-        ]
-        messages = load_transcript(_write_jsonl(entries, tmp_path / "t.jsonl"))
-        first = messages[0]
-        assert isinstance(first, AssistantTranscriptEntry)
-        original_content_count = len(first.message.content)
-        _filter_by_detail(messages, DetailLevel.MINIMAL)
-        assert len(first.message.content) == original_content_count
+        _types, visible = self._render_minimal(
+            [
+                _user_entry("Main prompt"),
+                sidechain_user,
+                sidechain_assistant,
+                _assistant_entry("Main reply"),
+            ],
+            tmp_path,
+        )
+        assert not any(m.is_sidechain for m in visible), (
+            "sidechain messages should be ghosted (not visible) at MINIMAL"
+        )
 
 
 # -- Tests for HIGH detail level -----------------------------------------------


### PR DESCRIPTION
Final phase of the ghosting epic (after #193 Phase 1 and #194 Phase 2).

## What

Detail-level filtering now happens entirely **post-render** via
`_ghost_template_by_detail` (each content class's `detail_visibility`
predicate, plus the `_LOW_KEEP_TOOLS` allowlist and sidechain dropping
below FULL). The **pre-render** `_filter_by_detail` pass on
`TranscriptEntry` is deleted along with its call.

The pre-render filter existed only to avoid the reindex dance that
ghosting already eliminated, so keeping it after Phase 2 meant
maintaining two filter axes for no benefit. This collapses to a single
axis.

## Behavior

Byte-identical except:

- **Snapshot — one intermediate-index shift** (`async LOW` fixture,
  `d-7 → d-10`). Without the pre-render strip, non-visible messages are
  built-then-ghosted (`None` slots) instead of removed, so surviving
  messages' raw `message_index` values move. The rendered logical
  content is unchanged (the tree iteration skips ghosts); the full
  snapshot diff is exactly the one `data-message-id`/`id` line.

- **One backlink change.** When a within-session fork's anchor is itself
  detail-stripped (e.g. a tool-only assistant at MINIMAL), the branch
  header's "from #msg-d-N" backlink is now **omitted** rather than
  retargeting the trunk session header. Previously the anchor was
  dropped pre-render so the backlink fell back to the trunk header; now
  it is built-then-ghosted and the anchor-repair pass nulls the dangling
  ref — consistent with the rest of the ghosting model (don't link a
  non-visible target). Branch nesting (trunk-header-before-branch) is
  unaffected.

## Tests / docs

- `test_detail_levels`: `TestFilterMinimal` rewritten end-to-end through
  `generate_template_messages` (the unit-level `_filter_by_detail` it
  called is gone), asserting on visible messages; added a static check
  pinning the deletion of `_filter_by_detail` / `_reindex_filtered_context`.
- `test_dag_integration`: `None`-guards on `ctx.messages` iterations
  (ghost slots now appear at MINIMAL where entries were previously
  pre-removed) and the fork-anchor backlink assertion updated.
- `dev-docs/application_model.md` §2.6 and `rendering-architecture.md` §5
  updated to the single-axis (post-render ghosting) model.

`just ci` green (format / lint / pyright / ty / unit / tui / browser /
benchmark).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured detail-level filtering logic for improved consistency and maintainability.

* **Documentation**
  * Updated internal documentation to reflect revised rendering pipeline and detail-filtering mechanics.

* **Tests**
  * Updated integration and snapshot tests to validate detail-level filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->