### PR TITLE
Regenerate single-file output when its source grows; fix success-message accuracy (#221 follow-up)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1346,15 +1346,25 @@ def main(
             click.echo(f"Successfully converted {input_path} to {output_path}")
         else:
             jsonl_count = len(list(input_path.glob("*.jsonl")))
+            session_suffix = ""
             if write_individual:
                 ext = get_file_extension(output_format)
                 session_files = list(input_path.glob(f"session-*.{ext}"))
+                session_suffix = (
+                    f" and generated {len(session_files)} individual session files"
+                )
+            if write_combined:
                 click.echo(
-                    f"Successfully combined {jsonl_count} transcript files from {input_path} to {output_path} and generated {len(session_files)} individual session files"
+                    f"Successfully combined {jsonl_count} transcript files "
+                    f"from {input_path} to {output_path}{session_suffix}"
                 )
             else:
+                # `--combined no`: only per-session files were written. Don't
+                # claim to have "combined" anything, nor name a combined file
+                # that wasn't produced — report the per-session work instead.
                 click.echo(
-                    f"Successfully combined {jsonl_count} transcript files from {input_path} to {output_path}"
+                    f"Successfully processed {jsonl_count} transcript files "
+                    f"from {input_path}{session_suffix}"
                 )
 
         if open_browser:

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1332,12 +1332,17 @@ def main(
             force_regenerate=output is not None and _output_path_is_file(output),
             regenerated=regenerated,
         )
-        # On a skip the converter already printed "is current, skipping
-        # regeneration"; suppress the redundant/misleading success line.
-        was_regenerated = regenerated != [False]
-        if input_path.is_file():
-            if was_regenerated:
-                click.echo(f"Successfully converted {input_path} to {output_path}")
+        # On a skip the converter already printed its "... is current,
+        # skipping regeneration" line (single-file and directory paths alike),
+        # so suppress the redundant/misleading success line for BOTH. The
+        # `regenerated` out-param carries exactly one bool from
+        # convert_jsonl_to (it tracks the combined-output write; a directory
+        # whose combined is current early-exits / skips, reporting False).
+        was_regenerated = any(regenerated)
+        if not was_regenerated:
+            pass
+        elif input_path.is_file():
+            click.echo(f"Successfully converted {input_path} to {output_path}")
         else:
             jsonl_count = len(list(input_path.glob("*.jsonl")))
             if write_individual:

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1332,12 +1332,13 @@ def main(
             force_regenerate=output is not None and _output_path_is_file(output),
             regenerated=regenerated,
         )
-        # On a skip the converter already printed its "... is current,
+        # On a pure skip the converter already printed its "... is current,
         # skipping regeneration" line (single-file and directory paths alike),
         # so suppress the redundant/misleading success line for BOTH. The
         # `regenerated` out-param carries exactly one bool from
-        # convert_jsonl_to (it tracks the combined-output write; a directory
-        # whose combined is current early-exits / skips, reporting False).
+        # convert_jsonl_to: True if the combined transcript OR any individual
+        # session file was (re)written (so `--combined no`, which writes only
+        # session files, still confirms its work), False when all is current.
         was_regenerated = any(regenerated)
         if not was_regenerated:
             pass

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1299,6 +1299,10 @@ def main(
             )
             return
 
+        # Out-param: convert_jsonl_to appends whether it actually (re)wrote
+        # the combined output, so we don't print "Successfully converted" on
+        # top of its own "is current, skipping regeneration" line on a skip.
+        regenerated: list[bool] = []
         output_path = convert_jsonl_to(
             output_format,
             input_path,
@@ -1326,9 +1330,14 @@ def main(
             # same dir still regenerates), and `--all-projects` calls this
             # with output=None anyway, so its skip is never forced.
             force_regenerate=output is not None and _output_path_is_file(output),
+            regenerated=regenerated,
         )
+        # On a skip the converter already printed "is current, skipping
+        # regeneration"; suppress the redundant/misleading success line.
+        was_regenerated = regenerated != [False]
         if input_path.is_file():
-            click.echo(f"Successfully converted {input_path} to {output_path}")
+            if was_regenerated:
+                click.echo(f"Successfully converted {input_path} to {output_path}")
         else:
             jsonl_count = len(list(input_path.glob("*.jsonl")))
             if write_individual:

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -13,6 +13,7 @@ import click
 from git import Repo, InvalidGitRepositoryError
 
 from .converter import (
+    RegenerationReport,
     convert_jsonl_to,
     convert_jsonl_to_html,
     ensure_fresh_cache,
@@ -1299,10 +1300,12 @@ def main(
             )
             return
 
-        # Out-param: convert_jsonl_to appends whether it actually (re)wrote
-        # the combined output, so we don't print "Successfully converted" on
-        # top of its own "is current, skipping regeneration" line on a skip.
-        regenerated: list[bool] = []
+        # Out-param: convert_jsonl_to reports what it actually (re)wrote —
+        # the combined output and/or how many session files — so we don't
+        # print a success line on top of its own "is current, skipping
+        # regeneration" line, and don't claim to have "combined" anything
+        # when only session files were written.
+        report = RegenerationReport()
         output_path = convert_jsonl_to(
             output_format,
             input_path,
@@ -1330,38 +1333,37 @@ def main(
             # same dir still regenerates), and `--all-projects` calls this
             # with output=None anyway, so its skip is never forced.
             force_regenerate=output is not None and _output_path_is_file(output),
-            regenerated=regenerated,
+            report=report,
         )
-        # On a pure skip the converter already printed its "... is current,
-        # skipping regeneration" line (single-file and directory paths alike),
-        # so suppress the redundant/misleading success line for BOTH. The
-        # `regenerated` out-param carries exactly one bool from
-        # convert_jsonl_to: True if the combined transcript OR any individual
-        # session file was (re)written (so `--combined no`, which writes only
-        # session files, still confirms its work), False when all is current.
-        was_regenerated = any(regenerated)
-        if not was_regenerated:
+        # Report only work actually done this run. On a pure skip the converter
+        # already printed its "... is current, skipping regeneration" line, so
+        # print nothing more. Otherwise gate the wording on WHICH output was
+        # (re)written: "combined" only when the combined transcript itself was,
+        # and the per-session count only for sessions rewritten this run — so
+        # we never claim to have combined something we skipped.
+        combined_written = report.combined_regenerated
+        sessions_written = report.sessions_regenerated
+        if not combined_written and not sessions_written:
             pass
         elif input_path.is_file():
             click.echo(f"Successfully converted {input_path} to {output_path}")
         else:
             jsonl_count = len(list(input_path.glob("*.jsonl")))
-            session_suffix = ""
-            if write_individual:
-                ext = get_file_extension(output_format)
-                session_files = list(input_path.glob(f"session-*.{ext}"))
-                session_suffix = (
-                    f" and generated {len(session_files)} individual session files"
-                )
-            if write_combined:
+            session_suffix = (
+                f" and generated {sessions_written} individual session files"
+                if sessions_written
+                else ""
+            )
+            if combined_written:
                 click.echo(
                     f"Successfully combined {jsonl_count} transcript files "
                     f"from {input_path} to {output_path}{session_suffix}"
                 )
             else:
-                # `--combined no`: only per-session files were written. Don't
-                # claim to have "combined" anything, nor name a combined file
-                # that wasn't produced — report the per-session work instead.
+                # The combined transcript was skipped as current (or never
+                # requested, e.g. `--combined no`); only per-session files were
+                # written. Don't claim to have "combined" anything or name a
+                # combined file that wasn't produced this run.
                 click.echo(
                     f"Successfully processed {jsonl_count} transcript files "
                     f"from {input_path}{session_suffix}"

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1732,11 +1732,14 @@ def convert_jsonl_to(
             transcript was requested — silent stale content. The tool's own
             managed ``combined_transcripts*`` artifacts still use the skip.
         regenerated: Optional out-parameter. When a list is passed, a single
-            bool is appended reporting whether the combined output was
-            actually (re)written (True) or skipped as current (False). Lets
-            the CLI avoid printing a misleading "Successfully converted" line
-            on a skip, without changing the ``Path`` return contract that
-            ~20 callers rely on.
+            bool is appended reporting whether ANY output was actually
+            (re)written — the combined transcript OR at least one individual
+            session file (True) — versus everything being current/skipped
+            (False). Lets the CLI avoid printing a misleading "Successfully
+            converted" line on a pure skip while still confirming per-session
+            work (e.g. ``--combined no``, which never writes a combined),
+            without changing the ``Path`` return contract that ~20 callers
+            rely on.
     """
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {input_path}")
@@ -2022,9 +2025,16 @@ def convert_jsonl_to(
                 f"{format.upper()} file {output_path.name} is current, skipping regeneration"
             )
 
-    # Generate individual session files if requested and in directory mode
+    # Generate individual session files if requested and in directory mode.
+    # Its return count feeds `regenerated` below: per-session output is an
+    # independent axis from the combined write, so a run that rewrites session
+    # files while the combined stays current (or `--combined no`, which never
+    # writes a combined) still counts as work done — otherwise the CLI would
+    # fall silent on it (the combined-only flag is what made `--combined no`
+    # print nothing despite producing every session file).
+    sessions_regenerated = 0
     if generate_individual_sessions and input_path.is_dir():
-        _generate_individual_session_files(
+        sessions_regenerated = _generate_individual_session_files(
             format,
             messages,
             effective_output_dir,
@@ -2043,7 +2053,7 @@ def convert_jsonl_to(
         )
 
     if regenerated is not None:
-        regenerated.append(did_regenerate)
+        regenerated.append(did_regenerate or sessions_regenerated > 0)
 
     return output_path
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1973,6 +1973,15 @@ def convert_jsonl_to(
             # source file is newer than the existing output. Scoped to a file
             # source — a directory source has no single mtime and is handled
             # by the cache branch / `cache_was_updated` above.
+            #
+            # The directory cache persists the *source* mtime in its DB to
+            # detect change; single-file mode has no DB, so the *output* file's
+            # own mtime is the natural, persistence-free basis. It is sufficient
+            # because the output is always written after its source is read, so
+            # `output.mtime >= source.mtime` holds post-write; a later append
+            # bumps the source past it. Both approaches share the same
+            # filesystem-mtime granularity limit (a sub-tick append racing the
+            # prior write resolves on the next run) — no worse than the cache.
             source_is_newer = (
                 input_path.is_file()
                 and output_path.exists()

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1083,6 +1083,21 @@ class GenerationStats:
         return "\n".join(parts)
 
 
+@dataclass
+class RegenerationReport:
+    """What ``convert_jsonl_to`` actually (re)wrote on a call.
+
+    Combined output and per-session files are independent axes, so the CLI
+    needs both to report accurately — e.g. it must not claim to have
+    "combined" anything when only session files were rewritten and the
+    combined transcript was skipped as current. Passed in by the caller and
+    populated in place (the ``Path`` return contract is unchanged).
+    """
+
+    combined_regenerated: bool = False
+    sessions_regenerated: int = 0
+
+
 def _get_page_html_path(page_number: int, variant_suffix: str = "") -> str:
     """Get the HTML filename for a given page number.
 
@@ -1465,7 +1480,7 @@ def _generate_paginated_html(
     detail: DetailLevel = DetailLevel.FULL,
     compact: bool = False,
     no_recaps: bool = False,
-) -> Path:
+) -> tuple[Path, bool]:
     """Generate paginated HTML files for combined transcript.
 
     Args:
@@ -1479,7 +1494,10 @@ def _generate_paginated_html(
         silent: Suppress verbose output
 
     Returns:
-        Path to the first page (combined_transcripts.html)
+        ``(first_page_path, wrote_any)`` — the path to the first page
+        (combined_transcripts.html) and whether at least one page was
+        actually (re)written (False when every page was current/skipped), so
+        the caller can report regeneration accurately.
     """
     from .html.renderer import HtmlRenderer
     from .utils import format_timestamp, variant_suffix as _variant_suffix
@@ -1529,6 +1547,10 @@ def _generate_paginated_html(
             messages_by_session[key].append(msg)
 
     first_page_path = output_dir / _get_page_html_path(1, suffix)
+
+    # Track whether any page was actually (re)written this call — pages that
+    # are current are skipped individually, so a run can write nothing.
+    wrote_any = False
 
     # Generate each page
     for page_num, page_session_ids in enumerate(pages, start=1):
@@ -1641,6 +1663,7 @@ def _generate_paginated_html(
         # encoding crashes here. Replace with U+FFFD so output stays
         # valid UTF-8.
         page_file.write_text(html_content, encoding="utf-8", errors="replace")
+        wrote_any = True
 
         # Update cache
         cache_manager.update_page_cache(
@@ -1658,7 +1681,7 @@ def _generate_paginated_html(
             variant_suffix=suffix,
         )
 
-    return first_page_path
+    return first_page_path, wrote_any
 
 
 def convert_jsonl_to_html(
@@ -1707,7 +1730,7 @@ def convert_jsonl_to(
     no_timestamps: bool = False,
     no_recaps: bool = False,
     force_regenerate: bool = False,
-    regenerated: Optional[list[bool]] = None,
+    report: Optional["RegenerationReport"] = None,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -1731,15 +1754,16 @@ def convert_jsonl_to(
             file at a user-chosen path was kept even when a different
             transcript was requested — silent stale content. The tool's own
             managed ``combined_transcripts*`` artifacts still use the skip.
-        regenerated: Optional out-parameter. When a list is passed, a single
-            bool is appended reporting whether ANY output was actually
-            (re)written — the combined transcript OR at least one individual
-            session file (True) — versus everything being current/skipped
-            (False). Lets the CLI avoid printing a misleading "Successfully
-            converted" line on a pure skip while still confirming per-session
-            work (e.g. ``--combined no``, which never writes a combined),
-            without changing the ``Path`` return contract that ~20 callers
-            rely on.
+        report: Optional out-parameter (a ``RegenerationReport``). When
+            provided, it is populated in place with what was actually
+            (re)written: ``combined_regenerated`` (the combined transcript /
+            paginated pages) and ``sessions_regenerated`` (count of individual
+            session files). Kept separate so the CLI can report accurately —
+            it must gate the word "combined" on ``combined_regenerated`` and
+            not claim to have combined anything when only session files were
+            written (e.g. ``--combined no``, or a current combined alongside a
+            regenerated session). Leaves the ``Path`` return contract (that
+            ~20 callers rely on) unchanged.
     """
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {input_path}")
@@ -1839,8 +1863,7 @@ def convert_jsonl_to(
                             f"All HTML files are current for {input_path.name}, "
                             "skipping regeneration"
                         )
-                    if regenerated is not None:
-                        regenerated.append(False)
+                    # Nothing regenerated: report defaults (False / 0) stand.
                     return output_path
 
         # Phase 2: Load messages (will use fresh cache when available)
@@ -1907,7 +1930,7 @@ def convert_jsonl_to(
     # below. The function still returns `output_path` for the caller's
     # index linking, but the file at that path is not (re-)written.
     # Tracks whether the combined output was actually (re)written this call,
-    # reported via the `regenerated` out-parameter for the CLI's message.
+    # reported via the `report` out-parameter for the CLI's message.
     did_regenerate = False
     if not write_combined:
         pass
@@ -1933,7 +1956,7 @@ def convert_jsonl_to(
             }
         else:
             session_data = _build_session_data_from_messages(messages)
-        output_path = _generate_paginated_html(
+        output_path, did_regenerate = _generate_paginated_html(
             messages,
             effective_output_dir,
             title,
@@ -1947,7 +1970,6 @@ def convert_jsonl_to(
             compact=compact,
             no_recaps=no_recaps,
         )
-        did_regenerate = True
     else:
         # Use single-file generation for small projects or filtered views
         # Use incremental regeneration via html_cache when available
@@ -2026,12 +2048,12 @@ def convert_jsonl_to(
             )
 
     # Generate individual session files if requested and in directory mode.
-    # Its return count feeds `regenerated` below: per-session output is an
+    # Its return count feeds the `report` below: per-session output is an
     # independent axis from the combined write, so a run that rewrites session
     # files while the combined stays current (or `--combined no`, which never
     # writes a combined) still counts as work done — otherwise the CLI would
-    # fall silent on it (the combined-only flag is what made `--combined no`
-    # print nothing despite producing every session file).
+    # fall silent on it. Kept separate from `did_regenerate` so the CLI can
+    # confirm session work without falsely claiming to have "combined".
     sessions_regenerated = 0
     if generate_individual_sessions and input_path.is_dir():
         sessions_regenerated = _generate_individual_session_files(
@@ -2052,8 +2074,9 @@ def convert_jsonl_to(
             no_recaps=no_recaps,
         )
 
-    if regenerated is not None:
-        regenerated.append(did_regenerate or sessions_regenerated > 0)
+    if report is not None:
+        report.combined_regenerated = did_regenerate
+        report.sessions_regenerated = sessions_regenerated
 
     return output_path
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1707,6 +1707,7 @@ def convert_jsonl_to(
     no_timestamps: bool = False,
     no_recaps: bool = False,
     force_regenerate: bool = False,
+    regenerated: Optional[list[bool]] = None,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -1730,6 +1731,12 @@ def convert_jsonl_to(
             file at a user-chosen path was kept even when a different
             transcript was requested — silent stale content. The tool's own
             managed ``combined_transcripts*`` artifacts still use the skip.
+        regenerated: Optional out-parameter. When a list is passed, a single
+            bool is appended reporting whether the combined output was
+            actually (re)written (True) or skipped as current (False). Lets
+            the CLI avoid printing a misleading "Successfully converted" line
+            on a skip, without changing the ``Path`` return contract that
+            ~20 callers rely on.
     """
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {input_path}")
@@ -1829,6 +1836,8 @@ def convert_jsonl_to(
                             f"All HTML files are current for {input_path.name}, "
                             "skipping regeneration"
                         )
+                    if regenerated is not None:
+                        regenerated.append(False)
                     return output_path
 
         # Phase 2: Load messages (will use fresh cache when available)
@@ -1894,6 +1903,9 @@ def convert_jsonl_to(
     # requested) are still produced by `_generate_individual_session_files`
     # below. The function still returns `output_path` for the caller's
     # index linking, but the file at that path is not (re-)written.
+    # Tracks whether the combined output was actually (re)written this call,
+    # reported via the `regenerated` out-parameter for the CLI's message.
+    did_regenerate = False
     if not write_combined:
         pass
     elif use_pagination:
@@ -1932,6 +1944,7 @@ def convert_jsonl_to(
             compact=compact,
             no_recaps=no_recaps,
         )
+        did_regenerate = True
     else:
         # Use single-file generation for small projects or filtered views
         # Use incremental regeneration via html_cache when available
@@ -1949,16 +1962,33 @@ def convert_jsonl_to(
                 or not output_path.exists()
             )
         else:
-            # Fallback: old logic for single file mode or no cache
+            # Fallback: old logic for single file mode or no cache.
+            #
+            # is_outdated() only compares the embedded tool version, not the
+            # source's freshness, so a single .jsonl that grows between runs
+            # (e.g. an in-progress session re-exported with the same tool
+            # version) would be wrongly skipped as "current" and serve stale
+            # HTML (issue #221 follow-up). Mirror the directory path's
+            # source-tracking intent with an mtime check: regenerate when the
+            # source file is newer than the existing output. Scoped to a file
+            # source — a directory source has no single mtime and is handled
+            # by the cache branch / `cache_was_updated` above.
+            source_is_newer = (
+                input_path.is_file()
+                and output_path.exists()
+                and input_path.stat().st_mtime > output_path.stat().st_mtime
+            )
             should_regenerate = (
                 force_regenerate
                 or renderer.is_outdated(output_path)
+                or source_is_newer
                 or from_date is not None
                 or to_date is not None
                 or not output_path.exists()
                 or (input_path.is_dir() and cache_was_updated)
             )
 
+        did_regenerate = should_regenerate
         if should_regenerate:
             # For referenced images, pass the output directory
             output_dir = output_path.parent
@@ -2002,6 +2032,9 @@ def convert_jsonl_to(
             no_timestamps=no_timestamps,
             no_recaps=no_recaps,
         )
+
+    if regenerated is not None:
+        regenerated.append(did_regenerate)
 
     return output_path
 

--- a/test/test_html_regeneration.py
+++ b/test/test_html_regeneration.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for HTML regeneration when JSONL files change."""
 
+import os
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -332,10 +333,13 @@ class TestHtmlRegeneration:
         # (e.g. an in-progress session) MUST regenerate — the output is now
         # older than its source (issue #221 follow-up). Previously single
         # file mode wrongly skipped on the version marker alone.
-        time.sleep(0.1)
         new_message = '{"type":"user","timestamp":"2025-07-03T16:40:00Z","parentUuid":null,"isSidechain":false,"userType":"human","cwd":"/tmp","sessionId":"test_session","version":"1.0.0","uuid":"single_file_msg","message":{"role":"user","content":[{"type":"text","text":"Single file mode test."}]}}\n'
         with open(jsonl_file, "a", encoding="utf-8") as f:
             f.write(new_message)
+        # The regeneration hinges on source.mtime > output.mtime; a wall-clock
+        # sleep is unreliable on coarse-granularity filesystems, so force the
+        # source strictly newer than the output rather than racing the clock.
+        os.utime(jsonl_file, (original_mtime + 2, original_mtime + 2))
 
         with patch("builtins.print") as mock_print:
             convert_jsonl_to_html(jsonl_file)

--- a/test/test_html_regeneration.py
+++ b/test/test_html_regeneration.py
@@ -300,7 +300,8 @@ class TestHtmlRegeneration:
         assert "This should force regeneration despite same version" in new_content
 
     def test_single_file_mode_regeneration_behavior(self, tmp_path):
-        """Test that single file mode doesn't use cache but still respects version checks."""
+        """Single file mode has no cache: it skips on an unchanged source
+        (version marker current) but regenerates when the source is newer."""
         # Setup: Create a single JSONL file
         test_data_dir = Path(__file__).parent / "test_data"
         jsonl_file = tmp_path / "single_test.jsonl"
@@ -327,21 +328,28 @@ class TestHtmlRegeneration:
         # Verify file wasn't regenerated (same mtime)
         assert output_file.stat().st_mtime == original_mtime
 
-        # Modify file - should NOT auto-regenerate in single file mode because there's no cache
+        # Modify the source: even without a cache, a single file that grows
+        # (e.g. an in-progress session) MUST regenerate — the output is now
+        # older than its source (issue #221 follow-up). Previously single
+        # file mode wrongly skipped on the version marker alone.
         time.sleep(0.1)
         new_message = '{"type":"user","timestamp":"2025-07-03T16:40:00Z","parentUuid":null,"isSidechain":false,"userType":"human","cwd":"/tmp","sessionId":"test_session","version":"1.0.0","uuid":"single_file_msg","message":{"role":"user","content":[{"type":"text","text":"Single file mode test."}]}}\n'
         with open(jsonl_file, "a", encoding="utf-8") as f:
             f.write(new_message)
 
-        # Single file mode doesn't have cache, so it should still skip based on version
         with patch("builtins.print") as mock_print:
             convert_jsonl_to_html(jsonl_file)
-            mock_print.assert_any_call(
-                "HTML file single_test.html is current, skipping regeneration"
-            )
+            # No "skipping" line: it regenerated because the source is newer.
+            skip_calls = [
+                c
+                for c in mock_print.call_args_list
+                if c.args and "skipping regeneration" in str(c.args[0])
+            ]
+            assert not skip_calls, f"unexpected skip after source grew: {skip_calls}"
 
-        # Verify file wasn't regenerated (this is expected behavior for single file mode)
-        assert output_file.stat().st_mtime == original_mtime
+        # The output was rewritten (newer mtime) and now contains the new message.
+        assert output_file.stat().st_mtime > original_mtime
+        assert "Single file mode test." in output_file.read_text(encoding="utf-8")
 
 
 class TestIncrementalHtmlCache:

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -205,5 +205,53 @@ class TestIsOutdatedNonRegularFileGuard:
         assert MarkdownRenderer().is_outdated(missing) is True
 
 
+class TestSingleFileStaleness:
+    """#221 follow-up: the *default* single-file output (no ``-o``, detail-
+    suffixed naming) rides the version-only skip, so a source that grows
+    between runs was wrongly kept stale. And a genuine skip printed BOTH the
+    converter's "is current, skipping" line and the CLI's "Successfully
+    converted" line. These pin the fixes for the exact CLI repro:
+    ``claude-code-log <file>.jsonl --detail low`` run, grow source, re-run."""
+
+    def test_grown_source_regenerates(self, tmp_path: Path):
+        src = _write_jsonl(tmp_path / "session.jsonl", "FIRST_turn_marker")
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(src), "--detail", "low"])
+        assert r1.exit_code == 0, r1.output
+        out = next(tmp_path.glob("*.low.html"))
+        assert "FIRST_turn_marker" in out.read_text(encoding="utf-8")
+        out_mtime = out.stat().st_mtime
+
+        # Source progresses (a real append, not a synthetic mtime bump), then
+        # forced strictly newer than the output so the check is robust on
+        # coarse-granularity filesystems.
+        with open(src, "a", encoding="utf-8") as f:
+            f.write(json.dumps(_user_entry("SECOND_turn_marker")) + "\n")
+        os.utime(src, (out_mtime + 2, out_mtime + 2))
+
+        r2 = runner.invoke(main, [str(src), "--detail", "low"])
+        assert r2.exit_code == 0, r2.output
+        assert "skipping regeneration" not in r2.output
+        second = out.read_text(encoding="utf-8")
+        assert "SECOND_turn_marker" in second, "stale HTML served after source grew"
+        assert out.stat().st_mtime > out_mtime
+
+    def test_unchanged_source_skips_without_success_line(self, tmp_path: Path):
+        src = _write_jsonl(tmp_path / "session.jsonl", "ONLY_turn_marker")
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(src), "--detail", "low"])
+        assert r1.exit_code == 0, r1.output
+        assert "Successfully converted" in r1.output
+
+        # Re-run with the source untouched: skip announced exactly once, and
+        # NOT also "Successfully converted" (the misleading double message).
+        r2 = runner.invoke(main, [str(src), "--detail", "low"])
+        assert r2.exit_code == 0, r2.output
+        assert "skipping regeneration" in r2.output
+        assert "Successfully converted" not in r2.output
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -289,6 +289,10 @@ class TestSingleFileStaleness:
         assert "individual session files" in r1.output, (
             f"--combined no produced no confirmation; output was:\n{r1.output}"
         )
+        # ...and it does NOT claim to have "combined" anything (no combined
+        # file is written under --combined no); it reports "processed" instead.
+        assert "Successfully processed" in r1.output
+        assert "Successfully combined" not in r1.output
 
 
 if __name__ == "__main__":

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -270,6 +270,26 @@ class TestSingleFileStaleness:
         assert "skipping regeneration" in r2.output
         assert "Successfully combined" not in r2.output
 
+    def test_combined_no_confirms_session_generation(self, tmp_path: Path):
+        """`--combined no` writes only per-session files (no combined). The
+        success line is gated on regeneration, and that gate must count
+        per-session output too — otherwise the run falls completely silent
+        despite writing every session file. Regression guard: the first
+        version of the skip-suppression tracked only the combined write."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_jsonl(proj / "aaaaaaaa.jsonl", "SESSION_A_marker")
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(proj), "--combined", "no"])
+        assert r1.exit_code == 0, r1.output
+        # Per-session files were produced...
+        assert list(proj.glob("session-*.html")), "no session files written"
+        # ...and the run confirms that work rather than printing nothing.
+        assert "individual session files" in r1.output, (
+            f"--combined no produced no confirmation; output was:\n{r1.output}"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -252,6 +252,24 @@ class TestSingleFileStaleness:
         assert "skipping regeneration" in r2.output
         assert "Successfully converted" not in r2.output
 
+    def test_directory_skip_suppresses_success_line(self, tmp_path: Path):
+        """Directory symmetry: a no-op directory re-run early-exits with a
+        skip line and must NOT also print 'Successfully combined ...' (the
+        same double-message fix applied to the directory branch)."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_jsonl(proj / "s.jsonl", "DIR_turn_marker")
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(proj)])
+        assert r1.exit_code == 0, r1.output
+        assert "Successfully combined" in r1.output
+
+        r2 = runner.invoke(main, [str(proj)])
+        assert r2.exit_code == 0, r2.output
+        assert "skipping regeneration" in r2.output
+        assert "Successfully combined" not in r2.output
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -294,6 +294,43 @@ class TestSingleFileStaleness:
         assert "Successfully processed" in r1.output
         assert "Successfully combined" not in r1.output
 
+    def test_combined_current_but_session_regenerated_says_processed(
+        self, tmp_path: Path
+    ):
+        """When the combined transcript is current but a session file is
+        regenerated (e.g. a deleted session HTML), the CLI must NOT claim
+        'Successfully combined … to combined_transcripts.html' — the combined
+        was skipped. It should report the per-session work as 'processed'
+        instead, so it never contradicts the converter's 'combined … is
+        current, skipping regeneration' line. The combined-write and
+        session-write signals are tracked separately for exactly this."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_jsonl(proj / "aaaaaaaa.jsonl", "SESSION_A_marker")
+        runner = CliRunner()
+
+        r1 = runner.invoke(main, [str(proj)])  # default --combined yes: full run
+        assert r1.exit_code == 0, r1.output
+        assert "Successfully combined" in r1.output
+        session_htmls = list(proj.glob("session-*.html"))
+        assert session_htmls, "no session HTML produced on first run"
+        session_html = session_htmls[0]
+
+        # Remove just the session HTML; the combined stays current.
+        session_html.unlink()
+        r2 = runner.invoke(main, [str(proj)])
+        assert r2.exit_code == 0, r2.output
+        # The session was regenerated...
+        assert session_html.exists(), "session HTML not regenerated"
+        assert "individual session files" in r2.output
+        # ...the combined was skipped (converter says so)...
+        assert "skipping regeneration" in r2.output
+        # ...and the CLI does NOT falsely claim to have combined it.
+        assert "Successfully combined" not in r2.output, (
+            f"claimed 'combined' when combined was skipped; output:\n{r2.output}"
+        )
+        assert "Successfully processed" in r2.output
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Follow-up to #221/#237. Two user-visible staleness/messaging bugs in the
default single-file conversion path, plus message-accuracy fixes surfaced
while reviewing the change.

### Bug 1 — stale HTML on a grown single-file source
`claude-code-log <file>.jsonl [--detail low]` writes `<file>[.low].html`, then
re-runs were skipped purely on the embedded **tool version**
(`renderer.is_outdated`), which ignores source freshness. So an in-progress
session that grew between runs was wrongly reported "current" and served stale
HTML. #237 only forced regeneration for the explicit `-o file` case.

**Fix:** add a source-mtime term to the single-file/no-cache branch —
regenerate when the source file is newer than the existing output. Scoped to a
file source (a directory source has no single mtime and is handled by the
cache path). The version-marker check is kept for tool-version bumps.

### Bug 2 — misleading success message
On a skip, the CLI printed `Successfully converted …` on top of the
converter's `… is current, skipping regeneration`. The converter now reports
whether it actually (re)wrote output via a non-breaking optional `regenerated`
out-param (the `Path` return is unchanged — ~20 callers unaffected); the CLI
prints the success line only on a real regeneration. Applied symmetrically to
the directory branch (`Successfully combined …`).

### Message-accuracy fix
The regeneration gate initially tracked only the **combined** write, so
`--combined no` (which writes only per-session files, never a combined) fell
completely silent despite producing every session file — and the per-session
count was dropped whenever the combined was current but a session was
rewritten. The gate now also counts `_generate_individual_session_files`'s
return, i.e. "combined **or** any session file (re)written". Pure skips still
stay quiet.

## Tests
- `TestSingleFileStaleness` (test_output_explicit.py): grown source regenerates;
  unchanged source skips with no redundant success line; directory no-op skip
  suppresses the combined success line; `--combined no` confirms its
  per-session work.
- Flipped `test_single_file_mode_regeneration_behavior`, which previously
  enshrined the stale behavior as "expected".

All four behavioral tests were verified RED on the prior code and GREEN after.

## Not addressed here
`--no-cache` on a **directory** with a grown source can still serve stale HTML
(the source-mtime term is scoped to file sources). This is pre-existing, not
introduced here, and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI conversion messaging to show “Successfully …” only when regeneration actually occurs, with distinct output for single-file, directory runs, and `--combined no`.
  * Improved regeneration detection for combined/paginated outputs and refined directory reporting when only session files are regenerated.

* **Tests**
  * Strengthened single-file staleness/skip assertions to regenerate only when the source JSONL is newer and to avoid extra success lines when skipped.
  * Added coverage for directory/session-only regeneration scenarios, including missing sessions and `--combined no` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->