### PR TITLE
Dedupe "unrecognized message type" warnings per file

### DIFF
--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -262,6 +262,9 @@ def load_transcript(
     # Parse from source file
     messages: list[TranscriptEntry] = []
     agent_ids: set[str] = set()  # Collect agentId references while parsing
+    # Track unrecognized message types already warned about so we emit at
+    # most one warning per distinct type per file (these tend to repeat a lot).
+    warned_unrecognized_types: set[str | None] = set()
 
     try:
         f = open(jsonl_path, "r", encoding="utf-8", errors="replace")
@@ -347,7 +350,10 @@ def load_transcript(
                         # agent-name). Warn so we notice when Claude Code
                         # introduces new metadata worth supporting — add to
                         # SILENT_SKIP_TYPES once confirmed safe to drop.
-                        if not silent:
+                        # Only warn on the first occurrence of each distinct
+                        # type per file to avoid flooding the output.
+                        if not silent and entry_type not in warned_unrecognized_types:
+                            warned_unrecognized_types.add(entry_type)
                             print(
                                 f"Line {line_no} of {jsonl_path}: unrecognized message type "
                                 f"{entry_type!r} - skipping"

--- a/test/test_silent_skip.py
+++ b/test/test_silent_skip.py
@@ -180,6 +180,32 @@ class TestUnrecognizedTypesWarn:
         assert "unrecognized message type" in captured.out
         assert repr(entry["type"]) in captured.out
 
+    def test_repeated_unknown_type_warns_only_once(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The same unrecognized type repeated within a file warns once,
+        but each distinct type still gets its own first-occurrence warning."""
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {"type": "mode", "payload": 1},
+                {"type": "pr-link", "url": "x"},
+                {"type": "mode", "payload": 2},
+                {"type": "pr-link", "url": "y"},
+                {"type": "mode", "payload": 3},
+            ],
+        )
+
+        messages = load_transcript(jsonl, silent=False)
+        captured = capsys.readouterr()
+
+        assert messages == []
+        # One warning per distinct type, not per occurrence.
+        assert captured.out.count("unrecognized message type") == 2
+        assert captured.out.count("'mode'") == 1
+        assert captured.out.count("'pr-link'") == 1
+
     def test_silent_mode_suppresses_warning(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Problem

The `unrecognized message type '...' - skipping` warnings flood the output. The same type (e.g. `mode`, `pr-link`) recurs many times within a single transcript, producing dozens of identical lines:

```
Line 4580 of …/session.jsonl: unrecognized message type 'mode' - skipping
Line 4582 of …/session.jsonl: unrecognized message type 'pr-link' - skipping
Line 4603 of …/session.jsonl: unrecognized message type 'mode' - skipping
Line 4605 of …/session.jsonl: unrecognized message type 'pr-link' - skipping
…
```

## Fix

In `load_transcript` (`claude_code_log/converter.py`), track which unrecognized types have already been warned about in a per-file `warned_unrecognized_types` set. Each distinct type now warns **only on its first occurrence** (keeping the real line number); subsequent duplicates are silenced.

Deduplication is **per file**, not process-global: the `file:line` in the message is the actionable pointer for investigating a newly-introduced type, and in directory mode you still want to know which file surfaced it.

## Tests

Added `test_repeated_unknown_type_warns_only_once` in `test/test_silent_skip.py`: 5 entries (3×`mode`, 2×`pr-link`) → exactly 2 warnings, one per distinct type. Full `test_silent_skip.py` suite passes (16). `just ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced warning spam when processing files with repeated unrecognized message types. Warnings for each unknown type are now emitted only once per file instead of repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->