### PR TITLE
Explicit --output: always regenerate, infer format from suffix, fix stdout hang (#221, #222, #223 part 1)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -639,7 +639,9 @@ def _validate_git_link_template(template: str) -> None:
     "output_format",
     type=click.Choice(["html", "md", "markdown", "json"]),
     default="html",
-    help="Output format (default: html). Supports html, md/markdown, or json.",
+    help="Output format. Supports html, md/markdown, or json. When omitted, "
+    "inferred from the --output file suffix (.md/.markdown/.html/.json); "
+    "otherwise defaults to html.",
 )
 @click.option(
     "--image-export-mode",
@@ -722,7 +724,9 @@ def _validate_git_link_template(template: str) -> None:
     default=False,
     help="Show full traceback on errors.",
 )
+@click.pass_context
 def main(
+    ctx: click.Context,
     input_path: Optional[Path],
     output: Optional[Path],
     expand_paths: bool,
@@ -841,6 +845,31 @@ def main(
             "directory (no recognised file suffix); ignoring.",
             err=True,
         )
+
+    # Infer --format from an explicit --output file suffix when -f was not
+    # given; error on an explicit conflict like `-o foo.md -f html` rather
+    # than writing mismatched content (issue #222). `.md`/`.markdown` both
+    # imply the canonical `markdown` format.
+    if output is not None and _output_path_is_file(output):
+        from .utils import format_from_output_suffix
+
+        suffix_format = format_from_output_suffix(output)
+        if suffix_format is not None:
+            format_explicit = (
+                ctx.get_parameter_source("output_format")
+                is not click.core.ParameterSource.DEFAULT
+            )
+            canonical_format = (
+                "markdown" if output_format in ("md", "markdown") else output_format
+            )
+            if not format_explicit:
+                output_format = suffix_format
+            elif canonical_format != suffix_format:
+                raise click.UsageError(
+                    f"--format {output_format} conflicts with the --output "
+                    f"suffix '{output.suffix}' (implies {suffix_format}); "
+                    "pass only one, or make them agree."
+                )
 
     # `--no-timestamps` is Markdown-only (#160). Warn (not error) when
     # paired with HTML/JSON so the flag is benignly ignored rather than
@@ -1138,6 +1167,15 @@ def main(
             write_combined=write_combined,
             no_timestamps=no_timestamps,
             no_recaps=no_recaps,
+            # An explicit `-o` *file* always regenerates: the version-marker
+            # skip only knows the embedded version, not which source produced
+            # the file, so it would keep stale content at a user-chosen path
+            # (issue #221). Scoped to file destinations — directory exports
+            # keep the cache's per-source incremental skip (is_html_stale),
+            # which already tracks the source (a different transcript to the
+            # same dir still regenerates), and `--all-projects` calls this
+            # with output=None anyway, so its skip is never forced.
+            force_regenerate=output is not None and _output_path_is_file(output),
         )
         if input_path.is_file():
             click.echo(f"Successfully converted {input_path} to {output_path}")

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1698,6 +1698,7 @@ def convert_jsonl_to(
     write_combined: bool = True,
     no_timestamps: bool = False,
     no_recaps: bool = False,
+    force_regenerate: bool = False,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -1714,6 +1715,13 @@ def convert_jsonl_to(
         page_size: Maximum messages per page for combined transcript pagination.
             If None, uses format default (embedded for HTML, referenced for Markdown).
         detail: Output detail level (full, high, low, minimal).
+        force_regenerate: Always (re)generate, bypassing the version-marker
+            staleness skip. The CLI sets this for an explicit ``--output``
+            (issue #221): the staleness heuristic only knows the embedded
+            version, not which source produced the file, so a same-version
+            file at a user-chosen path was kept even when a different
+            transcript was requested — silent stale content. The tool's own
+            managed ``combined_transcripts*`` artifacts still use the skip.
     """
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {input_path}")
@@ -1799,6 +1807,7 @@ def convert_jsonl_to(
             and not cache_was_updated
             and from_date is None
             and to_date is None
+            and not force_regenerate
         ):
             # Check if combined HTML is stale
             combined_stale, _ = cache_manager.is_html_stale(output_path.name, None)
@@ -1921,7 +1930,11 @@ def convert_jsonl_to(
         if cache_manager is not None and input_path.is_dir():
             is_stale, _reason = cache_manager.is_html_stale(output_path.name, None)
             should_regenerate = (
-                is_stale
+                # force_regenerate first so the is_outdated() sniff is
+                # short-circuited for an explicit --output (issue #221, and
+                # avoids touching a /dev/stdout destination for #223).
+                force_regenerate
+                or is_stale
                 or renderer.is_outdated(output_path)
                 or from_date is not None
                 or to_date is not None
@@ -1930,7 +1943,8 @@ def convert_jsonl_to(
         else:
             # Fallback: old logic for single file mode or no cache
             should_regenerate = (
-                renderer.is_outdated(output_path)
+                force_regenerate
+                or renderer.is_outdated(output_path)
                 or from_date is not None
                 or to_date is not None
                 or not output_path.exists()

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -211,7 +211,11 @@ def check_html_version(html_file_path: Path) -> Optional[str]:
     Returns:
         The version string if found, None if no version comment or file doesn't exist.
     """
-    if not html_file_path.exists():
+    # is_file() (not exists()) so a non-regular destination — e.g.
+    # /dev/stdout, which is a pipe when stdout is piped — is treated as
+    # "no version" rather than opened read-only, which would deadlock the
+    # version sniff on readline() (issue #223).
+    if not html_file_path.is_file():
         return None
 
     try:

--- a/claude_code_log/json/renderer.py
+++ b/claude_code_log/json/renderer.py
@@ -215,7 +215,11 @@ class JsonRenderer(Renderer):
 
     def is_outdated(self, file_path: Path) -> bool:
         """Check if a JSON file is outdated based on version field."""
-        if not file_path.exists():
+        # is_file() (not exists()) so a non-regular destination — e.g.
+        # /dev/stdout, which is a pipe when stdout is piped — is treated as
+        # outdated rather than opened read-only, which would deadlock the
+        # version sniff on json.load() (issue #223).
+        if not file_path.is_file():
             return True
         try:
             with open(file_path, "r", encoding="utf-8") as f:

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -2291,7 +2291,11 @@ class MarkdownRenderer(Renderer):
 
     def is_outdated(self, file_path: Path) -> bool:
         """Check if a Markdown file is outdated based on version comment."""
-        if not file_path.exists():
+        # is_file() (not exists()) so a non-regular destination — e.g.
+        # /dev/stdout, which is a pipe when stdout is piped — is treated as
+        # outdated rather than opened read-only, which would deadlock the
+        # version sniff on readline() (issue #223).
+        if not file_path.is_file():
             return True
         try:
             with open(file_path, "r", encoding="utf-8") as f:

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -330,9 +330,17 @@ def _peek_jsonl_for_cwd(jsonl_path: Path) -> Optional[str]:
 
 
 # Recognised output format suffixes for the `--output` dir-vs-file
-# heuristic. If a user passes ``--output /tmp/out.md`` we treat it as
-# a file; ``--output /tmp/obsidian/`` is a directory.
-_OUTPUT_FILE_SUFFIXES = frozenset({".html", ".md", ".markdown", ".json"})
+# heuristic and for format inference. If a user passes
+# ``--output /tmp/out.md`` we treat it as a file (and, when ``-f`` is
+# omitted, infer markdown); ``--output /tmp/obsidian/`` is a directory.
+# ``.md`` / ``.markdown`` both map to the canonical ``markdown`` format.
+_SUFFIX_TO_FORMAT: dict[str, str] = {
+    ".html": "html",
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".json": "json",
+}
+_OUTPUT_FILE_SUFFIXES = frozenset(_SUFFIX_TO_FORMAT)
 
 
 def output_path_is_file(output: Path) -> bool:
@@ -344,6 +352,16 @@ def output_path_is_file(output: Path) -> bool:
     inspection.
     """
     return output.suffix.lower() in _OUTPUT_FILE_SUFFIXES
+
+
+def format_from_output_suffix(output: Path) -> Optional[str]:
+    """Canonical output format implied by an ``--output`` file suffix.
+
+    Returns ``"html"`` / ``"markdown"`` / ``"json"`` for a recognised
+    suffix, or ``None`` otherwise (issue #222). ``.md`` and ``.markdown``
+    both map to ``"markdown"``.
+    """
+    return _SUFFIX_TO_FORMAT.get(output.suffix.lower())
 
 
 def project_destination(

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -187,7 +187,12 @@ A few JSON-specific touches:
 - `is_outdated(file_path)` reads the `version` field from existing
   JSON output and compares against the current library version —
   same invalidation contract as the HTML cache so re-runs skip
-  unchanged outputs.
+  unchanged outputs. It guards on `Path.is_file()` (not `exists()`)
+  so a non-regular destination like `/dev/stdout` is treated as
+  outdated rather than opened, which would deadlock the version sniff
+  (issue #223). An explicit `--output` bypasses the skip entirely
+  (`force_regenerate`, issue #221) since the version marker can't tell
+  which source produced a user-chosen file.
 - `combined_transcripts.json` per project; `session-{id}.json` for
   individual sessions. The naming respects `variant_suffix` for
   detail/compact variants.

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -25,6 +25,11 @@ from claude_code_log.json.renderer import JsonRenderer
 from claude_code_log.markdown.renderer import MarkdownRenderer
 
 
+_requires_mkfifo = pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="os.mkfifo is POSIX-only (not on Windows)"
+)
+
+
 def _user_entry(text: str, session_id: str = "s") -> dict[str, Any]:
     return {
         "type": "user",
@@ -68,11 +73,12 @@ class TestExplicitOutputAlwaysRegenerates:
         # And it did not announce a skip.
         assert "skipping regeneration" not in r2.output
 
-    def test_directory_input_cross_source_still_regenerates(self, tmp_path: Path):
-        """force_regenerate is scoped to *file* outputs, so a directory input
-        does not force. The cache's source-aware staleness must still keep the
-        cross-source case correct (no stale content) — pinning that the
-        narrowing didn't reintroduce #221 for directory inputs."""
+    def test_directory_input_to_file_output_cross_source(self, tmp_path: Path):
+        """A *directory* input exported to an explicit `-o` *file* also fixes
+        #221: `combined.html` is a file destination, so force_regenerate is
+        set and a second, different source produces fresh content rather than
+        the stale first export. Complements the file-input case above and
+        exercises the directory-mode regeneration branch."""
         dir_a = tmp_path / "proj_a"
         dir_a.mkdir()
         _write_jsonl(dir_a / "a.jsonl", "ALPHA_dir_source")
@@ -156,20 +162,43 @@ class TestIsOutdatedNonRegularFileGuard:
         assert not t.is_alive(), "is_outdated blocked on a non-regular file (hang)"
         return result["value"]
 
+    # FIFO pins the actual deadlock scenario (opening a pipe read-only blocks
+    # on readline); os.mkfifo is POSIX-only, so these skip on Windows. The
+    # directory-based tests below cover the is_file() guard cross-platform.
+    @_requires_mkfifo
     def test_markdown_is_outdated_on_fifo_returns_true(self, tmp_path: Path):
         fifo = tmp_path / "f"
         os.mkfifo(fifo)
         assert self._call_with_timeout(MarkdownRenderer().is_outdated, fifo) is True
 
+    @_requires_mkfifo
     def test_json_is_outdated_on_fifo_returns_true(self, tmp_path: Path):
         fifo = tmp_path / "f"
         os.mkfifo(fifo)
         assert self._call_with_timeout(JsonRenderer().is_outdated, fifo) is True
 
+    @_requires_mkfifo
     def test_check_html_version_on_fifo_returns_none(self, tmp_path: Path):
         fifo = tmp_path / "f"
         os.mkfifo(fifo)
         assert self._call_with_timeout(check_html_version, fifo) is None
+
+    def test_markdown_is_outdated_on_directory_returns_true(self, tmp_path: Path):
+        """Cross-platform: a directory is not a regular file → outdated,
+        without opening it (the is_file() guard, sans POSIX FIFO)."""
+        d = tmp_path / "subdir"
+        d.mkdir()
+        assert MarkdownRenderer().is_outdated(d) is True
+
+    def test_json_is_outdated_on_directory_returns_true(self, tmp_path: Path):
+        d = tmp_path / "subdir"
+        d.mkdir()
+        assert JsonRenderer().is_outdated(d) is True
+
+    def test_check_html_version_on_directory_returns_none(self, tmp_path: Path):
+        d = tmp_path / "subdir"
+        d.mkdir()
+        assert check_html_version(d) is None
 
     def test_nonexistent_path_is_outdated(self, tmp_path: Path):
         missing = tmp_path / "nope.md"

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -1,0 +1,180 @@
+"""Tests for explicit --output correctness (PR 1 of the #220-223 set).
+
+Covers:
+- #221: an explicit ``-o`` always regenerates (no stale content kept when
+  a different source is written to the same path).
+- #222: output format is inferred from the ``-o`` file suffix when ``-f``
+  is omitted, and an explicit conflict is an error.
+- #223-part1: the ``is_outdated`` version sniff no longer opens a
+  non-regular destination (e.g. a FIFO / ``/dev/stdout``), which deadlocked.
+"""
+
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_log.cli import main
+from claude_code_log.html.renderer import check_html_version
+from claude_code_log.json.renderer import JsonRenderer
+from claude_code_log.markdown.renderer import MarkdownRenderer
+
+
+def _user_entry(text: str, session_id: str = "s") -> dict[str, Any]:
+    return {
+        "type": "user",
+        "timestamp": "2025-01-01T10:00:00Z",
+        "sessionId": session_id,
+        "uuid": f"u-{uuid.uuid4().hex[:8]}",
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "version": "1.0.0",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _write_jsonl(path: Path, text: str) -> Path:
+    path.write_text(json.dumps(_user_entry(text)) + "\n", encoding="utf-8")
+    return path
+
+
+class TestExplicitOutputAlwaysRegenerates:
+    """#221: same-version file at a user path must not keep stale content."""
+
+    def test_second_source_overwrites_first(self, tmp_path: Path):
+        a = _write_jsonl(tmp_path / "a.jsonl", "AAA_alpha_source")
+        b = _write_jsonl(tmp_path / "b.jsonl", "BBB_beta_source")
+        out = tmp_path / "out.md"
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(a), "-f", "markdown", "-o", str(out)])
+        assert r1.exit_code == 0, r1.output
+        first = out.read_text(encoding="utf-8")
+        assert "AAA_alpha_source" in first
+
+        r2 = runner.invoke(main, [str(b), "-f", "markdown", "-o", str(out)])
+        assert r2.exit_code == 0, r2.output
+        second = out.read_text(encoding="utf-8")
+        # Regenerated from B — not the stale A content.
+        assert "BBB_beta_source" in second
+        assert "AAA_alpha_source" not in second
+        # And it did not announce a skip.
+        assert "skipping regeneration" not in r2.output
+
+    def test_directory_input_cross_source_still_regenerates(self, tmp_path: Path):
+        """force_regenerate is scoped to *file* outputs, so a directory input
+        does not force. The cache's source-aware staleness must still keep the
+        cross-source case correct (no stale content) — pinning that the
+        narrowing didn't reintroduce #221 for directory inputs."""
+        dir_a = tmp_path / "proj_a"
+        dir_a.mkdir()
+        _write_jsonl(dir_a / "a.jsonl", "ALPHA_dir_source")
+        dir_b = tmp_path / "proj_b"
+        dir_b.mkdir()
+        _write_jsonl(dir_b / "b.jsonl", "BETA_dir_source")
+        out = tmp_path / "combined.html"
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(dir_a), "-o", str(out)])
+        assert r1.exit_code == 0, r1.output
+        assert "ALPHA_dir_source" in out.read_text(encoding="utf-8")
+
+        r2 = runner.invoke(main, [str(dir_b), "-o", str(out)])
+        assert r2.exit_code == 0, r2.output
+        after = out.read_text(encoding="utf-8")
+        assert "BETA_dir_source" in after
+        assert "ALPHA_dir_source" not in after
+
+
+class TestFormatInferenceFromSuffix:
+    """#222: infer -f from the -o suffix; error on explicit conflict."""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def _src(self, tmp_path: Path) -> Path:
+        return _write_jsonl(tmp_path / "s.jsonl", "hello_inference")
+
+    def test_md_suffix_infers_markdown(self, tmp_path: Path):
+        out = tmp_path / "o.md"
+        r = self.runner.invoke(main, [str(self._src(tmp_path)), "-o", str(out)])
+        assert r.exit_code == 0, r.output
+        assert "<!DOCTYPE html>" not in out.read_text(encoding="utf-8")
+
+    def test_html_suffix_stays_html(self, tmp_path: Path):
+        out = tmp_path / "o.html"
+        r = self.runner.invoke(main, [str(self._src(tmp_path)), "-o", str(out)])
+        assert r.exit_code == 0, r.output
+        assert "<!DOCTYPE html>" in out.read_text(encoding="utf-8")
+
+    def test_json_suffix_infers_json(self, tmp_path: Path):
+        out = tmp_path / "o.json"
+        r = self.runner.invoke(main, [str(self._src(tmp_path)), "-o", str(out)])
+        assert r.exit_code == 0, r.output
+        json.loads(out.read_text(encoding="utf-8"))  # parses as JSON
+
+    def test_explicit_format_matching_suffix_ok(self, tmp_path: Path):
+        out = tmp_path / "o.md"
+        # `md` is canonically the same as the `.md` suffix's `markdown`.
+        r = self.runner.invoke(
+            main, [str(self._src(tmp_path)), "-o", str(out), "-f", "md"]
+        )
+        assert r.exit_code == 0, r.output
+
+    def test_conflicting_format_and_suffix_errors(self, tmp_path: Path):
+        out = tmp_path / "o.md"
+        r = self.runner.invoke(
+            main, [str(self._src(tmp_path)), "-o", str(out), "-f", "html"]
+        )
+        assert r.exit_code != 0
+        assert "conflicts" in r.output
+        # Nothing should have been written.
+        assert not out.exists()
+
+
+class TestIsOutdatedNonRegularFileGuard:
+    """#223-part1: version sniff must not open a non-regular destination."""
+
+    def _call_with_timeout(
+        self, fn: Callable[..., Any], *args: Any, timeout: float = 3.0
+    ) -> Any:
+        result: dict[str, Any] = {}
+
+        def run() -> None:
+            result["value"] = fn(*args)
+
+        t = threading.Thread(target=run)
+        t.start()
+        t.join(timeout)
+        assert not t.is_alive(), "is_outdated blocked on a non-regular file (hang)"
+        return result["value"]
+
+    def test_markdown_is_outdated_on_fifo_returns_true(self, tmp_path: Path):
+        fifo = tmp_path / "f"
+        os.mkfifo(fifo)
+        assert self._call_with_timeout(MarkdownRenderer().is_outdated, fifo) is True
+
+    def test_json_is_outdated_on_fifo_returns_true(self, tmp_path: Path):
+        fifo = tmp_path / "f"
+        os.mkfifo(fifo)
+        assert self._call_with_timeout(JsonRenderer().is_outdated, fifo) is True
+
+    def test_check_html_version_on_fifo_returns_none(self, tmp_path: Path):
+        fifo = tmp_path / "f"
+        os.mkfifo(fifo)
+        assert self._call_with_timeout(check_html_version, fifo) is None
+
+    def test_nonexistent_path_is_outdated(self, tmp_path: Path):
+        missing = tmp_path / "nope.md"
+        assert MarkdownRenderer().is_outdated(missing) is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/work/tui-output-fixes.md
+++ b/work/tui-output-fixes.md
@@ -1,0 +1,64 @@
+# TUI / output fixes — #220, #221, #222, #223
+
+Consolidated plan for the `--output` / `--format` / regeneration + TUI
+tetralogy. External contributor (samestep) reports; all claims verified
+against current code (line numbers below are current, not the v1.4.0
+ones in the issues).
+
+## Verified findings
+
+| Issue | Claim | Verdict | Current location |
+|------|-------|---------|------------------|
+| #221 | Existing `-o` file w/ matching version marker → write skipped, stale content kept, CLI still prints success | TRUE | skip `converter.py:1940-1962`; `is_outdated` only gate (no source identity); "Successfully converted" at `cli.py:1143` |
+| #222 | `-o foo.md` w/o `-f` emits HTML | TRUE | `output_path_is_file` (`utils.py:338`) uses suffix for routing only; never feeds `output_format` (default `html`, `cli.py:636`) |
+| #223-1 | `-o /dev/stdout` hangs | TRUE | `is_outdated` opens path read-only + `readline()`, **no `is_file()` guard** (`markdown/renderer.py:2292`, `html/renderer.py:208`, `json/renderer.py:216`); deadlocks on a pipe |
+| #223-2 | progress/status pollutes stdout | TRUE | ~30 bare `print()` in `converter.py` + ~45 `click.echo()` w/o `err=True` in `cli.py` |
+| #220 | `--tui` ignores `-o`/`-f`, no export-to-path | TRUE | `run_session_browser` (`tui.py:2136`) never gets them; `_ensure_session_file` (`tui.py:1827`) hardcodes `project_path/session-{id}.{ext}` |
+
+### Refinement to the shared-root-cause hypothesis
+"Bypass the regeneration-skip for explicit `-o` → fixes #221 AND the
+#223 hang" is only partly right:
+- #221 (correctness): force-regenerate on explicit `-o` is the right fix.
+- #223 hang: bypass alone is NOT reliable — a *second* `is_outdated`
+  call exists in directory mode (`converter.py:1805`), and even the
+  single-file path only avoids it if the force-term short-circuits ahead
+  of `is_outdated` in the `or`. **The robust hang fix is a `Path.is_file()`
+  guard inside `is_outdated`** (char device like `/dev/stdout` isn't a
+  regular file → "outdated" without opening). Issue called this
+  "hardening"; it's actually the primary fix.
+
+### Extra findings (not in the issues)
+- `-o -` is misrouted: `Path("-").suffix == ""` → `output_path_is_file`
+  treats `-` as a **directory**. `-o -` support needs explicit dash handling.
+- `generate_single_session_file` (`--session-id`, `converter.py:2444`)
+  **already always overwrites** — only `convert_jsonl_to`'s single-file
+  branch has the stale bug. The #221 fix aligns the two.
+
+## Plan — 3 PRs (seam-aligned)
+
+### PR 1 — "Explicit `-o` correctness" (#221 + #222 + #223-part1)
+Cohesive concern: make explicit `--output` behave correctly. Seam =
+regeneration/`is_outdated` machinery + CLI `-o`/`-f` resolution.
+- `Path.is_file()` guard in all three `is_outdated` / `check_html_version` → fixes hang at every call site (#223-1).
+- `force_regenerate` param on `convert_jsonl_to`, set when `output is not None`, **first** in the `should_regenerate` `or` → fixes stale-skip (#221).
+- Infer `output_format` from `-o` suffix when `-f` source is `DEFAULT` (Click `ctx.get_parameter_source`); error on explicit conflict (`-o foo.md -f html`) (#222).
+- Separate commits per issue for clean `Closes #`. Smallest, highest-value, no deps → ship first.
+
+### PR 2 — "stdout streaming + stderr hygiene" (#223-part2 + `-o -`)
+Stacks on PR 1.
+- `-o -` → stream-to-stdout: always regenerate (PR 1 force path), no cache, no browser, write doc to `sys.stdout`.
+- Status/progress/summary → stderr **only when streaming the document to stdout** (`-o -` / `/dev/stdout`). Every other invocation keeps status on stdout exactly as today (behavior-preserving; no PowerShell red-text concern for normal runs, no ~75-site unconditional sweep). Mechanism: a status sink that is `sys.stderr` in stream mode, `sys.stdout` otherwise.
+
+### PR 3 — "TUI honors `-o`/`-f`" (#220) — minimal only
+Isolated (no shared code w/ PR 1/2).
+- Warn that `-o`/`-f` are no-ops under `--tui`, mirroring `cli.py:825-843`. ~3 lines.
+- Export-to-path action DEFERRED — decide with daaain after minimal lands + CR.
+
+### Ordering / deps
+PR 1 first (foundational). PR 2 stacks on PR 1. PR 3 independent, any time.
+
+## Process
+Single implementer (no delegation). Each PR: implement → tests →
+`just ci` (fresh venv) → review → PR vs main → merge. PRs land
+progressively (PR 1 to main first, then PR 2 branched off updated main)
+to avoid base≠main CI/review gating.

--- a/work/tui-output-fixes.md
+++ b/work/tui-output-fixes.md
@@ -5,7 +5,7 @@ tetralogy. External contributor (samestep) reports; all claims verified
 against current code (line numbers below are current, not the v1.4.0
 ones in the issues).
 
-## Verified findings
+## Verified findings (state *before* this work — what each PR then fixes)
 
 | Issue | Claim | Verdict | Current location |
 |------|-------|---------|------------------|


### PR DESCRIPTION
First of a small series addressing the `--output` / `--format` / stdout group of issues (#220–#223). Three related fixes around how an explicit `--output` destination is handled.

## #221 — existing `-o` file silently kept stale content
The single-file regeneration gate only compared the embedded `<!-- Generated by claude-code-log vX -->` marker — it had no notion of *which source* produced the file. Converting a **different** transcript into an existing same-version path was skipped while the CLI still printed `Successfully converted`.

`convert_jsonl_to` gains a `force_regenerate` flag (first in the `should_regenerate` `or`, and gating the directory-mode early exit); the CLI sets it for an explicit `-o` **file** destination. Scoped to files because directory inputs already track source staleness via the cache (`is_html_stale`) — a different transcript written to the same directory regenerates correctly without forcing — and `--all-projects` converts with `output=None`, so its incremental skip is never forced. This also aligns `convert_jsonl_to` with the `--session-id` path, which already always overwrites.

## #222 — format ignored the `--output` suffix
`-o foo.md` was routed as a file but still rendered HTML. When `-f` is omitted, the format is now inferred from a recognised `--output` suffix (`.md`/`.markdown` → markdown, `.html`, `.json`). An explicit conflict (`-o foo.md -f html`) is a clear `UsageError` (before any write) instead of mismatched content. Adds `utils.format_from_output_suffix`; uses the Click parameter source to detect an omitted `-f`.

## #223 (part 1) — `-o /dev/stdout` hung
`is_outdated` / `check_html_version` opened the path read-only and `readline()`'d to sniff the version; on a pipe that deadlocks. They now guard on `Path.is_file()` (not `exists()`), so a non-regular destination is treated as outdated/no-version without being opened. (Part 2 — routing status to stderr for clean stdout streaming — follows in a separate PR.)

## Tests
`test/test_output_explicit.py` (11 cases): stale-overwrite for file output, the directory-input cross-source case (handled by the cache), the three suffix inferences, matching-format OK, conflict error (asserts nothing written), and FIFO no-hang for all three renderers. `just ci` green; no snapshot churn.

Closes #221
Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When you provide an explicit output path, the export format can be inferred from the filename suffix (HTML/Markdown/JSON) if `--format` is omitted.

* **Bug Fixes**
  * Exporting to a specific file path now regenerates as needed, preventing stale results.
  * Conflicts between `--format` and the output filename suffix now fail with a nonzero exit.
  * Improved handling of special destinations (pipes/stdout/FIFOs) to avoid hangs during version checks.

* **Tests**
  * Added coverage for explicit output, format inference/conflicts, and non-regular destination behavior.

* **Documentation**
  * Clarified outdated-check behavior for non-regular destinations and explicit `--output`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->