### PR TITLE
Surface the model each agent ran on, once per agent context (#246)

### DIFF
--- a/claude_code_log/factories/meta_factory.py
+++ b/claude_code_log/factories/meta_factory.py
@@ -4,7 +4,7 @@ This module handles extraction of common metadata from transcript entries
 that is shared across all message types.
 """
 
-from ..models import BaseTranscriptEntry, MessageMeta
+from ..models import AssistantTranscriptEntry, BaseTranscriptEntry, MessageMeta
 
 
 def create_meta(transcript: BaseTranscriptEntry) -> MessageMeta:
@@ -33,4 +33,10 @@ def create_meta(transcript: BaseTranscriptEntry) -> MessageMeta:
         cwd=transcript.cwd,
         git_branch=transcript.gitBranch,
         team_name=getattr(transcript, "teamName", None),
+        # The model id lives on the assistant message body, not the base entry.
+        model=(
+            transcript.message.model
+            if isinstance(transcript, AssistantTranscriptEntry)
+            else None
+        ),
     )

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -1032,7 +1032,11 @@ class HtmlRenderer(Renderer):
             if input.run_in_background
             else ""
         )
-        suffix = async_hint + self._agent_depth_badge(message)
+        suffix = (
+            async_hint
+            + self._agent_depth_badge(message)
+            + self._agent_model_badge(message)
+        )
         if input.description and input.subagent_type:
             escaped_desc = escape_html(input.description)
             return (
@@ -1067,6 +1071,21 @@ class HtmlRenderer(Renderer):
             f" <span class='agent-depth-badge agent-ring-{ring}'"
             f" title='Opens a depth-{spawned_depth} sub-agent transcript'>"
             f"Depth {spawned_depth}</span>"
+        )
+
+    def _agent_model_badge(self, message: TemplateMessage) -> str:
+        """Model badge for a spawn card (#246): the model the spawned
+        sub-agent ran on, stamped on the always-visible Task/Agent launch
+        card by ``_surface_agent_models`` (``display_model``). Shown for
+        every spawn depth — unlike the depth badge, it isn't suppressed at
+        depth 1, since the top-level Explore/Task spawn is the common case a
+        reader wants to see. Empty when no model was resolved (e.g. an
+        interrupted spawn whose sub-agent produced no assistant turn)."""
+        if not message.display_model:
+            return ""
+        return (
+            f" <span class='message-model' title='Model this sub-agent ran on'>"
+            f"{escape_html(message.display_model)}</span>"
         )
 
     def _async_id_suffix(

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -278,6 +278,13 @@
     color: #888;
 }
 
+/* Model id surfaced on sub-agent message headers (issue #246) */
+.message-model {
+    font-size: 0.75em;
+    font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+    color: var(--text-secondary, #888);
+}
+
 /* Paired message styling */
 .message.pair_first {
     margin-bottom: 0;

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -129,7 +129,7 @@
        card itself, not the whole subtree (issue #174 nested-DOM follow-up). #}
     <div class='message-node'>
     <div class='message session-header{% if message.is_branch_header %} branch-header{% endif %}' data-message-id='{{ message.message_id }}' data-session-id='{{ message.session_id }}' id='msg-{{ message.message_id }}'{% if message.branch_depth %} style='margin-left: {{ message.branch_depth * 2 }}em'{% endif %}>
-        <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}{% if message.display_model %} <span class='message-model' title='Main agent model'>{{ message.display_model }}</span>{% endif %}</div>
+        <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}{% if message.display_model and not message.is_branch_header %} <span class='message-model' title='Main agent model'>{{ message.display_model }}</span>{% endif %}</div>
         {% if message.has_children %}
         <div class='fold-bar' data-message-id='{{ message.message_id }}' data-border-color='session-header'>
             {% if message.immediate_children_count == message.total_descendants_count %}

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -129,7 +129,7 @@
        card itself, not the whole subtree (issue #174 nested-DOM follow-up). #}
     <div class='message-node'>
     <div class='message session-header{% if message.is_branch_header %} branch-header{% endif %}' data-message-id='{{ message.message_id }}' data-session-id='{{ message.session_id }}' id='msg-{{ message.message_id }}'{% if message.branch_depth %} style='margin-left: {{ message.branch_depth * 2 }}em'{% endif %}>
-        <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}</div>
+        <div class='header'>{% if message.is_branch_header %}&#x21b3; {% else %}Session: {% endif %}{{ html_content|safe }}{% if message.display_model %} <span class='message-model' title='Main agent model'>{{ message.display_model }}</span>{% endif %}</div>
         {% if message.has_children %}
         <div class='fold-bar' data-message-id='{{ message.message_id }}' data-border-color='session-header'>
             {% if message.immediate_children_count == message.total_descendants_count %}
@@ -187,6 +187,9 @@
                 </div>
                 {% if message.token_usage %}
                 <span class='token-usage'>{{ message.token_usage }}</span>
+                {% endif %}
+                {% if message.display_model %}
+                <span class='message-model' title='Model used by this sub-agent'>{{ message.display_model }}</span>
                 {% endif %}
             </div>
         </div>

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -188,9 +188,6 @@
                 {% if message.token_usage %}
                 <span class='token-usage'>{{ message.token_usage }}</span>
                 {% endif %}
-                {% if message.display_model %}
-                <span class='message-model' title='Model used by this sub-agent'>{{ message.display_model }}</span>
-                {% endif %}
             </div>
         </div>
         {% if message.meta %}<div class='debug-info'>{{ message.meta.uuid[:12] }}{% if message.meta.parent_uuid %} &rarr; {{ message.meta.parent_uuid[:12] }}{% endif %}</div>{% endif %}

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -1804,12 +1804,14 @@ class MarkdownRenderer(Renderer):
         base = f"🔎 Grep `{input.pattern}`"
         return f"{base} in `{input.path}`" if input.path else base
 
-    def title_TaskInput(self, input: TaskInput, _: TemplateMessage) -> str:
-        """Title → '🤖 Task (subagent): *description* [async #<id>]'.
+    def title_TaskInput(self, input: TaskInput, message: TemplateMessage) -> str:
+        """Title → '🤖 Task (subagent): *description* [async #<id>] · `model`'.
 
         ``[async]`` muted hint when ``run_in_background=True``; once the
         launch confirmation has been parsed, the minted ``#<agent_id>``
         is appended (PR #158 follow-up, parallels the Bash spawn shape).
+        The trailing `` · `model` `` is the model the spawned sub-agent ran
+        on (issue #246), stamped on the spawn card by ``_surface_agent_models``.
         """
         subagent = f" ({input.subagent_type})" if input.subagent_type else ""
         async_hint = (
@@ -1817,9 +1819,15 @@ class MarkdownRenderer(Renderer):
             if input.run_in_background
             else ""
         )
+        model_hint = (
+            f" · {_inline_code(message.display_model)}" if message.display_model else ""
+        )
         if desc := input.description:
-            return f"🤖 Task{subagent}: *{self._escape_stars(desc)}*{async_hint}"
-        return f"🤖 Task{subagent}{async_hint}"
+            return (
+                f"🤖 Task{subagent}: *{self._escape_stars(desc)}*"
+                f"{async_hint}{model_hint}"
+            )
+        return f"🤖 Task{subagent}{async_hint}{model_hint}"
 
     @staticmethod
     def _async_id_hint(minted_id: Optional[str]) -> str:
@@ -2099,11 +2107,6 @@ class MarkdownRenderer(Renderer):
                     ts_line = self._format_message_timestamp(msg)
                     if ts_line:
                         parts.append(ts_line)
-
-            # Sub-agent model, surfaced once on its first message (issue #246).
-            # Outside the suppress-heading guard so it survives compact mode.
-            if msg.display_model and not is_session_header:
-                parts.append(f"Model: {_inline_code(msg.display_model)}")
 
             # Format content (if not already output above)
             if content:

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -708,7 +708,12 @@ class MarkdownRenderer(Renderer):
     def title_SessionHeaderMessage(
         self, content: SessionHeaderMessage, message: TemplateMessage
     ) -> str:
-        """Title → '📋 Session `abc12345`: summary — Team: `t`' (or '🌿 Branch …').
+        """Title → '📋 Session `abc12345`: summary — Model: `m` — Team: `t`'
+        (or '🌿 Branch …').
+
+        The ``— Model: `…``` segment (issue #246) carries the trunk/main
+        model and appears, before any Team suffix, only on non-branch
+        session headers that have a ``display_model`` set.
 
         Branch session headers surface the ``Branch • <uuid8> • <preview>``
         shape that the renderer's ``_branch_label`` helper composes for

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -706,7 +706,7 @@ class MarkdownRenderer(Renderer):
         return f'<a id="{_session_anchor(content)}"></a>'
 
     def title_SessionHeaderMessage(
-        self, content: SessionHeaderMessage, _: TemplateMessage
+        self, content: SessionHeaderMessage, message: TemplateMessage
     ) -> str:
         """Title → '📋 Session `abc12345`: summary — Team: `t`' (or '🌿 Branch …').
 
@@ -739,6 +739,9 @@ class MarkdownRenderer(Renderer):
             title = f"📋 Session `{session_short}`: {content.summary}"
         else:
             title = f"📋 Session `{session_short}`"
+        # Main agent model, surfaced once on the session header (issue #246).
+        if message.display_model:
+            title = f"{title} — Model: {_inline_code(message.display_model)}"
         if content.team_name:
             # Boundary hygiene: a malformed transcript could in theory
             # carry a backtick in teamName. CommonMark code spans don't
@@ -2091,6 +2094,11 @@ class MarkdownRenderer(Renderer):
                     ts_line = self._format_message_timestamp(msg)
                     if ts_line:
                         parts.append(ts_line)
+
+            # Sub-agent model, surfaced once on its first message (issue #246).
+            # Outside the suppress-heading guard so it survives compact mode.
+            if msg.display_model and not is_session_header:
+                parts.append(f"Model: {_inline_code(msg.display_model)}")
 
             # Format content (if not already output above)
             if content:

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -412,6 +412,11 @@ class MessageMeta:
     cwd: str = ""
     git_branch: Optional[str] = None
     team_name: Optional[str] = None  # Active team name (teammates feature)
+    # The model id the assistant entry ran on (AssistantMessageModel.model),
+    # e.g. ``claude-opus-4-8``. Only assistant entries carry it; None elsewhere.
+    # Surfaced on sub-agent message headers so a reader can see which model a
+    # spawned agent used (issue #246).
+    model: Optional[str] = None
 
     @classmethod
     def empty(cls, uuid: str = "") -> "MessageMeta":

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4875,11 +4875,16 @@ def _surface_agent_models(ctx: RenderingContext) -> None:
         model = msg.meta.model
         if not model:
             continue
-        if msg.meta.is_sidechain and msg.meta.agent_id:
-            if msg.meta.agent_id not in seen_subagents:
-                seen_subagents.add(msg.meta.agent_id)
+        if msg.meta.is_sidechain:
+            # Sub-agent context: attribute to its agent_id. A sidechain entry
+            # that somehow lacks an agent_id is left unattributed rather than
+            # leaking into the trunk header below.
+            agent_id = msg.meta.agent_id
+            if agent_id and agent_id not in seen_subagents:
+                seen_subagents.add(agent_id)
                 msg.display_model = model
         else:
+            # Trunk context: the main model goes on the session header.
             session_id = msg.meta.session_id
             if session_id and session_id not in seen_sessions:
                 seen_sessions.add(session_id)

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -899,6 +899,12 @@ def generate_template_messages(
     with log_timing("Link async notifications", t_start):
         _link_async_notifications(ctx, detail)
 
+    # Surface the model each agent ran on (issue #246). Runs here — after
+    # pairing and async linking — so a spawn card can reach its paired
+    # tool_result and its hoisted ``minted_agent_id`` to resolve the sub-agent.
+    with log_timing("Surface agent models", t_start):
+        _surface_agent_models(ctx)
+
     # Link parsed dynamic-workflow runs to their Workflow tool_use by taskId
     # (#174 PR3) so the formatter can render snapshot-first meta (and step 3
     # can splice the phase/agent tree).
@@ -4849,24 +4855,33 @@ def _render_messages(
                     tool_msg.render_session_id = effective_session
                 ctx.register(tool_msg)
 
-    _surface_agent_models(ctx)
     return ctx
 
 
 def _surface_agent_models(ctx: RenderingContext) -> None:
     """Mark which messages should display their model id (issue #246).
 
-    Surfaced once per agent context rather than on every message:
+    Surfaced once per agent context rather than on every message, and on a
+    node that stays visible when the agent's transcript is folded:
     - the **session header** carries the trunk/main agent's model (the first
       non-sidechain assistant model seen for that session);
-    - the **first message of each sub-agent** carries that sub-agent's model.
+    - each **spawn card** (the Task/Agent ``tool_use`` that opens a sub-agent)
+      carries the model that sub-agent ran on — looked up from the sub-agent's
+      own first assistant model via ``spawned_agent_id``. The spawn card sits
+      at the *parent's* depth and stays on screen even when the sub-agent's
+      transcript collapses, so the model shows exactly where the reader looks
+      for it (issue #246 follow-up).
 
     A mid-course ``/model`` switch surfaces as its own command message, so a
     single first-seen value per context is enough. ``meta.model`` is only set
     on assistant entries, so a truthy value already filters to assistant-origin
     chunks (text or tool_use).
     """
-    seen_subagents: set[str] = set()
+    from .models import TaskInput, ToolUseMessage
+
+    # Pass 1: collect each sub-agent's model (first-seen) and stamp the
+    # trunk/main model onto each session header.
+    agent_model: dict[str, str] = {}
     seen_sessions: set[str] = set()
     for msg in ctx.messages:
         # ctx.messages may carry None slots (ghosted entries); skip them.
@@ -4876,15 +4891,10 @@ def _surface_agent_models(ctx: RenderingContext) -> None:
         if not model:
             continue
         if msg.meta.is_sidechain:
-            # Sub-agent context: attribute to its agent_id. A sidechain entry
-            # that somehow lacks an agent_id is left unattributed rather than
-            # leaking into the trunk header below.
             agent_id = msg.meta.agent_id
-            if agent_id and agent_id not in seen_subagents:
-                seen_subagents.add(agent_id)
-                msg.display_model = model
+            if agent_id and agent_id not in agent_model:
+                agent_model[agent_id] = model
         else:
-            # Trunk context: the main model goes on the session header.
             session_id = msg.meta.session_id
             if session_id and session_id not in seen_sessions:
                 seen_sessions.add(session_id)
@@ -4894,6 +4904,27 @@ def _surface_agent_models(ctx: RenderingContext) -> None:
                 )
                 if header is not None:
                     header.display_model = model
+
+    # Pass 2: stamp each sub-agent's model onto its spawn card — the Task/Agent
+    # ``tool_use`` that opens it, which carries the depth badge and stays visible
+    # when the sub-agent's transcript folds. Gated strictly to ``TaskInput`` so a
+    # regular tool inside a sub-agent never picks up the model. The spawned
+    # agent id is resolved from whichever linkage the transcript carries: the
+    # async ``minted_agent_id`` on the input, else the paired tool_result's
+    # ``spawned_agent_id`` (#213) or ``agent_id`` (async #90 ``toolUseResult``).
+    for msg in ctx.messages:
+        if msg is None or not isinstance(msg.content, ToolUseMessage):
+            continue
+        task_input = msg.content.input
+        if not isinstance(task_input, TaskInput):
+            continue
+        spawned = task_input.minted_agent_id
+        if not spawned and msg.pair_last is not None:
+            result = ctx.messages[msg.pair_last]
+            if result is not None:
+                spawned = result.meta.spawned_agent_id or result.meta.agent_id
+        if spawned and spawned in agent_model:
+            msg.display_model = agent_model[spawned]
 
 
 # -- Project Index Generation -------------------------------------------------

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -284,6 +284,14 @@ class TemplateMessage:
         # spawn that produced no transcript at all (#213 visual layer).
         self.spawns_collapsed_transcript: bool = False
 
+        # Model id to surface in this message's header (issue #246). Set by
+        # _surface_agent_models once per agent context — on the session header
+        # (the trunk/main model) and on the first message of each sub-agent
+        # (the model that sub-agent ran on) — so the id shows once rather than
+        # on every message. None elsewhere. The raw per-entry value lives on
+        # ``meta.model``; this is the render-once decision derived from it.
+        self.display_model: Optional[str] = None
+
         # Per-render annotations populated by the HTML renderer's tree walk
         # (HtmlRenderer._annotate_tree_for_render). The recursive template
         # macro reads these instead of receiving a flat (msg, title, html,
@@ -4841,7 +4849,46 @@ def _render_messages(
                     tool_msg.render_session_id = effective_session
                 ctx.register(tool_msg)
 
+    _surface_agent_models(ctx)
     return ctx
+
+
+def _surface_agent_models(ctx: RenderingContext) -> None:
+    """Mark which messages should display their model id (issue #246).
+
+    Surfaced once per agent context rather than on every message:
+    - the **session header** carries the trunk/main agent's model (the first
+      non-sidechain assistant model seen for that session);
+    - the **first message of each sub-agent** carries that sub-agent's model.
+
+    A mid-course ``/model`` switch surfaces as its own command message, so a
+    single first-seen value per context is enough. ``meta.model`` is only set
+    on assistant entries, so a truthy value already filters to assistant-origin
+    chunks (text or tool_use).
+    """
+    seen_subagents: set[str] = set()
+    seen_sessions: set[str] = set()
+    for msg in ctx.messages:
+        # ctx.messages may carry None slots (ghosted entries); skip them.
+        if msg is None:
+            continue
+        model = msg.meta.model
+        if not model:
+            continue
+        if msg.meta.is_sidechain and msg.meta.agent_id:
+            if msg.meta.agent_id not in seen_subagents:
+                seen_subagents.add(msg.meta.agent_id)
+                msg.display_model = model
+        else:
+            session_id = msg.meta.session_id
+            if session_id and session_id not in seen_sessions:
+                seen_sessions.add(session_id)
+                header_index = ctx.session_first_message.get(session_id)
+                header = (
+                    ctx.messages[header_index] if header_index is not None else None
+                )
+                if header is not None:
+                    header.display_model = model
 
 
 # -- Project Index Generation -------------------------------------------------

--- a/dev-docs/agents.md
+++ b/dev-docs/agents.md
@@ -318,7 +318,7 @@ transcript:
   0.5em) so very deep chains (79 levels seen in the wild) stay
   on-screen — depth is carried by the badge + colour, not the indent.
 
-Two card-level annotations complete the layer:
+Three card-level annotations complete the layer:
 
 - **Depth badge** (`_agent_depth_badge`, `html/renderer.py`): a "Depth
   N" pill on a spawn card showing the depth of the sub-agent it *opens*
@@ -332,6 +332,18 @@ Two card-level annotations complete the layer:
   shown is its whole transcript, distinct from a spawn that produced
   none. Nested-only (`agent_depth >= 1`); trunk-level direct
   sub-agents keep their pre-#213 rendering.
+- **Model id** (`TemplateMessage.display_model`, set by
+  `_surface_agent_models` in `renderer.py`; issue #246): the model an
+  agent ran on, surfaced **once per agent context** rather than on
+  every message — on the session header (the trunk/main model, from the
+  first non-sidechain assistant entry) and on the first message of each
+  sub-agent (that sub-agent's model). A mid-course `/model` switch
+  surfaces as its own command message, so a single first-seen value per
+  context suffices. The raw per-entry value is `MessageMeta.model`
+  (only assistant entries carry it); `display_model` is the render-once
+  decision derived from it. HTML renders a muted `.message-model` pill
+  in the header (beside the timestamp / on the session line); Markdown
+  emits a `Model: ` `` `…` `` line / inline `— Model:` heading suffix.
 
 ### 5.5 Fixture
 

--- a/dev-docs/agents.md
+++ b/dev-docs/agents.md
@@ -334,16 +334,27 @@ Three card-level annotations complete the layer:
   sub-agents keep their pre-#213 rendering.
 - **Model id** (`TemplateMessage.display_model`, set by
   `_surface_agent_models` in `renderer.py`; issue #246): the model an
-  agent ran on, surfaced **once per agent context** rather than on
-  every message — on the session header (the trunk/main model, from the
-  first non-sidechain assistant entry) and on the first message of each
-  sub-agent (that sub-agent's model). A mid-course `/model` switch
-  surfaces as its own command message, so a single first-seen value per
-  context suffices. The raw per-entry value is `MessageMeta.model`
-  (only assistant entries carry it); `display_model` is the render-once
-  decision derived from it. HTML renders a muted `.message-model` pill
-  in the header (beside the timestamp / on the session line); Markdown
-  emits a `Model: ` `` `…` `` line / inline `— Model:` heading suffix.
+  agent ran on, surfaced **once per agent context** and on a node that
+  stays visible when the agent's transcript folds — on the session
+  header (the trunk/main model, from the first non-sidechain assistant
+  entry) and on each **spawn card** (the Task/Agent `tool_use` that
+  opens a sub-agent). The sub-agent's model comes from its own first
+  assistant entry, joined back to the spawn card via `tool_use_id`
+  (`spawned_agent_id` lands on the tool_result; the two-pass helper maps
+  agent→model, then stamps the paired tool_use — pairing indices aren't
+  assigned yet, so it uses the id join, not `pair_first`). The spawn
+  card sits at the parent's depth and stays on screen even when the
+  sub-agent collapses, so the model shows where the reader looks — and
+  co-locates with the depth badge. A mid-course `/model` switch surfaces
+  as its own command message, so a single first-seen value per context
+  suffices. The raw per-entry value is `MessageMeta.model` (only
+  assistant entries carry it); `display_model` is the render-once
+  decision. HTML renders a muted `.message-model` pill — in the spawn
+  card title (`_agent_model_badge`, beside the depth badge) and inline
+  on the session-header line; Markdown appends `` · `…` `` to the Task
+  title and an inline `— Model:` on the session heading. Unlike the
+  depth badge it is **not** suppressed at depth 1 (the top-level
+  Explore/Task spawn is the common case a reader wants).
 
 ### 5.5 Fixture
 

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -647,6 +647,13 @@
       color: #888;
   }
   
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
+  }
+  
   /* Paired message styling */
   .message.pair_first {
       margin-bottom: 0;
@@ -4599,7 +4606,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='eb000000-0000-4000-8000-000000000001' id='msg-d-0'>
-          <div class='header'>Session: eb000000</div>
+          <div class='header'>Session: eb000000 <span class='message-model' title='Main agent model'>claude-opus-4-7</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -4629,6 +4636,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -4665,6 +4673,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -4686,6 +4695,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:03:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -4725,6 +4735,9 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:04:00.000Z'>2026-04-19 10:04:00</span>
                   </div>
                   
+                  
+                  <span class='message-model' title='Model used by this sub-agent'>claude-opus-4-7</span>
+                  
               </div>
           </div>
           <div class='debug-info'>cccccccc-000 &rarr; cccccccc-000</div>
@@ -4752,6 +4765,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:04:00.000Z'>2026-04-19 10:04:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -4772,6 +4786,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:05:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:05:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -4794,6 +4809,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:06:00.000Z'>2026-04-19 10:06:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
@@ -4814,6 +4830,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:07:00.000Z'>2026-04-19 10:07:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -7081,6 +7098,13 @@
   .token-usage {
       font-size: 0.75em;
       color: #888;
+  }
+  
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
   }
   
   /* Paired message styling */
@@ -11035,7 +11059,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='eb000000-0000-4000-8000-000000000001' id='msg-d-0'>
-          <div class='header'>Session: eb000000</div>
+          <div class='header'>Session: eb000000 <span class='message-model' title='Main agent model'>claude-opus-4-7</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -11065,6 +11089,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -11097,6 +11122,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -11118,6 +11144,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:03:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -11149,6 +11176,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:07:00.000Z'>2026-04-19 10:07:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -15621,6 +15649,13 @@
       color: #888;
   }
   
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
+  }
+  
   /* Paired message styling */
   .message.pair_first {
       margin-bottom: 0;
@@ -19573,7 +19608,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='test_session' id='msg-d-0'>
-          <div class='header'>Session: test_ses</div>
+          <div class='header'>Session: test_ses <span class='message-model' title='Main agent model'>claude-3-sonnet-20240229</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -19603,6 +19638,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874907Z'>2025-07-03 15:50:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -19636,6 +19672,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 25 | Output: 120</span>
+                  
                   
               </div>
           </div>
@@ -19683,6 +19720,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874907Z'>2025-07-03 15:54:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_003</div>
@@ -19714,6 +19752,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:56:07.874907Z'>2025-07-03 15:56:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_004</div>
@@ -19734,6 +19773,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:58:07.874907Z' data-duration='took 2m 0s'>2025-07-03 15:58:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -19757,6 +19797,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 78 | Output: 95</span>
+                  
                   
               </div>
           </div>
@@ -19797,6 +19838,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:02:07.874907Z'>2025-07-03 16:02:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_007</div>
@@ -19828,6 +19870,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:04:07.874907Z'>2025-07-03 16:04:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_008</div>
@@ -19848,6 +19891,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:06:07.874907Z' data-duration='took 2m 0s'>2025-07-03 16:06:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -19873,6 +19917,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 45 | Output: 110</span>
+                  
                   
               </div>
           </div>
@@ -19908,6 +19953,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:10:07.874907Z'>2025-07-03 16:10:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -22170,6 +22216,13 @@
   .token-usage {
       font-size: 0.75em;
       color: #888;
+  }
+  
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
   }
   
   /* Paired message styling */
@@ -26124,7 +26177,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='ef000000-0000-4000-8000-000000000001' id='msg-d-0'>
-          <div class='header'>Session: ef000000<span class="session-team-badge" style="--cc-color: var(--cc-purple); --cc-color-bg: var(--cc-purple-bg);"><span class="session-team-icon">👥</span>Team: test-coverage</span></div>
+          <div class='header'>Session: ef000000<span class="session-team-badge" style="--cc-color: var(--cc-purple); --cc-color-bg: var(--cc-purple-bg);"><span class="session-team-icon">👥</span>Team: test-coverage</span> <span class='message-model' title='Main agent model'>claude-opus-4-7</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -26154,6 +26207,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26190,6 +26244,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26211,6 +26266,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:03:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26231,6 +26287,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:04:00.000Z'>2026-04-19 10:04:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26257,6 +26314,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:06:00.000Z'>2026-04-19 10:06:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26282,6 +26340,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:08:00.000Z'>2026-04-19 10:08:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26305,6 +26364,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:10:00.000Z'>2026-04-19 10:10:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26326,6 +26386,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:11:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:11:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26358,6 +26419,9 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
+                  
+                  <span class='message-model' title='Model used by this sub-agent'>claude-opus-4-7</span>
+                  
               </div>
           </div>
           <div class='debug-info'>aaaaaaaa-000 &rarr; aaaaaaaa-000</div>
@@ -26379,6 +26443,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z'>2026-04-19 10:03:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26407,6 +26472,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:12:00.000Z'>2026-04-19 10:12:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26428,6 +26494,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:13:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:13:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26460,6 +26527,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>bbbbbbbb-000</div>
@@ -26482,6 +26550,9 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
+                  
+                  <span class='message-model' title='Model used by this sub-agent'>claude-opus-4-7</span>
+                  
               </div>
           </div>
           <div class='debug-info'>bbbbbbbb-000 &rarr; bbbbbbbb-000</div>
@@ -26503,6 +26574,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z'>2026-04-19 10:03:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26536,6 +26608,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:14:00.000Z'>2026-04-19 10:14:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
@@ -26561,6 +26634,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:15:00.000Z'>2026-04-19 10:15:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26595,6 +26669,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:16:00.000Z'>2026-04-19 10:16:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26616,6 +26691,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:17:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:17:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26636,6 +26712,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:18:00.000Z'>2026-04-19 10:18:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26659,6 +26736,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:19:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:19:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26679,6 +26757,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:20:00.000Z'>2026-04-19 10:20:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -26701,6 +26780,7 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:21:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:21:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26721,6 +26801,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:22:00.000Z'>2026-04-19 10:22:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -28988,6 +29069,13 @@
   .token-usage {
       font-size: 0.75em;
       color: #888;
+  }
+  
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
   }
   
   /* Paired message styling */
@@ -32942,7 +33030,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='edge_cases' id='msg-d-0'>
-          <div class='header'>Session: Tested various edge cases including markdown formatting, long text, tool errors, system messages, command outputs, special characters and emojis. All message types render correctly in the transcript viewer. • edge_cas</div>
+          <div class='header'>Session: Tested various edge cases including markdown formatting, long text, tool errors, system messages, command outputs, special characters and emojis. All message types render correctly in the transcript viewer. • edge_cas <span class='message-model' title='Main agent model'>claude-3-sonnet-20240229</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -32972,6 +33060,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:00:00Z'>2025-06-14 11:00:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -33005,6 +33094,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 35 | Output: 145</span>
+                  
                   
               </div>
           </div>
@@ -33071,6 +33161,7 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:01:00Z'>2025-06-14 11:01:00</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>edge_003</div>
@@ -33102,6 +33193,7 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:01:30Z'>2025-06-14 11:01:30</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>edge_004</div>
@@ -33127,6 +33219,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:01:31Z' data-duration='took 1.0s'>2025-06-14 11:01:31</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -33154,6 +33247,7 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:02:10Z'>2025-06-14 11:02:10</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>edge_007</div>
@@ -33176,6 +33270,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:02:20Z'>2025-06-14 11:02:20</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -33218,6 +33313,7 @@
                   
                   <span class='token-usage'>Input: 85 | Output: 180</span>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>edge_009</div>
@@ -33248,6 +33344,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:03:00Z'>2025-06-14 11:03:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -33280,6 +33377,7 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:03:30Z'>2025-06-14 11:03:30</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>edge_011</div>
@@ -33302,6 +33400,7 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:03:01Z'>2025-06-14 11:03:01</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>edge_010</div>
@@ -33323,7 +33422,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-11' data-session-id='todowrite_session' id='msg-d-11'>
-          <div class='header'>Session: todowrit</div>
+          <div class='header'>Session: todowrit <span class='message-model' title='Main agent model'>claude-sonnet-4</span></div>
           
           <div class='fold-bar' data-message-id='d-11' data-border-color='session-header'>
               
@@ -33349,6 +33448,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T10:02:00Z'>2025-06-14 10:02:00</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -35769,6 +35869,13 @@
   .token-usage {
       font-size: 0.75em;
       color: #888;
+  }
+  
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
   }
   
   /* Paired message styling */
@@ -39784,7 +39891,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='session_b' id='msg-d-0'>
-          <div class='header'>Session: session_</div>
+          <div class='header'>Session: session_ <span class='message-model' title='Main agent model'>claude-3-sonnet-20240229</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -39814,6 +39921,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874717Z'>2025-07-03 15:50:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -39848,6 +39956,7 @@
                   
                   <span class='token-usage'>Input: 20 | Output: 35</span>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>session_b_00</div>
@@ -39875,6 +39984,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874717Z'>2025-07-03 15:54:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>session_b_00</div>
@@ -39896,7 +40006,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-4' data-session-id='test_session' id='msg-d-4'>
-          <div class='header'>Session: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. • test_ses</div>
+          <div class='header'>Session: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. • test_ses <span class='message-model' title='Main agent model'>claude-3-sonnet-20240229</span></div>
           
           <div class='fold-bar' data-message-id='d-4' data-border-color='session-header'>
               
@@ -39926,6 +40036,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874907Z'>2025-07-03 15:50:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -39959,6 +40070,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 25 | Output: 120</span>
+                  
                   
               </div>
           </div>
@@ -40006,6 +40118,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874907Z'>2025-07-03 15:54:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_003</div>
@@ -40037,6 +40150,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:56:07.874907Z'>2025-07-03 15:56:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_004</div>
@@ -40057,6 +40171,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:58:07.874907Z' data-duration='took 2m 0s'>2025-07-03 15:58:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -40080,6 +40195,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 78 | Output: 95</span>
+                  
                   
               </div>
           </div>
@@ -40120,6 +40236,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:02:07.874907Z'>2025-07-03 16:02:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_007</div>
@@ -40151,6 +40268,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:04:07.874907Z'>2025-07-03 16:04:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_008</div>
@@ -40171,6 +40289,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:06:07.874907Z' data-duration='took 2m 0s'>2025-07-03 16:06:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -40196,6 +40315,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 45 | Output: 110</span>
+                  
                   
               </div>
           </div>
@@ -40231,6 +40351,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:10:07.874907Z'>2025-07-03 16:10:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -42493,6 +42614,13 @@
   .token-usage {
       font-size: 0.75em;
       color: #888;
+  }
+  
+  /* Model id surfaced on sub-agent message headers (issue #246) */
+  .message-model {
+      font-size: 0.75em;
+      font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+      color: var(--text-secondary, #888);
   }
   
   /* Paired message styling */
@@ -46447,7 +46575,7 @@
       
       <div class='message-node'>
       <div class='message session-header' data-message-id='d-0' data-session-id='test_session' id='msg-d-0'>
-          <div class='header'>Session: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. • test_ses</div>
+          <div class='header'>Session: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. • test_ses <span class='message-model' title='Main agent model'>claude-3-sonnet-20240229</span></div>
           
           <div class='fold-bar' data-message-id='d-0' data-border-color='session-header'>
               
@@ -46477,6 +46605,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874907Z'>2025-07-03 15:50:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -46510,6 +46639,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 25 | Output: 120</span>
+                  
                   
               </div>
           </div>
@@ -46557,6 +46687,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874907Z'>2025-07-03 15:54:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_003</div>
@@ -46588,6 +46719,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:56:07.874907Z'>2025-07-03 15:56:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_004</div>
@@ -46608,6 +46740,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:58:07.874907Z' data-duration='took 2m 0s'>2025-07-03 15:58:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -46631,6 +46764,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 78 | Output: 95</span>
+                  
                   
               </div>
           </div>
@@ -46671,6 +46805,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:02:07.874907Z'>2025-07-03 16:02:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_007</div>
@@ -46702,6 +46837,7 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:04:07.874907Z'>2025-07-03 16:04:07</span>
                   </div>
                   
+                  
               </div>
           </div>
           <div class='debug-info'>msg_008</div>
@@ -46722,6 +46858,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:06:07.874907Z' data-duration='took 2m 0s'>2025-07-03 16:06:07</span>
                   </div>
+                  
                   
               </div>
           </div>
@@ -46747,6 +46884,7 @@
                   </div>
                   
                   <span class='token-usage'>Input: 45 | Output: 110</span>
+                  
                   
               </div>
           </div>
@@ -46782,6 +46920,7 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:10:07.874907Z'>2025-07-03 16:10:07</span>
                   </div>
+                  
                   
               </div>
           </div>

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -4637,7 +4637,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000</div>
@@ -4667,12 +4666,11 @@
       <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-2' id='msg-d-2'>
           <div class='header'>
-              <span title="ID: tu_Task_async_001">🔧 Task <span class='tool-summary'>Coverage analysis</span> <span class='tool-subagent'>(Explore)</span> <span class='task-async-hint'>[async <a class='task-id-forward-link' href='#msg-d-7'><code>#cccc333</code></a>]</span></span>
+              <span title="ID: tu_Task_async_001">🔧 Task <span class='tool-summary'>Coverage analysis</span> <span class='tool-subagent'>(Explore)</span> <span class='task-async-hint'>[async <a class='task-id-forward-link' href='#msg-d-7'><code>#cccc333</code></a>]</span> <span class='message-model' title='Model this sub-agent ran on'>claude-opus-4-7</span></span>
               <div class='header-info'>
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -4695,7 +4693,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:03:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -4735,9 +4732,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:04:00.000Z'>2026-04-19 10:04:00</span>
                   </div>
                   
-                  
-                  <span class='message-model' title='Model used by this sub-agent'>claude-opus-4-7</span>
-                  
               </div>
           </div>
           <div class='debug-info'>cccccccc-000 &rarr; cccccccc-000</div>
@@ -4765,7 +4759,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:04:00.000Z'>2026-04-19 10:04:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -4786,7 +4779,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:05:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:05:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -4809,7 +4801,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:06:00.000Z'>2026-04-19 10:06:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
@@ -4830,7 +4821,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:07:00.000Z'>2026-04-19 10:07:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -11090,7 +11080,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000</div>
@@ -11122,7 +11111,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -11144,7 +11132,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:03:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -11176,7 +11163,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:07:00.000Z'>2026-04-19 10:07:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -19639,7 +19625,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874907Z'>2025-07-03 15:50:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_001</div>
@@ -19672,7 +19657,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 25 | Output: 120</span>
-                  
                   
               </div>
           </div>
@@ -19720,7 +19704,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874907Z'>2025-07-03 15:54:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_003</div>
@@ -19752,7 +19735,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:56:07.874907Z'>2025-07-03 15:56:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_004</div>
@@ -19773,7 +19755,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:58:07.874907Z' data-duration='took 2m 0s'>2025-07-03 15:58:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -19797,7 +19778,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 78 | Output: 95</span>
-                  
                   
               </div>
           </div>
@@ -19838,7 +19818,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:02:07.874907Z'>2025-07-03 16:02:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_007</div>
@@ -19870,7 +19849,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:04:07.874907Z'>2025-07-03 16:04:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_008</div>
@@ -19891,7 +19869,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:06:07.874907Z' data-duration='took 2m 0s'>2025-07-03 16:06:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -19917,7 +19894,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 45 | Output: 110</span>
-                  
                   
               </div>
           </div>
@@ -19953,7 +19929,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:10:07.874907Z'>2025-07-03 16:10:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26208,7 +26183,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000</div>
@@ -26244,7 +26218,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26266,7 +26239,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:03:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26287,7 +26259,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:04:00.000Z'>2026-04-19 10:04:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26314,7 +26285,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:06:00.000Z'>2026-04-19 10:06:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26340,7 +26310,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:08:00.000Z'>2026-04-19 10:08:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26358,12 +26327,11 @@
       <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-10' id='msg-d-10'>
           <div class='header'>
-              <span title="ID: tu_Task_alice">🔧 Task <span class='tool-summary'>Run alice&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span></span>
+              <span title="ID: tu_Task_alice">🔧 Task <span class='tool-summary'>Run alice&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span> <span class='message-model' title='Model this sub-agent ran on'>claude-opus-4-7</span></span>
               <div class='header-info'>
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:10:00.000Z'>2026-04-19 10:10:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26386,7 +26354,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:11:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:11:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26419,9 +26386,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
-                  
-                  <span class='message-model' title='Model used by this sub-agent'>claude-opus-4-7</span>
-                  
               </div>
           </div>
           <div class='debug-info'>aaaaaaaa-000 &rarr; aaaaaaaa-000</div>
@@ -26444,7 +26408,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z'>2026-04-19 10:03:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>aaaaaaaa-000 &rarr; aaaaaaaa-000</div>
@@ -26466,12 +26429,11 @@
       <div class='message-node'>
       <div class='message tool_use pair_first' data-message-id='d-15' id='msg-d-15'>
           <div class='header'>
-              <span title="ID: tu_Task_bob">🔧 Task <span class='tool-summary'>Run bob&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span></span>
+              <span title="ID: tu_Task_bob">🔧 Task <span class='tool-summary'>Run bob&#x27;s test work</span> <span class='tool-subagent'>(general-purpose)</span> <span class='message-model' title='Model this sub-agent ran on'>claude-opus-4-7</span></span>
               <div class='header-info'>
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:12:00.000Z'>2026-04-19 10:12:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26494,7 +26456,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:13:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:13:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26527,7 +26488,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:01:00.000Z'>2026-04-19 10:01:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>bbbbbbbb-000</div>
@@ -26550,9 +26510,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:02:00.000Z'>2026-04-19 10:02:00</span>
                   </div>
                   
-                  
-                  <span class='message-model' title='Model used by this sub-agent'>claude-opus-4-7</span>
-                  
               </div>
           </div>
           <div class='debug-info'>bbbbbbbb-000 &rarr; bbbbbbbb-000</div>
@@ -26574,7 +26531,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:03:00.000Z'>2026-04-19 10:03:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26608,7 +26564,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:14:00.000Z'>2026-04-19 10:14:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 11111111-000</div>
@@ -26634,7 +26589,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:15:00.000Z'>2026-04-19 10:15:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26669,7 +26623,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:16:00.000Z'>2026-04-19 10:16:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>22222222-000 &rarr; 11111111-000</div>
@@ -26691,7 +26644,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:17:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:17:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26712,7 +26664,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:18:00.000Z'>2026-04-19 10:18:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26736,7 +26687,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:19:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:19:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26757,7 +26707,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:20:00.000Z'>2026-04-19 10:20:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -26780,7 +26729,6 @@
                       <span class='timestamp' data-timestamp='2026-04-19T10:21:00.000Z' data-duration='took 1m 0s'>2026-04-19 10:21:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>11111111-000 &rarr; 22222222-000</div>
@@ -26801,7 +26749,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2026-04-19T10:22:00.000Z'>2026-04-19 10:22:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -33061,7 +33008,6 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:00:00Z'>2025-06-14 11:00:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>edge_001</div>
@@ -33094,7 +33040,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 35 | Output: 145</span>
-                  
                   
               </div>
           </div>
@@ -33161,7 +33106,6 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:01:00Z'>2025-06-14 11:01:00</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>edge_003</div>
@@ -33193,7 +33137,6 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:01:30Z'>2025-06-14 11:01:30</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>edge_004</div>
@@ -33219,7 +33162,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:01:31Z' data-duration='took 1.0s'>2025-06-14 11:01:31</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -33247,7 +33189,6 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:02:10Z'>2025-06-14 11:02:10</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>edge_007</div>
@@ -33270,7 +33211,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:02:20Z'>2025-06-14 11:02:20</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -33313,7 +33253,6 @@
                   
                   <span class='token-usage'>Input: 85 | Output: 180</span>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>edge_009</div>
@@ -33344,7 +33283,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:03:00Z'>2025-06-14 11:03:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -33377,7 +33315,6 @@
                       <span class='timestamp' data-timestamp='2025-06-14T11:03:30Z'>2025-06-14 11:03:30</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>edge_011</div>
@@ -33399,7 +33336,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T11:03:01Z'>2025-06-14 11:03:01</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -33448,7 +33384,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-06-14T10:02:00Z'>2025-06-14 10:02:00</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -39922,7 +39857,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874717Z'>2025-07-03 15:50:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>session_b_00</div>
@@ -39956,7 +39890,6 @@
                   
                   <span class='token-usage'>Input: 20 | Output: 35</span>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>session_b_00</div>
@@ -39983,7 +39916,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874717Z'>2025-07-03 15:54:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -40037,7 +39969,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874907Z'>2025-07-03 15:50:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_001</div>
@@ -40070,7 +40001,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 25 | Output: 120</span>
-                  
                   
               </div>
           </div>
@@ -40118,7 +40048,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874907Z'>2025-07-03 15:54:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_003</div>
@@ -40150,7 +40079,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:56:07.874907Z'>2025-07-03 15:56:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_004</div>
@@ -40171,7 +40099,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:58:07.874907Z' data-duration='took 2m 0s'>2025-07-03 15:58:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -40195,7 +40122,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 78 | Output: 95</span>
-                  
                   
               </div>
           </div>
@@ -40236,7 +40162,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:02:07.874907Z'>2025-07-03 16:02:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_007</div>
@@ -40268,7 +40193,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:04:07.874907Z'>2025-07-03 16:04:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_008</div>
@@ -40289,7 +40213,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:06:07.874907Z' data-duration='took 2m 0s'>2025-07-03 16:06:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -40315,7 +40238,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 45 | Output: 110</span>
-                  
                   
               </div>
           </div>
@@ -40351,7 +40273,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:10:07.874907Z'>2025-07-03 16:10:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -46606,7 +46527,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:50:07.874907Z'>2025-07-03 15:50:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_001</div>
@@ -46639,7 +46559,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 25 | Output: 120</span>
-                  
                   
               </div>
           </div>
@@ -46687,7 +46606,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:54:07.874907Z'>2025-07-03 15:54:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_003</div>
@@ -46719,7 +46637,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T15:56:07.874907Z'>2025-07-03 15:56:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_004</div>
@@ -46740,7 +46657,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T15:58:07.874907Z' data-duration='took 2m 0s'>2025-07-03 15:58:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -46764,7 +46680,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 78 | Output: 95</span>
-                  
                   
               </div>
           </div>
@@ -46805,7 +46720,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:02:07.874907Z'>2025-07-03 16:02:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_007</div>
@@ -46837,7 +46751,6 @@
                       <span class='timestamp' data-timestamp='2025-07-03T16:04:07.874907Z'>2025-07-03 16:04:07</span>
                   </div>
                   
-                  
               </div>
           </div>
           <div class='debug-info'>msg_008</div>
@@ -46858,7 +46771,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:06:07.874907Z' data-duration='took 2m 0s'>2025-07-03 16:06:07</span>
                   </div>
-                  
                   
               </div>
           </div>
@@ -46884,7 +46796,6 @@
                   </div>
                   
                   <span class='token-usage'>Input: 45 | Output: 110</span>
-                  
                   
               </div>
           </div>
@@ -46920,7 +46831,6 @@
                   <div class='timestamp-row'>
                       <span class='timestamp' data-timestamp='2025-07-03T16:10:07.874907Z'>2025-07-03 16:10:07</span>
                   </div>
-                  
                   
               </div>
           </div>

--- a/test/__snapshots__/test_snapshot_markdown.ambr
+++ b/test/__snapshots__/test_snapshot_markdown.ambr
@@ -13,7 +13,7 @@
   
   <a id="session-eb000000"></a>
   
-  # 📋 Session `eb000000`
+  # 📋 Session `eb000000` — Model: `claude-opus-4-7`
   
   ## 🤷 User: *Spawn a coverage analysis agent in the background…*
   
@@ -53,6 +53,8 @@
   #### 🔗 Sub-assistant: *Reading the source files now...*
   
   `10:04:00`
+  
+  Model: `claude-opus-4-7`
   
   > Reading the source files now...
   
@@ -114,7 +116,7 @@
   
   <a id="session-test_ses"></a>
   
-  # 📋 Session `test_ses`
+  # 📋 Session `test_ses` — Model: `claude-3-sonnet-20240229`
   
   ## 🤷 User: *Hello Claude!*
   
@@ -255,7 +257,7 @@
   
   <a id="session-ef000000"></a>
   
-  # 📋 Session `ef000000` — Team: `test-coverage`
+  # 📋 Session `ef000000` — Model: `claude-opus-4-7` — Team: `test-coverage`
   
   ## 🤷 User: *Start a test-coverage team and dispatch two…*
   
@@ -323,6 +325,8 @@
   
   `10:02:00`
   
+  Model: `claude-opus-4-7`
+  
   > Starting relay coverage work.
   
   #### 🔗 Sub-assistant: *Relay module coverage is now 96%.*
@@ -358,6 +362,8 @@
   #### 🔗 Sub-assistant: *Starting server coverage work.*
   
   `10:02:00`
+  
+  Model: `claude-opus-4-7`
   
   > Starting server coverage work.
   
@@ -453,7 +459,7 @@
   
   <a id="session-edge_cas"></a>
   
-  # 📋 Session `edge_cas`: Tested various edge cases including markdown formatting, long text, tool errors, system messages, command outputs, special characters and emojis. All message types render correctly in the transcript viewer.
+  # 📋 Session `edge_cas`: Tested various edge cases including markdown formatting, long text, tool errors, system messages, command outputs, special characters and emojis. All message types render correctly in the transcript viewer. — Model: `claude-3-sonnet-20240229`
   
   ## 🤷 User: *Here's a message with some \*\*markdown\*\* formatting…*
   
@@ -585,7 +591,7 @@
   
   <a id="session-todowrit"></a>
   
-  # 📋 Session `todowrit`
+  # 📋 Session `todowrit` — Model: `claude-sonnet-4`
   
   ## TodoWrite
   
@@ -638,7 +644,7 @@
   
   <a id="session-session_"></a>
   
-  # 📋 Session `session_`
+  # 📋 Session `session_` — Model: `claude-3-sonnet-20240229`
   
   ## 🤷 User: *This is from a different session file to…*
   
@@ -660,7 +666,7 @@
   
   <a id="session-test_ses"></a>
   
-  # 📋 Session `test_ses`: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator.
+  # 📋 Session `test_ses`: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. — Model: `claude-3-sonnet-20240229`
   
   ## 🤷 User: *Hello Claude!*
   
@@ -801,7 +807,7 @@
   
   <a id="session-test_ses"></a>
   
-  # 📋 Session `test_ses`: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator.
+  # 📋 Session `test_ses`: User learned about Python decorators, including basic decorators and parameterized decorators. Created and ran examples showing how decorators work with functions. User is now ready to implement their own timing decorator. — Model: `claude-3-sonnet-20240229`
   
   ## 🤷 User: *Hello Claude!*
   

--- a/test/__snapshots__/test_snapshot_markdown.ambr
+++ b/test/__snapshots__/test_snapshot_markdown.ambr
@@ -21,7 +21,7 @@
   
   Spawn a coverage analysis agent in the background and wait for the result.
   
-  ### 🤖 Task (Explore): *Coverage analysis* *[async `#cccc333`]*
+  ### 🤖 Task (Explore): *Coverage analysis* *[async `#cccc333`]* · `claude-opus-4-7`
   
   `10:02:00`
   
@@ -53,8 +53,6 @@
   #### 🔗 Sub-assistant: *Reading the source files now...*
   
   `10:04:00`
-  
-  Model: `claude-opus-4-7`
   
   > Reading the source files now...
   
@@ -305,7 +303,7 @@
   
   ✓ Updated `#1` — `owner`, `status`
   
-  ### 🤖 Task (general-purpose): *Run alice's test work*
+  ### 🤖 Task (general-purpose): *Run alice's test work* · `claude-opus-4-7`
   
   `10:10:00`
   
@@ -325,8 +323,6 @@
   
   `10:02:00`
   
-  Model: `claude-opus-4-7`
-  
   > Starting relay coverage work.
   
   #### 🔗 Sub-assistant: *Relay module coverage is now 96%.*
@@ -335,7 +331,7 @@
   
   > Relay module coverage is now 96%.
   
-  ### 🤖 Task (general-purpose): *Run bob's test work*
+  ### 🤖 Task (general-purpose): *Run bob's test work* · `claude-opus-4-7`
   
   `10:12:00`
   
@@ -362,8 +358,6 @@
   #### 🔗 Sub-assistant: *Starting server coverage work.*
   
   `10:02:00`
-  
-  Model: `claude-opus-4-7`
   
   > Starting server coverage work.
   

--- a/test/test_nested_agents.py
+++ b/test/test_nested_agents.py
@@ -262,6 +262,49 @@ class TestNestedVisualLayer:
         # The collapsed marker renders.
         assert "≡ full transcript" in html
 
+    def test_model_surfaced_once_per_subagent(self) -> None:
+        """Issue #246: each sub-agent's model id is marked for display on
+        exactly one of its messages (its first), not on every message."""
+        from collections import Counter
+
+        msgs = self._ctx_messages()
+        sub = [m for m in msgs if m.display_model and m.meta.is_sidechain]
+        per_agent = Counter(m.meta.agent_id for m in sub)
+        # Every sub-agent surfaces its model once, never twice.
+        assert set(per_agent) == set(ALL_AGENTS)
+        assert all(count == 1 for count in per_agent.values())
+        # The fixture's sub-agents all run on haiku.
+        assert all(m.display_model == "claude-haiku-4-5-20251001" for m in sub)
+
+    def test_trunk_model_surfaced_only_on_session_header(self) -> None:
+        """Issue #246: the trunk/main model shows on the session header, and
+        no trunk body message carries the pill."""
+        msgs = self._ctx_messages()
+        headers = [m for m in msgs if m.display_model and m.is_session_header]
+        assert len(headers) == 1
+        assert headers[0].display_model == "claude-haiku-4-5-20251001"
+        trunk_body = [
+            m
+            for m in msgs
+            if m.display_model and not m.meta.is_sidechain and not m.is_session_header
+        ]
+        assert trunk_body == []
+
+    def test_model_renders_in_html_and_markdown(self) -> None:
+        from claude_code_log.html.renderer import generate_html
+        from claude_code_log.markdown.renderer import MarkdownRenderer
+
+        entries = _load_integrated()
+        html = generate_html(entries, "model")
+        assert "class='message-model'" in html
+        assert "claude-haiku-4-5-20251001" in html
+
+        md = MarkdownRenderer().generate(entries, "model")
+        # First message of a sub-agent gets a standalone model line.
+        assert "Model: `claude-haiku-4-5-20251001`" in md
+        # The session header carries the main model inline on its heading.
+        assert "— Model: `claude-haiku-4-5-20251001`" in md
+
     def test_new_sidecar_invalidates_cached_trunk(self, tmp_path: Path) -> None:
         """Sidecar inputs are part of the cache key (PR #218 review).
 

--- a/test/test_nested_agents.py
+++ b/test/test_nested_agents.py
@@ -262,19 +262,24 @@ class TestNestedVisualLayer:
         # The collapsed marker renders.
         assert "≡ full transcript" in html
 
-    def test_model_surfaced_once_per_subagent(self) -> None:
-        """Issue #246: each sub-agent's model id is marked for display on
-        exactly one of its messages (its first), not on every message."""
-        from collections import Counter
+    def test_model_surfaced_on_spawn_cards(self) -> None:
+        """Issue #246: a sub-agent's model is stamped on its spawn card (the
+        Task/Agent tool_use that opens it) so it stays visible when the
+        sub-agent transcript is folded — never on the sub-agent's own body
+        messages. The only other carrier is the session header (trunk model)."""
+        from claude_code_log.models import ToolUseMessage
 
         msgs = self._ctx_messages()
-        sub = [m for m in msgs if m.display_model and m.meta.is_sidechain]
-        per_agent = Counter(m.meta.agent_id for m in sub)
-        # Every sub-agent surfaces its model once, never twice.
-        assert set(per_agent) == set(ALL_AGENTS)
-        assert all(count == 1 for count in per_agent.values())
+        pill_bearers = [m for m in msgs if m.display_model]
+        # Every pill lives on a spawn card (tool_use) or the session header.
+        assert all(
+            isinstance(m.content, ToolUseMessage) or m.is_session_header
+            for m in pill_bearers
+        )
+        spawn_pills = [m for m in pill_bearers if isinstance(m.content, ToolUseMessage)]
+        assert spawn_pills, "sub-agent spawns should carry the model"
         # The fixture's sub-agents all run on haiku.
-        assert all(m.display_model == "claude-haiku-4-5-20251001" for m in sub)
+        assert all(m.display_model == "claude-haiku-4-5-20251001" for m in spawn_pills)
 
     def test_trunk_model_surfaced_only_on_session_header(self) -> None:
         """Issue #246: the trunk/main model shows on the session header, and
@@ -288,7 +293,10 @@ class TestNestedVisualLayer:
             for m in msgs
             if m.display_model and not m.meta.is_sidechain and not m.is_session_header
         ]
-        assert trunk_body == []
+        # Trunk-level spawn cards are the only non-header trunk carriers.
+        from claude_code_log.models import ToolUseMessage
+
+        assert all(isinstance(m.content, ToolUseMessage) for m in trunk_body)
 
     def test_model_renders_in_html_and_markdown(self) -> None:
         from claude_code_log.html.renderer import generate_html
@@ -296,25 +304,27 @@ class TestNestedVisualLayer:
 
         entries = _load_integrated()
         html = generate_html(entries, "model")
-        assert "class='message-model'" in html
+        # Spawn-card model badge (visible even when the sub-agent is folded).
+        assert "title='Model this sub-agent ran on'" in html
         assert "claude-haiku-4-5-20251001" in html
 
         md = MarkdownRenderer().generate(entries, "model")
-        # First message of a sub-agent gets a standalone model line.
-        assert "Model: `claude-haiku-4-5-20251001`" in md
+        # Spawn card (Task title) carries the model inline.
+        assert "· `claude-haiku-4-5-20251001`" in md
         # The session header carries the main model inline on its heading.
         assert "— Model: `claude-haiku-4-5-20251001`" in md
 
     def test_model_attribution_distinguishes_trunk_from_subagents(self) -> None:
         """Issue #246's raison d'être: trunk and sub-agents can run on
         DIFFERENT models. The fixture runs everything on haiku, so the
-        once-per-context tests above can't tell correct attribution from
-        cross-contamination. Retarget only the trunk's assistant entries to
-        a distinct model and pin that the session header shows IT while each
-        sub-agent keeps its own — no leakage either way (monk #3959)."""
+        placement tests above can't tell correct attribution from cross-
+        contamination. Retarget only the trunk's assistant entries to a
+        distinct model and pin that the session header shows IT while each
+        spawn card shows its sub-agent's model — no leakage either way
+        (monk #3959)."""
         from claude_code_log.html.renderer import generate_html
         from claude_code_log.markdown.renderer import MarkdownRenderer
-        from claude_code_log.models import AssistantTranscriptEntry
+        from claude_code_log.models import AssistantTranscriptEntry, ToolUseMessage
 
         trunk_model = "claude-opus-4-8"
         sub_model = "claude-haiku-4-5-20251001"
@@ -332,9 +342,11 @@ class TestNestedVisualLayer:
             m.display_model for m in msgs if m.display_model and m.is_session_header
         ]
         assert headers == [trunk_model], "trunk model must land on the session header"
-        subs = [m for m in msgs if m.display_model and m.meta.is_sidechain]
-        assert subs and all(m.display_model == sub_model for m in subs), (
-            "sub-agents must keep their own model, not inherit the trunk's"
+        spawn_pills = [
+            m for m in msgs if m.display_model and isinstance(m.content, ToolUseMessage)
+        ]
+        assert spawn_pills and all(m.display_model == sub_model for m in spawn_pills), (
+            "spawn cards must show their sub-agent's model, not the trunk's"
         )
 
         # Both renderers attribute correctly end-to-end.
@@ -342,9 +354,9 @@ class TestNestedVisualLayer:
         assert trunk_model in html and sub_model in html
         md = MarkdownRenderer().generate(entries, "diff")
         assert f"— Model: `{trunk_model}`" in md  # session header only
-        assert f"Model: `{sub_model}`" in md  # a sub-agent
-        # The trunk model never appears as a standalone sub-agent Model line.
-        assert f"\nModel: `{trunk_model}`" not in md
+        assert f"· `{sub_model}`" in md  # a spawn card
+        # The trunk model never appears as a spawn-card model suffix.
+        assert f"· `{trunk_model}`" not in md
 
     def test_sidechain_without_agent_id_never_leaks_into_header(self) -> None:
         """A sidechain message lacking an agent_id stays unattributed — it

--- a/test/test_nested_agents.py
+++ b/test/test_nested_agents.py
@@ -358,6 +358,41 @@ class TestNestedVisualLayer:
         # The trunk model never appears as a spawn-card model suffix.
         assert f"· `{trunk_model}`" not in md
 
+    def test_each_spawn_card_shows_its_own_subagents_model(self) -> None:
+        """Issue #246: with the all-haiku fixture, the placement tests can't
+        catch a spawn card resolving to the WRONG sub-agent (parent/child
+        collapse in the nested chain, or an async-fallback mixup). Give every
+        sub-agent a distinct model and pin the bijection: each spawn card
+        carries exactly its own spawned child's model — no duplicates, no
+        leakage — including the 3-deep chain (monk #3990)."""
+        from claude_code_log.models import AssistantTranscriptEntry, ToolUseMessage
+
+        entries = _load_integrated()
+        for entry in entries:
+            if (
+                isinstance(entry, AssistantTranscriptEntry)
+                and entry.isSidechain
+                and entry.agentId
+            ):
+                entry.message.model = f"model-{entry.agentId}"
+
+        _roots, _nav, ctx = generate_template_messages(entries)
+        msgs = [m for m in ctx.messages if m is not None]
+        spawn_models = [
+            m.display_model
+            for m in msgs
+            if m.display_model and isinstance(m.content, ToolUseMessage)
+        ]
+        # Bijection: one distinct model per spawn card, each its own sub-agent's.
+        assert len(spawn_models) == len(set(spawn_models)), (
+            "a spawn card reused another agent's model (parent/child collapse)"
+        )
+        assert set(spawn_models) == {f"model-{agent}" for agent in ALL_AGENTS}
+        # The nested chain must each carry their OWN distinct model.
+        assert {f"model-{CHAIN1}", f"model-{CHAIN2}", f"model-{CHAIN3}"} <= set(
+            spawn_models
+        )
+
     def test_sidechain_without_agent_id_never_leaks_into_header(self) -> None:
         """A sidechain message lacking an agent_id stays unattributed — it
         must not fall through and overwrite the session header's trunk model

--- a/test/test_nested_agents.py
+++ b/test/test_nested_agents.py
@@ -346,6 +346,38 @@ class TestNestedVisualLayer:
         # The trunk model never appears as a standalone sub-agent Model line.
         assert f"\nModel: `{trunk_model}`" not in md
 
+    def test_sidechain_without_agent_id_never_leaks_into_header(self) -> None:
+        """A sidechain message lacking an agent_id stays unattributed — it
+        must not fall through and overwrite the session header's trunk model
+        (CodeRabbit, PR #252). Registered BEFORE the trunk message so the old
+        ``else`` fall-through would have set the header to the rogue model."""
+        from claude_code_log.models import MessageMeta, SystemMessage
+        from claude_code_log.renderer import (
+            RenderingContext,
+            _surface_agent_models,
+        )
+
+        def _sys(uuid: str, **meta_kwargs: object) -> TemplateMessage:
+            meta = MessageMeta(session_id="s", timestamp="t", uuid=uuid, **meta_kwargs)  # type: ignore[arg-type]
+            return TemplateMessage(SystemMessage(meta=meta, level="info", text=""))
+
+        ctx = RenderingContext()
+        header = _sys("h")
+        ctx.session_first_message["s"] = ctx.register(header)
+        # Rogue sidechain entry: is_sidechain but no agent_id, distinct model.
+        rogue = _sys(
+            "r", is_sidechain=True, agent_id=None, model="claude-haiku-4-5-20251001"
+        )
+        ctx.register(rogue)
+        # Real trunk model, registered after the rogue.
+        trunk = _sys("a", model="claude-opus-4-8")
+        ctx.register(trunk)
+
+        _surface_agent_models(ctx)
+
+        assert header.display_model == "claude-opus-4-8"
+        assert rogue.display_model is None
+
     def test_new_sidecar_invalidates_cached_trunk(self, tmp_path: Path) -> None:
         """Sidecar inputs are part of the cache key (PR #218 review).
 

--- a/test/test_nested_agents.py
+++ b/test/test_nested_agents.py
@@ -305,6 +305,47 @@ class TestNestedVisualLayer:
         # The session header carries the main model inline on its heading.
         assert "— Model: `claude-haiku-4-5-20251001`" in md
 
+    def test_model_attribution_distinguishes_trunk_from_subagents(self) -> None:
+        """Issue #246's raison d'être: trunk and sub-agents can run on
+        DIFFERENT models. The fixture runs everything on haiku, so the
+        once-per-context tests above can't tell correct attribution from
+        cross-contamination. Retarget only the trunk's assistant entries to
+        a distinct model and pin that the session header shows IT while each
+        sub-agent keeps its own — no leakage either way (monk #3959)."""
+        from claude_code_log.html.renderer import generate_html
+        from claude_code_log.markdown.renderer import MarkdownRenderer
+        from claude_code_log.models import AssistantTranscriptEntry
+
+        trunk_model = "claude-opus-4-8"
+        sub_model = "claude-haiku-4-5-20251001"
+        entries = _load_integrated()
+        retargeted = 0
+        for entry in entries:
+            if isinstance(entry, AssistantTranscriptEntry) and not entry.isSidechain:
+                entry.message.model = trunk_model
+                retargeted += 1
+        assert retargeted, "fixture should carry trunk assistant entries"
+
+        _roots, _nav, ctx = generate_template_messages(entries)
+        msgs = [m for m in ctx.messages if m is not None]
+        headers = [
+            m.display_model for m in msgs if m.display_model and m.is_session_header
+        ]
+        assert headers == [trunk_model], "trunk model must land on the session header"
+        subs = [m for m in msgs if m.display_model and m.meta.is_sidechain]
+        assert subs and all(m.display_model == sub_model for m in subs), (
+            "sub-agents must keep their own model, not inherit the trunk's"
+        )
+
+        # Both renderers attribute correctly end-to-end.
+        html = generate_html(entries, "diff")
+        assert trunk_model in html and sub_model in html
+        md = MarkdownRenderer().generate(entries, "diff")
+        assert f"— Model: `{trunk_model}`" in md  # session header only
+        assert f"Model: `{sub_model}`" in md  # a sub-agent
+        # The trunk model never appears as a standalone sub-agent Model line.
+        assert f"\nModel: `{trunk_model}`" not in md
+
     def test_new_sidecar_invalidates_cached_trunk(self, tmp_path: Path) -> None:
         """Sidecar inputs are part of the cache key (PR #218 review).
 


### PR DESCRIPTION
Closes #246.

Sub-agent transcripts can run on a **different model** than the trunk — e.g. a workflow fans out `haiku` agents under an `opus` main, or a `Task(model="sonnet")` spawn. This surfaces the model id each agent ran on so a reader can see it at a glance, **once per agent context** rather than repeated on every message:

- the **session header** carries the trunk/main model (from the first non-sidechain assistant entry);
- the **first message of each sub-agent** carries that sub-agent's model.

A mid-course `/model` switch already shows as its own command message, so a single first-seen value per context is enough.

### How it looks

- **HTML** — a muted mono `.message-model` pill in the message header (beside the timestamp) and inline on the session-header line, mirroring the existing `workflow-agent-model` style.
- **Markdown** — a `Model: ` `` `…` `` line per sub-agent and an inline `— Model:` suffix on the session heading.

### Plumbing

`AssistantMessageModel.model` → `MessageMeta.model` (set in the meta factory, guarded to assistant entries) → `TemplateMessage.display_model`, the render-once decision made by the new `_surface_agent_models` pass at the end of `_render_messages` (keys sub-agents by `agent_id`, the trunk by `session_id` → its session header; guards ghosted `None` slots).

The model id is transcript-derived (attacker-controllable via a crafted transcript, post-#245), so both sinks neutralise it: HTML autoescapes via Jinja (no `|safe`), Markdown fences it via `_inline_code`.

### Tests

`test/test_nested_agents.py` (`TestNestedVisualLayer`): once-per-sub-agent marking, trunk-model-on-session-header-only, HTML+Markdown rendering, and — pinning #246's core promise — a **distinct-model** case (retarget the trunk to `opus`, sub-agents stay `haiku`) asserting correct per-context attribution with no cross-contamination.

`dev-docs/agents.md` §5.4 documents the new annotation. `just ci` green (incl. tui+browser); snapshots updated.

Reviewed by `monk` (approved; 3 watch-points + XSS verified). Design driven in-session by @daaain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Model id” badges across session headers and sub-agent spawn/task cards in both HTML and Markdown.
  * Model display is rendered once per agent context (trunk model on the session header; sub-agent model on spawn/task entries).

* **Bug Fixes**
  * Improved model attribution so trunk and sub-agent models don’t duplicate or leak into the wrong parts of the nested-agent view.

* **Documentation**
  * Updated nested-agent visuals documentation with the new “Model id” annotation and render-once behavior.

* **Tests**
  * Expanded nested-agent coverage and refreshed HTML/Markdown snapshots for model badge rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->