### PR TITLE
Keep fork points visible when their host message is detail-filtered

### DIFF
--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -103,7 +103,26 @@
     {%- set message_title = message.rendered_title %}
     {%- set html_content = message.rendered_html %}
     {%- set formatted_timestamp = message.rendered_timestamp %}
-    {% if is_session_header(message) %}
+    {% if message.fork_only %}
+    {# Fork-only landmark (#233 follow-up): this slot is a fork point whose own
+       message body was filtered out at the current detail level, but it is kept
+       (not ghosted) so the fork point stays visible and anchorable — like the
+       branches it connects. Render ONLY the fork-point box (no message card),
+       at the slot's original position. The anchor id lives on the box so branch
+       back-links (`from ⟂ Fork point`) and the nav fork item resolve here. #}
+    <div class='message-node'>
+    <div class='children'>{% for child in message.children %}{{ render_message(child) }}{% endfor %}{% if message.junction_forward_links %}
+        <div class='fork-point' id='msg-{{ message.message_id }}'>
+            <div class='fork-point-header'>&#x2442; Fork point{% if message.fork_point_preview %} &bull; {{ message.fork_point_preview }}{% endif %}</div>
+            <div class='fork-point-branches'>
+                {% for branch_sid, branch_idx, branch_preview in message.junction_forward_links %}
+                <a href='#msg-d-{{ branch_idx }}' class='fork-point-branch'>&#x21b3; Branch{% if branch_preview %} &bull; {{ branch_preview }}{% endif %}</a>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}</div>
+    </div>
+    {% elif is_session_header(message) %}
     {% if not message.is_branch_header %}<div class="session-divider"></div>{% endif %}
     {# Structural wrapper: the message card and its nested .children render as
        SIBLINGS here, so the card's border/background/margins frame only the

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -305,6 +305,15 @@ class TemplateMessage:
         # Fork point preview text (short excerpt of fork point message content)
         self.fork_point_preview: str = ""
 
+        # Set by ``_ghost_template_by_detail`` when this slot is a fork point
+        # whose own message body is filtered out at the current detail level,
+        # but which is kept (not ghosted to None) so the fork point stays a
+        # visible, anchorable landmark. The template renders only the
+        # fork-point box for such a slot, not the message card (issue #233
+        # follow-up — fork points survive detail filtering like the branches
+        # they connect, instead of vanishing and orphaning the branches).
+        self.fork_only: bool = False
+
     # -- Properties derived from content/meta --
 
     @property
@@ -4050,7 +4059,35 @@ def _ghost_template_by_detail(
             visible = False
 
         if not visible:
-            ctx.messages[idx] = None
+            # A fork point is navigational structure, not message content: the
+            # branches it connects (session headers) always survive detail
+            # filtering, so the fork point must too — otherwise the branches
+            # render with no visible fork point above them and the back-links
+            # have nothing to anchor to (#233 follow-up). Keep the slot as a
+            # fork-only landmark (body suppressed, just the box) instead of
+            # ghosting it to None. Because the slot stays non-None, the
+            # back-link / nav anchor reactivate for free in
+            # ``_repair_stale_anchor_refs`` (which only nulls refs to None
+            # slots). The box data (``junction_forward_links`` /
+            # ``fork_point_preview``) was already populated by
+            # ``_link_junction_forwards``, which runs before this pass.
+            #
+            # Load-bearing invariant: this no-dead-anchor guarantee depends on
+            # branch session headers ALWAYS surviving detail filtering
+            # (``SessionHeaderMessage`` declares no ``detail_visibility`` →
+            # ``visible_at`` is True at every level). If a branch could be
+            # ghosted, a 2-branch fork could drop below 2 survivors →
+            # ``_repair_stale_anchor_refs`` empties ``junction_forward_links``
+            # → the template suppresses the box → this kept slot would render
+            # with no ``id='msg-d-N'`` and a still-visible sibling branch's
+            # back-link would dangle. Pinned by
+            # ``test_branch_headers_always_visible_keeps_fork_anchored`` so a
+            # future ``SessionHeaderMessage.detail_visibility`` trips a test
+            # rather than silently activating a dead anchor (monk review note).
+            if msg.junction_forward_links:
+                msg.fork_only = True
+            else:
+                ctx.messages[idx] = None
 
     _repair_stale_anchor_refs(ctx)
 

--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -1474,21 +1474,28 @@ class TestRenderSessionResetAcrossSessions:
                 f"template_messages will emit it as a root, not nested "
                 "under the trunk. Header order: " + str(header_order)
             )
-            # 3) Single-axis collapse (Phase 3): the fork anchor a1 is a
-            #    tool-only assistant, ghosted at MINIMAL. Pre-collapse a1 was
-            #    dropped pre-render and the branch backlink fell back to the
-            #    trunk header; now a1 is built-then-ghosted, so the branch's
-            #    parent_message_index points at a1's ghosted slot and the
-            #    anchor-repair pass correctly NULLS it — the "from #msg-d-N"
-            #    backlink is omitted (rendered as plain text via the
-            #    `is not None` guard) rather than mis-targeting the trunk
-            #    header. The D11 invariant under test — trunk header registered
-            #    BEFORE the branch (assertions 1+2) — is unaffected.
-            assert parent_msg_idx is None, (
+            # 3) The fork anchor a1 is a tool-only assistant, filtered at
+            #    MINIMAL. Since the #233 follow-up, a filtered fork anchor is
+            #    KEPT as a fork_only landmark (not ghosted to None), so the
+            #    fork point stays visible and the branch's back-link resolves
+            #    to it — active, not omitted. (Pre-#233-follow-up this asserted
+            #    parent_message_index is None.) The D11 invariant under test —
+            #    trunk header registered BEFORE the branch (assertions 1+2) —
+            #    is unaffected either way.
+            assert parent_msg_idx is not None, (
                 f"branch header {sid!r}.parent_message_index={parent_msg_idx}: "
-                "expected None because its fork anchor (tool-only assistant "
-                "'a1') is ghosted at MINIMAL, so the backlink must be omitted. "
+                "expected a live index — its fork anchor 'a1' is kept as a "
+                "fork_only landmark at MINIMAL, so the backlink resolves to it. "
                 "Header order: " + str(header_order)
+            )
+            anchor = ctx.get(parent_msg_idx)  # type: ignore[arg-type]
+            assert (
+                anchor is not None
+                and anchor.meta.uuid == "a1"
+                and anchor.fork_only is True
+            ), (
+                f"branch header {sid!r} back-link must resolve to the live "
+                f"fork_only landmark 'a1'; got {anchor!r}."
             )
 
 

--- a/test/test_detail_levels.py
+++ b/test/test_detail_levels.py
@@ -1519,8 +1519,15 @@ def _assert_system_messages_are_recaps(messages: list, label: str) -> None:
 
     Recaps report ``message_type == "system"`` and are the only system content
     kept below FULL; this verifies no other system subclass leaked in.
+
+    Exception: a ``fork_only`` landmark (#233 follow-up) is a fork point whose
+    own body is filtered out — the template renders only its fork-point box,
+    never the system content — so even though its content is system-typed, no
+    system *body* leaks. Skip those.
     """
     for msg in messages:
+        if getattr(msg, "fork_only", False):
+            continue
         if msg.type == "system":
             cls = type(msg.content).__name__
             assert cls == "AwaySummaryMessage", (

--- a/test/test_fork_invisible_node.py
+++ b/test/test_fork_invisible_node.py
@@ -21,9 +21,10 @@ from typing import Any
 import re
 
 from claude_code_log.converter import load_transcript
-from claude_code_log.html.renderer import generate_html
+from claude_code_log.html.renderer import HtmlRenderer, generate_html
 from claude_code_log.html.system_formatters import format_session_header_content
 from claude_code_log.models import (
+    DetailLevel,
     MessageMeta,
     SessionHeaderMessage,
     SystemTranscriptEntry,
@@ -181,7 +182,7 @@ def _raw_turn_duration(uuid: str, parent: str, ts: str) -> dict[str, Any]:
     }
 
 
-def _build_fork_fixture(tmp_path: Path) -> str:
+def _write_fork_jsonl(tmp_path: Path) -> Path:
     # u0 → a1 → sd(turn_duration) ⇒ { u1 (rewind A), u2 (rewind B) }
     # Two human prompts at different timestamps = a genuine within-session fork
     # whose fork point is the content-less system node sd.
@@ -200,7 +201,18 @@ def _build_fork_fixture(tmp_path: Path) -> str:
 
         for e in entries:
             f.write(json.dumps(e) + "\n")
-    return generate_html(load_transcript(fixture), "fork")
+    return fixture
+
+
+def _build_fork_fixture(tmp_path: Path) -> str:
+    return generate_html(load_transcript(_write_fork_jsonl(tmp_path)), "fork")
+
+
+def _render_fork_at_detail(tmp_path: Path, detail: DetailLevel) -> str:
+    messages = load_transcript(_write_fork_jsonl(tmp_path))
+    renderer = HtmlRenderer()
+    renderer.detail = detail
+    return renderer.generate(messages, f"fork {detail.value}")
 
 
 class TestForkInvisibleNodeIntegration:
@@ -237,3 +249,90 @@ class TestForkInvisibleNodeIntegration:
         nav = re.search(r"<a href='(#msg-d-\d+)' class='fork-link'>", html)
         assert nav is not None, "nav fork item should have a real anchor, not a span"
         assert nav.group(1) != "#msg-d-2"
+
+
+class TestForkSurvivesDetailFiltering:
+    """When the fork node's own message is filtered by --detail, the fork
+    point must still render as a landmark at its position, and the branch
+    back-links must stay active (#233 follow-up — fork points get the same
+    always-visible treatment as the branches they connect)."""
+
+    # The placeholder (a content-less ``turn_duration`` SystemMessage) has
+    # detail_visibility=FULL, so it's filtered at every level below FULL —
+    # exercising the fork_only landmark path at all reduced levels.
+    REDUCED = [
+        DetailLevel.HIGH,
+        DetailLevel.LOW,
+        DetailLevel.MINIMAL,
+        DetailLevel.USER_ONLY,
+    ]
+
+    def test_fork_box_survives_but_body_suppressed_at_reduced_detail(
+        self, tmp_path: Path
+    ):
+        for detail in self.REDUCED:
+            html = _render_fork_at_detail(tmp_path, detail)
+            # The fork node's own message body is filtered out…
+            assert "(turn_duration)" not in html, detail
+            assert "<div class='debug-info'>sd &rarr; a1</div>" not in html, detail
+            # …but the fork-point box still renders as a landmark.
+            assert "fork-point-header" in html, detail
+
+    def test_backlinks_reactivate_to_the_landmark_at_reduced_detail(
+        self, tmp_path: Path
+    ):
+        for detail in self.REDUCED:
+            html = _render_fork_at_detail(tmp_path, detail)
+            backlinks = re.findall(
+                r'class="branch-from">from <a href="(#msg-d-\d+)"', html
+            )
+            # Both branch back-links are ACTIVE links (not the plain-text span
+            # fallback), pointing at one landmark, never the session header.
+            assert len(backlinks) == 2, (detail, backlinks)
+            assert len(set(backlinks)) == 1, (detail, backlinks)
+            assert "#msg-d-2" not in backlinks, (detail, backlinks)
+            # The landmark anchor (on the fork-point box) matches the target.
+            fork_idx = backlinks[0].rsplit("-", 1)[-1]
+            assert f"class='fork-point' id='msg-d-{fork_idx}'" in html, detail
+
+    def test_no_dead_anchors_at_reduced_detail(self, tmp_path: Path):
+        # Every #msg-d-N href must have a matching id in the same document.
+        for detail in self.REDUCED:
+            html = _render_fork_at_detail(tmp_path, detail)
+            ids = set(re.findall(r"id=['\"]msg-d-(\d+)['\"]", html))
+            hrefs = set(re.findall(r"href=['\"]#msg-d-(\d+)['\"]", html))
+            assert not (hrefs - ids), (detail, sorted(hrefs - ids))
+
+    def test_branch_headers_always_visible_keeps_fork_anchored(self):
+        """Pin the load-bearing invariant the fork_only no-dead-anchor
+        guarantee rests on (monk review note): branch session headers must
+        survive detail filtering at EVERY level. If they could be ghosted, a
+        2-branch fork could drop below 2 survivors, the fork-point box would be
+        suppressed, and a kept fork_only slot would render with no anchor id —
+        silently dangling a sibling branch's back-link.
+
+        ``SessionHeaderMessage`` declares no ``detail_visibility``, so
+        ``visible_at`` is True at every level. Assert that directly so a future
+        ``detail_visibility`` added to the class trips HERE rather than as a
+        downstream dead anchor.
+        """
+        branch = SessionHeaderMessage(
+            title="Branch • abcdef01",
+            session_id="s1@abcdef012345",
+            is_branch=True,
+            meta=MessageMeta(uuid="b1", session_id="s1@abcdef012345", timestamp="t"),
+        )
+        for detail in (
+            DetailLevel.FULL,
+            DetailLevel.HIGH,
+            DetailLevel.LOW,
+            DetailLevel.MINIMAL,
+            DetailLevel.USER_ONLY,
+        ):
+            assert branch.visible_at(detail) is True, (
+                f"branch SessionHeaderMessage must stay visible at {detail} — "
+                "fork_only's no-dead-anchor guarantee depends on a 2-branch "
+                "fork keeping >=2 visible branches. A detail_visibility on "
+                "SessionHeaderMessage would break it; update the fork_only "
+                "ghost-pass logic (renderer.py) accordingly."
+            )

--- a/test/test_ghost_repair.py
+++ b/test/test_ghost_repair.py
@@ -138,50 +138,57 @@ def _fork_fixture(path: Path) -> Path:
 
 
 class TestGhostedForkAnchorBackrefRepair:
-    """The deleted-guard coverage monk required before Phase 2 merges.
+    """Fork-point anchor handling under detail ghosting.
 
-    `_repair_stale_anchor_refs` (called at the end of
-    `_ghost_template_by_detail`) must null any
-    ``SessionHeaderMessage.parent_message_index`` whose target slot
-    was ghosted by the detail filter — otherwise the branch header's
-    ``#msg-d-{N}`` back-link resolves to a phantom slot and renders
-    as a dead anchor.
+    Original premise (Phase 2 of the ghosting epic): when the detail
+    filter ghosted a fork anchor to ``None``, the branch back-link had
+    to be sanitized so its ``#msg-d-{N}`` href didn't dangle.
+
+    Superseded by the #233 follow-up (fork points survive detail
+    filtering): a fork anchor whose body is filtered is now KEPT as a
+    ``fork_only`` landmark (non-``None``) rather than ghosted, so its
+    body is suppressed but the fork-point box stays visible and the
+    branch back-link resolves to it — active, never dead. The deeper
+    "no dead anchor" invariant is unchanged and additionally pinned by
+    ``TestHtmlAnchorIntegrity``; the genuine-ghost sanitize path in
+    ``_repair_stale_anchor_refs`` still exists for non-fork anchors and
+    degenerate (<2-branch) forks whose box is dropped.
     """
 
-    def test_branch_backref_is_sanitized_when_anchor_ghosted(
+    def test_fork_anchor_survives_as_landmark_with_live_backref_at_user_only(
         self, tmp_path: Path
     ) -> None:
-        """Render the fork at USER_ONLY (ghosts assistant text), then
-        assert NO branch header carries a non-None
-        ``parent_message_index`` that resolves to a ghost.
-
-        The forbidden state is exactly the dead ``#msg-d-N``: a
-        non-None index whose ``ctx.get(...)`` returns None.
-        """
+        """At USER_ONLY (ghosts assistant text), the fork anchor is kept as a
+        ``fork_only`` landmark — not ghosted — and every branch header's
+        back-link resolves to it (a live slot, never a dead ``#msg-d-N``)."""
         messages = load_transcript(_fork_fixture(tmp_path / "fork.jsonl"))
         _, _, ctx = generate_template_messages(messages, detail=DetailLevel.USER_ONLY)
 
         survivors = [m for m in ctx.messages if m is not None]
 
-        # Precondition: the fork anchor MUST be ghosted at USER_ONLY,
-        # otherwise this test exercises nothing — the repair pass would be a
-        # no-op and the regression could rot silently. Assert it directly so
-        # a preserved anchor fails here instead of passing vacuously below.
-        anchor_idx = next(
-            (
-                i
-                for i, m in enumerate(ctx.messages)
-                if m is not None and m.meta.uuid == "a-anchor"
-            ),
+        # New behavior: the fork anchor is KEPT (not ghosted) as a fork-only
+        # landmark — its own body is filtered, but it stays a visible,
+        # anchorable fork point so the branches it connects aren't orphaned.
+        anchor = next(
+            (m for m in ctx.messages if m is not None and m.meta.uuid == "a-anchor"),
             None,
         )
-        assert anchor_idx is None, (
-            "expected fork-anchor assistant 'a-anchor' to be ghosted at "
-            "USER_ONLY; otherwise this test does not validate stale-anchor "
-            f"repair. anchor still present at index {anchor_idx}."
+        assert anchor is not None, (
+            "fork-anchor assistant 'a-anchor' must be KEPT at USER_ONLY (as a "
+            "fork-only landmark), not ghosted — otherwise the branches render "
+            "with no visible fork point above them (#233 follow-up)."
+        )
+        assert anchor.fork_only is True, (
+            "the kept fork anchor must be flagged fork_only so the template "
+            "renders only its fork-point box, not its (filtered) message body."
+        )
+        assert anchor.junction_forward_links, (
+            "the fork-only landmark must retain its junction_forward_links so "
+            "the fork-point box (with branch-jump links) still renders."
         )
 
-        # The actual invariant: no branch header points at a ghost slot.
+        # Deeper invariant (unchanged): no branch header points at a ghost slot.
+        # Now they resolve to the live fork-only landmark rather than to None.
         branch_headers = [
             m
             for m in survivors
@@ -195,16 +202,18 @@ class TestGhostedForkAnchorBackrefRepair:
         for bh in branch_headers:
             assert isinstance(bh.content, SessionHeaderMessage)
             parent_idx = bh.content.parent_message_index
-            if parent_idx is None:
-                continue
+            # The back-link is now ACTIVE (resolves to the kept landmark),
+            # not omitted — and never dangling.
+            assert parent_idx is not None, (
+                f"branch header session_id={bh.content.session_id!r} lost its "
+                "fork back-link (parent_message_index=None) — the fork anchor "
+                "is kept now, so the back-link should resolve to it."
+            )
             target = ctx.get(parent_idx)
-            assert target is not None, (
+            assert target is not None and target.meta.uuid == "a-anchor", (
                 f"branch header session_id={bh.content.session_id!r} "
-                f"carries parent_message_index={parent_idx} that resolves "
-                f"to a GHOST slot — this is the dead-anchor failure that "
-                f"`_repair_stale_anchor_refs` is supposed to prevent. "
-                f"Either the repair pass didn't run, the predicate is "
-                f"wrong, or `ctx.get()` semantics drifted."
+                f"parent_message_index={parent_idx} must resolve to the live "
+                f"fork-only landmark 'a-anchor', not a ghost/other slot."
             )
 
 


### PR DESCRIPTION
A follow-up to #233. A fork point is navigational structure, not message content — the branches it connects (session headers) always survive `--detail` filtering, so the fork point should too. Previously the fork-point box was a *rider* on its host message, and when `_ghost_template_by_detail` ghosted that host to `None` at reduced detail, the box vanished — leaving branches with no visible fork point above them and (per #233's belt-and-suspenders) plain-text back-links.

## Change

Instead of ghosting a slot that carries `junction_forward_links`, keep it as a **`fork_only` landmark**: a non-`None` slot with its `.content` intact, body suppressed at *render time only*. A new `TemplateMessage.fork_only` flag is set in the ghost pass; a template branch in `render_message` (checked **first**, before `is_session_header` / `should_render`) emits just the ⟂ fork-point box — `message-node > children > fork-point`, with the anchor `id` on the box — no message card.

Because the slot stays non-`None`, the branch back-links and nav anchor **reactivate for free**: `_repair_stale_anchor_refs` only nulls refs to `None` slots. Linking runs before ghosting, so the box data already exists at ghost time. Non-fork slots still ghost to `None`, so #233's genuine-ghost sanitize path is preserved for non-fork anchors and degenerate (<2-branch) forks.

Net: **fork points are now visible at every detail level**, full parity with the branches they connect. Verified at full/high/low/minimal/user-only — FULL shows card+box (unchanged #233); reduced suppresses the body, keeps the box + active back-links, zero dead anchors.

> **Knob:** this implements full parity *including* `user-only`. If a `user-only` floor is preferred (fork points drop in the prompts-only view), it's a one-line guard at the `fork_only` assignment.

## Latent-coupling guard

The no-dead-anchor guarantee rests on an unstated cross-class invariant: **branch session headers are always visible** (`SessionHeaderMessage` declares no `detail_visibility`). If a branch could be ghosted, a 2-branch fork could drop below 2 survivors → box suppressed → the kept slot renders with no `id` → a sibling back-link dangles. A comment at the `fork_only` assignment documents this, and `test_branch_headers_always_visible_keeps_fork_anchored` pins it directly — so a future `SessionHeaderMessage.detail_visibility` trips a test instead of silently activating a dead anchor.

## Testing

Three existing tests pinned the superseded #233 behavior ("fork ghosted → omit/sanitize backlink"); each is updated to the new "fork survives" behavior while preserving the deeper invariant (no dead `#msg-d-N`, D11 trunk-before-branch):

- `test_ghost_repair`: fork anchor kept as a `fork_only` landmark, back-link live (the "no dead anchor" invariant stays independently pinned by `TestHtmlAnchorIntegrity`).
- `test_detail_levels`: `fork_only` landmarks are exempt from "only recaps survive among system messages" (they render only the box, no body leaks).
- `test_dag_integration` (D11): a filtered fork anchor's back-link is now active (resolves to the kept landmark); the trunk-before-branch invariant is unaffected.

New `TestForkSurvivesDetailFiltering`: box survives / body suppressed / back-links reactivate / no dead anchors, across all reduced levels; plus the always-visible-branch invariant pin.

`just ci` green (unit + TUI + browser + snapshots, ruff, pyright, ty); no snapshot churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fork points now remain visible as anchored landmarks even when their full message content is hidden by detail settings.
  * Branch back-links continue to point to the fork landmark, helping preserve navigation in filtered views.

* **Bug Fixes**
  * Prevented broken or dead anchors when rendering transcripts at reduced detail.
  * Improved handling of forked threads so visible links stay stable across different display levels.

* **Tests**
  * Expanded coverage for fork rendering and detail filtering to verify anchors, back-links, and visibility stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->