### PR TITLE
Connect fork-point and branch headers to their anchor message

### DIFF
--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -806,8 +806,11 @@ div.system-hook .header {
     box-shadow: none;
     border: none;
     border-left: 3px solid var(--branch-point-color);
+    /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+       margin so the header sticks to its own branch content below. */
+    border-top: 1px dashed var(--branch-point-color);
     padding: 8px 14px;
-    margin: 2em 0 1em 0;
+    margin: 2em 0 0 0;
 }
 
 .branch-header .header {

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -807,8 +807,11 @@ div.system-hook .header {
     border: none;
     border-left: 3px solid var(--branch-point-color);
     /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-       margin so the header sticks to its own branch content below. */
+       margin so the header sticks to its own branch content below. The bottom
+       corners are squared (mirroring .fork-point's squared top) so the left
+       rail flows cleanly into the branch content rather than rounding off. */
     border-top: 1px dashed var(--branch-point-color);
+    border-radius: 8px 8px 0 0;
     padding: 8px 14px;
     margin: 2em 0 0 0;
 }
@@ -816,6 +819,14 @@ div.system-hook .header {
 .branch-header .header {
     font-size: 1em;
     margin-bottom: 0;
+}
+
+/* The header's own fold-bar sits at the bottom of the card; square its
+   bottom corners too so the squared branch-header bottom isn't undone by the
+   fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+   message nested inside the branch content. */
+.branch-header > .fold-bar {
+    border-radius: 0;
 }
 
 .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {

--- a/claude_code_log/html/templates/components/session_nav_styles.css
+++ b/claude_code_log/html/templates/components/session_nav_styles.css
@@ -125,14 +125,19 @@ a.session-backlink:hover {
     line-height: 1.3;
 }
 
-/* Fork point element — standalone structural element after a fork message */
+/* Fork point element — rendered inside the fork node's .children, so it
+   reads as hanging off the message above it. Pull it up against that
+   message (negative top margin cancels the card's 1em bottom margin) and
+   add a dashed top border as a connector, while the .children indent still
+   shows it's subordinate. */
 .fork-point {
-    margin: 8px 0 2em 0;
+    margin: -1.2em 0 2em 0;
     padding: 8px 14px;
     font-size: 0.85em;
     color: var(--text-muted, #6c757d);
     border-left: 3px solid var(--fork-point-color);
-    border-radius: 8px;
+    border-top: 1px dashed var(--fork-point-color);
+    border-radius: 0 0 8px 8px;
 }
 
 .fork-point-header {

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -1175,8 +1175,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -2230,14 +2233,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -7592,8 +7600,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -8647,14 +8658,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -13227,14 +13243,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -16106,8 +16127,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -17161,14 +17185,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -22638,8 +22667,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -23693,14 +23725,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -29437,8 +29474,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -30492,14 +30532,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -36199,8 +36244,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -37254,14 +37302,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {
@@ -42904,8 +42957,11 @@
       box-shadow: none;
       border: none;
       border-left: 3px solid var(--branch-point-color);
+      /* Dashed top border as a connector (mirrors .fork-point), and no bottom
+         margin so the header sticks to its own branch content below. */
+      border-top: 1px dashed var(--branch-point-color);
       padding: 8px 14px;
-      margin: 2em 0 1em 0;
+      margin: 2em 0 0 0;
   }
   
   .branch-header .header {
@@ -43959,14 +44015,19 @@
       line-height: 1.3;
   }
   
-  /* Fork point element — standalone structural element after a fork message */
+  /* Fork point element — rendered inside the fork node's .children, so it
+     reads as hanging off the message above it. Pull it up against that
+     message (negative top margin cancels the card's 1em bottom margin) and
+     add a dashed top border as a connector, while the .children indent still
+     shows it's subordinate. */
   .fork-point {
-      margin: 8px 0 2em 0;
+      margin: -1.2em 0 2em 0;
       padding: 8px 14px;
       font-size: 0.85em;
       color: var(--text-muted, #6c757d);
       border-left: 3px solid var(--fork-point-color);
-      border-radius: 8px;
+      border-top: 1px dashed var(--fork-point-color);
+      border-radius: 0 0 8px 8px;
   }
   
   .fork-point-header {

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -1176,8 +1176,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -1185,6 +1188,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
@@ -7601,8 +7612,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -7610,6 +7624,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
@@ -16128,8 +16150,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -16137,6 +16162,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
@@ -22668,8 +22701,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -22677,6 +22713,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
@@ -29475,8 +29519,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -29484,6 +29531,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
@@ -36245,8 +36300,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -36254,6 +36312,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {
@@ -42958,8 +43024,11 @@
       border: none;
       border-left: 3px solid var(--branch-point-color);
       /* Dashed top border as a connector (mirrors .fork-point), and no bottom
-         margin so the header sticks to its own branch content below. */
+         margin so the header sticks to its own branch content below. The bottom
+         corners are squared (mirroring .fork-point's squared top) so the left
+         rail flows cleanly into the branch content rather than rounding off. */
       border-top: 1px dashed var(--branch-point-color);
+      border-radius: 8px 8px 0 0;
       padding: 8px 14px;
       margin: 2em 0 0 0;
   }
@@ -42967,6 +43036,14 @@
   .branch-header .header {
       font-size: 1em;
       margin-bottom: 0;
+  }
+  
+  /* The header's own fold-bar sits at the bottom of the card; square its
+     bottom corners too so the squared branch-header bottom isn't undone by the
+     fold-bar's own rounded corners. Direct child only — never a fold-bar of a
+     message nested inside the branch content. */
+  .branch-header > .fold-bar {
+      border-radius: 0;
   }
   
   .branch-header .fold-bar[data-border-color="session-header"] .fold-bar-section.folded {


### PR DESCRIPTION
A visual follow-up to #233 (fork points whose node is an unrendered system message). Now that such a fork node renders as a landmark, the fork-point box — and the branch headers generally — read as detached floating elements with a gap above. This ties both to their anchor with a dashed top-border "connector" and a closed gap, while the `.children` indent still shows subordination.

## Change (CSS only)

- **`.fork-point`** (`session_nav_styles.css`): top margin `8px → -1.2em` (the negative margin cancels the `.message` card's `1em` bottom margin, so the box sticks up under the message it hangs off), `border-top: 1px dashed var(--fork-point-color)`, `border-radius: 0 0 8px 8px` (square top so the dashed edge reads as a connector tab).
- **`.branch-header`** (`message_styles.css`): bottom margin `1em → 0` (sticks the header to its own branch content below), matching `border-top: 1px dashed var(--branch-point-color)`.

No template / Python / JS change; `border-top` is added to two existing rules, no new selectors. Affects all fork points and branch headers (every within-session rewind fork), intentionally. The fork-point box is still rendered inside `.children`, so it continues to fold away with its subtree.

## Testing

CSS is inlined into the HTML output, so the 8 `test_snapshot_html` snapshots regenerated (updated serially with `-n0` per the CONTRIBUTING xdist-race warning). The `.ambr` churn is limited to these two rules + their comments across the inlined copies — no message-HTML body changed. `just ci` green (unit + TUI + browser + snapshots, ruff, pyright, ty); the browser fold-invariant test stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the branch header visuals with a dashed top connector and adjusted vertical spacing so headers visually “stack” directly onto their branch content.
  * Refined corner rounding for the branch header’s fold bar to preserve the connected rail geometry.
  * Reworked fork-point rendering to act as a hanging connector within the preceding node’s children, including a dashed top-border connector and bottom-only corner rounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->