### PR TITLE
Linearize assistant-continuation tool-flow forks instead of branching

### DIFF
--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -21,6 +21,7 @@ from .models import (
     SummaryTranscriptEntry,
     QueueOperationTranscriptEntry,
     ToolUseContent,
+    ToolResultContent,
     UserTranscriptEntry,
     AssistantTranscriptEntry,
     PassthroughTranscriptEntry,
@@ -601,6 +602,60 @@ def _stitch_tool_results(
     return dead_ends + user_with_cont
 
 
+def _is_continuation_fork(
+    parent: MessageNode,
+    children: list[str],
+    nodes: dict[str, MessageNode],
+) -> bool:
+    """True for the assistant-continuation tool-flow artifact.
+
+    An assistant turn that issues tool_use(s) records, as same-session
+    children, BOTH the tool_result(s) for those calls AND the turn's
+    continuation — a further assistant message: the next parallel tool_use, or
+    a ``max_tokens``-split continuation. When *both* sides carry live
+    conversation the existing ``_stitch_tool_results`` variants bail (they each
+    need one side to be dead-end/structural), and the walk would otherwise
+    mis-read this as a real rewind and fork — recursively, since each
+    continuation hits the same shape, producing a staircase of spurious
+    branches.
+
+    This recognizes the shape so the caller can linearize it instead. It is
+    distinct from a genuine user rewind: a rewind forks at a *user* turn into
+    new user *prompts*; here the parent is an assistant and **every** user
+    child is a ``tool_result`` for one of the parent's own ``tool_use`` ids.
+    """
+    if not isinstance(parent.entry, AssistantTranscriptEntry):
+        return False
+    parent_tool_ids = {
+        item.id
+        for item in parent.entry.message.content
+        if isinstance(item, ToolUseContent)
+    }
+    if not parent_tool_ids:
+        return False
+    has_assistant_continuation = False
+    has_tool_result = False
+    for child_uuid in children:
+        entry = nodes[child_uuid].entry
+        if isinstance(entry, AssistantTranscriptEntry):
+            has_assistant_continuation = True
+        elif isinstance(entry, UserTranscriptEntry):
+            content = entry.message.content
+            if isinstance(content, str):
+                return False  # a user-typed rewind prompt, not a tool_result
+            results = [x for x in content if isinstance(x, ToolResultContent)]
+            if not results or not all(
+                r.tool_use_id in parent_tool_ids for r in results
+            ):
+                return False
+            has_tool_result = True
+        else:
+            # Any other child type (structural/system) is handled by the
+            # earlier variants; be conservative and don't claim this shape.
+            return False
+    return has_assistant_continuation and has_tool_result
+
+
 def _walk_session_with_forks(
     root: MessageNode,
     session_id: str,
@@ -754,6 +809,20 @@ def _walk_session_with_forks(
                             chain.append(o)
                         current = nodes[live]
                         continue
+
+                if _is_continuation_fork(current, same_session_children, nodes):
+                    # Tool-flow continuation, NOT a rewind: an assistant turn
+                    # whose tool_result(s) and continuation (next tool_use /
+                    # max_tokens split) landed as siblings. End the chain here
+                    # and re-enqueue each child as a same-line (non-branch)
+                    # continuation; the timestamp merge in
+                    # ``extract_session_dag_lines`` re-links the segments
+                    # chronologically, so the turn renders linearly instead of
+                    # as a recursive staircase of spurious forks.
+                    for child_uuid in same_session_children:
+                        queue.append((child_uuid, line_id, parent_line_id))
+                    current = None
+                    continue
 
                 unique_timestamps = {nodes[c].timestamp for c in same_session_children}
                 if len(unique_timestamps) == 1:

--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -962,23 +962,38 @@ def extract_session_dag_lines(
                 first_timestamp=sorted_nodes[0].timestamp,
             )
         else:
-            # Merge non-branch DAG-lines that share the same session_id
-            # (happens when multiple roots exist due to orphan promotion)
-            trunk_lines = [dl for dl in dag_lines if dl.session_id == session_id]
-            branch_lines = [dl for dl in dag_lines if dl.session_id != session_id]
-            if trunk_lines:
-                # Merge all trunk lines into one, ordered by first_timestamp
-                trunk_lines.sort(key=lambda dl: dl.first_timestamp)
+            # Merge DAG-line segments that share a session_id, ordered by
+            # first_timestamp. Multiple segments arise for the trunk when a
+            # session has several roots (orphan promotion, /compact) and for
+            # any line — trunk or *branch* — when continuation-fork
+            # linearization re-enqueues children as same-line segments.
+            # Branch segments must be merged too: inserting them by key
+            # would keep only the last segment and silently drop the rest.
+            lines_by_id: dict[str, list[SessionDAGLine]] = {}
+            for dl in dag_lines:
+                lines_by_id.setdefault(dl.session_id, []).append(dl)
+            for line_id, segments in lines_by_id.items():
+                if len(segments) == 1:
+                    sessions[line_id] = segments[0]
+                    continue
+                segments.sort(key=lambda dl: dl.first_timestamp)
                 merged_uuids: list[str] = []
-                for tl in trunk_lines:
-                    merged_uuids.extend(tl.uuids)
-                sessions[session_id] = SessionDAGLine(
-                    session_id=session_id,
+                for seg in segments:
+                    merged_uuids.extend(seg.uuids)
+                # The earliest segment starts the line, so its attachment
+                # metadata (fork point, branch flags) describes the whole
+                # merged line.
+                first = segments[0]
+                sessions[line_id] = SessionDAGLine(
+                    session_id=line_id,
                     uuids=merged_uuids,
-                    first_timestamp=trunk_lines[0].first_timestamp,
+                    first_timestamp=first.first_timestamp,
+                    parent_session_id=first.parent_session_id,
+                    attachment_uuid=first.attachment_uuid,
+                    is_branch=first.is_branch,
+                    original_session_id=first.original_session_id,
+                    is_sidechain=first.is_sidechain,
                 )
-            for dag_line in branch_lines:
-                sessions[dag_line.session_id] = dag_line
 
     return sessions
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -1889,21 +1889,68 @@ def _try_pair_triple(
     return False
 
 
+def _is_continuation_content(msg: TemplateMessage) -> bool:
+    """Is this message assistant *continuation* content (prose/thinking)?
+
+    Used by the tool_use↔tool_result pairing rule: when the assistant kept
+    talking between issuing a tool call and receiving its (lagging) result —
+    a ``max_tokens`` split, a thinking block, the prose of a next turn —
+    the result must stay in its chronological place rather than be pulled
+    back across the continuation (the DAG linearizes this shape instead of
+    forking; see ``dag._is_continuation_fork``).
+
+    Sidechain / subagent-session messages don't count: they interleave
+    between every Task/Agent tool_use and its result by construction and
+    are relocated after pair-reordering (``_relocate_subagent_blocks``).
+    Sibling tool_use/tool_result messages don't count either, so parallel
+    tool batches keep pairing adjacent as before.
+    """
+    if msg.is_sidechain or "#agent-" in msg.session_id:
+        return False
+    if isinstance(msg.content, AssistantTextMessage):
+        return bool(msg.content.items)  # an empty split carries no visible content
+    return msg.type == "thinking"
+
+
+def _continuation_between(
+    first: TemplateMessage,
+    last: TemplateMessage,
+    positions: dict[int, int],
+    continuation_prefix: list[int],
+) -> bool:
+    """True when assistant continuation content sits strictly between
+    ``first`` and ``last`` in the current linear order."""
+    i = positions.get(id(first))
+    j = positions.get(id(last))
+    if i is None or j is None or j <= i + 1:
+        return False
+    return continuation_prefix[j] - continuation_prefix[i + 1] > 0
+
+
 def _try_pair_by_index(
     current: TemplateMessage,
     indices: PairingIndices,
+    positions: dict[int, int],
+    continuation_prefix: list[int],
 ) -> None:
     """Try to pair current message with another using index lookups.
 
     Index-based pairing rules (can be any distance apart):
-    - tool_use + tool_result (by tool_use_id within same session)
+    - tool_use + tool_result (by tool_use_id within same session) —
+      *unless* assistant continuation content sits between them, in which
+      case the lagging result keeps its chronological position so the
+      continuation renders in between (see ``_is_continuation_content``)
     - system parent + system child (by uuid/parent_uuid)
     """
     # Tool use + tool result (by tool_use_id within same session)
     if current.type == "tool_use" and current.tool_use_id and current.session_id:
         key = (current.session_id, current.tool_use_id)
         if key in indices.tool_result:
-            _mark_pair(current, indices.tool_result[key])
+            result = indices.tool_result[key]
+            if not _continuation_between(
+                current, result, positions, continuation_prefix
+            ):
+                _mark_pair(current, result)
 
     # System child message finding its parent (by parent_uuid).
     # The uuid index only contains system messages, so this is a
@@ -1967,6 +2014,17 @@ def _identify_message_pairs(messages: list[TemplateMessage]) -> None:
     # Pass 1: Build all indices for efficient lookups
     indices = _build_pairing_indices(messages)
 
+    # Positions + prefix counts of continuation content, so the tool
+    # pairing rule can tell in O(1) whether assistant prose/thinking sits
+    # between a tool_use and its lagging result (in which case they must
+    # not pair — the continuation renders in between).
+    positions = {id(msg): pos for pos, msg in enumerate(messages)}
+    continuation_prefix = [0]
+    for msg in messages:
+        continuation_prefix.append(
+            continuation_prefix[-1] + (1 if _is_continuation_content(msg) else 0)
+        )
+
     # Pass 2: Sequential scan to identify pairs
     i = 0
     while i < len(messages):
@@ -1995,7 +2053,7 @@ def _identify_message_pairs(messages: list[TemplateMessage]) -> None:
                 continue
 
         # Try index-based pairing (doesn't skip, continues to next message)
-        _try_pair_by_index(current, indices)
+        _try_pair_by_index(current, indices, positions, continuation_prefix)
 
         i += 1
 

--- a/dev-docs/dag.md
+++ b/dev-docs/dag.md
@@ -2,28 +2,22 @@
 
 > See [application_model.md](application_model.md) for the system overview.
 
-Replaces timestamp-based ordering with `parentUuid` → `uuid` graph traversal.
+Message ordering is derived from the `parentUuid` → `uuid` graph recorded in
+the transcript JSONL — not from timestamps. The graph is the authoritative
+structure; timestamps are metadata, used only to merge parallel chain
+segments, order sibling sessions, and disambiguate fork artifacts. This is
+what lets resumed sessions, rewinds, compaction replays, subagents, and
+parallel tool flows all render in a coherent order that timestamp sorting
+cannot express.
 
-Reference: [Messages as Commits: Claude Code's Git-Like DAG of Conversations](https://piebald.ai/blog/messages-as-commits-claude-codes-git-like-dag-of-conversations)
+Background reading: [Messages as Commits: Claude Code's Git-Like DAG of
+Conversations](https://piebald.ai/blog/messages-as-commits-claude-codes-git-like-dag-of-conversations)
 
-Related issues: #79, #85, #90, #91
-
----
-
-## Motivation
-
-Currently, messages are sorted by timestamp and then patched with post-hoc
-fixups (pair reordering, sidechain reordering by `agentId`). This is fragile:
-
-- **Sync agents**: Works "well enough" because timestamps align with causality
-- **Async agents** (#90): Agent runs in background; launch and notification
-  are temporally distant; agent transcript interleaves arbitrarily
-- **Teammates** (#91): Multiple agents send messages concurrently
-- **Resume/fork** (#85): Conversation branches share a prefix; timestamp
-  ordering can't express the branching structure
-
-The transcript data already contains the structural information we need:
-each message's `parentUuid` points to its predecessor, forming a DAG.
+All graph code lives in `claude_code_log/dag.py`. The entry point is
+`build_dag_from_entries(entries)`, which runs the four construction steps in
+sequence (index → DAG → session DAG-lines → session tree);
+`traverse_session_tree(tree)` then yields the final linear entry order that
+feeds the rendering pipeline.
 
 ---
 
@@ -32,8 +26,7 @@ each message's `parentUuid` points to its predecessor, forming a DAG.
 ### The DAG
 
 Every message has a `uuid` and a `parentUuid` (null for first messages).
-Together they form a directed acyclic graph. The graph is the authoritative
-ordering; timestamps are metadata, not structure.
+Together they form a directed acyclic graph.
 
 ### Sessions and DAG-lines
 
@@ -42,9 +35,11 @@ forms a single contiguous chain in the DAG — its **DAG-line**. A session's
 DAG-line contains only the messages unique to that session (after
 deduplication).
 
-**Assertion**: Within a session, the default `parentUuid` chain is linear.
-Explicit rewinds create within-session forks that are rendered as branch
-pseudo-sessions. Unexpected non-rewind branching logs a warning.
+Within a session, the trunk `parentUuid` chain is linear after artifact
+linearization. Only explicit user rewinds create within-session forks,
+rendered as branch pseudo-sessions; every other multi-child shape is a
+recording artifact that gets linearized — see
+[Fork Disambiguation](#fork-disambiguation-the-linearization-ladder).
 
 ### Junction Points
 
@@ -105,31 +100,13 @@ Where `s1`, `s2`, `s3` are synthesized session header messages.
 > for the functions involved (`_branch_label`, `_build_branch_header`,
 > `create_session_preview`, `simplify_command_tags`).
 
-#### Current: `d-{index}` anchors (combined transcript only)
-
-Backlinks use `#msg-d-{N}` anchors which are sequential indices assigned
-during rendering. These are stable within a single render pass (the
-combined transcript is always regenerated whole), but shift when any
-session grows.
-
-This works for the combined transcript because all links and targets are
-on the same page. Individual session pages have independent indices.
-
-#### Future: UUID-based anchors for cross-page linking
-
-Each session's DAG-line can grow independently. If session B grows and
-its page is regenerated, `d-{index}` values shift — breaking any link
-from session A's (cached) page into B.
-
-When cross-session-page links are needed (e.g. session page A links to
-a junction point in session page B), add stable UUID-based anchors:
-
-```html
-<div id="msg-{uuid}" ...>  <!-- stable, never shifts -->
-```
-
-Use `msg-{uuid}` on junction points and attachment messages. Keep
-`msg-d-{N}` for everything else (session nav, timeline, etc.).
+Backlinks use `#msg-d-{N}` anchors — sequential indices assigned during
+rendering. They are stable within a single render pass (the combined
+transcript is always regenerated whole) but shift when any session grows,
+so they only work where all links and targets are on the same page.
+Individual session pages have independent indices; if cross-page links
+into another session's page are ever needed, they will require stable
+UUID-based anchors (`msg-{uuid}`) instead.
 
 ### Deduplication
 
@@ -143,350 +120,449 @@ session 2 (those with previously-unseen `uuid`) form its DAG-line.
 
 ### Agent Transcripts
 
-Agent transcripts also form DAG-lines. They come in two flavors:
+Subagent transcripts live in `<session>/subagents/agent-*.jsonl` with
+`parentUuid: null` on their first entry. Before the DAG is built,
+`_integrate_agent_entries` (converter.py) makes two adjustments per agent:
 
-1. **Continuing agents**: Their `parentUuid` chains into a previous agent's
-   DAG-line (same session, different `agentId`). These naturally fit the
-   DAG.
+1. **Re-parent** the agent's root to the trunk entry whose `agentId`
+   references this agent (the spawning Task/Agent `tool_result`). Nested
+   spawns (agent A spawns agent B) anchor inside A's sidechain; a
+   cross-agent-boundary guard prevents an agent's own root from acting as
+   its anchor (which would self-loop).
+2. **Stamp** every entry of the agent with a synthetic session id,
+   `{trunk}#agent-{agentId}`, so each agent becomes its own DAG-line that
+   attaches at the anchor — rather than folding into the trunk's chain.
 
-2. **Top-level agents**: `parentUuid` is null. These need explicit
-   **parenting** — splicing them into the main session's DAG-line at the
-   appropriate point.
-
-   For `x → y → z` where `y` is a Task, and agent transcript `u → v` needs
-   to be rooted at `y`, the result is: `x → y → u → v → z`.
-
-**Parenting strategies** (by agent type):
-
-| Agent type | Link mechanism | Parent at |
-|------------|---------------|-----------|
-| Sync Task | `agentId` on tool_result | Task tool_result message |
-| Async Task (#90) | `agentId` on launch tool_result, `task-id` in `<task-notification>` | Launch tool_result |
-| Teammate (#91) | `team_name` + agent name | TBD — likely TeamCreate or Task-with-team |
+With both in place, agents fall out of the normal session-tree machinery:
+no special-casing in the walk or the traversal. Per-agent-type linking
+details (sync, async, teammates) are covered in [agents.md](agents.md)
+and [teammates.md](teammates.md).
 
 ---
 
-## Algorithm
+## Pipeline
 
-### Phase 1: Load All Sessions
+### Step 1 — Index (`build_message_index`)
 
-Load **all** `.jsonl` files for a project directory. Build a unified message
-index:
+Parse all entries, index by `uuid` (oldest instance wins on duplicates),
+group by `sessionId`:
 
 ```python
-messages_by_uuid: dict[str, TranscriptEntry]   # uuid → entry (oldest wins)
-children_by_uuid: dict[str, list[str]]          # parentUuid → [child uuids]
-sessions: dict[str, list[str]]                  # sessionId → [uuids in chain order]
+messages_by_uuid: dict[str, MessageNode]   # uuid → node (oldest wins)
+children_by_uuid: dict[str, list[str]]     # parentUuid → [child uuids]
+sessions: dict[str, list[str]]             # sessionId → [uuids]
 ```
 
-When targeting a single session, still load all files but only render
-that session's subtree. Optionally warn that context from other sessions
-is available.
+### Step 2 — DAG construction (`build_dag`)
 
-### Phase 2: Build DAG and Deduplicate
+Populates `children_uuids` in three steps that **must run in this order**:
 
-1. Parse all entries, index by `uuid`
-2. For duplicate `uuid`s, keep the one from the earliest `sessionId`
-3. Group messages by `sessionId`
-4. `build_dag(nodes, sidechain_uuids)` populates `children_uuids` —
-   in three steps that **must run in this order** (PR #135):
+```mermaid
+flowchart TB
+    A["entries indexed by uuid<br/>(parent_uuid pointers may<br/>dangle or cycle)"] --> S1
+    S1["Step 1 — orphan promotion<br/>parent_uuid not in nodes →<br/>null it; warn unless the<br/>parent is a known sidechain<br/>uuid (silently promote)"] --> S2
+    S2["Step 2 — cycle break<br/>walk parent_uuid from each<br/>node; revisit ⇒ null the<br/>revisited node's parent;<br/>warn"] --> S3
+    S3["Step 3 — children build<br/>for each node with non-null<br/>parent_uuid, append to<br/>parent.children_uuids;<br/>skip self-loops, dedup"] --> O["acyclic parent→children DAG<br/>safe to walk"]
+    classDef step fill:#eef,stroke:#99c
+    class S1,S2,S3 step
+```
 
-   ```mermaid
-   flowchart TB
-       A["entries indexed by uuid<br/>(parent_uuid pointers may<br/>dangle or cycle)"] --> S1
-       S1["Step 1 — orphan promotion<br/>parent_uuid not in nodes →<br/>null it; warn unless the<br/>parent is a known sidechain<br/>uuid (silently promote)"] --> S2
-       S2["Step 2 — cycle break<br/>walk parent_uuid from each<br/>node; revisit ⇒ null the<br/>revisited node's parent;<br/>warn"] --> S3
-       S3["Step 3 — children build<br/>for each node with non-null<br/>parent_uuid, append to<br/>parent.children_uuids;<br/>skip self-loops, dedup"] --> O["acyclic parent→children DAG<br/>safe to walk"]
-       classDef step fill:#eef,stroke:#99c
-       class S1,S2,S3 step
-   ```
+Steps 1 and 2 mutate `parent_uuid` on the input nodes (they're one-way: a
+promoted-to-root node can't recover its dangling parent later). Step 3 is
+the only step that builds the `children_uuids` lists. Doing children first
+would propagate any cyclic edge into the children graph, and downstream
+walks via `children_uuids` would loop forever — so cycles must be broken
+at the parent-pointer layer before children are materialised.
 
-   Steps 1 and 2 mutate `parent_uuid` on the input nodes (they're
-   one-way: a promoted-to-root node can't recover its dangling
-   parent later). Step 3 is the only step that builds the
-   `children_uuids` lists. Doing children first would propagate
-   any cyclic edge into the children graph, and downstream walks
-   via `children_uuids` would loop forever — so cycles must be
-   broken at the parent-pointer layer before children are
-   materialised.
+### Step 3 — Session DAG-lines (`extract_session_dag_lines`)
 
-### Phase 3: Extract Session DAG-lines
+For each session:
 
-For each session (`extract_session_dag_lines` in `dag.py`):
 1. Identify the session's unique messages (those whose authoritative
-   `sessionId` matches)
+   `sessionId` matches).
 2. Find roots (nodes whose `parent_uuid` is null or points outside the
    session). A session may have **multiple roots** — see
    [Compact Boundaries and Multi-Root Sessions](#compact-boundaries-and-multi-root-sessions).
 3. Walk each root via `_walk_session_with_forks`, following same-session
-   children. Single-child → chain continues. Multiple same-session
-   children → distinguish real forks from artifacts using the heuristics
-   below.
-4. Merge trunk DAG-lines from multiple roots into a single chain
-   (ordered by `first_timestamp`); branch DAG-lines stay separate.
-5. If DAG walk coverage is incomplete, fall back to a timestamp sort for
-   the whole session.
+   children. Single child → chain continues. Multiple same-session
+   children → the [linearization ladder](#fork-disambiguation-the-linearization-ladder)
+   decides between artifact (linearize) and real fork (branch).
+4. Merge trunk DAG-lines (`session_id == sessionId`) from all roots — and
+   any trunk *segments* produced by continuation-fork linearization — into
+   a single chain ordered by `first_timestamp`; branch DAG-lines stay
+   separate under synthetic ids (`{sessionId}@{uuid12}`).
+5. **Coverage check**: `walked ∪ skipped` must equal the session's node
+   set; otherwise fall back to a timestamp sort for the whole session and
+   log a warning. (`skipped` collects nodes intentionally dropped by the
+   ladder — replay chains, dead-end descendants — so legitimate
+   linearization doesn't trip the fallback.)
 
-**Defence-in-depth in the walker** (PR #135): even though `build_dag`
-breaks parent-pointer cycles before populating `children_uuids`, a
-future bug or hand-edited fixture could reintroduce a cyclic edge
-*after* DAG construction. `_walk_session_with_forks` keeps a
-`walk_visited: set[str]` across the whole queue-driven walk; if a
-uuid is visited twice, the chain is truncated at that point and a
-warning is logged. The build-time cycle break and this walk-time
-guard together rule out the unbounded-loop class of hangs that
-motivated the PR.
+**Defence-in-depth in the walker**: even though `build_dag` breaks
+parent-pointer cycles before populating `children_uuids`, a future bug or
+hand-edited fixture could reintroduce a cyclic edge *after* DAG
+construction. `_walk_session_with_forks` keeps a `walk_visited` set across
+the whole queue-driven walk; a uuid visited twice truncates the chain at
+that point with a warning. The build-time cycle break and this walk-time
+guard together rule out the unbounded-loop class of hangs.
 
-### Phase 4: Build Session Tree
+### Step 4 — Session tree (`build_session_tree`)
 
-1. For each session, find where its DAG-line attaches to the DAG:
-   - Walk back from the session's first unique message via `parentUuid`
-   - The first message belonging to a **different** session is the
-     attachment point
-2. The session whose message is the attachment point is the parent session
-3. Root sessions have no attachment point (first message is `parentUuid: null`
-   or points outside loaded data)
-4. Order children chronologically
+1. For each session, find where its DAG-line attaches: walk back from the
+   session's first unique message via `parentUuid`; the first message
+   belonging to a **different** session is the attachment point.
+2. The session owning the attachment point is the parent session. Root
+   sessions have no attachment point.
+3. Children are ordered chronologically.
+4. Junction points are annotated: a message is a junction point if its
+   children include messages from a different session. The annotations
+   drive forward-link rendering.
 
-### Phase 5: Identify Junction Points
+### Handoff to rendering
 
-A message is a junction point if `children_by_uuid[msg.uuid]` contains
-messages from multiple sessions, or from a session different than the
-message's own.
-
-Annotate junction points with their target sessions for forward-link
-rendering.
-
-### Phase 6: Splice Agent Transcripts
-
-For each agent transcript (identified by `agentId`):
-1. Determine parenting strategy (see table above)
-2. Find the anchor message in the main session's DAG-line
-3. Splice the agent's DAG-line after the anchor
-
-This replaces the current `_reorder_sidechain_template_messages` approach
-with a principled graph operation.
-
-### Phase 7: Process and Render
-
-Within each DAG-line, apply existing processing:
-- Pairing (tool_use+tool_result, thinking+assistant, etc.)
-- Hierarchy building
-- Tree construction
-
-Pairing should be **scoped to DAG-lines** — no pairing across session
-boundaries. This is both correct and faster.
+`traverse_session_tree` flattens the tree depth-first into the final
+entry order. Downstream processing (pairing, hierarchy, tree building)
+lives in `renderer.py` and operates on that order. Pairing is keyed by
+`(session_id, tool_use_id)`, so pairs never span sessions. One pairing
+rule exists specifically to preserve DAG order — see the
+[assistant-continuation rung](#5-assistant-continuation-tool-flow-_is_continuation_fork)
+below.
 
 ---
 
-## Caveats
+## Fork disambiguation: the linearization ladder
 
-### Context Compaction Replays
+A node with multiple same-session children is either a **real fork** (the
+user rewound the conversation) or one of several **recording artifacts**
+that must be linearized. `_walk_session_with_forks` tries the following
+checks in order; the first match wins. Only a shape that survives every
+rung is treated as a real fork.
 
-When Claude Code compacts context (inserting a `SummaryTranscriptEntry`), it
-**replays** the conversation from a certain point with **new UUIDs** but the
-**same `parentUuid` and timestamp** as the original entries. This creates
-multiple same-session children from a single parent — structurally identical
-to a user rewind (fork), but semantically a replay.
+| # | Rung | Detection | Action |
+|---|------|-----------|--------|
+| 1 | [Structural side-branch collapse](#1-structural-side-branch-collapse) | ≥1 structural child (Passthrough/Attachment with structural subtree), ≤1 non-structural child | Stitch structural children in chronologically; continue via the non-structural child (or end) |
+| 2 | [Stitch V1 — structural tool_result](#2-tool-result-stitching-variant-1-structural-tool_result) | Every user child's subtree is structural; exactly one assistant child | Splice user children ahead of the assistant continuation |
+| 3 | [Stitch V2 — dead-end continuation](#3-tool-result-stitching-variant-2-dead-end-continuation) | Every assistant child's subtree dead-ends; exactly one user child continues | Splice dead-end children ahead of the continuing user child |
+| 4 | [Live passthrough chain (V3)](#4-live-passthrough-chain-variant-3) | Exactly one passthrough child has a live subtree; all other children structural | Stitch the structural siblings in; continue through the live passthrough |
+| 5 | [Assistant continuation](#5-assistant-continuation-tool-flow-_is_continuation_fork) | Assistant parent with tool_use(s); children = assistant continuation(s) + tool_result(s) addressed to the parent's own tool ids | End chain; re-enqueue each child as a trunk *segment*; timestamp merge re-links them |
+| 6 | [Compaction replay](#6-compaction-replay) | All children share one timestamp | Follow the first child; skip the replays |
+| 7 | [Real rewind](#7-real-rewind-branch-pseudo-sessions) | None of the above (different timestamps) | Fork: each child becomes a branch pseudo-session |
 
-**Distinguishing heuristic**: timestamps.
+Diagram conventions: "recorded" shows the DAG as written to JSONL (the
+shape that *looks like* a fork); "linearized" shows the resulting chain.
+Blue = structural entries, red = dead ends (descendants dropped to
+`skipped`), green = live continuation.
 
-- **Real fork (rewind)**: the user goes back and types a new message at a
-  different time → children have **different** timestamps.
-- **Compaction replay**: the system re-emits the same turn → children share
-  the **same** timestamp as the original.
+### Helper predicates
 
-When `_walk_session_with_forks()` encounters a node with multiple same-session
-children that all share the same timestamp, it follows only the **first**
-child (the original chain) and ignores the later replay chains. This avoids
-creating hundreds of false branch pseudo-sessions in long-running sessions
-with frequent compaction.
+- **`_is_structural_subtree(uuid)`** — true when the node's *descendants*
+  (the root itself is not inspected) contain no user/assistant entries —
+  only passthrough/attachment material (hook callbacks, `progress`
+  chains, …). Unbounded traversal (bounded by the session's uuid set):
+  real `progress` chains regularly run more than 20 entries deep, so a
+  depth cap would misclassify pure-passthrough tails as live.
+- **`_is_subtree_dead_end(uuid)`** — true when every path in the subtree
+  terminates within depth 20. A subtree deeper than the cap is assumed
+  **live** ("too deep to tell"). This is why a deep `max_tokens`
+  continuation chain is *not* a V2 dead end and falls through to rung 5.
+- **`_is_continuation_fork(parent, children)`** — true when the parent is
+  an assistant entry carrying `tool_use` block(s) and every child is
+  either an assistant entry (the continuation) or a user entry whose
+  content is exclusively `tool_result` blocks addressed to the parent's
+  own tool ids. A user child with *typed text* (a rewind prompt) or a
+  `tool_result` for some other tool id fails the predicate — those are
+  real forks. Both an assistant child and a tool_result child must be
+  present.
+- **`_StructuralEntry`** = `PassthroughTranscriptEntry` (legacy
+  unknown-but-DAG-relevant types: `progress`, `agent-setting`, `pr-link`,
+  `ai-title`) + `AttachmentTranscriptEntry` (typed `attachment` entries:
+  hook callbacks, deferred-tool deltas, queued commands, …). Both are
+  treated uniformly here.
 
-The heuristic is validated on real data: across all fork points, forks
-partition cleanly into same-timestamp (compaction) vs different-timestamp
-(rewind) groups, with no mixed cases observed.
+### 1. Structural side-branch collapse
 
-### Tool-Result Side-Branches
+A structural entry alongside a regular sibling is an artifact, not a
+fork. The walker partitions children into `structural_kids` (structural
+roots with structural subtrees) and `non_structural`, and collapses when
+at most one non-structural child remains. Two shapes, one rule:
 
-When the assistant makes **multiple tool calls** in one turn, the JSONL
-records both the next `tool_use` and the previous `tool_result` as children
-of the same parent entry. Without intervention this creates a fake fork at
-every parallel-tool_use turn. `_stitch_tool_results()` and the all-passthrough
-clause in `_walk_session_with_forks()` detect three patterns and splice the
-side-branch back into the main chain.
-
-#### Variant 1 — User child's subtree is purely structural
-
-The `tool_result` for the first parallel call is recorded as a sibling of
-the `tool_use` for the second call. The `tool_result` itself is conversation
-content, but its subtree carries only a `hook_success` attachment leaf and
-no further user/assistant descendants.
-
-Pre-fix DAG (looks like a fork):
-
-```mermaid
-graph TD
-    A1["A(tool_use₁)"] --> U1["U(tool_result₁)"]
-    A1 --> A2["A(tool_use₂)"]
-    U1 --> H["📎 attachment (hook_success)"]
-    A2 --> U2["U(tool_result₂)"]
-    U2 --> rest["..."]
-    classDef structural fill:#eef,stroke:#99c
-    class H structural
-```
-
-Post-fix — `_is_structural_subtree(U₁)` returns true (no user/assistant
-descendants), so `U₁` is stitched into the chain ahead of the continuation
-`A₂`, and the attachment is collapsed in as a non-rendered side entry:
-
-```mermaid
-graph LR
-    A1["A(tool_use₁)"] --> U1["U(tool_result₁)"]
-    U1 --> A2["A(tool_use₂)"]
-    A2 --> U2["U(tool_result₂)"]
-    U2 --> rest["..."]
-```
-
-The earlier "no immediate same-session child" check missed Variant 1 when
-a `hook_success` attachment sat under the `tool_result`. That's the shape
-of all 22 fake forks observed in the BCT Teamcenter 1594-entry test file.
-
-#### Variant 2 — Assistant subtree dead-ends
-
-Claude Code sometimes emits a second `tool_use` that terminates without
-producing a continuation — a progress artifact. The `tool_result` for the
-first call **does** continue the main conversation, so the fix stitches the
-dead `tool_use` subtree into the chain before the continuing `tool_result`.
+**Shape A — all-structural** (e.g. two hook attachments on one parent,
+often at far-apart timestamps, so the replay heuristic would not apply):
 
 ```mermaid
 graph TD
-    A1["A(tool_use₁)"] --> U1["U(tool_result₁)"]
-    U1 --> Amain["A(response) — continues"]
-    A1 --> A2["A(tool_use₂)"]
-    A2 --> U2["U(tool_result₂) — dead end"]
-    classDef dead fill:#fee,stroke:#c99
-    class A2,U2 dead
-```
-
-Detected by `_is_subtree_dead_end()`: exactly one user child has a live
-continuation; every assistant child's subtree dead-ends within the session.
-
-#### Structural-side-branch collapse — at most one non-structural sibling
-
-A `PassthroughTranscriptEntry` (attachment, `hook_success`,
-`SessionStart:resume`, `progress`) alongside a regular sibling is an
-artifact, not a fork. The DAG walker partitions children into
-`structural_kids` (passthrough roots with a structural subtree per
-`_is_structural_subtree`) and `non_structural`, then collapses when
-`structural_kids and len(non_structural) <= 1`. The chain continues
-through the single non-structural child, or terminates if there isn't
-one.
-
-This catches two real-world shapes with the same rule:
-
-**Shape A — all-passthrough:** two attachments on the same parent, often
-at far-apart timestamps so the compaction-replay heuristic doesn't apply.
-
-```mermaid
-graph TD
-    A["A(assistant)"] --> P1["📎 hook_success"]
+    A["A (assistant)"] --> P1["📎 hook_success"]
     A --> P2["📎 SessionStart:resume"]
     classDef structural fill:#eef,stroke:#99c
     class P1,P2 structural
 ```
 
-Collapsed: both passthroughs appended to the chain (chronological), chain
-terminates (`current = None`).
+Linearized — both stitched in chronologically, chain ends:
 
-**Shape B — mixed user + progress sibling:** a conversational child
-alongside a bare `<progress>` leaf or chain. Previously fell through to
-the different-timestamps fork path and produced a spurious
-`Fork point (1 branches)` entry after `alice-fix-nav-anchors` pruned the
-dead-link side.
+```mermaid
+graph LR
+    A["A (assistant)"] --> P1["📎 hook_success"] --> P2["📎 SessionStart:resume"]
+    classDef structural fill:#eef,stroke:#99c
+    class P1,P2 structural
+```
+
+**Shape B — mixed**: a conversational child alongside a bare `progress`
+leaf or chain. Without this rung it would fall through to the rewind path
+and produce a spurious one-branch fork point.
 
 ```mermaid
 graph TD
-    A["A(assistant)"] --> U["U(next turn)"]
-    A --> P["🗿 progress (structural leaf or chain)"]
+    A["A (assistant)"] --> U["U (next turn)"]
+    A --> P["🗿 progress"]
     classDef structural fill:#eef,stroke:#99c
     class P structural
 ```
 
-Collapsed: `P` stitched chronologically into the chain, `current = U`
-continues the conversation.
+Linearized — the structural child is stitched in, the conversation
+continues:
 
-The partition is strict about what counts as structural: only
-`PassthroughTranscriptEntry` roots with a purely structural subtree
-qualify. A `UserTranscriptEntry` with a passthrough-only subtree (the
-Variant 1 shape in the next subsection) falls into `non_structural` and
-is handled by `_stitch_tool_results` instead — Variant 1 and the
-structural-collapse paths don't overlap.
+```mermaid
+graph LR
+    A["A (assistant)"] --> P["🗿 progress"] --> U["U (next turn)"] --> rest["…"]
+    classDef structural fill:#eef,stroke:#99c
+    class P structural
+```
 
-**Defense-in-depth** — the `_is_structural_subtree(c)` check is applied
-in addition to the `isinstance(c, PassthroughTranscriptEntry)` test.
-Today passthrough entries are always leaves, but if a future passthrough
-type ever carries conversational descendants, it will correctly fall
-through to the normal fork logic instead of masking the content.
+The partition is strict: only structural-typed roots with purely
+structural subtrees qualify. A `UserTranscriptEntry` whose subtree is
+passthrough-only (the V1 shape below) lands in `non_structural` and is
+handled by `_stitch_tool_results` instead — the rungs don't overlap. And
+if a future passthrough type ever carries conversational descendants, the
+subtree check makes it fall through to the fork logic rather than masking
+content.
 
-#### Variant 3 — Parallel-tool_use chain via passthrough
+### 2. Tool-result stitching, variant 1: structural tool_result
 
-Real Claude Code teammate transcripts (CC 2.1.32+) thread parallel
-tool_uses through `progress` passthroughs rather than as direct
-`tool_use` siblings. Each parallel turn produces a 2-child fork at the
-spawning assistant: the user(tool_result) for the first parallel call
-sits beside a passthrough that chains into the next assistant tool_use.
-The passthrough subtree carries the live continuation; the
-user(tool_result) carries only structural callbacks (a hook
-acknowledgement leaf), so it dead-ends.
+When the assistant makes **multiple tool calls in one turn**, the JSONL
+can record the `tool_result` for the first call and the `tool_use` for
+the second as *siblings*. The `tool_result` is conversation content, but
+its subtree carries only structural callbacks (e.g. a `hook_success`
+leaf) — the assistant sibling is the real continuation.
 
 ```mermaid
 graph TD
-    A1["A(tool_use₁)"] --> U1["U(tool_result₁)"]
-    A1 --> P1["🗿 progress (passthrough)"]
-    U1 --> H1["🗿 hook callback (leaf)"]
-    P1 --> A2["A(tool_use₂)"]
-    A2 --> U2["U(tool_result₂)"]
-    A2 --> P2["🗿 progress"]
-    P2 --> rest["..."]
+    A1["A (tool_use₁)"] --> U1["U (tool_result₁)"]
+    A1 --> A2["A (tool_use₂)"]
+    U1 --> H["📎 hook_success (leaf)"]
+    A2 --> U2["U (tool_result₂)"] --> rest["…"]
     classDef structural fill:#eef,stroke:#99c
-    class P1,H1,P2 structural
+    class H structural
 ```
 
-Detection in `_walk_session_with_forks`: exactly one passthrough child
-has a non-structural subtree (live continuation), and every other
-sibling has a structural subtree (no user/assistant descendants). The
-passthrough sibling becomes the chain continuation; the dead-end
-user/assistant siblings are appended to the chain inline and their
-descendants are collected into `skipped`.
+Linearized — the result is spliced ahead of the continuation; its
+structural descendants go to `skipped`:
 
-Variants 1 and 2 in `_stitch_tool_results` share the same
-"user-tool_result vs assistant-tool_use" framing and don't fire when
-the live continuation is a passthrough; the earlier
-structural-side-branch collapse (which only treats *passthrough* kids
-as structural) doesn't fire when the structural sibling is a
-user(tool_result). Variant 3 fills that gap. Distinct from real user
-rewinds, which never include passthrough children.
+```mermaid
+graph LR
+    A1["A (tool_use₁)"] --> U1["U (tool_result₁)"] --> A2["A (tool_use₂)"] --> U2["U (tool_result₂)"] --> rest["…"]
+```
 
-The fix also relies on `_is_structural_subtree` being unbounded over
-the subtree (no depth cap): real `progress` chains under a
-parallel-tool_use anchor regularly run >20 entries deep.
+Detection: *every* user child has a structural subtree
+(`_is_structural_subtree`), and there is exactly one assistant child.
 
-#### Summary of detection criteria
+### 3. Tool-result stitching, variant 2: dead-end continuation
 
-| Pattern | Detection | Action |
-|---------|-----------|--------|
-| Variant 1 | `_is_structural_subtree(U)` true for every user child; exactly one assistant continuation | Splice user children ahead of assistant continuation |
-| Variant 2 | `_is_subtree_dead_end(A)` true for every assistant child; exactly one user continuation | Splice assistant children ahead of user continuation |
-| Variant 3 | Exactly one passthrough child with non-structural subtree; every other child has a structural subtree | Append dead-end siblings to chain; continue through the live passthrough |
-| Structural side-branch collapse | At least one structural passthrough child; ≤1 non-structural child | Collapse structural children into chain; continue via the single non-structural (or terminate) |
-| Real rewind | Multiple non-structural children at different timestamps | Real within-session fork → branch pseudo-sessions |
-| Compaction replay | Multiple children sharing the same timestamp | Follow first, skip rest (see next section) |
+Claude Code sometimes emits a second `tool_use` that terminates without
+producing a continuation — a progress artifact. Here the `tool_result`
+for the first call **does** continue the conversation, so the dead
+`tool_use` subtree is spliced in before it.
 
-Subtree descendants of stitched/collapsed side-branch nodes are added to
-the `skipped` set for coverage accounting, so the "DAG walk coverage
-incomplete" fallback doesn't fire.
+```mermaid
+graph TD
+    A1["A (tool_use₁)"] --> U1["U (tool_result₁)"] --> Am["A (response)"] --> rest["…"]
+    A1 --> A2["A (tool_use₂) — artifact"]
+    A2 --> U2["U (tool_result₂)"]
+    classDef dead fill:#fee,stroke:#c99
+    class A2,U2 dead
+```
 
-### Compact Boundaries and Multi-Root Sessions
+Linearized — the dead-end root is stitched in (its descendants go to
+`skipped`), the user child continues the chain:
+
+```mermaid
+graph LR
+    A1["A (tool_use₁)"] --> A2["A (tool_use₂)"] --> U1["U (tool_result₁)"] --> Am["A (response)"] --> rest["…"]
+    classDef dead fill:#fee,stroke:#c99
+    class A2 dead
+```
+
+Detection: exactly one user child has a live continuation; every
+assistant child's subtree dead-ends (`_is_subtree_dead_end`), as does
+every other user child.
+
+**Agent-anchor preservation**: parallel `Task`/`Agent` tool_uses emit
+sibling tool_result anchors whose parent assistants sit in each other's
+dead-end subtree. Before stitching, `_collect_agent_anchors` lifts two
+kinds of nodes out of dead-end subtrees back into the chain: trunk
+tool_results carrying an `agentId` (subagent attachment points) and
+assistants carrying `Task`/`Agent` tool_use blocks (nested-spawn cards).
+Without this, classifying the subtree as dead-end would detach the
+subagent sessions and hide nested Agent invocations.
+
+### 4. Live passthrough chain (Variant 3)
+
+Recent Claude Code versions (observed 2.1.32+) thread parallel tool_uses
+through `progress` passthroughs rather than direct `tool_use` siblings.
+The passthrough subtree carries the live continuation; the
+user(tool_result) sibling carries only structural callbacks.
+
+```mermaid
+graph TD
+    A1["A (tool_use₁)"] --> U1["U (tool_result₁)"]
+    A1 --> P1["🗿 progress"]
+    U1 --> H1["📎 hook callback (leaf)"]
+    P1 --> A2["A (tool_use₂)"]
+    A2 --> U2["U (tool_result₂)"]
+    A2 --> P2["🗿 progress"]
+    P2 --> rest["…"]
+    classDef structural fill:#eef,stroke:#99c
+    classDef live fill:#efe,stroke:#9c9
+    class H1,P2 structural
+    class P1 live
+```
+
+Linearized — structural siblings stitched in, the chain continues
+*through* the live passthrough (which repeats the same shape at `A₂`):
+
+```mermaid
+graph LR
+    A1["A (tool_use₁)"] --> U1["U (tool_result₁)"] --> P1["🗿 progress"] --> A2["A (tool_use₂)"] --> rest["…"]
+    classDef structural fill:#eef,stroke:#99c
+    class P1 structural
+```
+
+Detection: exactly one structural-typed child has a **non**-structural
+subtree (the live one), and every other sibling has a structural subtree.
+Rungs 2–3 don't fire here (no assistant sibling at this level); rung 1
+doesn't fire (the live passthrough is not structural-subtree). Distinct
+from real rewinds, which never include passthrough children.
+
+### 5. Assistant continuation tool-flow (`_is_continuation_fork`)
+
+The shape rungs 1–4 *cannot* catch: **both** siblings carry live
+conversation. An assistant turn issues a `tool_use`, and the JSONL
+records as siblings both the turn's **continuation** — a thinking block,
+a `max_tokens` split, or the next parallel `tool_use` — and the
+**lagging `tool_result`** (which arrives when the tool finishes, possibly
+minutes later, and continues the conversation from there).
+
+```mermaid
+graph TD
+    A1["A (tool_use X)"] --> C["A (continuation)<br/>thinking / max_tokens split /<br/>next tool_use Y"]
+    A1 --> U["U (tool_result X)<br/>arrives after the tool's runtime"]
+    C --> Cmore["… live conversation …"]
+    U --> Umore["… live conversation …"]
+    classDef live fill:#efe,stroke:#9c9
+    class C,U live
+```
+
+Both subtrees are live, so V1/V2 bail (each needs one side structural or
+dead-end) and there is no passthrough for V3. Without this rung the walk
+would read the shape as a rewind and fork — *recursively*, because each
+continuation immediately hits the same shape at its own next tool call,
+producing a staircase of spurious nested branches.
+
+Linearized — continuation inline, lagging result after:
+
+```mermaid
+graph LR
+    A1["A (tool_use X)"] --> C["A (continuation)"] --> Cmore["…"] --> U["U (tool_result X)"] --> Umore["…"]
+    classDef live fill:#efe,stroke:#9c9
+    class C,U live
+```
+
+Mechanism — unlike rungs 1–4, nothing is stitched at the fork point.
+The chain **ends** at `A₁` and each child is re-enqueued as a trunk
+*segment* (same DAG-line id, not a branch). The trunk merge in
+`extract_session_dag_lines` then concatenates all trunk segments by
+`first_timestamp`: the continuation (issued within seconds) sorts before
+the lagging tool_result. This reuses the multi-root merge machinery, so
+arbitrarily deep repetitions of the shape flatten into one chain.
+
+Discrimination from a real rewind: a rewind forks at new typed user
+*prompts* (string content); here every user child consists exclusively
+of `tool_result` blocks addressed to the parent's own `tool_use` ids.
+Anything else — typed text, a result for a foreign tool id, any other
+child type — fails the predicate and falls through.
+
+**Renderer complement** — DAG order alone isn't enough: the renderer's
+pair-reordering (`_reorder_paired_messages`) normally pulls each
+`tool_result` adjacent to its `tool_use`, which would yank the lagging
+result back *across* the continuation. `_identify_message_pairs`
+(renderer.py) therefore skips marking the pair when assistant
+continuation content (prose or thinking — `_is_continuation_content`)
+sits between the two in linear order, so the result keeps its
+chronological place. Sibling tool messages (parallel batches),
+sidechain/subagent threads, and empty splits don't block pairing. At
+reduced detail levels the ghost pass runs *before* pairing, so once the
+continuation is filtered out the pair re-forms and renders adjacent —
+the compact view wanted there. Pinned by `test_continuation_fork.py`
+(DAG side) and `test_continuation_pairing.py` (renderer side).
+
+### 6. Compaction replay
+
+When Claude Code compacts context, it **replays** the conversation from
+some point with **new UUIDs** but the **same `parentUuid` and timestamp**
+as the originals — structurally identical to a rewind, semantically a
+replay.
+
+```mermaid
+graph TD
+    A["A (assistant)"] --> U1["U (original) — ts T"]
+    A --> U2["U (replay) — ts T"]
+    U2 --> U2more["… replayed chain …"]
+    classDef dead fill:#fee,stroke:#c99
+    class U2,U2more dead
+```
+
+Linearized — follow the first child only; replay chains go to `skipped`:
+
+```mermaid
+graph LR
+    A["A (assistant)"] --> U1["U (original)"] --> rest["…"]
+```
+
+The heuristic is the **shared timestamp**: a real rewind means the user
+typed a new message at a different time, so children differ; a replay
+re-emits the same turn at the same instant. Validated on real data: fork
+points partition cleanly into same-timestamp (compaction) and
+different-timestamp (rewind) groups, with no mixed cases observed.
+
+### 7. Real rewind: branch pseudo-sessions
+
+What remains — multiple live, non-structural children at different
+timestamps — is a genuine fork: the user went back and re-prompted.
+
+```mermaid
+graph TD
+    A["A (assistant)"] --> U1["U: first attempt — 10:02"]
+    A --> U2["U: rewound prompt — 10:35"]
+    U1 --> B1["… branch 1 …"]
+    U2 --> B2["… branch 2 …"]
+```
+
+The trunk chain ends at the fork point; **each** child becomes a branch
+DAG-line with a synthetic id (`{sessionId}@{uuid12}`), rendered as a
+branch pseudo-session with a fork-point navigation box on the parent
+message and backlinks on the branch headers:
+
+```mermaid
+graph LR
+    A["A (assistant) — fork point"]
+    A --> H1["Branch • uuid₁ …"] --> B1["… branch 1 …"]
+    A --> H2["Branch • uuid₂ …"] --> B2["… branch 2 …"]
+```
+
+Branch nodes get their `session_id` rewritten to the branch id so the
+session tree attaches them at the fork point (`attachment_uuid`).
+
+---
+
+## Compact Boundaries and Multi-Root Sessions
 
 When the user runs `/compact`, Claude Code writes a `system/compact_boundary`
 entry with `parentUuid: null`, followed by a user entry carrying the summary
@@ -514,13 +590,13 @@ graph TB
     class U0,CB1,CB2 root
 ```
 
-**Multi-root handling in `extract_session_dag_lines`** (dag.py):
+**Multi-root handling in `extract_session_dag_lines`**:
 
 1. Walk every root via `_walk_session_with_forks` (not just the earliest)
    so orphan-promoted subtrees are covered.
 2. Merge non-branch DAG-lines from all roots into a single trunk, ordered
    by `first_timestamp`.
-3. Classify roots to decide log level:
+3. Classify roots to decide log level (`_classify_unexpected_roots`):
    - `_EXPECTED_ROOT_SYSTEM_SUBTYPES = {"compact_boundary", "local_command"}`
      covers system entries; `_EXPECTED_ROOT_PASSTHROUGH_TYPES = {"progress"}`
      covers passthrough entries. See [Expected Root Types](#expected-root-types)
@@ -533,7 +609,7 @@ This keeps the signal useful: orphan user/assistant entries still surface
 as warnings; routine `/compact` multi-root sessions and async-hook
 remnants stay quiet.
 
-#### Expected Root Types
+### Expected Root Types
 
 Six known shapes legitimately appear as parentless (or orphan-promoted)
 roots within a session. Long-running sessions that span multiple
@@ -546,7 +622,7 @@ roots within a session. Long-running sessions that span multiple
 | `SystemTranscriptEntry` `subtype="local_command"` | sometimes `null` | Early `/memory`, `/config` etc. occasionally land before any user prompt has been recorded. |
 | `PassthroughTranscriptEntry` `type="progress"` from a session-start hook (e.g. `SessionStart:clear`) | `null` | Hooks fire **before** the first user turn has a uuid to point at — so the very first entry of a session can be a session-start hook rather than the user prompt. |
 | `PassthroughTranscriptEntry` `type="progress"` from an in-flight tool hook (e.g. `PostToolUse:Read`) | promoted from missing parent | A hook still in flight when `/compact` fires loses its spawning `tool_use` to the discarded pre-compaction context. `build_dag` clears the dangling parent and promotes the entry to a root. Always temporally adjacent to a following `compact_boundary`. |
-| **Subagent root** (first entry of an agent transcript) | `null` (in the agent file), then back-patched | Subagent transcripts live in `<session>/subagents/agent-*.jsonl` with `parentUuid: null` on entry zero. `_integrate_agent_entries` re-points it at the spawning Task/Agent `tool_result` and assigns a synthetic sessionId `{trunk}#agent-{agentId}`, so by the time `extract_session_dag_lines` runs the subagent has a proper parent and a per-agent root in its own DAG-line — not in the trunk's root list. |
+| **Subagent root** (first entry of an agent transcript) | `null` (in the agent file), then back-patched | `_integrate_agent_entries` re-points it at the spawning Task/Agent `tool_result` and assigns a synthetic sessionId `{trunk}#agent-{agentId}`, so by the time `extract_session_dag_lines` runs the subagent has a proper parent and a per-agent root in its own DAG-line — not in the trunk's root list. |
 
 The first five all sit in the trunk's session and feed into the
 `extract_session_dag_lines` multi-root warning logic. The subagent shape
@@ -554,7 +630,9 @@ is structurally similar but resolved one layer earlier — the trunk
 never sees these as orphans because `_integrate_agent_entries` runs
 first; see [Agent Transcripts](#agent-transcripts).
 
-**Nav landmarks** (`prepare_session_navigation` in renderer.py): each
+### Compaction nav landmarks
+
+(`prepare_session_navigation` in renderer.py): each
 `CompactedSummaryMessage` in a session becomes an `is_compaction_point`
 nav item (📦 glyph, solid border, depth = parent+1), chronologically
 ordered. Clicking jumps to the summary's `#msg-d-X` anchor so the reader
@@ -592,24 +670,21 @@ dropping the `(Nk tokens)` fragment while still appending the summary's
 own timestamp. Older transcripts without `compactMetadata` get
 `Conversation compacted • <timestamp>`.
 
-`compact_trigger` (`"manual"` / `"auto"`) is plumbed but not yet
-rendered; visualization is deferred pending a decision on whether to
-distinguish the two in the label glyph or suffix.
+`compact_trigger` (`"manual"` / `"auto"`) is plumbed but not rendered.
 
 ---
 
 ## Assertions / Invariants
 
-These should be checked at runtime (log warnings, don't crash):
+These are checked at runtime (log warnings, don't crash):
 
-1. **Session trunk is linear after stitching**: each session's non-branch
-   DAG-line is a single chain. Branching within a `sessionId` comes from
-   exactly three sources:
-   - **Explicit user rewinds** → rendered as branch pseudo-sessions
-   - **Parallel tool_use / dead-end tool_use / all-passthrough
-     children** → stitched or collapsed (not rendered as branches); see
-     [Tool-Result Side-Branches](#tool-result-side-branches)
-   - **Compaction replays** (same-timestamp children) → first child only
+1. **Session trunk is linear after linearization**: each session's
+   non-branch DAG-line is a single chain. Branching within a `sessionId`
+   comes from exactly one source that *renders* as branches — explicit
+   user rewinds. Every artifact shape (structural side-branches,
+   tool-result siblings, live passthrough chains, assistant
+   continuations, compaction replays) is linearized by the
+   [ladder](#fork-disambiguation-the-linearization-ladder).
 2. **Multi-root sessions are tolerated**: `/compact` and `local_command`
    produce multiple roots within one `sessionId`; all are walked and the
    trunks are merged. Other multi-root causes warn (may indicate missing
@@ -619,83 +694,18 @@ These should be checked at runtime (log warnings, don't crash):
    detected (warns and promotes that node to root). The DAG seen by
    downstream walks is always acyclic; `_walk_session_with_forks`
    adds a `walk_visited` belt for defence-in-depth.
-4. **Unique ownership**: After deduplication, each `uuid` belongs to
-   exactly one session
-5. **Agent parenting**: Every top-level agent transcript has an identifiable
-   anchor in the main session
-6. **DAG walk coverage**: `walked | skipped` must equal the session's
+4. **Unique ownership**: after deduplication, each `uuid` belongs to
+   exactly one session.
+5. **Agent parenting**: every top-level agent transcript has an
+   identifiable anchor in the main session.
+6. **DAG walk coverage**: `walked ∪ skipped` must equal the session's
    node set; if not, fall back to a timestamp sort for the whole session
-   and log a warning
-
----
-
-## Impact on Existing Code
-
-### What changes
-
-| Component | Current | After |
-|-----------|---------|-------|
-| `converter.py` | Load single file + agent files; timestamp sort | Load all project files; build DAG |
-| `renderer.py` message ordering | Timestamp sort + pair reorder + sidechain reorder | DAG-line traversal; pairing within DAG-lines |
-| Session index | Flat list sorted by timestamp | Session tree with parent/child relationships |
-| Agent handling | `agentId`-based insertion after timestamp sort | Agent DAG-line splicing at anchor points |
-
-### What stays
-
-- Factory layer (transcript entry → MessageContent)
-- TemplateMessage wrapper and RenderingContext
-- Hierarchy building within sessions (user → assistant → tools)
-- Renderer dispatch and format_* methods
-- HTML templates and JavaScript (fold, timeline, filters)
-- Deduplication heuristics (sidechain cleanup, etc.) — may simplify over time
-
----
-
-## Implementation Plan
-
-### Phase A: DAG Infrastructure (new module: `dag.py`)
-
-1. **Message indexing**: Load all session files, build `uuid` index,
-   deduplicate
-2. **DAG construction**: Build parent→children graph
-3. **Session extraction**: Group by `sessionId`, extract DAG-lines,
-   verify linearity
-4. **Session tree**: Build parent/child session relationships, identify
-   junction points
-
-This phase is purely additive — new code alongside existing. Tests can
-validate DAG construction against known transcripts.
-
-### Phase B: Integration with Rendering Pipeline
-
-1. Replace `load_transcript` / `load_directory_transcripts` with
-   DAG-based loading in `converter.py`
-2. Pass DAG-lines (per session) into `generate_template_messages`
-3. Scope pairing to DAG-lines
-4. Generate session headers with navigation links (forward/back)
-5. Update session index from flat to hierarchical
-
-### Phase C: Agent Transcript Rework (Steps 1-2 done)
-
-1. ~~Implement parenting strategies for each agent type~~ — Done:
-   `_integrate_agent_entries()` parents agent roots to anchors and assigns
-   synthetic session IDs (`{sessionId}#agent-{agentId}`)
-2. ~~Replace `_reorder_sidechain_template_messages` with DAG-line splicing~~
-   — Done: agents are now DAG-ordered; the old function is kept as fallback
-3. Simplify or remove `_cleanup_sidechain_duplicates` (dedup now
-   happens at DAG level) — TODO
-4. Agent tool renderer (separate PR, `dev/user-sidechain` branch) — TODO
-
-### Phase D: Async Agent and Teammate Support
-
-1. Parse `<task-notification>` to extract `task-id` for async agent linking
-2. Implement teammate parenting strategy (#91)
-3. This is where #90 and #91 get properly resolved
+   and log a warning.
 
 ---
 
 ## Related Documentation
 
-- [rendering-architecture.md](rendering-architecture.md) — Current pipeline
+- [rendering-architecture.md](rendering-architecture.md) — Rendering pipeline
 - [messages.md](messages.md) — Message type reference
-- [../work/rendering-next.md](../work/rendering-next.md) — Future rendering improvements
+- [agents.md](agents.md) — Sync/async/teammate agent integration

--- a/test/test_continuation_fork.py
+++ b/test/test_continuation_fork.py
@@ -1,0 +1,190 @@
+"""Regression: assistant-continuation tool-flow forks must NOT branch.
+
+When an assistant turn issues a tool_use and Claude Code records both the
+turn's continuation (a further assistant message — a parallel next tool_use or
+a max_tokens split) AND the tool_result for that tool_use as siblings, the DAG
+walker previously mis-read it as a user rewind and forked — recursively,
+producing a staircase of spurious branches. It must instead linearize:
+continuation inline, then the lagging tool_result.
+
+(The existing ``_stitch_tool_results`` Variant 2 already handles the case where
+the continuation subtree is *shallow* / dead-ends; this covers the *deep* live
+continuation — `max_tokens` streaming — which Variant 2 bails on.)
+"""
+
+from claude_code_log.dag import (
+    _is_continuation_fork,
+    build_dag_from_entries,
+    build_dag,
+    build_message_index,
+)
+from claude_code_log.factories import create_transcript_entry
+
+
+def _user(uuid, parent, content, ts):
+    return create_transcript_entry(
+        {
+            "type": "user",
+            "uuid": uuid,
+            "parentUuid": parent,
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/x",
+            "sessionId": "s1",
+            "version": "1.0",
+            "timestamp": ts,
+            "message": {"role": "user", "content": content},
+        }
+    )
+
+
+def _assistant(uuid, parent, content, ts, stop_reason="tool_use"):
+    return create_transcript_entry(
+        {
+            "type": "assistant",
+            "uuid": uuid,
+            "parentUuid": parent,
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/x",
+            "sessionId": "s1",
+            "version": "1.0",
+            "timestamp": ts,
+            "requestId": "r-" + uuid,
+            "message": {
+                "id": "m-" + uuid,
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "stop_reason": stop_reason,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+                "content": content,
+            },
+        }
+    )
+
+
+def _tool_use(tool_id, name="Bash"):
+    return {"type": "tool_use", "id": tool_id, "name": name, "input": {"command": "x"}}
+
+
+def _tool_result(tool_id):
+    return [{"type": "tool_result", "tool_use_id": tool_id, "content": "ok"}]
+
+
+class TestIsContinuationForkDetection:
+    """The detection predicate (depth-independent)."""
+
+    def _nodes(self, entries):
+        nodes = build_message_index(entries)
+        build_dag(nodes)
+        return nodes
+
+    def test_assistant_continuation_plus_toolresult_is_continuation_fork(self):
+        # a1(tool_use X) → {a2 (assistant continuation), u1 (tool_result for X)}
+        nodes = self._nodes(
+            [
+                _user("u0", None, "go", "2025-01-01T00:00:00Z"),
+                _assistant("a1", "u0", [_tool_use("X")], "2025-01-01T00:00:01Z"),
+                _assistant("a2", "a1", [_tool_use("Y")], "2025-01-01T00:00:02Z"),
+                _user("u1", "a1", _tool_result("X"), "2025-01-01T00:00:30Z"),
+            ]
+        )
+        assert _is_continuation_fork(nodes["a1"], ["a2", "u1"], nodes) is True
+
+    def test_user_rewind_is_not_a_continuation_fork(self):
+        # a1 → {a2, u1(new user PROMPT text)} — a real rewind, not tool-flow
+        nodes = self._nodes(
+            [
+                _user("u0", None, "go", "2025-01-01T00:00:00Z"),
+                _assistant("a1", "u0", [_tool_use("X")], "2025-01-01T00:00:01Z"),
+                _assistant("a2", "a1", [_tool_use("Y")], "2025-01-01T00:00:02Z"),
+                _user(
+                    "u1", "a1", "actually, do something else", "2025-01-01T00:00:30Z"
+                ),
+            ]
+        )
+        assert _is_continuation_fork(nodes["a1"], ["a2", "u1"], nodes) is False
+
+    def test_toolresult_for_unrelated_tool_is_not_continuation_fork(self):
+        # u1's tool_result is for a DIFFERENT tool_use id than a1's
+        nodes = self._nodes(
+            [
+                _user("u0", None, "go", "2025-01-01T00:00:00Z"),
+                _assistant("a1", "u0", [_tool_use("X")], "2025-01-01T00:00:01Z"),
+                _assistant("a2", "a1", [_tool_use("Y")], "2025-01-01T00:00:02Z"),
+                _user("u1", "a1", _tool_result("ZZZ"), "2025-01-01T00:00:30Z"),
+            ]
+        )
+        assert _is_continuation_fork(nodes["a1"], ["a2", "u1"], nodes) is False
+
+    def test_no_assistant_child_is_not_continuation_fork(self):
+        nodes = self._nodes(
+            [
+                _user("u0", None, "go", "2025-01-01T00:00:00Z"),
+                _assistant("a1", "u0", [_tool_use("X")], "2025-01-01T00:00:01Z"),
+                _user("u1", "a1", _tool_result("X"), "2025-01-01T00:00:30Z"),
+            ]
+        )
+        assert _is_continuation_fork(nodes["a1"], ["u1"], nodes) is False
+
+
+def _deep_continuation_chain(parent, n, start_sec):
+    """A single-child assistant chain of length n, so its subtree exceeds the
+    dead-end depth cap (>20) — i.e. a *live* continuation, like a max_tokens
+    streaming turn."""
+    entries = []
+    cur = parent
+    for i in range(n):
+        uid = f"c{i:02d}"
+        entries.append(
+            _assistant(
+                uid,
+                cur,
+                [{"type": "text", "text": f"step {i}"}],
+                f"2025-01-01T00:01:{start_sec + i:02d}Z",
+                "end_turn",
+            )
+        )
+        cur = uid
+    return entries
+
+
+class TestContinuationForkLinearization:
+    def _build(self):
+        # a1(tool_use X) → { a2 (deep live continuation), u1 (tool_result X) }
+        entries = [
+            _user("u0", None, "go", "2025-01-01T00:00:00Z"),
+            _assistant("a1", "u0", [_tool_use("X")], "2025-01-01T00:00:01Z"),
+            _assistant("a2", "a1", [_tool_use("Y")], "2025-01-01T00:00:02Z"),
+        ]
+        entries += _deep_continuation_chain("a2", 25, 0)  # a2 → c00 … c24 (live)
+        # the lagging tool_result for a1's X, and its own follow-up
+        entries.append(_user("u1", "a1", _tool_result("X"), "2025-01-01T00:02:00Z"))
+        entries.append(
+            _assistant(
+                "a3",
+                "u1",
+                [{"type": "text", "text": "X done"}],
+                "2025-01-01T00:02:01Z",
+                "end_turn",
+            )
+        )
+        return build_dag_from_entries(entries)
+
+    def test_no_branch_created(self):
+        tree = self._build()
+        branches = [s for s in tree.sessions.values() if s.is_branch]
+        assert branches == [], [s.session_id for s in branches]
+
+    def test_continuation_and_result_both_preserved_and_ordered(self):
+        tree = self._build()
+        trunk = [s for s in tree.sessions.values() if not s.is_branch]
+        assert len(trunk) == 1
+        uuids = trunk[0].uuids
+        # nothing dropped: the continuation chain AND the lagging result survive
+        assert "a2" in uuids and "c24" in uuids and "u1" in uuids and "a3" in uuids
+        # continuation (a2) inline after its tool_use (a1); lagging result after it
+        assert uuids.index("a1") < uuids.index("a2") < uuids.index("u1")
+        assert uuids.index("c24") < uuids.index("u1")

--- a/test/test_continuation_fork.py
+++ b/test/test_continuation_fork.py
@@ -151,6 +151,75 @@ def _deep_continuation_chain(parent, n, start_sec):
     return entries
 
 
+class TestContinuationForkInsideBranch:
+    """A continuation fork occurring *within* a rewind branch must not drop
+    branch segments.
+
+    The re-enqueued continuation/result chains carry the branch's line id,
+    so the branch ends up as multiple SessionDAGLine segments. Inserting
+    branch lines by key would keep only the last segment — the merge in
+    ``extract_session_dag_lines`` must cover branch ids too (PR #214
+    review finding).
+    """
+
+    def _build(self):
+        entries = [
+            _user("u0", None, "go", "2025-01-01T00:00:00Z"),
+            _assistant(
+                "a1",
+                "u0",
+                [{"type": "text", "text": "which approach?"}],
+                "2025-01-01T00:00:01Z",
+                "end_turn",
+            ),
+            # Real rewind at a1: two user prompts at different timestamps.
+            _user("u1", "a1", "try approach A", "2025-01-01T00:00:30Z"),
+            _user("u2", "a1", "actually, approach B", "2025-01-01T00:10:00Z"),
+            # Branch 1 contains a continuation fork at a2.
+            _assistant("a2", "u1", [_tool_use("X")], "2025-01-01T00:00:31Z"),
+            _assistant("a3", "a2", [_tool_use("Y")], "2025-01-01T00:00:32Z"),
+            _user("u3", "a2", _tool_result("X"), "2025-01-01T00:03:00Z"),
+            _assistant(
+                "a4",
+                "u3",
+                [{"type": "text", "text": "X done"}],
+                "2025-01-01T00:03:01Z",
+                "end_turn",
+            ),
+            # Branch 2 is a plain reply.
+            _assistant(
+                "a5",
+                "u2",
+                [{"type": "text", "text": "doing B"}],
+                "2025-01-01T00:10:01Z",
+                "end_turn",
+            ),
+        ]
+        # Deep live chain under a3 so the continuation fork isn't a V2 dead end.
+        entries += _deep_continuation_chain("a3", 25, 0)
+        return build_dag_from_entries(entries)
+
+    def test_branch_segments_are_merged_not_overwritten(self):
+        tree = self._build()
+        branches = [s for s in tree.sessions.values() if s.is_branch]
+        assert len(branches) == 2
+        (b1,) = [b for b in branches if "u1" in b.uuids]
+        # Every segment of branch 1 survives the merge:
+        for uuid in ("u1", "a2", "a3", "c24", "u3", "a4"):
+            assert uuid in b1.uuids, f"{uuid} dropped from branch line"
+        # Continuation inline after its tool_use; lagging result after it.
+        assert b1.uuids.index("a2") < b1.uuids.index("a3") < b1.uuids.index("u3")
+
+    def test_merged_branch_keeps_fork_point_attachment(self):
+        tree = self._build()
+        b1 = next(b for b in tree.sessions.values() if "u1" in b.uuids)
+        # The merged line's attachment is the rewind fork point (a1), not
+        # the continuation fork's parent (a2) from a later segment.
+        assert b1.attachment_uuid == "a1"
+        b2 = next(b for b in tree.sessions.values() if "u2" in b.uuids)
+        assert b2.attachment_uuid == "a1"
+
+
 class TestContinuationForkLinearization:
     def _build(self):
         # a1(tool_use X) → { a2 (deep live continuation), u1 (tool_result X) }

--- a/test/test_continuation_pairing.py
+++ b/test/test_continuation_pairing.py
@@ -1,0 +1,189 @@
+"""tool_use ↔ tool_result pairing must not span an assistant continuation.
+
+When the assistant keeps talking between issuing a tool call and receiving
+its (lagging) result — a ``max_tokens`` split, a thinking block, the prose
+of a next turn — pair-reordering used to pull the tool_result back adjacent
+to its tool_use, rendering it *before* the continuation and scrambling the
+chronology the DAG linearization (``dag._is_continuation_fork``) had just
+restored. In that situation the pair must not be marked at all: the
+continuation renders between the tool_use and its result.
+
+Sibling tool messages (parallel batches) and sidechain/subagent threads do
+NOT block pairing — those keep the existing adjacent-pair rendering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_code_log.models import (
+    AssistantTextMessage,
+    BashInput,
+    MessageMeta,
+    TextContent,
+    ThinkingMessage,
+    ToolResultContent,
+    ToolResultMessage,
+    ToolUseMessage,
+)
+from claude_code_log.renderer import (
+    RenderingContext,
+    TemplateMessage,
+    _identify_message_pairs,
+    _reorder_paired_messages,
+)
+
+
+# ----------------------------- helpers ---------------------------------------
+
+
+def _meta(
+    uuid: str, *, ts: str = "2026-01-01T00:00:00Z", sidechain: bool = False
+) -> MessageMeta:
+    return MessageMeta(session_id="s", timestamp=ts, uuid=uuid, is_sidechain=sidechain)
+
+
+def _tool_use(ctx: RenderingContext, uuid: str, tool_id: str) -> TemplateMessage:
+    msg = TemplateMessage(
+        ToolUseMessage(
+            meta=_meta(uuid),
+            input=BashInput(command="ls"),
+            tool_use_id=tool_id,
+            tool_name="Bash",
+        )
+    )
+    ctx.register(msg)
+    return msg
+
+
+def _tool_result(
+    ctx: RenderingContext, uuid: str, tool_id: str, *, ts: str = "2026-01-01T00:01:00Z"
+) -> TemplateMessage:
+    msg = TemplateMessage(
+        ToolResultMessage(
+            meta=_meta(uuid, ts=ts),
+            tool_use_id=tool_id,
+            output=ToolResultContent(
+                type="tool_result", tool_use_id=tool_id, content="ok"
+            ),
+        )
+    )
+    ctx.register(msg)
+    return msg
+
+
+def _thinking(ctx: RenderingContext, uuid: str) -> TemplateMessage:
+    msg = TemplateMessage(ThinkingMessage(meta=_meta(uuid), thinking="hmm"))
+    ctx.register(msg)
+    return msg
+
+
+def _assistant(
+    ctx: RenderingContext,
+    uuid: str,
+    text: str = "carrying on",
+    *,
+    sidechain: bool = False,
+) -> TemplateMessage:
+    msg = TemplateMessage(
+        AssistantTextMessage(
+            meta=_meta(uuid, sidechain=sidechain),
+            items=[TextContent(type="text", text=text)],
+        )
+    )
+    ctx.register(msg)
+    return msg
+
+
+def _empty_assistant(ctx: RenderingContext, uuid: str) -> TemplateMessage:
+    msg = TemplateMessage(AssistantTextMessage(meta=_meta(uuid), items=[]))
+    ctx.register(msg)
+    return msg
+
+
+@pytest.fixture
+def ctx() -> RenderingContext:
+    return RenderingContext()
+
+
+# ----------------------------- pairing rule ----------------------------------
+
+
+class TestContinuationBlocksToolPairing:
+    def test_adjacent_pair_still_pairs(self, ctx: RenderingContext):
+        use = _tool_use(ctx, "u1", "X")
+        res = _tool_result(ctx, "u2", "X")
+        _identify_message_pairs([use, res])
+        assert use.is_first_in_pair and res.is_last_in_pair
+
+    def test_thinking_between_blocks_pairing(self, ctx: RenderingContext):
+        use = _tool_use(ctx, "u1", "X")
+        think = _thinking(ctx, "u2")
+        res = _tool_result(ctx, "u3", "X")
+        _identify_message_pairs([use, think, res])
+        assert not use.is_paired and not res.is_paired
+
+    def test_assistant_prose_between_blocks_pairing(self, ctx: RenderingContext):
+        use = _tool_use(ctx, "u1", "X")
+        prose = _assistant(ctx, "u2")
+        res = _tool_result(ctx, "u3", "X")
+        _identify_message_pairs([use, prose, res])
+        assert not use.is_paired and not res.is_paired
+
+    def test_empty_assistant_between_does_not_block(self, ctx: RenderingContext):
+        # An empty max_tokens split carries no visible content — pulling the
+        # result across it changes nothing the reader can see.
+        use = _tool_use(ctx, "u1", "X")
+        empty = _empty_assistant(ctx, "u2")
+        res = _tool_result(ctx, "u3", "X")
+        _identify_message_pairs([use, empty, res])
+        assert use.is_first_in_pair and res.is_last_in_pair
+
+    def test_sidechain_thread_between_does_not_block(self, ctx: RenderingContext):
+        # Task/Agent flows: the subagent's sidechain messages interleave
+        # between the trunk tool_use and its result by construction.
+        use = _tool_use(ctx, "u1", "X")
+        side = _assistant(ctx, "u2", "subagent work", sidechain=True)
+        res = _tool_result(ctx, "u3", "X")
+        _identify_message_pairs([use, side, res])
+        assert use.is_first_in_pair and res.is_last_in_pair
+
+    def test_parallel_batch_still_pairs(self, ctx: RenderingContext):
+        # toolA, toolB, resA, resB — sibling tool messages between A and
+        # its result don't block; both pairs are marked.
+        use_a = _tool_use(ctx, "u1", "A")
+        use_b = _tool_use(ctx, "u2", "B")
+        res_a = _tool_result(ctx, "u3", "A")
+        res_b = _tool_result(ctx, "u4", "B")
+        _identify_message_pairs([use_a, use_b, res_a, res_b])
+        assert use_a.is_first_in_pair and res_a.is_last_in_pair
+        assert use_b.is_first_in_pair and res_b.is_last_in_pair
+
+
+# ----------------------------- reorder behavior ------------------------------
+
+
+class TestContinuationStaysBetween:
+    def test_result_not_pulled_back_across_continuation(self, ctx: RenderingContext):
+        use = _tool_use(ctx, "u1", "X")
+        think = _thinking(ctx, "u2")
+        prose = _assistant(ctx, "u3")
+        res = _tool_result(ctx, "u4", "X", ts="2026-01-01T00:02:00Z")
+        messages = [use, think, prose, res]
+        _identify_message_pairs(messages)
+        reordered = _reorder_paired_messages(messages)
+        uuids = [m.meta.uuid for m in reordered]
+        assert uuids == ["u1", "u2", "u3", "u4"]
+
+    def test_result_pulled_adjacent_without_continuation(self, ctx: RenderingContext):
+        # Control: with only sibling tool messages between, the existing
+        # adjacent-pair reordering still applies.
+        use_a = _tool_use(ctx, "u1", "A")
+        use_b = _tool_use(ctx, "u2", "B")
+        res_a = _tool_result(ctx, "u3", "A")
+        res_b = _tool_result(ctx, "u4", "B", ts="2026-01-01T00:02:00Z")
+        messages = [use_a, use_b, res_a, res_b]
+        _identify_message_pairs(messages)
+        reordered = _reorder_paired_messages(messages)
+        uuids = [m.meta.uuid for m in reordered]
+        assert uuids == ["u1", "u3", "u2", "u4"]


### PR DESCRIPTION
## Problem

When an assistant turn issues a `tool_use` and the transcript records both the turn's **continuation** (a further assistant message — a `max_tokens` split, a thinking block, or the next parallel tool call) *and* the `tool_result` as siblings of that turn, the DAG walker mis-read the shape as a user rewind and forked. Since the pattern repeats for every such tool call, the result was a recursive staircase of spurious "Fork point (2 branches)" → "Branch" nesting that made large sessions unreadable (e.g. a 4951-message session rendered with 18 fork points / 36 branches, all spurious).

## Fix

**Commit 1 — linearize instead of branching (dag.py).** Add `_is_continuation_fork()` to recognize the shape structurally: the parent is an assistant message with `tool_use`(s), and every child is either an assistant continuation or a user `tool_result` addressed to one of the parent's tool_use ids. Anything else (e.g. a user-typed prompt sibling — a real rewind) keeps the existing fork behavior. When detected, the walker enqueues the children as same-session (non-branch) lines instead of branching; the existing timestamp-based trunk merge then linearizes them: continuation inline, lagging `tool_result` after.

The existing `_stitch_tool_results` Variant 2 already handled the case where the continuation subtree is shallow/dead-ends; this covers the *deep, live* continuation that Variant 2 bails on.

**Commit 2 — don't pair across the continuation (renderer.py).** With the DAG order fixed, the renderer's pair-reordering still pulled the lagging `tool_result` back adjacent to its `tool_use`, rendering it *before* the continuation and scrambling the chronology again. Skip marking the pair when assistant continuation content (prose or thinking) sits between the two in the linear order — the result keeps its chronological place and the continuation renders in between (O(1) per pair via prefix counts). Sibling tool messages (parallel batches), sidechain/subagent threads, and empty splits don't block, so existing adjacent-pair rendering is preserved for those. At reduced detail levels the ghost pass runs before pairing, so once the continuation is filtered out the pair re-forms and renders adjacent — the compact view wanted there.

On the motivating session: 36 branches → 0 with identical message coverage (nothing dropped), and each lagging result now renders after the continuation, in true order. Real forks (user rewinds, compaction replays) are unaffected.

## Testing

- New `test/test_continuation_fork.py`: detection-predicate unit tests (incl. negatives: user rewind, unrelated tool_result, no assistant child) and an end-to-end linearization test with a >20-deep live continuation chain.
- New `test/test_continuation_pairing.py`: pairing-rule tests (continuation blocks, parallel batches / sidechain threads / empty splits don't) and reorder-behavior tests.
- Full `just ci` green (unit + TUI + browser + snapshots, ruff, pyright, ty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of assistant continuation blocks so transcripts keep logical order and tool results remain chronologically placed, and merged branch segments for the same session rather than overwriting them.

* **Tests**
  * Added and expanded regression tests covering continuation-fork detection, branch merging, and pairing/reordering around continuation content.

* **Documentation**
  * Expanded DAG/session documentation and processing guidance for transcript linearization and fork disambiguation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->