### PR TITLE
Stream output to stdout: support -o - / /dev/stdout (#223 part 2)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -48,7 +48,7 @@ def _render_to_stdout(
     """Render to a throwaway temp file, then stream it to stdout (issue #223).
 
     The temp file lets the full conversion pipeline run unchanged; we then
-    copy its bytes to stdout and discard the temp dir. ``render_to_temp``
+    copy its raw bytes to stdout and discard the temp dir. ``render_to_temp``
     receives the temp directory and returns the written file path. The
     rendered document is the only thing written to stdout; a confirmation
     goes to stderr so the stream stays clean for piping.
@@ -67,13 +67,23 @@ def _render_to_stdout(
     try:
         with contextlib.redirect_stdout(captured):
             written = render_to_temp(tmpdir)
-        content = Path(written).read_text(encoding="utf-8", errors="replace")
+        # Read/write RAW BYTES: the document is UTF-8 (transcripts are
+        # emoji-heavy), but stdout's text encoding follows the locale and may
+        # not be UTF-8 — decoding then re-encoding via sys.stdout.write would
+        # mangle or raise on those characters. Pass the bytes through verbatim.
+        content = Path(written).read_bytes()
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
     progress = captured.getvalue()
     if progress:
         click.echo(progress, nl=False, err=True)
-    sys.stdout.write(content)
+    stdout_buffer = getattr(sys.stdout, "buffer", None)
+    if stdout_buffer is not None:
+        stdout_buffer.write(content)
+        stdout_buffer.flush()
+    else:
+        # Fallback (e.g. a text-only stdout shim): decode best-effort.
+        sys.stdout.write(content.decode("utf-8", errors="replace"))
     click.echo(f"Successfully converted {input_path} to stdout", err=True)
 
 
@@ -921,10 +931,22 @@ def main(
 
     # Streaming the rendered document to stdout (`-o -`) is a single-document
     # mode; it can't express the multi-file --all-projects export (issue #223).
-    if _is_stdout_target(output) and will_run_all_projects:
+    # `--session-id` is exempt: it's a single-session export (resolved from
+    # cache when no input path is given), which streams fine — so don't reject
+    # it just because `input_path is None` makes will_run_all_projects true.
+    if _is_stdout_target(output) and will_run_all_projects and session_id is None:
         raise click.UsageError(
             "--output - (stream to stdout) is not supported with --all-projects; "
             "pass a single transcript file, directory, or --session-id."
+        )
+
+    # `--combined no` asks to skip the combined transcript (per-session files
+    # only); stdout can carry only one document, so streaming forces the
+    # combined doc — fail fast rather than silently doing the opposite (#223).
+    if _is_stdout_target(output) and not write_combined:
+        raise click.UsageError(
+            "--combined no is incompatible with --output - (stream to stdout), "
+            "which emits a single combined document."
         )
 
     # `--no-timestamps` is Markdown-only (#160). Warn (not error) when

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -7,7 +7,7 @@ import os
 import signal
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import click
 from git import Repo, InvalidGitRepositoryError
@@ -28,6 +28,53 @@ from .cache import (
     get_cache_db_path,
     get_library_version,
 )
+
+
+# Output values that mean "stream the rendered document to stdout" (issue
+# #223): write the document to stdout, always regenerate, never consult or
+# write the cache, never open a browser, and keep status text off stdout
+# (it goes to stderr) so the stream carries only the rendered document.
+_STDOUT_TARGETS = {"-", "/dev/stdout"}
+
+
+def _is_stdout_target(output: "Optional[Path]") -> bool:
+    """Whether ``--output`` requests a stdout stream (``-`` or /dev/stdout)."""
+    return output is not None and str(output) in _STDOUT_TARGETS
+
+
+def _render_to_stdout(
+    input_path: Path, render_to_temp: "Callable[[Path], Path]"
+) -> None:
+    """Render to a throwaway temp file, then stream it to stdout (issue #223).
+
+    The temp file lets the full conversion pipeline run unchanged; we then
+    copy its bytes to stdout and discard the temp dir. ``render_to_temp``
+    receives the temp directory and returns the written file path. The
+    rendered document is the only thing written to stdout; a confirmation
+    goes to stderr so the stream stays clean for piping.
+    """
+    import contextlib
+    import io
+    import shutil
+    import tempfile
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="ccl-stream-"))
+    # Capture anything the render prints to stdout (e.g. the per-file
+    # "Processing ..." progress, which generate_single_session_file emits
+    # without a silent switch) so it can't pollute the document stream;
+    # forward it to stderr instead.
+    captured = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(captured):
+            written = render_to_temp(tmpdir)
+        content = Path(written).read_text(encoding="utf-8", errors="replace")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    progress = captured.getvalue()
+    if progress:
+        click.echo(progress, nl=False, err=True)
+    sys.stdout.write(content)
+    click.echo(f"Successfully converted {input_path} to stdout", err=True)
 
 
 def _install_stack_dump_signal() -> None:
@@ -528,10 +575,11 @@ def _validate_git_link_template(template: str) -> None:
     "--output",
     type=click.Path(path_type=Path),
     help=(
-        "Output destination. With a recognised file suffix "
-        "(.html/.md/.markdown/.json) treated as a single output file; "
-        "otherwise treated as a directory root (and now also honoured "
-        "for --all-projects, where outputs land at "
+        "Output destination. Use '-' (or /dev/stdout) to stream the "
+        "rendered document to stdout (status goes to stderr) for piping. "
+        "With a recognised file suffix (.html/.md/.markdown/.json) treated "
+        "as a single output file; otherwise treated as a directory root "
+        "(and now also honoured for --all-projects, where outputs land at "
         "<output>/<project>/...). Pair with --expand-paths to project "
         "back to the real on-disk tree."
     ),
@@ -871,6 +919,14 @@ def main(
                     "pass only one, or make them agree."
                 )
 
+    # Streaming the rendered document to stdout (`-o -`) is a single-document
+    # mode; it can't express the multi-file --all-projects export (issue #223).
+    if _is_stdout_target(output) and will_run_all_projects:
+        raise click.UsageError(
+            "--output - (stream to stdout) is not supported with --all-projects; "
+            "pass a single transcript file, directory, or --session-id."
+        )
+
     # `--no-timestamps` is Markdown-only (#160). Warn (not error) when
     # paired with HTML/JSON so the flag is benignly ignored rather than
     # silently misapplied.
@@ -1035,6 +1091,27 @@ def main(
                     if claude_path.exists():
                         input_path = claude_path
 
+            if _is_stdout_target(output):
+                # Stream a single session to stdout (issue #223): render to a
+                # throwaway file (no cache, embedded images), copy to stdout.
+                session_input = input_path
+                _render_to_stdout(
+                    session_input,
+                    lambda tmpdir: generate_single_session_file(
+                        output_format,
+                        session_input,
+                        session_id,
+                        tmpdir / f"session.{get_file_extension(output_format)}",
+                        False,  # use_cache: one-off stream, don't touch cache
+                        "embedded",  # inline images; the temp dir is discarded
+                        detail=detail_level,
+                        compact=compact,
+                        no_timestamps=no_timestamps,
+                        no_recaps=no_recaps,
+                    ),
+                )
+                return
+
             output_path = generate_single_session_file(
                 output_format,
                 input_path,
@@ -1141,13 +1218,47 @@ def main(
         if should_convert:
             claude_path = convert_project_path_to_claude_dir(input_path, projects_dir)
             if claude_path.exists():
-                click.echo(f"Converting project path {input_path} to {claude_path}")
+                # Route to stderr when streaming so the document stream stays
+                # clean (issue #223); normal runs keep this on stdout as before.
+                click.echo(
+                    f"Converting project path {input_path} to {claude_path}",
+                    err=_is_stdout_target(output),
+                )
                 input_path = claude_path
             elif not input_path.exists():
                 # Original path doesn't exist and conversion failed
                 raise FileNotFoundError(
                     f"Neither {input_path} nor {claude_path} exists"
                 )
+
+        if _is_stdout_target(output):
+            # Stream the combined document to stdout (issue #223): render to a
+            # throwaway file (no cache so no pagination, embedded images, always
+            # regenerate, no individual session files), then copy to stdout.
+            stream_input = input_path
+            _render_to_stdout(
+                stream_input,
+                lambda tmpdir: convert_jsonl_to(
+                    output_format,
+                    stream_input,
+                    tmpdir / f"stream.{get_file_extension(output_format)}",
+                    from_date,
+                    to_date,
+                    generate_individual_sessions=False,
+                    use_cache=False,
+                    silent=True,
+                    image_export_mode="embedded",
+                    page_size=page_size,
+                    detail=detail_level,
+                    compact=compact,
+                    update_cache=False,
+                    write_combined=True,
+                    no_timestamps=no_timestamps,
+                    no_recaps=no_recaps,
+                    force_regenerate=True,
+                ),
+            )
+            return
 
         output_path = convert_jsonl_to(
             output_format,

--- a/test/test_output_stdout.py
+++ b/test/test_output_stdout.py
@@ -109,3 +109,46 @@ class TestStreamToStdout:
         assert "Processing" not in r.stdout
         assert "Loading" not in r.stdout
         assert "to stdout" in r.stderr
+
+    def test_unicode_document_round_trips(self, tmp_path: Path):
+        """The document is streamed as raw UTF-8 bytes, so non-ASCII content
+        (transcripts are emoji-heavy) survives regardless of stdout's locale
+        encoding — not re-encoded via sys.stdout.write (CodeRabbit)."""
+        src = _write_jsonl(tmp_path / "s.jsonl", "emoji 🎉 accent café 日本語")
+        r = self.runner.invoke(main, [str(src), "-f", "markdown", "-o", "-"])
+        assert r.exit_code == 0, r.output
+        assert "🎉" in r.stdout
+        assert "café" in r.stdout
+        assert "日本語" in r.stdout
+
+    def test_global_session_id_stream_not_rejected_by_all_projects_guard(
+        self, tmp_path: Path
+    ):
+        """`--session-id <id> -o -` with no input path (global cache lookup)
+        must NOT be rejected by the --all-projects+stream guard just because
+        input_path is None (CodeRabbit). It should reach session resolution
+        and fail there (session not in cache), not at the guard."""
+        r = self.runner.invoke(
+            main,
+            [
+                "--session-id",
+                "deadbeef",
+                "-o",
+                "-",
+                "--projects-dir",
+                str(tmp_path / "empty"),
+            ],
+        )
+        assert r.exit_code != 0
+        # Reached session resolution, not the all-projects guard.
+        assert "not supported with --all-projects" not in r.output
+        assert "not found in cache" in r.output
+
+    def test_combined_no_with_stream_errors(self, tmp_path: Path):
+        """`--combined no` (per-session only) is incompatible with streaming a
+        single document to stdout — fail fast instead of silently forcing the
+        combined doc (CodeRabbit)."""
+        src = _write_jsonl(tmp_path / "s.jsonl", "X")
+        r = self.runner.invoke(main, [str(src), "-o", "-", "--combined", "no"])
+        assert r.exit_code != 0
+        assert "--combined no is incompatible" in r.output

--- a/test/test_output_stdout.py
+++ b/test/test_output_stdout.py
@@ -1,0 +1,111 @@
+"""Tests for stdout streaming (PR 2 of the #220-223 set, issue #223).
+
+`-o -` (and `-o /dev/stdout`) streams the rendered document to stdout:
+always regenerate, no cache, no browser, and status text on stderr so the
+stream carries only the document. Previously `-o /dev/stdout` hung and
+progress was written to stdout.
+"""
+
+import json
+import uuid
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_log.cli import main
+
+
+def _user_entry(text: str, session_id: str = "sess-stream") -> dict[str, Any]:
+    return {
+        "type": "user",
+        "timestamp": "2025-01-01T10:00:00Z",
+        "sessionId": session_id,
+        "uuid": f"u-{uuid.uuid4().hex[:8]}",
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "version": "1.0.0",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _write_jsonl(path: Path, text: str, session_id: str = "sess-stream") -> Path:
+    path.write_text(json.dumps(_user_entry(text, session_id)) + "\n", encoding="utf-8")
+    return path
+
+
+class TestStreamToStdout:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_markdown_document_on_stdout_status_on_stderr(self, tmp_path: Path):
+        src = _write_jsonl(tmp_path / "s.jsonl", "STREAMED_MD_BODY")
+        r = self.runner.invoke(main, [str(src), "-f", "markdown", "-o", "-"])
+        assert r.exit_code == 0, r.output
+        # Document on stdout...
+        assert "STREAMED_MD_BODY" in r.stdout
+        assert "<!DOCTYPE html>" not in r.stdout
+        # ...and stdout is clean of progress/summary noise.
+        assert "Processing" not in r.stdout
+        assert "Successfully" not in r.stdout
+        # Confirmation routed to stderr.
+        assert "to stdout" in r.stderr
+
+    def test_html_document_on_stdout(self, tmp_path: Path):
+        src = _write_jsonl(tmp_path / "s.jsonl", "STREAMED_HTML_BODY")
+        r = self.runner.invoke(main, [str(src), "-f", "html", "-o", "-"])
+        assert r.exit_code == 0, r.output
+        assert "<!DOCTYPE html>" in r.stdout
+        assert "Successfully" not in r.stdout
+
+    def test_json_document_on_stdout(self, tmp_path: Path):
+        src = _write_jsonl(tmp_path / "s.jsonl", "STREAMED_JSON_BODY")
+        r = self.runner.invoke(main, [str(src), "-f", "json", "-o", "-"])
+        assert r.exit_code == 0, r.output
+        json.loads(r.stdout)  # stdout is pure JSON, not polluted
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="/dev/stdout is POSIX-only; use '-' on Windows"
+    )
+    def test_dev_stdout_does_not_hang(self, tmp_path: Path):
+        """The original bug: `-o /dev/stdout` deadlocked in the version sniff."""
+        src = _write_jsonl(tmp_path / "s.jsonl", "DEVSTDOUT_BODY")
+        r = self.runner.invoke(main, [str(src), "-f", "markdown", "-o", "/dev/stdout"])
+        assert r.exit_code == 0, r.output
+        assert "DEVSTDOUT_BODY" in r.stdout
+
+    def test_format_inferred_is_irrelevant_dash_has_no_suffix(self, tmp_path: Path):
+        """`-` has no suffix, so format stays the default/explicit one."""
+        src = _write_jsonl(tmp_path / "s.jsonl", "DASH_DEFAULT")
+        r = self.runner.invoke(main, [str(src), "-o", "-"])  # default html
+        assert r.exit_code == 0, r.output
+        assert "<!DOCTYPE html>" in r.stdout
+
+    def test_all_projects_with_stream_errors(self, tmp_path: Path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_jsonl(proj / "s.jsonl", "X")
+        r = self.runner.invoke(main, [str(tmp_path), "-o", "-", "--all-projects"])
+        assert r.exit_code != 0
+        assert "not supported with --all-projects" in r.output
+
+    def test_session_id_stream_to_stdout(self, tmp_path: Path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_jsonl(proj / "a.jsonl", "SESSION_STREAM_BODY", session_id="sess-aaa")
+        r = self.runner.invoke(
+            main, [str(proj), "--session-id", "sess-aaa", "-f", "markdown", "-o", "-"]
+        )
+        assert r.exit_code == 0, r.output
+        assert "SESSION_STREAM_BODY" in r.stdout
+        # stdout is ONLY the document — no progress/summary noise leaks
+        # (generate_single_session_file has no silent switch; the stream
+        # path captures its stdout and routes it to stderr).
+        assert "Successfully" not in r.stdout
+        assert "Processing" not in r.stdout
+        assert "Loading" not in r.stdout
+        assert "to stdout" in r.stderr

--- a/work/tui-output-fixes.md
+++ b/work/tui-output-fixes.md
@@ -44,10 +44,21 @@ regeneration/`is_outdated` machinery + CLI `-o`/`-f` resolution.
 - Infer `output_format` from `-o` suffix when `-f` source is `DEFAULT` (Click `ctx.get_parameter_source`); error on explicit conflict (`-o foo.md -f html`) (#222).
 - Separate commits per issue for clean `Closes #`. Smallest, highest-value, no deps → ship first.
 
-### PR 2 — "stdout streaming + stderr hygiene" (#223-part2 + `-o -`)
+### PR 2 — "stdout streaming + stderr hygiene" (#223-part2 + `-o -`) — IMPLEMENTED (branch dev/output-stdout-stream, awaiting #237 merge → rebase → PR)
 Stacks on PR 1.
-- `-o -` → stream-to-stdout: always regenerate (PR 1 force path), no cache, no browser, write doc to `sys.stdout`.
-- Status/progress/summary → stderr **only when streaming the document to stdout** (`-o -` / `/dev/stdout`). Every other invocation keeps status on stdout exactly as today (behavior-preserving; no PowerShell red-text concern for normal runs, no ~75-site unconditional sweep). Mechanism: a status sink that is `sys.stderr` in stream mode, `sys.stdout` otherwise.
+- `-o -` and `-o /dev/stdout` → stream-to-stdout. Implemented via a
+  throwaway temp file (`_render_to_stdout`): render with `use_cache=False`
+  (→ cache_manager None → no pagination, single document), `force_regenerate`,
+  `generate_individual_sessions=False`, embedded images (temp dir discarded),
+  then copy the file's bytes to `sys.stdout`. Reuses the whole pipeline
+  verbatim — no risk of divergence. Supported for the main convert path AND
+  `--session-id`; `--all-projects` + `-o -` is a clear UsageError.
+- Status hygiene (behavior-preserving, no ~75-site sweep): in stream mode the
+  converter runs `silent=True` (no progress on stdout) and the CLI prints its
+  one-line confirmation to **stderr**. Every non-stream invocation keeps status
+  on stdout exactly as today — so no PowerShell red-text concern for normal runs.
+  stdout therefore carries only the rendered document.
+- `--output` help updated to document `-`.
 
 ### PR 3 — "TUI honors `-o`/`-f`" (#220) — minimal only
 Isolated (no shared code w/ PR 1/2).


### PR DESCRIPTION
Completes #223 (part 1 — the `/dev/stdout` version-sniff hang — landed in #237).

## What

`-o -` (and `-o /dev/stdout`) streams the rendered document to stdout so it can be piped:

```
claude-code-log session.jsonl -f markdown -o - | pbcopy
```

Treated as: stream to stdout, always regenerate, no cache, no browser, and status/progress on **stderr** so stdout carries only the document. Supported for the main convert path and `--session-id`; `--all-projects` with `-o -` is a clear `UsageError` (it's a multi-file export).

## How

Implemented in `cli.py` by reusing the full conversion pipeline via a throwaway temp file (`_render_to_stdout`): render with `use_cache=False` (so no pagination → a single document), `force_regenerate`, no individual session files, embedded images (the temp dir is discarded), then copy the file's bytes to `sys.stdout`. This keeps the streamed document **byte-identical** to the equivalent `-o file` output.

**Status hygiene (only when streaming):** the render runs inside `contextlib.redirect_stdout`, and any captured progress is forwarded to stderr — so an in-render `print` from any callee (e.g. the per-file `Processing …`) can't pollute the document stream. The pre-render `Converting project path …` echo is routed to stderr too when streaming. Every non-stream invocation keeps status on stdout exactly as today (no unconditional sweep — no behavior change for normal runs, including on PowerShell).

## Cross-platform

`-` works everywhere. `/dev/stdout` is POSIX-only (on Windows the device doesn't exist and the path normalizes with backslashes, so detection won't match it there) — its test is `skipif(win32)`; `-` is the portable form. No FIFO/`mkfifo` in these tests.

## Tests

`test/test_output_stdout.py` (7): markdown/HTML/JSON document on stdout with stdout clean of status noise + confirmation on stderr; `/dev/stdout` no-hang (POSIX); `-` has no suffix so format inference doesn't fire; `--all-projects` + `-o -` errors; `--session-id` stream is clean (asserts no `Processing`/`Loading` on stdout). `just ci` green; no snapshot churn.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stdout-streaming for single-document exports: `-o -` and `/dev/stdout` now output only the rendered document bytes, with render-related messages sent to stderr.
  * Updated CLI help/behavior for streaming output, including format inference consistency for `-`.

* **Bug Fixes**
  * Blocked stdout streaming for multi-project (“all projects”) mode, and rejected `--combined no` with streaming.
  * Fixed the historical `/dev/stdout` hang issue on supported platforms.

* **Tests**
  * Added end-to-end tests covering Markdown/HTML/JSON streaming, stderr/stdout separation, Unicode round-trips, and invalid streaming combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->