### PR TITLE
Speed up integration-test fixtures on Windows (shrink copied transcripts; skip symlink tests when unavailable)

### DIFF
--- a/test/test_integration_realistic.py
+++ b/test/test_integration_realistic.py
@@ -36,6 +36,46 @@ from claude_code_log.cache import CacheManager, get_library_version
 # Path to realistic test data
 REAL_PROJECTS_DIR = Path(__file__).parent / "test_data" / "real_projects"
 
+# These integration tests exercise *behavior* (hierarchy processing, caching,
+# CLI flags, regeneration) rather than raw data volume, yet rendering cost
+# scales with transcript size. A couple of session files in the fixture are
+# ~5 MB each, and re-rendering them in every function-scoped copy dominates the
+# suite wall-time (especially on Windows, where the per-message render work is
+# the bottleneck). We therefore prefix-truncate the oversized session files in
+# the *copy* only — the source tree stays pristine, so the volume-sensitive
+# tests (test_performance / test_json_real_projects / test_dag*) keep the full
+# data. Truncating to a leading prefix is DAG-safe: a transcript entry's
+# parentUuid always refers to an earlier line, so dropping the tail only removes
+# leaf descendants and never dangles a parent reference.
+#
+# The 600 KB threshold sits above the largest content-sensitive fixture files
+# (JSSoundRecorder's 506 KB session, the teammates trunk at 285 KB), so those
+# projects are left intact without naming them. agent-*/subagents files are
+# skipped outright — the teammate-linking tests depend on their full content.
+_TRUNCATE_THRESHOLD = 600_000
+_TRUNCATE_KEEP = 100_000
+
+
+def _shrink_large_transcripts(projects_dir: Path) -> None:
+    """Prefix-truncate oversized standalone transcript files in a copied tree.
+
+    See the module comment above for the rationale and safety argument. Mutates
+    files in place; only call on a throwaway copy, never the source fixture.
+    """
+    for jsonl_file in projects_dir.rglob("*.jsonl"):
+        if jsonl_file.name.startswith("agent-") or "subagents" in jsonl_file.parts:
+            continue
+        if jsonl_file.stat().st_size <= _TRUNCATE_THRESHOLD:
+            continue
+        data = jsonl_file.read_bytes()
+        cut = data[:_TRUNCATE_KEEP]
+        # Trim back to the last complete line so we never leave a partial JSON
+        # record (which would be parsed as a malformed line, not a clean prefix).
+        last_newline = cut.rfind(b"\n")
+        if last_newline > 0:
+            cut = cut[: last_newline + 1]
+        jsonl_file.write_bytes(cut)
+
 
 def make_valid_user_entry(
     content: str,
@@ -105,6 +145,7 @@ def temp_projects_copy(real_projects_path: Path) -> Generator[Path, None, None]:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_projects = Path(temp_dir) / "projects"
         shutil.copytree(real_projects_path, temp_projects)
+        _shrink_large_transcripts(temp_projects)
 
         # Clean any existing cache/HTML to ensure fresh state
         for project_dir in temp_projects.iterdir():
@@ -130,6 +171,7 @@ def projects_with_cache(real_projects_path: Path) -> Generator[Path, None, None]
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_projects = Path(temp_dir) / "projects"
         shutil.copytree(real_projects_path, temp_projects)
+        _shrink_large_transcripts(temp_projects)
 
         # Clean any existing cache/HTML first
         for project_dir in temp_projects.iterdir():

--- a/test/test_integration_realistic.py
+++ b/test/test_integration_realistic.py
@@ -71,9 +71,13 @@ def _shrink_large_transcripts(projects_dir: Path) -> None:
         cut = data[:_TRUNCATE_KEEP]
         # Trim back to the last complete line so we never leave a partial JSON
         # record (which would be parsed as a malformed line, not a clean prefix).
+        # If the kept prefix has no newline (the first record alone exceeds
+        # _TRUNCATE_KEEP), leave the file untruncated rather than writing a
+        # partial record.
         last_newline = cut.rfind(b"\n")
-        if last_newline > 0:
-            cut = cut[: last_newline + 1]
+        if last_newline <= 0:
+            continue
+        cut = cut[: last_newline + 1]
         jsonl_file.write_bytes(cut)
 
 

--- a/test/test_session_scan_characterization.py
+++ b/test/test_session_scan_characterization.py
@@ -51,6 +51,27 @@ from claude_code_log.converter import (
 )
 
 
+def _symlinks_supported() -> bool:
+    """Whether the OS lets this process create symlinks.
+
+    On Windows, ``os.symlink`` raises ``OSError [WinError 1314]`` unless the
+    process is elevated or Developer Mode is on, so the symlink-based tests
+    below can't run there. Probe once at import time.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        link = Path(td) / "probe-link"
+        try:
+            link.symlink_to(Path(td))
+        except (OSError, NotImplementedError):
+            return False
+    return True
+
+
+_SYMLINKS_SUPPORTED = _symlinks_supported()
+
+
 # ----- fixture builders ----------------------------------------------------
 
 
@@ -457,6 +478,10 @@ class TestUpdateCacheCharacterization:
 # ----- characterization: index inline-aggregate loop -----------------------
 
 
+@pytest.mark.skipif(
+    not _SYMLINKS_SUPPORTED,
+    reason="symlink creation requires privilege/Developer Mode on Windows",
+)
 class TestIndexInlineAggregateLoopCharacterization:
     """Pin the project-aggregate totals produced by the inline loop
     inside `process_projects_hierarchy` (the cache-unavailable


### PR DESCRIPTION
Part of #248.

## Problem

The test suite is far slower on Windows than Linux. Profiling the worst
offenders — the `test_integration_realistic.py` family (18 of the 25
slowest tests, 30–45s each) — showed the cost is **not** the
`shutil.copytree` of the fixture data (~0.15s) but the repeated
**rendering + cache build** of the large fixture transcripts, which every
function-scoped test re-does. A couple of fixture session files are ~5 MB
each and dominate.

## Change

- **Shrink oversized transcripts in the copied fixture data only**
  (`_shrink_large_transcripts`), leaving the source tree pristine so
  volume-sensitive tests (`test_performance`, `test_dag*`, …) keep the
  full data. The truncation is a leading-prefix cut, which is DAG-safe:
  an entry's `parentUuid` always refers to an earlier line, so dropping
  the tail removes only leaf descendants. `agent-`/`subagents` files and
  content-sensitive fixtures stay below the 600 KB threshold.
- **Skip the symlink-based aggregate tests when symlinks aren't
  available.** On Windows without Developer Mode/elevation, `os.symlink`
  raises `OSError [WinError 1314]`; the tests now probe capability once
  and `skipif`, so they still run everywhere symlinks work
  (Linux/macOS/elevated Windows).

## Results (local Windows)

| Scope | Before | After |
|---|---|---|
| `test_integration_realistic.py` (serial) | 150.3s | 93.2s (**−38%**) |
| Full unit suite (`-n auto`) | 185.7s | 146.9s (**−21%**) |

No production code is touched; the coverage trade-off is documented in the
fixture module. This is an *absolute* speedup (it helps Linux
proportionally too); the Windows/Linux **ratio** is addressed by the
companion PRs tracked in #248.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability and speed by reducing oversized temporary transcript files during realistic integration runs.
  * Adjusted scan/characterization tests to automatically skip on platforms that don’t permit symlink creation, avoiding failures in restricted environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->