### PR TITLE
Hybrid JSON/Markdown rendering for tool params tables

### DIFF
--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -963,6 +963,24 @@ pre > code {
     border-radius: 3px;
 }
 
+/* Nested tables produced by the recursive params renderer: keep the
+   flat look but let the key column shrink (index/short keys) so depth
+   doesn't eat horizontal space. */
+.tool-params-nested .tool-param-key {
+    width: auto;
+    min-width: 4em;
+}
+
+/* Markdown-rendered string values: suppress the outer paragraph
+   margins so a prose value aligns with plain-text cells. */
+.tool-param-value .tool-param-markdown > p:first-child {
+    margin-top: 0;
+}
+
+.tool-param-value .tool-param-markdown > p:last-child {
+    margin-bottom: 0;
+}
+
 .tool-param-collapsible {
     margin: 0;
 }

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -920,11 +920,14 @@ pre > code {
     border-right: #00000017 1px solid;
 }
 
-/* Tool parameter table styling */
+/* Tool parameter table styling. The percentage font-size compounds at
+   each nesting level of the recursive params renderer — a deliberate
+   depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+   become unreadable. */
 .tool-params-table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 80%;
+    font-size: 90%;
 }
 
 /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -1009,6 +1012,40 @@ pre > code {
 .tool-param-full {
     margin-top: 4px;
     word-break: break-all;
+}
+
+/* Structured-table folds carry an explicit collapse hint plus a
+   rows-toggle button in the summary, so suppress the generic ::after
+   "collapse" hint for them and show the real elements only when open. */
+.tool-param-collapsible-rows[open] > summary::after {
+    content: none;
+}
+
+.tool-param-collapse-hint,
+.tool-param-rows-toggle {
+    display: none;
+}
+
+.tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+    display: inline;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+    display: inline;
+    margin-left: 1.5em;
+    padding: 0;
+    background: none;
+    border: none;
+    font: inherit;
+    color: var(--text-muted);
+    font-style: italic;
+    cursor: pointer;
+}
+
+.tool-param-rows-toggle:hover {
+    color: var(--text-primary);
 }
 
 .tool-params-empty {

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -1048,6 +1048,27 @@ pre > code {
     color: var(--text-primary);
 }
 
+/* Top-level expand/collapse-all control above a params/result table —
+   same quiet look as the in-summary rows-toggle. */
+.tool-params-controls {
+    margin-bottom: 2px;
+}
+
+.tool-params-expand-all {
+    padding: 0;
+    background: none;
+    border: none;
+    font: inherit;
+    font-size: 80%;
+    color: var(--text-muted);
+    font-style: italic;
+    cursor: pointer;
+}
+
+.tool-params-expand-all:hover {
+    color: var(--text-primary);
+}
+
 .tool-params-empty {
     color: var(--text-muted);
     font-style: italic;

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -414,9 +414,20 @@
             // that table (direct rows only — nested tables have their own).
             const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
 
-            function setRowsToggleState(button, expanded) {
-                button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+            // Derive the button label/state from the actual row state, so
+            // it stays in sync whatever opened the rows (button click,
+            // toggle-all, manual clicks).
+            function syncRowsToggle(details) {
+                const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                if (!button) return;
+                const rows = details.querySelectorAll(rowDetailsSelector);
+                const allOpen = rows.length > 0 &&
+                    Array.from(rows).every(row => row.open);
+                const kind = button.dataset.kind || 'rows';
+                button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                button.textContent = allOpen
+                    ? '▼ collapse all ' + kind
+                    : '▶ expand all ' + kind;
             }
 
             document.addEventListener('click', function (event) {
@@ -431,23 +442,27 @@
                 details.querySelectorAll(rowDetailsSelector).forEach(row => {
                     row.open = expand;
                 });
-                setRowsToggleState(button, expand);
+                syncRowsToggle(details);
             });
 
-            // Closing a fold restores its initial state: all rows collapsed,
-            // button back to "expand rows". Rows that are themselves folds
-            // reset their own rows through this same (capturing — toggle
-            // doesn't bubble) listener.
+            // Capturing listener (toggle doesn't bubble) keeps every fold
+            // consistent: closing one restores its initial state (rows
+            // collapsed — nested folds reset recursively through this same
+            // listener); any row toggling re-syncs its parent's button.
             document.addEventListener('toggle', function (event) {
                 const details = event.target;
-                if (!(details instanceof HTMLElement)) return;
-                if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                if (details.open) return;
-                details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                    row.open = false;
-                });
-                const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                if (button) setRowsToggleState(button, false);
+                if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                if (details.classList.contains('tool-param-collapsible-rows')) {
+                    if (!details.open) {
+                        details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                            row.open = false;
+                        });
+                    }
+                    syncRowsToggle(details);
+                }
+                const cell = details.parentElement;
+                const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                if (parent && parent !== details) syncRowsToggle(parent);
             }, true);
 
             // Filter toolbar toggle functionality

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -430,7 +430,30 @@
                     : '▶ expand all ' + kind;
             }
 
+            // Top-level expand-all for a whole params/result renderer:
+            // opens/closes every fold inside it, at all depths. Nested
+            // rows-toggle buttons follow via the toggle listener below.
+            function syncExpandAll(root) {
+                const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                if (!button) return;
+                const folds = root.querySelectorAll('details');
+                const allOpen = folds.length > 0 &&
+                    Array.from(folds).every(fold => fold.open);
+                button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+            }
+
             document.addEventListener('click', function (event) {
+                const expandAllButton = event.target.closest('.tool-params-expand-all');
+                if (expandAllButton) {
+                    const root = expandAllButton.closest('.tool-params-root');
+                    const expand = expandAllButton.dataset.state !== 'expanded';
+                    root.querySelectorAll('details').forEach(fold => {
+                        fold.open = expand;
+                    });
+                    syncExpandAll(root);
+                    return;
+                }
                 const button = event.target.closest('.tool-param-rows-toggle');
                 if (!button) return;
                 // The button sits inside a <summary>: keep the click from
@@ -463,6 +486,11 @@
                 const cell = details.parentElement;
                 const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                 if (parent && parent !== details) syncRowsToggle(parent);
+                // Keep the renderer's top-level expand-all button in step
+                // with whatever opened/closed this fold (rows-toggle,
+                // manual click, global toggle-all).
+                const root = details.closest('.tool-params-root');
+                if (root) syncExpandAll(root);
             }, true);
 
             // Filter toolbar toggle functionality

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -409,6 +409,47 @@
 
             toggleButton.addEventListener('click', toggleAllDetails);
 
+            // Per-table rows-toggle for structured params: the button in an
+            // open fold's summary expands/collapses all row-level folds of
+            // that table (direct rows only — nested tables have their own).
+            const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+
+            function setRowsToggleState(button, expanded) {
+                button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+            }
+
+            document.addEventListener('click', function (event) {
+                const button = event.target.closest('.tool-param-rows-toggle');
+                if (!button) return;
+                // The button sits inside a <summary>: keep the click from
+                // toggling the enclosing details.
+                event.preventDefault();
+                event.stopPropagation();
+                const details = button.closest('details');
+                const expand = button.dataset.state !== 'expanded';
+                details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                    row.open = expand;
+                });
+                setRowsToggleState(button, expand);
+            });
+
+            // Closing a fold restores its initial state: all rows collapsed,
+            // button back to "expand rows". Rows that are themselves folds
+            // reset their own rows through this same (capturing — toggle
+            // doesn't bubble) listener.
+            document.addEventListener('toggle', function (event) {
+                const details = event.target;
+                if (!(details instanceof HTMLElement)) return;
+                if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                if (details.open) return;
+                details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                    row.open = false;
+                });
+                const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                if (button) setRowsToggleState(button, false);
+            }, true);
+
             // Filter toolbar toggle functionality
             function toggleFilterToolbar() {
                 const isVisible = filterToolbar.classList.contains('visible');

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -1019,6 +1019,12 @@ def format_crondelete_output(output: CronDeleteOutput) -> str:
 # up the DOM.
 _PARAMS_TABLE_MAX_DEPTH = 4
 
+# Per-container breadth cap (CodeRabbit, PR #216): the depth guard and
+# the folded-by-default display don't stop the HTML for a huge array
+# from being GENERATED — one <tr> per element even when collapsed.
+# Wider containers fall back to the JSON dump.
+_PARAMS_TABLE_MAX_ITEMS = 200
+
 
 def _json_dump_value_html(formatted_value: str) -> str:
     """Escaped JSON dump in a ``<pre>``, collapsible when long."""
@@ -1090,7 +1096,11 @@ def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> s
         # Fallback: convert to string when JSON serialization fails
         return escape_html(str(cast(object, value)))
 
-    if not value or depth >= _PARAMS_TABLE_MAX_DEPTH:
+    if (
+        not value
+        or depth >= _PARAMS_TABLE_MAX_DEPTH
+        or len(value) > _PARAMS_TABLE_MAX_ITEMS
+    ):
         return _json_dump_value_html(formatted_value)
 
     if isinstance(value, dict):
@@ -1211,12 +1221,18 @@ def _json_result_table_html(raw_content: str) -> Optional[str]:
     except ValueError:
         return None
     if isinstance(parsed, dict) and parsed:
-        items: Iterable[tuple[Any, Any]] = cast("dict[Any, Any]", parsed).items()
+        container = cast("dict[Any, Any]", parsed)
+        items: Iterable[tuple[Any, Any]] = container.items()
         kind = "properties"
     elif isinstance(parsed, list) and parsed:
-        items = enumerate(cast("list[Any]", parsed))
+        container = cast("list[Any]", parsed)
+        items = enumerate(container)
         kind = "rows"
     else:
+        return None
+    if len(container) > _PARAMS_TABLE_MAX_ITEMS:
+        # Breadth cap: let huge results keep the legacy collapsible
+        # text rendering instead of generating one row per element.
         return None
     table_html = _params_table_html(items, 0)
     # Breadth guard: results past the legacy 200-char threshold keep

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -1080,8 +1080,9 @@ def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> s
 
     ``depth`` is the nesting level of the table containing this value;
     past ``_PARAMS_TABLE_MAX_DEPTH`` (and for empty containers) the
-    value falls back to the JSON dump. The >200-char collapsibility
-    keeps its JSON-text preview so deep structures fold, not flood.
+    value falls back to the JSON dump. The table always renders inside
+    a collapsed fold with a JSON-text preview — size-independent, so
+    sibling rows look consistent (no "auto-expanded" short values).
     """
     try:
         formatted_value = json.dumps(value, indent=2, ensure_ascii=False)
@@ -1092,21 +1093,26 @@ def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> s
     if not value or depth >= _PARAMS_TABLE_MAX_DEPTH:
         return _json_dump_value_html(formatted_value)
 
-    items = value.items() if isinstance(value, dict) else enumerate(value)
+    if isinstance(value, dict):
+        items: Iterable[tuple[Any, Any]] = value.items()
+        kind = "properties"
+    else:
+        items = enumerate(value)
+        kind = "rows"
     table_html = _params_table_html(items, depth + 1)
-    if len(formatted_value) > 200:
-        preview = escape_html(formatted_value[:100]) + "..."
-        # The summary carries an explicit collapse hint (instead of the
-        # generic ::after one) followed by a rows-toggle button that
-        # expands/collapses all row-level folds of this table at once
-        # (wired up in transcript.html).
-        return f"""
+    preview = escape_html(formatted_value[:100])
+    if len(formatted_value) > 100:
+        preview += "..."
+    # The summary carries an explicit collapse hint (instead of the
+    # generic ::after one) followed by a rows-toggle button that
+    # expands/collapses all row-level folds of this table at once
+    # (wired up in transcript.html).
+    return f"""
                         <details class='tool-param-collapsible tool-param-collapsible-rows'>
-                            <summary><span class='tool-param-preview'>{preview}</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed'>&#9654; expand rows</button></summary>
+                            <summary><span class='tool-param-preview'>{preview}</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='{kind}'>&#9654; expand all {kind}</button></summary>
                             {table_html}
                         </details>
                     """
-    return table_html
 
 
 def _param_value_html(value: Any, depth: int) -> str:
@@ -1151,6 +1157,29 @@ def render_params_table(params: dict[str, Any]) -> str:
 
 
 # -- Tool Result Content Fallback Formatter -----------------------------------
+
+
+def _json_result_table_html(raw_content: str) -> Optional[str]:
+    """Render a tool-result string as a params-style table when it
+    parses as a non-empty JSON object/array; ``None`` otherwise.
+
+    Objects become key/value tables, arrays become index/value tables,
+    with values rendered by the same hybrid rules as tool params
+    (Markdown-aware strings, nested structures folded).
+    """
+    if raw_content.lstrip()[:1] not in ("{", "["):
+        return None
+    try:
+        parsed = json.loads(raw_content)
+    except ValueError:
+        return None
+    if isinstance(parsed, dict) and parsed:
+        items: Iterable[tuple[Any, Any]] = cast("dict[Any, Any]", parsed).items()
+    elif isinstance(parsed, list) and parsed:
+        items = enumerate(cast("list[Any]", parsed))
+    else:
+        return None
+    return f"<div class='tool-result-json'>{_params_table_html(items, 0)}</div>"
 
 
 def format_tool_result_content_raw(tool_result: ToolResultContent) -> str:
@@ -1241,7 +1270,13 @@ def format_tool_result_content_raw(tool_result: ToolResultContent) -> str:
     </details>
     """
     else:
-        # Text-only content
+        # Text-only content that parses as structured JSON renders as a
+        # params-style table (not for errors — those read as text).
+        if not tool_result.is_error:
+            json_table = _json_result_table_html(raw_content)
+            if json_table is not None:
+                return json_table
+
         # For simple content, show directly without collapsible wrapper
         if len(raw_content) <= 200:
             return f"<pre>{full_html}</pre>"

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -1103,13 +1103,23 @@ def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> s
     preview = escape_html(formatted_value[:100])
     if len(formatted_value) > 100:
         preview += "..."
-    # The summary carries an explicit collapse hint (instead of the
-    # generic ::after one) followed by a rows-toggle button that
-    # expands/collapses all row-level folds of this table at once
-    # (wired up in transcript.html).
-    return f"""
+    # When the table has row-level folds, the summary carries an
+    # explicit collapse hint (instead of the generic ::after one)
+    # followed by a rows-toggle button that expands/collapses them all
+    # at once (wired up in transcript.html). The "<details" probe is
+    # exact: structures always fold, so a deeper fold can only exist
+    # inside a direct-row fold. All-scalar containers get a plain fold —
+    # no dead button.
+    if "<details" in table_html:
+        return f"""
                         <details class='tool-param-collapsible tool-param-collapsible-rows'>
                             <summary><span class='tool-param-preview'>{preview}</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='{kind}'>&#9654; expand all {kind}</button></summary>
+                            {table_html}
+                        </details>
+                    """
+    return f"""
+                        <details class='tool-param-collapsible'>
+                            <summary><span class='tool-param-preview'>{preview}</span></summary>
                             {table_html}
                         </details>
                     """

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -18,6 +18,7 @@ import base64
 import binascii
 import json
 import re
+from collections.abc import Iterable
 from typing import Any, Optional, cast
 
 from .utils import (
@@ -28,6 +29,7 @@ from .utils import (
     render_file_content_collapsible,
     render_markdown_collapsible,
     render_markdown_inline,
+    render_user_markdown,
     render_user_markdown_collapsible,
     resolve_memory_body_links,
 )
@@ -1012,67 +1014,136 @@ def format_crondelete_output(output: CronDeleteOutput) -> str:
 # -- Generic Parameter Table --------------------------------------------------
 
 
-def render_params_table(params: dict[str, Any]) -> str:
-    """Render a dictionary of parameters as an HTML table.
+# Nesting depth at which structured values stop recursing into tables
+# and fall back to the JSON dump, so a pathological payload can't blow
+# up the DOM.
+_PARAMS_TABLE_MAX_DEPTH = 4
 
-    Reusable for tool parameters, diagnostic objects, etc.
-    """
-    if not params:
-        return "<div class='tool-params-empty'>No parameters</div>"
 
-    html_parts = ["<table class='tool-params-table'>"]
-
-    for key, value in params.items():
-        escaped_key = escape_html(str(key))
-
-        # If value is structured (dict/list), render as JSON
-        if isinstance(value, (dict, list)):
-            try:
-                formatted_value = json.dumps(value, indent=2, ensure_ascii=False)
-                escaped_value = escape_html(formatted_value)
-
-                # Make long structured values collapsible
-                if len(formatted_value) > 200:
-                    preview = escape_html(formatted_value[:100]) + "..."
-                    value_html = f"""
+def _json_dump_value_html(formatted_value: str) -> str:
+    """Escaped JSON dump in a ``<pre>``, collapsible when long."""
+    escaped_value = escape_html(formatted_value)
+    if len(formatted_value) > 200:
+        preview = escape_html(formatted_value[:100]) + "..."
+        return f"""
                         <details class='tool-param-collapsible'>
                             <summary><span class='tool-param-preview'>{preview}</span></summary>
                             <pre class='tool-param-structured'>{escaped_value}</pre>
                         </details>
                     """
-                else:
-                    value_html = (
-                        f"<pre class='tool-param-structured'>{escaped_value}</pre>"
-                    )
-            except (TypeError, ValueError):
-                # Fallback: convert to string when JSON serialization fails
-                escaped_value = escape_html(str(cast(object, value)))
-                value_html = escaped_value
-        else:
-            # Simple value, render as-is (or collapsible if long)
-            escaped_value = escape_html(str(value))
+    return f"<pre class='tool-param-structured'>{escaped_value}</pre>"
 
-            # Make long string values collapsible
-            if len(str(value)) > 100:
-                preview = escape_html(str(value)[:80]) + "..."
-                value_html = f"""
+
+def _raw_string_value_html(value: str) -> str:
+    """Escaped plain text, collapsible when long."""
+    escaped_value = escape_html(value)
+    if len(value) > 100:
+        preview = escape_html(value[:80]) + "..."
+        return f"""
                     <details class='tool-param-collapsible'>
                         <summary><span class='tool-param-preview'>{preview}</span></summary>
                         <div class='tool-param-full'>{escaped_value}</div>
                     </details>
                 """
-            else:
-                value_html = escaped_value
+    return escaped_value
 
+
+def _string_value_html(value: str) -> str:
+    """Render a string param value, treating it as potential Markdown.
+
+    Strings that are obviously markup rather than Markdown — XML/HTML
+    (``<``) or JSON (``{`` / ``[``) after leading whitespace — keep the
+    escaped raw-text rendering. Both Markdown paths use the
+    ``escape=True`` renderers: params were always HTML-escaped, so the
+    Markdown upgrade must not open a raw-HTML injection route.
+
+    Long values keep the legacy >100-char ``<details>`` fold (length-,
+    not line-based — a long single-line prompt must fold too), with the
+    rendered Markdown as the expanded body.
+    """
+    if value.lstrip()[:1] in ("<", "{", "["):
+        return _raw_string_value_html(value)
+    if len(value) > 100:
+        preview = escape_html(value[:80]) + "..."
+        rendered = render_user_markdown(value)
+        return f"""
+                    <details class='tool-param-collapsible'>
+                        <summary><span class='tool-param-preview'>{preview}</span></summary>
+                        <div class='tool-param-markdown markdown'>{rendered}</div>
+                    </details>
+                """
+    return render_markdown_inline(value)
+
+
+def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> str:
+    """Render a dict/list param value as a nested key/value table.
+
+    ``depth`` is the nesting level of the table containing this value;
+    past ``_PARAMS_TABLE_MAX_DEPTH`` (and for empty containers) the
+    value falls back to the JSON dump. The >200-char collapsibility
+    keeps its JSON-text preview so deep structures fold, not flood.
+    """
+    try:
+        formatted_value = json.dumps(value, indent=2, ensure_ascii=False)
+    except (TypeError, ValueError):
+        # Fallback: convert to string when JSON serialization fails
+        return escape_html(str(cast(object, value)))
+
+    if not value or depth >= _PARAMS_TABLE_MAX_DEPTH:
+        return _json_dump_value_html(formatted_value)
+
+    items = value.items() if isinstance(value, dict) else enumerate(value)
+    table_html = _params_table_html(items, depth + 1)
+    if len(formatted_value) > 200:
+        preview = escape_html(formatted_value[:100]) + "..."
+        return f"""
+                        <details class='tool-param-collapsible'>
+                            <summary><span class='tool-param-preview'>{preview}</span></summary>
+                            {table_html}
+                        </details>
+                    """
+    return table_html
+
+
+def _param_value_html(value: Any, depth: int) -> str:
+    """Dispatch a single param value to its hybrid rendering."""
+    if isinstance(value, (dict, list)):
+        return _structured_value_html(cast("dict[Any, Any] | list[Any]", value), depth)
+    if isinstance(value, str):
+        return _string_value_html(value)
+    # Scalars (int/float/bool/None): plain escaped text as before.
+    return _raw_string_value_html(str(value))
+
+
+def _params_table_html(items: "Iterable[tuple[Any, Any]]", depth: int) -> str:
+    """Build one key/value table; nested levels get a marker class."""
+    css = "tool-params-table" if depth == 0 else "tool-params-table tool-params-nested"
+    html_parts = [f"<table class='{css}'>"]
+    for key, value in items:
+        escaped_key = escape_html(str(key))
+        value_html = _param_value_html(value, depth)
         html_parts.append(f"""
             <tr>
                 <td class='tool-param-key'>{escaped_key}</td>
                 <td class='tool-param-value'>{value_html}</td>
             </tr>
         """)
-
     html_parts.append("</table>")
     return "".join(html_parts)
+
+
+def render_params_table(params: dict[str, Any]) -> str:
+    """Render a dictionary of parameters as an HTML table.
+
+    Reusable for tool parameters, diagnostic objects, etc. Values render
+    as a JSON/Markdown hybrid: strings are treated as Markdown (unless
+    they look like XML/HTML or JSON), dicts and lists recurse into
+    nested tables, scalars stay plain.
+    """
+    if not params:
+        return "<div class='tool-params-empty'>No parameters</div>"
+
+    return _params_table_html(params.items(), 0)
 
 
 # -- Tool Result Content Fallback Formatter -----------------------------------

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -1131,6 +1131,27 @@ def _table_fold_html(formatted_value: str, table_html: str, kind: str) -> str:
                     """
 
 
+def _params_root_html(table_html: str) -> str:
+    """Wrap a top-level params/result table with an expand-all control.
+
+    The button opens/closes every fold inside this renderer at once and
+    keeps the nested rows-toggle buttons in sync (wired up in
+    transcript.html, state derived from the DOM). Only emitted when the
+    tree actually contains folds — no dead button on flat tables.
+    """
+    if "<details" not in table_html:
+        return table_html
+    return (
+        "<div class='tool-params-root'>"
+        "<div class='tool-params-controls'>"
+        "<button type='button' class='tool-params-expand-all'"
+        " data-state='collapsed'>&#9654; expand all</button>"
+        "</div>"
+        f"{table_html}"
+        "</div>"
+    )
+
+
 def _param_value_html(value: Any, depth: int) -> str:
     """Dispatch a single param value to its hybrid rendering."""
     if isinstance(value, (dict, list)):
@@ -1169,7 +1190,7 @@ def render_params_table(params: dict[str, Any]) -> str:
     if not params:
         return "<div class='tool-params-empty'>No parameters</div>"
 
-    return _params_table_html(params.items(), 0)
+    return _params_root_html(_params_table_html(params.items(), 0))
 
 
 # -- Tool Result Content Fallback Formatter -----------------------------------
@@ -1203,7 +1224,7 @@ def _json_result_table_html(raw_content: str) -> Optional[str]:
     # render as an unfolded thousand-row table.
     if len(raw_content) > 200:
         table_html = _table_fold_html(raw_content, table_html, kind)
-    return f"<div class='tool-result-json'>{table_html}</div>"
+    return f"<div class='tool-result-json'>{_params_root_html(table_html)}</div>"
 
 
 def format_tool_result_content_raw(tool_result: ToolResultContent) -> str:

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -1100,16 +1100,22 @@ def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> s
         items = enumerate(value)
         kind = "rows"
     table_html = _params_table_html(items, depth + 1)
+    return _table_fold_html(formatted_value, table_html, kind)
+
+
+def _table_fold_html(formatted_value: str, table_html: str, kind: str) -> str:
+    """Wrap a rendered params table in a collapsed fold.
+
+    When the table has row-level folds, the summary carries an explicit
+    collapse hint (instead of the generic ::after one) followed by a
+    rows-toggle button that expands/collapses them all at once (wired
+    up in transcript.html). The "<details" probe is exact: structures
+    always fold, so a deeper fold can only exist inside a direct-row
+    fold. All-scalar containers get a plain fold — no dead button.
+    """
     preview = escape_html(formatted_value[:100])
     if len(formatted_value) > 100:
         preview += "..."
-    # When the table has row-level folds, the summary carries an
-    # explicit collapse hint (instead of the generic ::after one)
-    # followed by a rows-toggle button that expands/collapses them all
-    # at once (wired up in transcript.html). The "<details" probe is
-    # exact: structures always fold, so a deeper fold can only exist
-    # inside a direct-row fold. All-scalar containers get a plain fold —
-    # no dead button.
     if "<details" in table_html:
         return f"""
                         <details class='tool-param-collapsible tool-param-collapsible-rows'>
@@ -1185,11 +1191,19 @@ def _json_result_table_html(raw_content: str) -> Optional[str]:
         return None
     if isinstance(parsed, dict) and parsed:
         items: Iterable[tuple[Any, Any]] = cast("dict[Any, Any]", parsed).items()
+        kind = "properties"
     elif isinstance(parsed, list) and parsed:
         items = enumerate(cast("list[Any]", parsed))
+        kind = "rows"
     else:
         return None
-    return f"<div class='tool-result-json'>{_params_table_html(items, 0)}</div>"
+    table_html = _params_table_html(items, 0)
+    # Breadth guard: results past the legacy 200-char threshold keep
+    # its folded-by-default behavior — a huge JSON array must not
+    # render as an unfolded thousand-row table.
+    if len(raw_content) > 200:
+        table_html = _table_fold_html(raw_content, table_html, kind)
+    return f"<div class='tool-result-json'>{table_html}</div>"
 
 
 def format_tool_result_content_raw(tool_result: ToolResultContent) -> str:

--- a/claude_code_log/html/tool_formatters.py
+++ b/claude_code_log/html/tool_formatters.py
@@ -1096,9 +1096,13 @@ def _structured_value_html(value: "dict[Any, Any] | list[Any]", depth: int) -> s
     table_html = _params_table_html(items, depth + 1)
     if len(formatted_value) > 200:
         preview = escape_html(formatted_value[:100]) + "..."
+        # The summary carries an explicit collapse hint (instead of the
+        # generic ::after one) followed by a rows-toggle button that
+        # expands/collapses all row-level folds of this table at once
+        # (wired up in transcript.html).
         return f"""
-                        <details class='tool-param-collapsible'>
-                            <summary><span class='tool-param-preview'>{preview}</span></summary>
+                        <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                            <summary><span class='tool-param-preview'>{preview}</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed'>&#9654; expand rows</button></summary>
                             {table_html}
                         </details>
                     """

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -4819,9 +4819,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -4836,23 +4847,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -10753,9 +10768,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -10770,23 +10796,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -19086,9 +19116,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -19103,23 +19144,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -25503,9 +25548,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -25520,23 +25576,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -31412,7 +31472,7 @@
     {
       &quot;id&quot;: &quot;2&quot;,
       &quot;content&quot;: &quot;Implement core functionality&quot;,
-      &quot;status&quot;: &quot;...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed'>&#9654; expand rows</button></summary>
+      &quot;status&quot;: &quot;...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='rows'>&#9654; expand all rows</button></summary>
                               <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>0</td>
@@ -31421,7 +31481,14 @@
           
               <tr>
                   <td class='tool-param-key'>1</td>
-                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+                  <td class='tool-param-value'>
+                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                              <summary><span class='tool-param-preview'>{
+    &quot;id&quot;: &quot;2&quot;,
+    &quot;content&quot;: &quot;Implement core functionality&quot;,
+    &quot;status&quot;: &quot;in_progress&quot;,
+    &quot;priority&quot;:...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+                              <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
                   <td class='tool-param-value'>2</td>
@@ -31441,12 +31508,21 @@
                   <td class='tool-param-key'>priority</td>
                   <td class='tool-param-value'>high</td>
               </tr>
-          </table></td>
+          </table>
+                          </details>
+                      </td>
               </tr>
           
               <tr>
                   <td class='tool-param-key'>2</td>
-                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+                  <td class='tool-param-value'>
+                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                              <summary><span class='tool-param-preview'>{
+    &quot;id&quot;: &quot;3&quot;,
+    &quot;content&quot;: &quot;Add comprehensive tests&quot;,
+    &quot;status&quot;: &quot;pending&quot;,
+    &quot;priority&quot;: &quot;medium&quot;...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+                              <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
                   <td class='tool-param-value'>3</td>
@@ -31466,12 +31542,22 @@
                   <td class='tool-param-key'>priority</td>
                   <td class='tool-param-value'>medium</td>
               </tr>
-          </table></td>
+          </table>
+                          </details>
+                      </td>
               </tr>
           
               <tr>
                   <td class='tool-param-key'>3</td>
-                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+                  <td class='tool-param-value'>
+                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                              <summary><span class='tool-param-preview'>{
+    &quot;id&quot;: &quot;4&quot;,
+    &quot;content&quot;: &quot;Write user documentation&quot;,
+    &quot;status&quot;: &quot;pending&quot;,
+    &quot;priority&quot;: &quot;low&quot;
+  }</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+                              <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
                   <td class='tool-param-value'>4</td>
@@ -31491,12 +31577,22 @@
                   <td class='tool-param-key'>priority</td>
                   <td class='tool-param-value'>low</td>
               </tr>
-          </table></td>
+          </table>
+                          </details>
+                      </td>
               </tr>
           
               <tr>
                   <td class='tool-param-key'>4</td>
-                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+                  <td class='tool-param-value'>
+                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                              <summary><span class='tool-param-preview'>{
+    &quot;id&quot;: &quot;5&quot;,
+    &quot;content&quot;: &quot;Perform code review&quot;,
+    &quot;status&quot;: &quot;pending&quot;,
+    &quot;priority&quot;: &quot;medium&quot;
+  }</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+                              <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
                   <td class='tool-param-value'>5</td>
@@ -31516,7 +31612,9 @@
                   <td class='tool-param-key'>priority</td>
                   <td class='tool-param-value'>medium</td>
               </tr>
-          </table></td>
+          </table>
+                          </details>
+                      </td>
               </tr>
           </table>
                           </details>
@@ -31844,9 +31942,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -31861,23 +31970,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -38167,9 +38280,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -38184,23 +38308,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -44317,9 +44445,20 @@
               // that table (direct rows only — nested tables have their own).
               const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
   
-              function setRowsToggleState(button, expanded) {
-                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
-                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              // Derive the button label/state from the actual row state, so
+              // it stays in sync whatever opened the rows (button click,
+              // toggle-all, manual clicks).
+              function syncRowsToggle(details) {
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (!button) return;
+                  const rows = details.querySelectorAll(rowDetailsSelector);
+                  const allOpen = rows.length > 0 &&
+                      Array.from(rows).every(row => row.open);
+                  const kind = button.dataset.kind || 'rows';
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen
+                      ? '▼ collapse all ' + kind
+                      : '▶ expand all ' + kind;
               }
   
               document.addEventListener('click', function (event) {
@@ -44334,23 +44473,27 @@
                   details.querySelectorAll(rowDetailsSelector).forEach(row => {
                       row.open = expand;
                   });
-                  setRowsToggleState(button, expand);
+                  syncRowsToggle(details);
               });
   
-              // Closing a fold restores its initial state: all rows collapsed,
-              // button back to "expand rows". Rows that are themselves folds
-              // reset their own rows through this same (capturing — toggle
-              // doesn't bubble) listener.
+              // Capturing listener (toggle doesn't bubble) keeps every fold
+              // consistent: closing one restores its initial state (rows
+              // collapsed — nested folds reset recursively through this same
+              // listener); any row toggling re-syncs its parent's button.
               document.addEventListener('toggle', function (event) {
                   const details = event.target;
-                  if (!(details instanceof HTMLElement)) return;
-                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
-                  if (details.open) return;
-                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
-                      row.open = false;
-                  });
-                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
-                  if (button) setRowsToggleState(button, false);
+                  if (!(details instanceof HTMLElement) || details.tagName !== 'DETAILS') return;
+                  if (details.classList.contains('tool-param-collapsible-rows')) {
+                      if (!details.open) {
+                          details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                              row.open = false;
+                          });
+                      }
+                      syncRowsToggle(details);
+                  }
+                  const cell = details.parentElement;
+                  const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
+                  if (parent && parent !== details) syncRowsToggle(parent);
               }, true);
   
               // Filter toolbar toggle functionality

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -1317,6 +1317,24 @@
       border-radius: 3px;
   }
   
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
+  }
+  
   .tool-param-collapsible {
       margin: 0;
   }
@@ -7254,6 +7272,24 @@
       background-color: var(--bg-neutral);
       padding: 4px;
       border-radius: 3px;
+  }
+  
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
   }
   
   .tool-param-collapsible {
@@ -15277,6 +15313,24 @@
       border-radius: 3px;
   }
   
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
+  }
+  
   .tool-param-collapsible {
       margin: 0;
   }
@@ -21329,6 +21383,24 @@
       background-color: var(--bg-neutral);
       padding: 4px;
       border-radius: 3px;
+  }
+  
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
   }
   
   .tool-param-collapsible {
@@ -27652,6 +27724,24 @@
       border-radius: 3px;
   }
   
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
+  }
+  
   .tool-param-collapsible {
       margin: 0;
   }
@@ -30974,33 +31064,112 @@
       &quot;id&quot;: &quot;2&quot;,
       &quot;content&quot;: &quot;Implement core functionality&quot;,
       &quot;status&quot;: &quot;...</span></summary>
-                              <pre class='tool-param-structured'>[
-    &quot;broken_todo&quot;,
-    {
-      &quot;id&quot;: &quot;2&quot;,
-      &quot;content&quot;: &quot;Implement core functionality&quot;,
-      &quot;status&quot;: &quot;in_progress&quot;,
-      &quot;priority&quot;: &quot;high&quot;
-    },
-    {
-      &quot;id&quot;: &quot;3&quot;,
-      &quot;content&quot;: &quot;Add comprehensive tests&quot;,
-      &quot;status&quot;: &quot;pending&quot;,
-      &quot;priority&quot;: &quot;medium&quot;
-    },
-    {
-      &quot;id&quot;: &quot;4&quot;,
-      &quot;content&quot;: &quot;Write user documentation&quot;,
-      &quot;status&quot;: &quot;pending&quot;,
-      &quot;priority&quot;: &quot;low&quot;
-    },
-    {
-      &quot;id&quot;: &quot;5&quot;,
-      &quot;content&quot;: &quot;Perform code review&quot;,
-      &quot;status&quot;: &quot;pending&quot;,
-      &quot;priority&quot;: &quot;medium&quot;
-    }
-  ]</pre>
+                              <table class='tool-params-table tool-params-nested'>
+              <tr>
+                  <td class='tool-param-key'>0</td>
+                  <td class='tool-param-value'>broken_todo</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>1</td>
+                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+              <tr>
+                  <td class='tool-param-key'>id</td>
+                  <td class='tool-param-value'>2</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>content</td>
+                  <td class='tool-param-value'>Implement core functionality</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>status</td>
+                  <td class='tool-param-value'>in_progress</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>priority</td>
+                  <td class='tool-param-value'>high</td>
+              </tr>
+          </table></td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>2</td>
+                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+              <tr>
+                  <td class='tool-param-key'>id</td>
+                  <td class='tool-param-value'>3</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>content</td>
+                  <td class='tool-param-value'>Add comprehensive tests</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>status</td>
+                  <td class='tool-param-value'>pending</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>priority</td>
+                  <td class='tool-param-value'>medium</td>
+              </tr>
+          </table></td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>3</td>
+                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+              <tr>
+                  <td class='tool-param-key'>id</td>
+                  <td class='tool-param-value'>4</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>content</td>
+                  <td class='tool-param-value'>Write user documentation</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>status</td>
+                  <td class='tool-param-value'>pending</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>priority</td>
+                  <td class='tool-param-value'>low</td>
+              </tr>
+          </table></td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>4</td>
+                  <td class='tool-param-value'><table class='tool-params-table tool-params-nested'>
+              <tr>
+                  <td class='tool-param-key'>id</td>
+                  <td class='tool-param-value'>5</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>content</td>
+                  <td class='tool-param-value'>Perform code review</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>status</td>
+                  <td class='tool-param-value'>pending</td>
+              </tr>
+          
+              <tr>
+                  <td class='tool-param-key'>priority</td>
+                  <td class='tool-param-value'>medium</td>
+              </tr>
+          </table></td>
+              </tr>
+          </table>
                           </details>
                       </td>
               </tr>
@@ -33816,6 +33985,24 @@
       background-color: var(--bg-neutral);
       padding: 4px;
       border-radius: 3px;
+  }
+  
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
   }
   
   .tool-param-collapsible {
@@ -40043,6 +40230,24 @@
       background-color: var(--bg-neutral);
       padding: 4px;
       border-radius: 3px;
+  }
+  
+  /* Nested tables produced by the recursive params renderer: keep the
+     flat look but let the key column shrink (index/short keys) so depth
+     doesn't eat horizontal space. */
+  .tool-params-nested .tool-param-key {
+      width: auto;
+      min-width: 4em;
+  }
+  
+  /* Markdown-rendered string values: suppress the outer paragraph
+     margins so a prose value aligns with plain-text cells. */
+  .tool-param-value .tool-param-markdown > p:first-child {
+      margin-top: 0;
+  }
+  
+  .tool-param-value .tool-param-markdown > p:last-child {
+      margin-bottom: 0;
   }
   
   .tool-param-collapsible {

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -31482,12 +31482,12 @@
               <tr>
                   <td class='tool-param-key'>1</td>
                   <td class='tool-param-value'>
-                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                          <details class='tool-param-collapsible'>
                               <summary><span class='tool-param-preview'>{
     &quot;id&quot;: &quot;2&quot;,
     &quot;content&quot;: &quot;Implement core functionality&quot;,
     &quot;status&quot;: &quot;in_progress&quot;,
-    &quot;priority&quot;:...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+    &quot;priority&quot;:...</span></summary>
                               <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
@@ -31516,12 +31516,12 @@
               <tr>
                   <td class='tool-param-key'>2</td>
                   <td class='tool-param-value'>
-                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                          <details class='tool-param-collapsible'>
                               <summary><span class='tool-param-preview'>{
     &quot;id&quot;: &quot;3&quot;,
     &quot;content&quot;: &quot;Add comprehensive tests&quot;,
     &quot;status&quot;: &quot;pending&quot;,
-    &quot;priority&quot;: &quot;medium&quot;...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+    &quot;priority&quot;: &quot;medium&quot;...</span></summary>
                               <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
@@ -31550,13 +31550,13 @@
               <tr>
                   <td class='tool-param-key'>3</td>
                   <td class='tool-param-value'>
-                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                          <details class='tool-param-collapsible'>
                               <summary><span class='tool-param-preview'>{
     &quot;id&quot;: &quot;4&quot;,
     &quot;content&quot;: &quot;Write user documentation&quot;,
     &quot;status&quot;: &quot;pending&quot;,
     &quot;priority&quot;: &quot;low&quot;
-  }</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+  }</span></summary>
                               <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>
@@ -31585,13 +31585,13 @@
               <tr>
                   <td class='tool-param-key'>4</td>
                   <td class='tool-param-value'>
-                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
+                          <details class='tool-param-collapsible'>
                               <summary><span class='tool-param-preview'>{
     &quot;id&quot;: &quot;5&quot;,
     &quot;content&quot;: &quot;Perform code review&quot;,
     &quot;status&quot;: &quot;pending&quot;,
     &quot;priority&quot;: &quot;medium&quot;
-  }</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed' data-kind='properties'>&#9654; expand all properties</button></summary>
+  }</span></summary>
                               <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>id</td>

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -1402,6 +1402,27 @@
       color: var(--text-primary);
   }
   
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
+      color: var(--text-primary);
+  }
+  
   .tool-params-empty {
       color: var(--text-muted);
       font-style: italic;
@@ -4835,7 +4856,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -4868,6 +4912,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -7449,6 +7498,27 @@
   }
   
   .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
+  }
+  
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
       color: var(--text-primary);
   }
   
@@ -10784,7 +10854,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -10817,6 +10910,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -15584,6 +15682,27 @@
       color: var(--text-primary);
   }
   
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
+      color: var(--text-primary);
+  }
+  
   .tool-params-empty {
       color: var(--text-muted);
       font-style: italic;
@@ -19132,7 +19251,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -19165,6 +19307,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -21746,6 +21893,27 @@
   }
   
   .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
+  }
+  
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
       color: var(--text-primary);
   }
   
@@ -25564,7 +25732,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -25597,6 +25788,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -28178,6 +28374,27 @@
   }
   
   .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
+  }
+  
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
       color: var(--text-primary);
   }
   
@@ -31462,7 +31679,7 @@
               </div>
           </div>
           <div class='debug-info'>assistant_00 &rarr; assistant_00</div>
-          <div class='content'><table class='tool-params-table'>
+          <div class='content'><div class='tool-params-root'><div class='tool-params-controls'><button type='button' class='tool-params-expand-all' data-state='collapsed'>&#9654; expand all</button></div><table class='tool-params-table'>
               <tr>
                   <td class='tool-param-key'>todos</td>
                   <td class='tool-param-value'>
@@ -31620,7 +31837,7 @@
                           </details>
                       </td>
               </tr>
-          </table></div>
+          </table></div></div>
           
       </div>
       
@@ -31958,7 +32175,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -31991,6 +32231,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -34572,6 +34817,27 @@
   }
   
   .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
+  }
+  
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
       color: var(--text-primary);
   }
   
@@ -38296,7 +38562,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -38329,6 +38618,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality
@@ -40910,6 +41204,27 @@
   }
   
   .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
+  }
+  
+  /* Top-level expand/collapse-all control above a params/result table —
+     same quiet look as the in-summary rows-toggle. */
+  .tool-params-controls {
+      margin-bottom: 2px;
+  }
+  
+  .tool-params-expand-all {
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      font-size: 80%;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-params-expand-all:hover {
       color: var(--text-primary);
   }
   
@@ -44461,7 +44776,30 @@
                       : '▶ expand all ' + kind;
               }
   
+              // Top-level expand-all for a whole params/result renderer:
+              // opens/closes every fold inside it, at all depths. Nested
+              // rows-toggle buttons follow via the toggle listener below.
+              function syncExpandAll(root) {
+                  const button = root.querySelector(':scope > .tool-params-controls > .tool-params-expand-all');
+                  if (!button) return;
+                  const folds = root.querySelectorAll('details');
+                  const allOpen = folds.length > 0 &&
+                      Array.from(folds).every(fold => fold.open);
+                  button.dataset.state = allOpen ? 'expanded' : 'collapsed';
+                  button.textContent = allOpen ? '▼ collapse all' : '▶ expand all';
+              }
+  
               document.addEventListener('click', function (event) {
+                  const expandAllButton = event.target.closest('.tool-params-expand-all');
+                  if (expandAllButton) {
+                      const root = expandAllButton.closest('.tool-params-root');
+                      const expand = expandAllButton.dataset.state !== 'expanded';
+                      root.querySelectorAll('details').forEach(fold => {
+                          fold.open = expand;
+                      });
+                      syncExpandAll(root);
+                      return;
+                  }
                   const button = event.target.closest('.tool-param-rows-toggle');
                   if (!button) return;
                   // The button sits inside a <summary>: keep the click from
@@ -44494,6 +44832,11 @@
                   const cell = details.parentElement;
                   const parent = cell ? cell.closest('details.tool-param-collapsible-rows') : null;
                   if (parent && parent !== details) syncRowsToggle(parent);
+                  // Keep the renderer's top-level expand-all button in step
+                  // with whatever opened/closed this fold (rows-toggle,
+                  // manual click, global toggle-all).
+                  const root = details.closest('.tool-params-root');
+                  if (root) syncExpandAll(root);
               }, true);
   
               // Filter toolbar toggle functionality

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -1274,11 +1274,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -1363,6 +1366,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -4777,6 +4814,47 @@
   
               toggleButton.addEventListener('click', toggleAllDetails);
   
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
+  
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {
                   const isVisible = filterToolbar.classList.contains('visible');
@@ -7231,11 +7309,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -7320,6 +7401,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -10632,6 +10747,47 @@
               }
   
               toggleButton.addEventListener('click', toggleAllDetails);
+  
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
   
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {
@@ -15270,11 +15426,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -15359,6 +15518,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -18888,6 +19081,47 @@
   
               toggleButton.addEventListener('click', toggleAllDetails);
   
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
+  
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {
                   const isVisible = filterToolbar.classList.contains('visible');
@@ -21342,11 +21576,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -21431,6 +21668,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -25227,6 +25498,47 @@
   
               toggleButton.addEventListener('click', toggleAllDetails);
   
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
+  
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {
                   const isVisible = filterToolbar.classList.contains('visible');
@@ -27681,11 +27993,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -27770,6 +28085,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -31057,13 +31406,13 @@
               <tr>
                   <td class='tool-param-key'>todos</td>
                   <td class='tool-param-value'>
-                          <details class='tool-param-collapsible'>
+                          <details class='tool-param-collapsible tool-param-collapsible-rows'>
                               <summary><span class='tool-param-preview'>[
     &quot;broken_todo&quot;,
     {
       &quot;id&quot;: &quot;2&quot;,
       &quot;content&quot;: &quot;Implement core functionality&quot;,
-      &quot;status&quot;: &quot;...</span></summary>
+      &quot;status&quot;: &quot;...</span><span class='tool-param-collapse-hint'>collapse</span><button type='button' class='tool-param-rows-toggle' data-state='collapsed'>&#9654; expand rows</button></summary>
                               <table class='tool-params-table tool-params-nested'>
               <tr>
                   <td class='tool-param-key'>0</td>
@@ -31489,6 +31838,47 @@
               }
   
               toggleButton.addEventListener('click', toggleAllDetails);
+  
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
   
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {
@@ -33944,11 +34334,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -34033,6 +34426,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -37735,6 +38162,47 @@
   
               toggleButton.addEventListener('click', toggleAllDetails);
   
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
+  
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {
                   const isVisible = filterToolbar.classList.contains('visible');
@@ -40189,11 +40657,14 @@
       border-right: #00000017 1px solid;
   }
   
-  /* Tool parameter table styling */
+  /* Tool parameter table styling. The percentage font-size compounds at
+     each nesting level of the recursive params renderer — a deliberate
+     depth cue — so keep the factor gentle (90%, not 80%) or deep tables
+     become unreadable. */
   .tool-params-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 80%;
+      font-size: 90%;
   }
   
   /* Skill-tool body folded into the Skill tool_use block (issue #93).
@@ -40278,6 +40749,40 @@
   .tool-param-full {
       margin-top: 4px;
       word-break: break-all;
+  }
+  
+  /* Structured-table folds carry an explicit collapse hint plus a
+     rows-toggle button in the summary, so suppress the generic ::after
+     "collapse" hint for them and show the real elements only when open. */
+  .tool-param-collapsible-rows[open] > summary::after {
+      content: none;
+  }
+  
+  .tool-param-collapse-hint,
+  .tool-param-rows-toggle {
+      display: none;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-collapse-hint {
+      display: inline;
+      color: var(--text-muted);
+      font-style: italic;
+  }
+  
+  .tool-param-collapsible-rows[open] > summary > .tool-param-rows-toggle {
+      display: inline;
+      margin-left: 1.5em;
+      padding: 0;
+      background: none;
+      border: none;
+      font: inherit;
+      color: var(--text-muted);
+      font-style: italic;
+      cursor: pointer;
+  }
+  
+  .tool-param-rows-toggle:hover {
+      color: var(--text-primary);
   }
   
   .tool-params-empty {
@@ -43806,6 +44311,47 @@
               }
   
               toggleButton.addEventListener('click', toggleAllDetails);
+  
+              // Per-table rows-toggle for structured params: the button in an
+              // open fold's summary expands/collapses all row-level folds of
+              // that table (direct rows only — nested tables have their own).
+              const rowDetailsSelector = ':scope > table > tbody > tr > td > details';
+  
+              function setRowsToggleState(button, expanded) {
+                  button.dataset.state = expanded ? 'expanded' : 'collapsed';
+                  button.textContent = expanded ? '▼ collapse rows' : '▶ expand rows';
+              }
+  
+              document.addEventListener('click', function (event) {
+                  const button = event.target.closest('.tool-param-rows-toggle');
+                  if (!button) return;
+                  // The button sits inside a <summary>: keep the click from
+                  // toggling the enclosing details.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const details = button.closest('details');
+                  const expand = button.dataset.state !== 'expanded';
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = expand;
+                  });
+                  setRowsToggleState(button, expand);
+              });
+  
+              // Closing a fold restores its initial state: all rows collapsed,
+              // button back to "expand rows". Rows that are themselves folds
+              // reset their own rows through this same (capturing — toggle
+              // doesn't bubble) listener.
+              document.addEventListener('toggle', function (event) {
+                  const details = event.target;
+                  if (!(details instanceof HTMLElement)) return;
+                  if (!details.classList.contains('tool-param-collapsible-rows')) return;
+                  if (details.open) return;
+                  details.querySelectorAll(rowDetailsSelector).forEach(row => {
+                      row.open = false;
+                  });
+                  const button = details.querySelector(':scope > summary .tool-param-rows-toggle');
+                  if (button) setRowsToggleState(button, false);
+              }, true);
   
               // Filter toolbar toggle functionality
               function toggleFilterToolbar() {

--- a/test/test_params_rows_toggle_browser.py
+++ b/test/test_params_rows_toggle_browser.py
@@ -109,7 +109,7 @@ class TestParamsRowsToggleBrowser:
 
         outer.locator("summary").first.click()
         assert button.is_visible()
-        assert "expand rows" in (button.text_content() or "")
+        assert "expand all rows" in (button.text_content() or "")
         row_states = outer.evaluate(ROW_DETAILS_JS)
         assert row_states and not any(row_states), "rows must start collapsed"
 
@@ -119,14 +119,14 @@ class TestParamsRowsToggleBrowser:
             "button click must not toggle the enclosing details"
         )
         row_states = outer.evaluate(ROW_DETAILS_JS)
-        assert all(row_states), "all rows must be open after expand rows"
-        assert "collapse rows" in (button.text_content() or "")
+        assert all(row_states), "all rows must be open after expand all rows"
+        assert "collapse all rows" in (button.text_content() or "")
 
         # Collapse all rows back.
         button.click()
         row_states = outer.evaluate(ROW_DETAILS_JS)
-        assert not any(row_states), "all rows must close after collapse rows"
-        assert "expand rows" in (button.text_content() or "")
+        assert not any(row_states), "all rows must close after collapse all rows"
+        assert "expand all rows" in (button.text_content() or "")
 
     @pytest.mark.browser
     def test_closing_fold_restores_initial_state(self, page: Page) -> None:
@@ -147,4 +147,25 @@ class TestParamsRowsToggleBrowser:
 
         row_states = outer.evaluate(ROW_DETAILS_JS)
         assert not any(row_states), "reopened fold must show rows collapsed"
-        assert "expand rows" in (button.text_content() or "")
+        assert "expand all rows" in (button.text_content() or "")
+
+    @pytest.mark.browser
+    def test_toggle_all_keeps_button_in_sync(self, page: Page) -> None:
+        """The global toggle-all button opens row folds without going
+        through the rows-toggle; its label must still flip (the state is
+        derived from the actual row state, not from past clicks)."""
+        html = self._render(_entries_with_structured_list())
+        page.goto(f"file://{html}")
+
+        outer = page.locator("details.tool-param-collapsible-rows").first
+        button = outer.locator("summary .tool-param-rows-toggle").first
+
+        page.locator("#toggleDetails").click()
+        assert outer.evaluate("el => el.open")
+        assert all(outer.evaluate(ROW_DETAILS_JS))
+        assert "collapse all rows" in (button.text_content() or "")
+
+        # And the button still works from this externally-reached state.
+        button.click()
+        assert not any(outer.evaluate(ROW_DETAILS_JS))
+        assert "expand all rows" in (button.text_content() or "")

--- a/test/test_params_rows_toggle_browser.py
+++ b/test/test_params_rows_toggle_browser.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from claude_code_log.converter import load_transcript
 from claude_code_log.html.renderer import generate_html
@@ -147,7 +147,7 @@ class TestParamsRowsToggleBrowser:
 
         row_states = outer.evaluate(ROW_DETAILS_JS)
         assert not any(row_states), "reopened fold must show rows collapsed"
-        assert "expand all rows" in (button.text_content() or "")
+        expect(button).to_contain_text("expand all rows")
 
     @pytest.mark.browser
     def test_toggle_all_keeps_button_in_sync(self, page: Page) -> None:
@@ -163,9 +163,69 @@ class TestParamsRowsToggleBrowser:
         page.locator("#toggleDetails").click()
         assert outer.evaluate("el => el.open")
         assert all(outer.evaluate(ROW_DETAILS_JS))
-        assert "collapse all rows" in (button.text_content() or "")
+        expect(button).to_contain_text("collapse all rows")
 
         # And the button still works from this externally-reached state.
         button.click()
         assert not any(outer.evaluate(ROW_DETAILS_JS))
         assert "expand all rows" in (button.text_content() or "")
+
+    @pytest.mark.browser
+    def test_expand_all_control_cascades(self, page: Page) -> None:
+        """The top-level expand-all opens every fold in the renderer and
+        flips the nested rows-toggle buttons; selectively closing one
+        fold flips the top button back to 'expand all'."""
+        html = self._render(_entries_with_structured_list())
+        page.goto(f"file://{html}")
+
+        root = page.locator(".tool-params-root").first
+        expand_all = root.locator(".tool-params-expand-all").first
+        all_open_js = (
+            "el => Array.from(el.querySelectorAll('details')).every(d => d.open)"
+        )
+        all_closed_js = (
+            "el => Array.from(el.querySelectorAll('details')).every(d => !d.open)"
+        )
+
+        assert root.evaluate(all_closed_js), "everything starts collapsed"
+        assert "expand all" in (expand_all.text_content() or "")
+
+        expand_all.click()
+        assert root.evaluate(all_open_js), "expand all must open every fold"
+        assert "collapse all" in (expand_all.text_content() or "")
+        # The toggle event is dispatched as a queued task, so label
+        # updates from the toggle listener are asynchronous — poll.
+        page.wait_for_function(
+            "() => Array.from(document.querySelectorAll("
+            "'.tool-params-root .tool-param-rows-toggle'))"
+            ".every(b => b.textContent.includes('collapse all'))"
+        )
+
+        # Selectively close one row: mixed state → top offers expand again.
+        outer = root.locator("details.tool-param-collapsible-rows").first
+        row = outer.locator(":scope > table > tbody > tr > td > details").first
+        row.locator("summary").first.click()
+        expect(expand_all).to_contain_text("expand all")
+
+        # Re-expand, then collapse all back to the initial state.
+        expand_all.click()
+        assert root.evaluate(all_open_js)
+        expand_all.click()
+        assert root.evaluate(all_closed_js)
+        assert "expand all" in (expand_all.text_content() or "")
+
+    @pytest.mark.browser
+    def test_global_toggle_all_activates_expand_all(self, page: Page) -> None:
+        """The global 'Open all details' button counts as expand-all for
+        every params renderer: its top button must read 'collapse all'."""
+        html = self._render(_entries_with_structured_list())
+        page.goto(f"file://{html}")
+
+        root = page.locator(".tool-params-root").first
+        expand_all = root.locator(".tool-params-expand-all").first
+
+        page.locator("#toggleDetails").click()
+        assert root.evaluate(
+            "el => Array.from(el.querySelectorAll('details')).every(d => d.open)"
+        )
+        expect(expand_all).to_contain_text("collapse all")

--- a/test/test_params_rows_toggle_browser.py
+++ b/test/test_params_rows_toggle_browser.py
@@ -1,0 +1,150 @@
+"""Playwright tests for the params-table rows-toggle button.
+
+An open structured-value fold shows "▶ expand rows" after the collapse
+hint; pressing it opens every row-level fold of that table and turns
+into "▼ collapse rows"; closing the outer fold restores the initial
+state (rows collapsed, button reset).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import List
+
+import pytest
+from playwright.sync_api import Page
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.models import TranscriptEntry
+
+ROW_DETAILS_JS = (
+    "el => Array.from("
+    "el.querySelectorAll(':scope > table > tbody > tr > td > details')"
+    ").map(d => d.open)"
+)
+
+
+def _entries_with_structured_list() -> List[dict]:
+    """A generic tool whose input holds a list of dicts, each large
+    enough (>200 chars JSON) that every row renders as its own fold."""
+    items = [
+        {
+            "name": f"item_{i}",
+            "role": f"row {i}: " + "padding words " * 20,
+        }
+        for i in range(4)
+    ]
+    return [
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T10:00:00.000Z",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/tmp",
+            "sessionId": "s",
+            "version": "1.0.0",
+            "uuid": "a1",
+            "message": {
+                "role": "assistant",
+                "id": "m1",
+                "type": "message",
+                "model": "claude",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "SomeTool",
+                        "input": {"items": items},
+                    }
+                ],
+            },
+        },
+    ]
+
+
+class TestParamsRowsToggleBrowser:
+    def setup_method(self) -> None:
+        self.temp_files: List[Path] = []
+
+    def teardown_method(self) -> None:
+        for f in self.temp_files:
+            try:
+                f.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _render(self, entries: List[dict]) -> Path:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        ) as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+            jsonl_path = Path(f.name)
+        self.temp_files.append(jsonl_path)
+
+        messages: List[TranscriptEntry] = load_transcript(jsonl_path)
+        html_content = generate_html(messages, "Rows Toggle Test")
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".html", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(html_content)
+            html_path = Path(f.name)
+        self.temp_files.append(html_path)
+        return html_path
+
+    @pytest.mark.browser
+    def test_rows_toggle_cycle(self, page: Page) -> None:
+        html = self._render(_entries_with_structured_list())
+        page.goto(f"file://{html}")
+
+        outer = page.locator("details.tool-param-collapsible-rows").first
+        button = outer.locator("summary .tool-param-rows-toggle").first
+
+        # Collapsed fold: the button is hidden.
+        assert not button.is_visible()
+
+        outer.locator("summary").first.click()
+        assert button.is_visible()
+        assert "expand rows" in (button.text_content() or "")
+        row_states = outer.evaluate(ROW_DETAILS_JS)
+        assert row_states and not any(row_states), "rows must start collapsed"
+
+        # Expand all rows.
+        button.click()
+        assert outer.evaluate("el => el.open"), (
+            "button click must not toggle the enclosing details"
+        )
+        row_states = outer.evaluate(ROW_DETAILS_JS)
+        assert all(row_states), "all rows must be open after expand rows"
+        assert "collapse rows" in (button.text_content() or "")
+
+        # Collapse all rows back.
+        button.click()
+        row_states = outer.evaluate(ROW_DETAILS_JS)
+        assert not any(row_states), "all rows must close after collapse rows"
+        assert "expand rows" in (button.text_content() or "")
+
+    @pytest.mark.browser
+    def test_closing_fold_restores_initial_state(self, page: Page) -> None:
+        html = self._render(_entries_with_structured_list())
+        page.goto(f"file://{html}")
+
+        outer = page.locator("details.tool-param-collapsible-rows").first
+        button = outer.locator("summary .tool-param-rows-toggle").first
+
+        outer.locator("summary").first.click()
+        button.click()
+        assert all(outer.evaluate(ROW_DETAILS_JS))
+
+        # Close the outer fold via its summary, then reopen.
+        outer.locator("summary").first.click()
+        assert not outer.evaluate("el => el.open")
+        outer.locator("summary").first.click()
+
+        row_states = outer.evaluate(ROW_DETAILS_JS)
+        assert not any(row_states), "reopened fold must show rows collapsed"
+        assert "expand rows" in (button.text_content() or "")

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -1,0 +1,146 @@
+"""Tests for the hybrid JSON/Markdown value rendering in render_params_table.
+
+String values render as (escaped) Markdown unless they look like
+XML/HTML or JSON; dict/list values recurse into nested tables with a
+depth guard; scalars and long-value collapsibility keep their legacy
+behavior.
+"""
+
+from claude_code_log.html.tool_formatters import (
+    _PARAMS_TABLE_MAX_DEPTH,
+    render_params_table,
+)
+
+
+class TestMarkdownStrings:
+    """String values are treated as potential Markdown."""
+
+    def test_short_markdown_string_renders_inline(self):
+        html = render_params_table({"note": "use `rg` over **grep**"})
+        assert "<code>rg</code>" in html
+        assert "<strong>grep</strong>" in html
+
+    def test_long_markdown_string_uses_collapsible_renderer(self):
+        body = "\n".join(f"- item {i} with `code`" for i in range(30))
+        html = render_params_table({"prompt": body})
+        assert "tool-param-markdown" in html
+        # Long multi-line content folds via the markdown collapsible.
+        assert "<details" in html
+        assert "<code>code</code>" in html
+
+    def test_markdown_path_escapes_raw_html(self):
+        """XSS posture: the Markdown path must escape, never inject."""
+        html = render_params_table({"v": "hello <script>alert(1)</script> world"})
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_long_markdown_path_escapes_raw_html(self):
+        body = "start\n\n<script>alert(1)</script>\n\n" + "filler\n" * 30
+        html = render_params_table({"v": body})
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+class TestMarkupLikeStrings:
+    """Strings that look like XML/HTML or JSON keep escaped raw text."""
+
+    def test_xmlish_string_stays_escaped_raw(self):
+        html = render_params_table({"v": "<task>do *not* render</task>"})
+        assert "&lt;task&gt;do *not* render&lt;/task&gt;" in html
+        assert "<em>" not in html
+
+    def test_jsonish_object_string_stays_escaped_raw(self):
+        html = render_params_table({"v": '{"a": "*x*"}'})
+        assert "&quot;*x*&quot;" in html
+        assert "<em>" not in html
+
+    def test_jsonish_array_string_stays_escaped_raw(self):
+        html = render_params_table({"v": '  ["*x*"]'})
+        assert "<em>" not in html
+
+    def test_long_raw_string_still_collapsible(self):
+        value = "<" + "x" * 200
+        html = render_params_table({"v": value})
+        assert "tool-param-collapsible" in html
+        assert "tool-param-preview" in html
+
+
+class TestNestedStructures:
+    """Dict and list values recurse into nested tables."""
+
+    def test_nested_dict_renders_table(self):
+        html = render_params_table({"cfg": {"mode": "fast", "retries": 3}})
+        assert html.count("<table class='tool-params-table") == 2
+        assert "tool-params-nested" in html
+        assert "mode" in html and "fast" in html
+        # No JSON dump for the recursed value.
+        assert "tool-param-structured" not in html
+
+    def test_list_renders_indexed_rows(self):
+        html = render_params_table({"items": ["alpha", "beta"]})
+        assert "tool-params-nested" in html
+        assert "<td class='tool-param-key'>0</td>" in html
+        assert "<td class='tool-param-key'>1</td>" in html
+        assert "alpha" in html and "beta" in html
+
+    def test_list_of_dicts_recurses_both_levels(self):
+        html = render_params_table({"qs": [{"q": "one"}, {"q": "two"}]})
+        # Outer + list + two element tables.
+        assert html.count("<table class='tool-params-table") == 4
+        assert "one" in html and "two" in html
+
+    def test_markdown_leaf_inside_nested_dict(self):
+        html = render_params_table({"cfg": {"desc": "see `cli.py`"}})
+        assert "<code>cli.py</code>" in html
+
+    def test_long_structure_folds_with_json_preview(self):
+        value = {f"key_{i}": f"value {i}" for i in range(20)}
+        html = render_params_table({"cfg": value})
+        assert "tool-param-collapsible" in html
+        assert "tool-param-preview" in html
+        # The expanded body is a table, not a JSON dump.
+        assert "tool-params-nested" in html
+
+    def test_empty_containers_fall_back_to_json_dump(self):
+        html = render_params_table({"a": {}, "b": []})
+        assert html.count("tool-param-structured") == 2
+        assert "{}" in html and "[]" in html
+
+
+class TestDepthGuard:
+    """Past the max depth, values fall back to the JSON dump."""
+
+    def test_pathological_nesting_falls_back_to_json(self):
+        value = {"leaf": "*md*"}
+        for _ in range(_PARAMS_TABLE_MAX_DEPTH + 2):
+            value = {"nested": value}
+        html = render_params_table({"deep": value})
+        # Table nesting is bounded...
+        assert html.count("<table") <= _PARAMS_TABLE_MAX_DEPTH + 1
+        # ...and the remainder renders as an escaped JSON dump.
+        assert "tool-param-structured" in html
+        assert "*md*" in html
+        assert "<em>" not in html
+
+    def test_depth_within_limit_renders_tables(self):
+        html = render_params_table({"a": {"b": {"c": "leaf"}}})
+        assert "tool-param-structured" not in html
+        assert "leaf" in html
+
+
+class TestScalarsAndLegacy:
+    """Scalars and the empty-params card are unchanged."""
+
+    def test_scalars_render_plain(self):
+        html = render_params_table({"n": 42, "flag": True, "none": None, "f": 1.5})
+        assert ">42<" in html
+        assert ">True<" in html
+        assert ">None<" in html
+        assert ">1.5<" in html
+
+    def test_empty_params(self):
+        assert "tool-params-empty" in render_params_table({})
+
+    def test_key_is_escaped(self):
+        html = render_params_table({"<key>": "v"})
+        assert "&lt;key&gt;" in html

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -8,6 +8,7 @@ behavior.
 
 from claude_code_log.html.tool_formatters import (
     _PARAMS_TABLE_MAX_DEPTH,
+    _PARAMS_TABLE_MAX_ITEMS,
     format_tool_result_content_raw,
     render_params_table,
 )
@@ -214,6 +215,37 @@ class TestDepthGuard:
         html = render_params_table({"a": {"b": {"c": "leaf"}}})
         assert "tool-param-structured" not in html
         assert "leaf" in html
+
+
+class TestBreadthCap:
+    """Wider containers than _PARAMS_TABLE_MAX_ITEMS fall back to the
+    JSON dump — the table HTML must not even be generated."""
+
+    def test_wide_list_falls_back_to_json_dump(self):
+        value = list(range(_PARAMS_TABLE_MAX_ITEMS + 1))
+        html = render_params_table({"items": value})
+        assert "tool-param-structured" in html
+        assert "tool-params-nested" not in html
+
+    def test_wide_dict_falls_back_to_json_dump(self):
+        value = {f"k{i}": i for i in range(_PARAMS_TABLE_MAX_ITEMS + 1)}
+        html = render_params_table({"cfg": value})
+        assert "tool-param-structured" in html
+        assert "tool-params-nested" not in html
+
+    def test_at_cap_still_renders_table(self):
+        value = list(range(_PARAMS_TABLE_MAX_ITEMS))
+        html = render_params_table({"items": value})
+        assert "tool-params-nested" in html
+        assert "tool-param-structured" not in html
+
+    def test_wide_json_result_keeps_legacy_text_rendering(self):
+        import json
+
+        content = json.dumps(list(range(_PARAMS_TABLE_MAX_ITEMS + 1)))
+        html = format_tool_result_content_raw(_tool_result(content))
+        assert "tool-result-json" not in html
+        assert "collapsible-details" in html
 
 
 class TestScalarsAndLegacy:

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -8,8 +8,16 @@ behavior.
 
 from claude_code_log.html.tool_formatters import (
     _PARAMS_TABLE_MAX_DEPTH,
+    format_tool_result_content_raw,
     render_params_table,
 )
+from claude_code_log.models import ToolResultContent
+
+
+def _tool_result(content: str, is_error: bool = False) -> ToolResultContent:
+    return ToolResultContent(
+        type="tool_result", tool_use_id="t1", content=content, is_error=is_error
+    )
 
 
 class TestMarkdownStrings:
@@ -83,6 +91,23 @@ class TestNestedStructures:
         assert "<td class='tool-param-key'>1</td>" in html
         assert "alpha" in html and "beta" in html
 
+    def test_structures_always_fold_regardless_of_size(self):
+        """Even short dict/list values render collapsed — sibling rows
+        must look consistent (no size-based auto-expand)."""
+        html = render_params_table({"a": {"k": 1}, "b": [1, 2]})
+        assert html.count("tool-param-collapsible-rows") == 2
+        # Short JSON: the preview is the full dump, no ellipsis.
+        assert "..." not in html
+
+    def test_fold_button_label_matches_container_kind(self):
+        dict_html = render_params_table({"cfg": {"k": "v"}})
+        assert "expand all properties" in dict_html
+        assert "data-kind='properties'" in dict_html
+
+        list_html = render_params_table({"items": [1, 2]})
+        assert "expand all rows" in list_html
+        assert "data-kind='rows'" in list_html
+
     def test_list_of_dicts_recurses_both_levels(self):
         html = render_params_table({"qs": [{"q": "one"}, {"q": "two"}]})
         # Outer + list + two element tables.
@@ -109,7 +134,7 @@ class TestNestedStructures:
         assert "tool-param-collapsible-rows" in html
         assert "tool-param-collapse-hint" in html
         assert "tool-param-rows-toggle" in html
-        assert "expand rows" in html
+        assert "expand all properties" in html
 
         string_fold = render_params_table({"v": "plain words " * 20})
         assert "tool-param-rows-toggle" not in string_fold
@@ -160,3 +185,48 @@ class TestScalarsAndLegacy:
     def test_key_is_escaped(self):
         html = render_params_table({"<key>": "v"})
         assert "&lt;key&gt;" in html
+
+
+class TestJsonToolResults:
+    """Generic tool results that parse as JSON render as tables."""
+
+    def test_object_result_renders_table(self):
+        result = _tool_result('{"status": "ok", "count": 3}')
+        html = format_tool_result_content_raw(result)
+        assert "tool-result-json" in html
+        assert "tool-params-table" in html
+        assert "status" in html and "ok" in html
+
+    def test_array_result_renders_indexed_table(self):
+        result = _tool_result('[{"id": 1}, {"id": 2}]')
+        html = format_tool_result_content_raw(result)
+        assert "tool-result-json" in html
+        assert "<td class='tool-param-key'>0</td>" in html
+        assert "<td class='tool-param-key'>1</td>" in html
+
+    def test_invalid_json_stays_text(self):
+        result = _tool_result('{"status": "ok", trailing')
+        html = format_tool_result_content_raw(result)
+        assert "tool-result-json" not in html
+        assert "<pre>" in html
+
+    def test_non_json_text_unchanged(self):
+        result = _tool_result("plain output\nlines")
+        html = format_tool_result_content_raw(result)
+        assert "tool-result-json" not in html
+
+    def test_scalar_and_empty_json_stay_text(self):
+        for content in ("42", '"quoted"', "{}", "[]"):
+            html = format_tool_result_content_raw(_tool_result(content))
+            assert "tool-result-json" not in html, content
+
+    def test_error_result_stays_text(self):
+        result = _tool_result('{"error": "boom"}', is_error=True)
+        html = format_tool_result_content_raw(result)
+        assert "tool-result-json" not in html
+
+    def test_json_result_values_are_escaped(self):
+        result = _tool_result('{"v": "<script>alert(1)</script>"}')
+        html = format_tool_result_content_raw(result)
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -95,18 +95,31 @@ class TestNestedStructures:
         """Even short dict/list values render collapsed — sibling rows
         must look consistent (no size-based auto-expand)."""
         html = render_params_table({"a": {"k": 1}, "b": [1, 2]})
-        assert html.count("tool-param-collapsible-rows") == 2
+        assert html.count("<details class='tool-param-collapsible") == 2
         # Short JSON: the preview is the full dump, no ellipsis.
         assert "..." not in html
 
     def test_fold_button_label_matches_container_kind(self):
-        dict_html = render_params_table({"cfg": {"k": "v"}})
+        dict_html = render_params_table({"cfg": {"k": {"nested": 1}}})
         assert "expand all properties" in dict_html
         assert "data-kind='properties'" in dict_html
 
-        list_html = render_params_table({"items": [1, 2]})
+        list_html = render_params_table({"items": [[1], [2]]})
         assert "expand all rows" in list_html
         assert "data-kind='rows'" in list_html
+
+    def test_no_rows_toggle_without_row_folds(self):
+        """All-scalar containers fold but carry no dead button; a long
+        string value counts as a row fold (it opens via the button)."""
+        scalar_only = render_params_table({"cfg": {"id": 2, "status": "ok"}})
+        assert "tool-param-collapsible" in scalar_only
+        assert "tool-param-rows-toggle" not in scalar_only
+        assert "tool-param-collapsible-rows" not in scalar_only
+
+        with_string_fold = render_params_table(
+            {"cfg": {"id": 2, "desc": "long prose " * 20}}
+        )
+        assert "tool-param-rows-toggle" in with_string_fold
 
     def test_list_of_dicts_recurses_both_levels(self):
         html = render_params_table({"qs": [{"q": "one"}, {"q": "two"}]})
@@ -127,9 +140,10 @@ class TestNestedStructures:
         assert "tool-params-nested" in html
 
     def test_table_fold_carries_rows_toggle(self):
-        """Structured-table folds get the explicit hint + rows-toggle
-        button; plain string folds and the JSON fallback do not."""
-        value = {f"key_{i}": f"value {i}" for i in range(20)}
+        """Structured-table folds with foldable rows get the explicit
+        hint + rows-toggle button; plain string folds and the JSON
+        fallback do not."""
+        value = {f"key_{i}": {"nested": i} for i in range(5)}
         html = render_params_table({"cfg": value})
         assert "tool-param-collapsible-rows" in html
         assert "tool-param-collapse-hint" in html

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -244,3 +244,31 @@ class TestJsonToolResults:
         html = format_tool_result_content_raw(result)
         assert "<script>" not in html
         assert "&lt;script&gt;" in html
+
+    def test_large_result_folds_with_rows_toggle(self):
+        """Breadth guard: a big JSON array result starts collapsed (like
+        the legacy >200-char text fold) with the expand-all button."""
+        import json
+
+        content = json.dumps([{"id": i, "msg": f"row {i} " * 10} for i in range(50)])
+        html = format_tool_result_content_raw(_tool_result(content))
+        # The top-level table is inside a fold, not bare in the card.
+        assert html.startswith("<div class='tool-result-json'>")
+        before_table = html.split("<table", 1)[0]
+        assert "tool-param-collapsible-rows" in before_table
+        assert "expand all rows" in before_table
+
+    def test_large_scalar_only_result_folds_plain(self):
+        import json
+
+        content = json.dumps({f"key_{i}": f"v{i}" for i in range(30)})
+        assert len(content) > 200
+        html = format_tool_result_content_raw(_tool_result(content))
+        before_table = html.split("<table", 1)[0]
+        assert "tool-param-collapsible" in before_table
+        assert "tool-param-rows-toggle" not in html
+
+    def test_small_result_table_stays_unfolded(self):
+        html = format_tool_result_content_raw(_tool_result('{"status": "ok"}'))
+        assert "<details" not in html
+        assert "tool-params-table" in html

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -162,6 +162,39 @@ class TestNestedStructures:
         assert "{}" in html and "[]" in html
 
 
+class TestExpandAllControl:
+    """Top-level expand-all button above renderers that contain folds."""
+
+    def test_control_present_when_folds_exist(self):
+        html = render_params_table({"cfg": {"k": 1}})
+        assert "tool-params-root" in html
+        assert "tool-params-expand-all" in html
+        assert "expand all" in html
+        # The control sits above the table.
+        assert html.index("tool-params-expand-all") < html.index("<table")
+
+    def test_no_control_on_flat_params(self):
+        html = render_params_table({"path": "/src", "mode": "fast"})
+        assert "tool-params-root" not in html
+        assert "tool-params-expand-all" not in html
+
+    def test_string_fold_counts_as_fold(self):
+        html = render_params_table({"prompt": "words " * 40})
+        assert "tool-params-expand-all" in html
+
+    def test_json_result_with_folds_gets_control(self):
+        import json
+
+        content = json.dumps([{"id": i, "msg": f"row {i}"} for i in range(40)])
+        html = format_tool_result_content_raw(_tool_result(content))
+        assert "tool-result-json" in html
+        assert "tool-params-expand-all" in html
+
+    def test_small_flat_json_result_has_no_control(self):
+        html = format_tool_result_content_raw(_tool_result('{"a": "b"}'))
+        assert "tool-params-expand-all" not in html
+
+
 class TestDepthGuard:
     """Past the max depth, values fall back to the JSON dump."""
 

--- a/test/test_params_table_hybrid.py
+++ b/test/test_params_table_hybrid.py
@@ -101,6 +101,22 @@ class TestNestedStructures:
         # The expanded body is a table, not a JSON dump.
         assert "tool-params-nested" in html
 
+    def test_table_fold_carries_rows_toggle(self):
+        """Structured-table folds get the explicit hint + rows-toggle
+        button; plain string folds and the JSON fallback do not."""
+        value = {f"key_{i}": f"value {i}" for i in range(20)}
+        html = render_params_table({"cfg": value})
+        assert "tool-param-collapsible-rows" in html
+        assert "tool-param-collapse-hint" in html
+        assert "tool-param-rows-toggle" in html
+        assert "expand rows" in html
+
+        string_fold = render_params_table({"v": "plain words " * 20})
+        assert "tool-param-rows-toggle" not in string_fold
+
+        json_fallback = render_params_table({"v": "{" + "x" * 300})
+        assert "tool-param-rows-toggle" not in json_fallback
+
     def test_empty_containers_fall_back_to_json_dump(self):
         html = render_params_table({"a": {}, "b": []})
         assert html.count("tool-param-structured") == 2


### PR DESCRIPTION
Upgrades `render_params_table` — the generic key/value table used for tool
inputs, MCP fallbacks, and (since #215) workflow agent results — into a
recursive, Markdown-aware renderer:

- **String values render as sanitized Markdown** (inline for short values, a
  collapsible fold above 100 chars), unless they look like XML/HTML (`<`) or
  JSON (`{` / `[`) — those keep the escaped raw-text rendering.
- **Dict values recurse** into nested key/value tables; **list values**
  render as value tables, one row per element, recursing by the same rules.
- **Depth guard** at 4 levels (and empty containers) falls back to the
  existing pretty-printed JSON `<pre>`, still collapsible when long, so a
  pathological payload can't blow up the DOM.
- **XSS posture preserved**: the Markdown path uses the escaping renderer
  family (params are tool-call-authored and were always HTML-escaped);
  tests pin `<script>` neutralization on both the inline and folded paths.

19 new tests cover each branch of the behavior (Markdown short/long, XML-ish
and JSON-ish strings, nested dicts, lists of dicts, depth guard, escaping,
empty containers, scalars). HTML snapshots regenerated serially; the content
delta is confined to params cells. Browser (including timeline), TUI, and
unit suites are green; ruff and pyright clean.

Known trade-offs, documented in the code: literal-ish string fields (e.g. a
glob like `*test*`) now markdownize (renders as emphasis), and a Markdown
link starting with `[` is classified JSON-ish and stays raw — candidates for
a future per-key literal hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid params renderer: nested structures render as nested key/value tables with per-table rows expand/collapse controls, JSON object/array results render as tables with JSON previews and breadth/depth guards; long string values may use inline or collapsible renderers and per-fold “expand all/collapse” controls.

* **Style**
  * Increased params table font-size, constrained nested-key sizing, tightened markdown cell spacing, and refined collapse hints, toggle visibility, and top-level expand/collapse control.

* **Tests**
  * New unit and browser tests covering rendering, escaping, folding behavior, depth/breadth guards, and rows-toggle interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->