### PR TITLE
Anchor fork points whose node is an unrendered system message

### DIFF
--- a/claude_code_log/html/system_formatters.py
+++ b/claude_code_log/html/system_formatters.py
@@ -244,7 +244,7 @@ def format_session_header_content(content: SessionHeaderMessage) -> str:
     """
     escaped_title = html.escape(content.title)
     badges = _team_badge(content.team_name) if content.team_name else ""
-    if content.is_branch and content.parent_message_index is not None:
+    if content.is_branch:
         # Branch header: compact with back-reference to fork point
         # Show session info for cross-session branches (different real session)
         session_info = ""
@@ -255,22 +255,25 @@ def format_session_header_content(content: SessionHeaderMessage) -> str:
                 session_info = (
                     f' <span class="branch-session">(in Session {esc_sid})</span>'
                 )
-        fork_backref = ""
+        # Fork-point back-reference. ``&#x2442;`` is the fork glyph; the
+        # optional summary suffix names the fork. When the fork point isn't
+        # resolvable to a visible message (``parent_message_index`` None —
+        # e.g. a content-less system node ghosted at reduced detail, #233),
+        # render it as plain text rather than a dangling anchor that would
+        # jump to the wrong place (previously the session header, ``#msg-d-2``).
         if content.parent_session_summary:
             escaped_fork = html.escape(content.parent_session_summary)
-            fork_backref = (
-                f'<div class="branch-from">'
-                f'from <a href="#msg-d-{content.parent_message_index}" '
-                f'class="branch-backlink">'
-                f"&#x2442; Fork point &bull; {escaped_fork}</a></div>"
+            fork_label = f"&#x2442; Fork point &bull; {escaped_fork}"
+        else:
+            fork_label = "&#x2442; Fork point"
+        if content.parent_message_index is not None:
+            inner = (
+                f'<a href="#msg-d-{content.parent_message_index}" '
+                f'class="branch-backlink">{fork_label}</a>'
             )
         else:
-            fork_backref = (
-                f'<div class="branch-from">'
-                f'from <a href="#msg-d-{content.parent_message_index}" '
-                f'class="branch-backlink">'
-                f"&#x2442; Fork point</a></div>"
-            )
+            inner = f'<span class="branch-backlink">{fork_label}</span>'
+        fork_backref = f'<div class="branch-from">from {inner}</div>'
         return f"{escaped_title}{badges}{session_info}{fork_backref}"
     if content.parent_session_id:
         parent_label = content.parent_session_summary or content.parent_session_id[:8]

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4294,8 +4294,13 @@ def _build_branch_header(
             if msg.meta.uuid == attachment_uuid and msg.message_index is not None:
                 parent_msg_idx = msg.message_index
                 break
-    if parent_msg_idx is None and parent_sid:
-        parent_msg_idx = ctx.session_first_message.get(parent_sid)
+    # When the fork point itself isn't visible (e.g. a content-less system
+    # node ghosted at reduced detail), leave ``parent_msg_idx`` None so the
+    # branch header renders "from ⟂ Fork point" as plain text — NOT retargeted
+    # at the parent session header, which produced a misleading anchor that
+    # jumped to the wrong place (issue #233). At full detail the #233
+    # placeholder keeps the fork point visible, so this fallback is only
+    # reached in the genuinely-unresolvable case.
     original_sid = b_hier.get("original_session_id", message.sessionId)
     branch_summary = (session_summaries or {}).get(original_sid)
 
@@ -4395,6 +4400,36 @@ def _build_branch_header(
         first_uuid=b_hier.get("first_uuid") or "",
         team_name=branch_team_name,
         preview=branch_preview or None,
+    )
+
+
+def _is_unrendered_within_session_fork(uuid: str, ctx: RenderingContext) -> bool:
+    """True if ``uuid`` is a within-session fork point (≥1 branch target).
+
+    A within-session branch session id carries an ``@`` (``{line}@{uuid12}``);
+    cross-session continuations don't. Used at the system build site to decide
+    whether a content-less, about-to-be-dropped node must be kept as an
+    anchorable fork-point landmark (issue #233).
+    """
+    return any("@" in sid for sid in ctx.junction_targets.get(uuid, []))
+
+
+def _fork_placeholder_content(message: SystemTranscriptEntry) -> SystemMessage:
+    """Minimal ``SystemMessage`` landmark for a dropped fork-point node (#233).
+
+    Reuses ``SystemMessage`` rather than a bespoke type so the placeholder
+    inherits the existing CSS / emoji / timeline / filter handling, and so
+    ``_fork_point_preview`` (which already walks up *past* system hosts) treats
+    it as the expected fork host. The label is the raw ``(subtype)`` — honest
+    about what the otherwise-invisible node is, and general across subtypes.
+    ``SystemMessage.detail_visibility`` is ``FULL``, so the placeholder ghosts
+    at reduced detail just like any system entry; the fork anchor then degrades
+    to no-link (handled in ``_build_branch_header`` / the nav), not a wrong one.
+    """
+    return SystemMessage(
+        level="info",
+        text=f"({message.subtype})" if message.subtype else "(system)",
+        meta=create_meta(message),
     )
 
 
@@ -4551,6 +4586,18 @@ def _render_messages(
         # Handle system messages (already filtered in pass 1)
         if isinstance(message, SystemTranscriptEntry):
             system_content = create_system_message(message)
+            # A content-less system entry (e.g. ``turn_duration``,
+            # ``stop_hook_summary`` with no body) is normally dropped — but if
+            # it is a *within-session fork point* (issue #233), dropping it
+            # leaves the fork's nav/back-link anchors dangling (they fall back
+            # to the session header). Synthesize a minimal placeholder so the
+            # fork point is a real, anchorable landmark and the existing
+            # fork-point machinery (``_link_junction_forwards`` box,
+            # ``_build_branch_header`` back-link, nav anchor) resolves to it.
+            if system_content is None and _is_unrendered_within_session_fork(
+                message.uuid, ctx
+            ):
+                system_content = _fork_placeholder_content(message)
             if system_content:
                 system_msg = TemplateMessage(system_content)
                 if effective_session:

--- a/test/test_fork_invisible_node.py
+++ b/test/test_fork_invisible_node.py
@@ -206,11 +206,14 @@ def _build_fork_fixture(tmp_path: Path) -> str:
 class TestForkInvisibleNodeIntegration:
     def test_placeholder_landmark_rendered(self, tmp_path: Path):
         html = _build_fork_fixture(tmp_path)
-        # The dropped fork node now renders as a minimal system landmark.
+        # The dropped fork node now renders as a minimal system landmark whose
+        # label is the raw subtype.
         assert "(turn_duration)" in html
-        # Its uuid is present as the rendered node (debug-info shows uuid8/12).
-        assert "57e7a875" not in html  # sanity: not leaking the real fixture
-        assert "sd" in html
+        # …and it is a *real node* carrying the fork node's identity: the
+        # debug-info shows the placeholder's own uuid → its parent. The exact
+        # fragment (not a bare "sd" substring, which matches unrelated markup)
+        # proves the synthesized node rendered with the fork uuid.
+        assert "<div class='debug-info'>sd &rarr; a1</div>" in html
 
     def test_fork_box_and_anchors_resolve_to_placeholder_not_session_header(
         self, tmp_path: Path

--- a/test/test_fork_invisible_node.py
+++ b/test/test_fork_invisible_node.py
@@ -1,0 +1,236 @@
+"""A fork point whose node is normally dropped must still be anchorable (#233).
+
+When the fork point is a content-less / unsupported system entry (the real
+example: ``system/turn_duration``), the factory drops it, yet the DAG still
+sees it as a within-session fork. Pre-fix, the fork's nav item and the branch
+back-links fell back to the parent **session header** (``#msg-d-2``) — a
+confusing anchor that jumped to the wrong place.
+
+The fix synthesizes a minimal ``SystemMessage`` placeholder for any
+content-less *fork-point* system node so it becomes a real ⟂ landmark, and the
+existing fork machinery resolves to it. As a belt-and-suspenders, when the fork
+point is genuinely unresolvable (e.g. ghosted at reduced detail), the branch
+back-link renders "from ⟂ Fork point" as plain text rather than a wrong anchor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import re
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.html.system_formatters import format_session_header_content
+from claude_code_log.models import (
+    MessageMeta,
+    SessionHeaderMessage,
+    SystemTranscriptEntry,
+)
+from claude_code_log.renderer import (
+    RenderingContext,
+    _fork_placeholder_content,
+    _is_unrendered_within_session_fork,
+)
+
+
+# ----------------------------- unit: detection -------------------------------
+
+
+class TestIsUnrenderedWithinSessionFork:
+    def _ctx(self, targets: dict[str, list[str]]) -> RenderingContext:
+        ctx = RenderingContext()
+        ctx.junction_targets = targets
+        return ctx
+
+    def test_within_session_branch_targets_match(self):
+        # Branch session ids carry an '@' ({line}@{uuid12}).
+        ctx = self._ctx({"fork": ["s1@aaaaaaaaaaaa", "s1@bbbbbbbbbbbb"]})
+        assert _is_unrendered_within_session_fork("fork", ctx) is True
+
+    def test_cross_session_continuation_does_not_match(self):
+        # A continuation (no '@') is not a within-session fork.
+        ctx = self._ctx({"fork": ["s2", "s3"]})
+        assert _is_unrendered_within_session_fork("fork", ctx) is False
+
+    def test_unknown_uuid_does_not_match(self):
+        ctx = self._ctx({"fork": ["s1@aaaaaaaaaaaa"]})
+        assert _is_unrendered_within_session_fork("other", ctx) is False
+
+
+# ----------------------------- unit: placeholder -----------------------------
+
+
+def _system_entry(subtype: str | None) -> SystemTranscriptEntry:
+    raw: dict[str, Any] = {
+        "type": "system",
+        "uuid": "sd",
+        "parentUuid": "a1",
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/x",
+        "sessionId": "s1",
+        "version": "1.0",
+        "timestamp": "2025-01-01T00:00:02Z",
+    }
+    if subtype is not None:
+        raw["subtype"] = subtype
+    return SystemTranscriptEntry.model_validate(raw)
+
+
+class TestForkPlaceholderContent:
+    def test_label_is_raw_subtype(self):
+        content = _fork_placeholder_content(_system_entry("turn_duration"))
+        assert content.text == "(turn_duration)"
+        assert content.level == "info"
+        assert content.meta.uuid == "sd"
+
+    def test_label_falls_back_to_system(self):
+        content = _fork_placeholder_content(_system_entry(None))
+        assert content.text == "(system)"
+
+
+# ----------------------------- unit: branch back-link ------------------------
+
+
+def _branch_header(parent_message_index: int | None) -> SessionHeaderMessage:
+    return SessionHeaderMessage(
+        title="Branch • abcdef01",
+        session_id="s1@abcdef012345",
+        is_branch=True,
+        parent_session_id="s1",
+        parent_message_index=parent_message_index,
+        meta=MessageMeta(uuid="b1", session_id="s1@abcdef012345", timestamp="t"),
+    )
+
+
+class TestBranchBacklinkRendering:
+    def test_resolved_fork_renders_anchor(self):
+        html = format_session_header_content(_branch_header(42))
+        assert '<a href="#msg-d-42" class="branch-backlink">' in html
+        assert "Fork point" in html
+
+    def test_unresolved_fork_renders_plain_text_not_dangling_anchor(self):
+        # parent_message_index None → plain <span>, never an anchor to the
+        # session header (the #233 bug was '#msg-d-2').
+        html = format_session_header_content(_branch_header(None))
+        assert '<span class="branch-backlink">' in html
+        assert "Fork point" in html
+        assert "<a href=" not in html
+
+
+# ----------------------------- integration: render ---------------------------
+
+
+def _raw_user(uuid: str, parent: str | None, text: str, ts: str) -> dict[str, Any]:
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/x",
+        "sessionId": "s1",
+        "version": "1.0",
+        "timestamp": ts,
+        "message": {"role": "user", "content": text},
+    }
+
+
+def _raw_assistant(uuid: str, parent: str, text: str, ts: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/x",
+        "sessionId": "s1",
+        "version": "1.0",
+        "timestamp": ts,
+        "requestId": "r-" + uuid,
+        "message": {
+            "id": "m-" + uuid,
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4",
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _raw_turn_duration(uuid: str, parent: str, ts: str) -> dict[str, Any]:
+    # A content-less system fork node — mirrors the real turn_duration entry.
+    return {
+        "type": "system",
+        "subtype": "turn_duration",
+        "durationMs": 1000,
+        "messageCount": 3,
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/x",
+        "sessionId": "s1",
+        "version": "1.0",
+        "timestamp": ts,
+    }
+
+
+def _build_fork_fixture(tmp_path: Path) -> str:
+    # u0 → a1 → sd(turn_duration) ⇒ { u1 (rewind A), u2 (rewind B) }
+    # Two human prompts at different timestamps = a genuine within-session fork
+    # whose fork point is the content-less system node sd.
+    entries = [
+        _raw_user("u0", None, "go", "2025-01-01T00:00:00Z"),
+        _raw_assistant("a1", "u0", "working on it", "2025-01-01T00:00:01Z"),
+        _raw_turn_duration("sd", "a1", "2025-01-01T00:00:02Z"),
+        _raw_user("u1", "sd", "actually try approach A", "2025-01-01T00:05:00Z"),
+        _raw_assistant("a2", "u1", "doing A", "2025-01-01T00:05:01Z"),
+        _raw_user("u2", "sd", "no, approach B instead", "2025-01-01T00:09:00Z"),
+        _raw_assistant("a3", "u2", "doing B", "2025-01-01T00:09:01Z"),
+    ]
+    fixture = tmp_path / "fork.jsonl"
+    with open(fixture, "w") as f:
+        import json
+
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+    return generate_html(load_transcript(fixture), "fork")
+
+
+class TestForkInvisibleNodeIntegration:
+    def test_placeholder_landmark_rendered(self, tmp_path: Path):
+        html = _build_fork_fixture(tmp_path)
+        # The dropped fork node now renders as a minimal system landmark.
+        assert "(turn_duration)" in html
+        # Its uuid is present as the rendered node (debug-info shows uuid8/12).
+        assert "57e7a875" not in html  # sanity: not leaking the real fixture
+        assert "sd" in html
+
+    def test_fork_box_and_anchors_resolve_to_placeholder_not_session_header(
+        self, tmp_path: Path
+    ):
+        html = _build_fork_fixture(tmp_path)
+        # The body fork-point box renders (it attaches to the now-visible node).
+        assert "fork-point-header" in html
+        # The branch back-links must NOT fall back to the session header (d-2).
+        backlinks = re.findall(r'class="branch-from">from <a href="(#msg-d-\d+)"', html)
+        assert len(backlinks) == 2, backlinks
+        assert "#msg-d-2" not in backlinks
+        # All back-links point at one and the same fork landmark.
+        assert len(set(backlinks)) == 1, backlinks
+        # The placeholder card carries the fork node's uuid in debug-info, and
+        # the back-link target index matches the placeholder's own anchor id.
+        fork_idx = backlinks[0].rsplit("-", 1)[-1]
+        assert f"id='msg-d-{fork_idx}'" in html
+
+    def test_nav_fork_item_has_working_anchor(self, tmp_path: Path):
+        html = _build_fork_fixture(tmp_path)
+        nav = re.search(r"<a href='(#msg-d-\d+)' class='fork-link'>", html)
+        assert nav is not None, "nav fork item should have a real anchor, not a span"
+        assert nav.group(1) != "#msg-d-2"


### PR DESCRIPTION
Closes #233.

## Problem

A within-session fork point can *be* a system entry that the factory drops because it has no `content` (the reported case: `system/turn_duration`; also content-less `stop_hook_summary`, etc.). The DAG still treats it as a fork, so the fork's nav item and each branch's "from ⟂ Fork point" back-link had no visible node to anchor to and fell back to the parent **session header** (`#msg-d-2`) — a confusing link that jumps to the wrong place. The body fork-point box was missing entirely (its builder also gates on the node being visible).

Reproduced on a real session: both branch back-links resolved to `#msg-d-2`, no fork box.

## Root cause (two layers)

1. `create_system_message` returns `None` when `not transcript.content` → the node never becomes a `TemplateMessage`.
2. `_build_branch_header`, when the fork uuid isn't among the visible messages, fell back to `session_first_message[parent_sid]` = the session-header index. (Wrinkle: the fork's own parent here is *also* a dropped content-less system node, so "nearest visible" would have to walk up past multiple drops.)

## Fix

Generalized to **any** content-less fork-point system node — keyed on fork-point-ness, not on a specific subtype.

- **Primary:** at the system build site, when `create_system_message` returns `None` *and* the entry's uuid is a within-session fork point (a junction target carrying `@`), synthesize a minimal `SystemMessage` placeholder labelled `(<subtype>)` / `(system)`. Reusing `SystemMessage` inherits the existing CSS / emoji / timeline / filter handling, and `_fork_point_preview` already treats fork hosts as system entries. The existing machinery then resolves to it automatically: the body **⟂ Fork-point box** renders with branch-jump links, and the branch back-links + nav item all anchor to the one landmark. `SystemMessage.detail_visibility` is `FULL`, so the placeholder ghosts at reduced detail like any system entry.
- **Belt-and-suspenders:** `_build_branch_header` no longer retargets an unresolved fork anchor at the session header — it leaves the index `None`, and `format_session_header_content` renders "from ⟂ Fork point" as plain text (a `<span>`, not a dangling `<a>`). So the genuinely-unresolvable case (e.g. the placeholder ghosted at reduced detail) degrades to *no link* rather than a wrong one. This removes the sole producer of the `#msg-d-2` anchor, so the bug can't recur at any detail level.

## Testing

New `test/test_fork_invisible_node.py` (10 tests): the within-session detection predicate (within `@` / cross-session / unknown), the placeholder label (`(subtype)` / `(system)`), the branch back-link rendering (resolved → `<a>`, unresolved → `<span>` with no anchor — pins the secondary fix, fails on old code), and a synthetic `turn_duration`-fork integration fixture asserting the placeholder landmark renders, the fork box is present, both back-links resolve to one landmark (never `#msg-d-2`), and the nav fork item gets a real anchor.

`just ci` green (unit + TUI + browser + snapshots, ruff, pyright, ty); no snapshot churn.

> Note: the tests import two `_`-prefixed renderer helpers — consistent with the existing test suite (which already imports many `_`-prefixed renderer helpers). If `test/` is ever added to the pyright include scope (the `# TODO` in `pyproject.toml`), these would surface `reportPrivateUsage` and want a one-sweep cleanup across the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed branch/fork navigation so unresolved fork backlinks no longer generate broken or dangling anchors, preventing incorrect jumps.
  * Improved fork-point rendering to degrade gracefully: show a real backlink anchor only when the target is resolvable; otherwise render plain text.
  * Ensured within-session, content-less system fork points remain visible as minimal anchorable landmarks for consistent navigation.

* **Tests**
  * Added coverage for invisible system fork nodes (including placeholder/anchor behavior) to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->