### PR TITLE
Warn that --output / --format are ignored under --tui (#220)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -904,11 +904,28 @@ def main(
             err=True,
         )
 
+    # `--output` / `--format` are no-ops under --tui: the TUI's export
+    # actions write to a fixed per-session path and run_session_browser
+    # never receives these flags (issue #220). Warn rather than silently
+    # ignore, mirroring the --expand-paths / --filter-path cases above.
+    if tui and (
+        output is not None
+        or ctx.get_parameter_source("output_format")
+        is not click.core.ParameterSource.DEFAULT
+    ):
+        click.echo(
+            "Warning: --output / --format are ignored in --tui mode; "
+            "use the TUI's in-app export actions instead.",
+            err=True,
+        )
+
     # Infer --format from an explicit --output file suffix when -f was not
     # given; error on an explicit conflict like `-o foo.md -f html` rather
     # than writing mismatched content (issue #222). `.md`/`.markdown` both
-    # imply the canonical `markdown` format.
-    if output is not None and _output_path_is_file(output):
+    # imply the canonical `markdown` format. Skipped under --tui: both flags
+    # are no-ops there (warned above), so erroring on their conflict would
+    # contradict the warning and block the TUI from launching (#220).
+    if not tui and output is not None and _output_path_is_file(output):
         from .utils import format_from_output_suffix
 
         suffix_format = format_from_output_suffix(output)

--- a/test/test_tui_output_warn.py
+++ b/test/test_tui_output_warn.py
@@ -1,0 +1,91 @@
+"""PR 3 of the #220-223 set (issue #220): warn that --output / --format
+are no-ops under --tui.
+
+The TUI ignores --output/--format (run_session_browser never receives them;
+its export actions write to a fixed per-session path). Rather than silently
+ignoring, the CLI now warns — mirroring the --expand-paths/--filter-path
+ignored-flag warnings. These tests drive the warn via an empty projects
+dir so the TUI returns early ("No projects ...") without launching Textual.
+"""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from claude_code_log.cli import main
+
+
+def _empty_projects(tmp_path: Path) -> Path:
+    d = tmp_path / "projects"
+    d.mkdir()
+    return d
+
+
+class TestTuiOutputWarn:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_warns_on_output_under_tui(self, tmp_path: Path):
+        r = self.runner.invoke(
+            main,
+            ["--tui", "--projects-dir", str(_empty_projects(tmp_path)), "-o", "x.md"],
+        )
+        assert r.exit_code == 0, r.output
+        assert "ignored in --tui mode" in r.stderr
+
+    def test_warns_on_explicit_format_under_tui(self, tmp_path: Path):
+        r = self.runner.invoke(
+            main,
+            [
+                "--tui",
+                "--projects-dir",
+                str(_empty_projects(tmp_path)),
+                "-f",
+                "markdown",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        assert "ignored in --tui mode" in r.stderr
+
+    def test_no_warn_under_tui_without_output_or_format(self, tmp_path: Path):
+        r = self.runner.invoke(
+            main, ["--tui", "--projects-dir", str(_empty_projects(tmp_path))]
+        )
+        assert r.exit_code == 0, r.output
+        assert "ignored in --tui mode" not in r.stderr
+
+    def test_warn_goes_to_stderr_not_stdout(self, tmp_path: Path):
+        r = self.runner.invoke(
+            main,
+            ["--tui", "--projects-dir", str(_empty_projects(tmp_path)), "-o", "x.md"],
+        )
+        assert "ignored in --tui mode" not in r.stdout
+        assert "ignored in --tui mode" in r.stderr
+
+    def test_conflicting_output_format_under_tui_warns_not_errors(self, tmp_path: Path):
+        """A `-o x.md -f html` conflict (#222) must NOT hard-error under --tui:
+        both flags are ignored there, so we warn and let the TUI proceed
+        rather than blocking on a conflict the user can't act on (#220)."""
+        r = self.runner.invoke(
+            main,
+            [
+                "--tui",
+                "--projects-dir",
+                str(_empty_projects(tmp_path)),
+                "-o",
+                "x.md",
+                "-f",
+                "html",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        assert "ignored in --tui mode" in r.stderr
+        assert "conflicts" not in r.output
+
+    def test_no_warn_when_not_tui(self, tmp_path: Path):
+        """A normal (non-TUI) `-o` conversion must not emit the TUI warning."""
+        src = tmp_path / "s.jsonl"
+        src.write_text("", encoding="utf-8")  # empty → no messages, still converts
+        out = tmp_path / "out.md"
+        r = self.runner.invoke(main, [str(src), "-o", str(out)])
+        assert "ignored in --tui mode" not in r.output


### PR DESCRIPTION
The last of the `--output` / `--format` / TUI group (#220–#223). #221/#222/#223-pt1 landed in #237; #223-pt2 in #239.

## Problem

In `--tui` mode, `--output` and `--format` were silently ignored — no effect, no warning. `run_session_browser` never receives them, and the TUI's export actions write to a fixed per-session path. A user running `claude-code-log --tui --format markdown --output log.md` got no `log.md` and no indication why.

## Fix (minimal)

Warn (to stderr) when `--output` or `--format` is passed with `--tui`, mirroring the existing `--expand-paths` / `--filter-path` ignored-flag warnings. An explicit `-f` is detected via the Click parameter source, so the `html` default doesn't false-trigger.

Also gate the #222 format-inference/conflict block (added in #237) on `not tui`: those flags are no-ops under `--tui`, so hard-erroring on a `-o x.md -f html` conflict there would contradict the warning and block the TUI from launching. Under `--tui` we warn and proceed; the non-TUI conflict error is unchanged.

The in-app "export to path" action (the other half of #220) is intentionally **deferred** — left for a follow-up once this minimal warn lands.

## Tests

`test/test_tui_output_warn.py` (6): warn on `-o`/explicit-`-f` under `--tui`; no warn without them; warn on stderr not stdout; no warn for non-TUI `-o`; and `-o x.md -f html --tui` warns-and-proceeds (no conflict error). Driven via an empty `--projects-dir` so the TUI returns early without launching Textual — runs in the fast unit suite. `just ci` green.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TUI mode so output and format options are safely ignored instead of causing conflicts or errors.
  * Added clear warnings in the terminal when unsupported output settings are used in TUI mode.
  * Prevented accidental format detection from file names during TUI runs, reducing unexpected behavior.

* **Tests**
  * Added coverage for TUI warning behavior, including supported and unsupported option combinations and correct warning placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->