### PR TITLE
Speed up cache freshness checks on large archives

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -970,7 +970,7 @@ class CacheManager:
                         with os.scandir(parent) as entries:
                             names = {e.name for e in entries if e.is_dir()}
                     except OSError:
-                        names = set()
+                        names = set[str]()
                     subdir_names[parent] = names
                 current_fp = (
                     subagents_fingerprint(jsonl_file)

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -39,7 +39,6 @@ class CachedFileInfo(BaseModel):
     source_mtime: float
     cached_mtime: float
     message_count: int
-    session_ids: list[str]
 
 
 class SessionCacheData(BaseModel):
@@ -280,6 +279,16 @@ def get_cache_db_path(projects_dir: Path) -> Path:
 # ========== Cache Manager ==========
 
 
+# Process-level memo of cache DBs whose migrations have already been
+# checked. CacheManager is constructed per project (the TUI project
+# selector builds one per table row, on every resize), so without the
+# memo every instance re-pays the migration check: a connection plus
+# version-table and migration-directory reads, ~2ms each (issue #12).
+# The exists() guard in _init_database covers --clear-cache deleting
+# the DB file mid-process.
+_migrated_db_paths: set[str] = set()
+
+
 class CacheManager:
     """SQLite-based cache manager for Claude Code Log."""
 
@@ -404,8 +413,11 @@ class CacheManager:
 
     def _init_database(self) -> None:
         """Create schema if needed using migration runner."""
-        # Run any pending migrations
+        key = str(self.db_path)
+        if key in _migrated_db_paths and self.db_path.exists():
+            return
         run_migrations(self.db_path)
+        _migrated_db_paths.add(key)
 
     def _ensure_project_exists(self) -> None:
         """Ensure project record exists and get its ID."""
@@ -887,20 +899,95 @@ class CacheManager:
             return []
 
         with self._get_connection() as conn:
-            rows = conn.execute(
-                "SELECT DISTINCT cwd FROM sessions WHERE project_id = ? AND cwd IS NOT NULL",
-                (self._project_id,),
-            ).fetchall()
+            return self._get_working_directories(conn)
 
+    def _get_working_directories(self, conn: sqlite3.Connection) -> List[str]:
+        """get_working_directories() on an already-open connection."""
+        rows = conn.execute(
+            "SELECT DISTINCT cwd FROM sessions WHERE project_id = ? AND cwd IS NOT NULL",
+            (self._project_id,),
+        ).fetchall()
         return [row["cwd"] for row in rows]
 
     def get_modified_files(self, jsonl_files: List[Path]) -> List[Path]:
-        """Get list of JSONL files that need to be reprocessed."""
-        return [
-            jsonl_file
-            for jsonl_file in jsonl_files
-            if not self.is_file_cached(jsonl_file)
-        ]
+        """Get list of JSONL files that need to be reprocessed.
+
+        Batched equivalent of calling is_file_cached() per file: one SQL
+        query fetches every cached row (one connection open instead of
+        one per file), and one scandir per parent directory rules out
+        subagent-sidecar fingerprints, replacing the per-file query +
+        directory probes that dominated freshness-check time on large
+        archives (issue #12).
+        """
+        if not jsonl_files:
+            return []
+        if self._project_id is None:
+            return list(jsonl_files)
+
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT file_name, source_mtime, subagents_fingerprint"
+                " FROM cached_files WHERE project_id = ?",
+                (self._project_id,),
+            ).fetchall()
+        cached = {row["file_name"]: row for row in rows}
+
+        # A session file's sidecars live under <parent>/<stem>/subagents,
+        # so one scandir of the parent tells us which files can have a
+        # non-empty fingerprint without any per-file stat probes.
+        subdir_names: Dict[Path, set[str]] = {}
+
+        modified: List[Path] = []
+        for jsonl_file in jsonl_files:
+            row = cached.get(jsonl_file.name)
+            if row is None:
+                modified.append(jsonl_file)
+                continue
+
+            try:
+                source_mtime = jsonl_file.stat().st_mtime
+            except OSError:
+                # Missing file: same outcome as is_file_cached()'s
+                # exists() check returning False.
+                modified.append(jsonl_file)
+                continue
+
+            # Cache is valid if modification times match (within 1 second
+            # tolerance)
+            if abs(source_mtime - row["source_mtime"]) >= 1.0:
+                modified.append(jsonl_file)
+                continue
+
+            parent = jsonl_file.parent
+            if parent.name == "subagents":
+                # Agent file in a subagents dir: its sidecars sit next to
+                # it, so the full fingerprint scan is required.
+                current_fp = subagents_fingerprint(jsonl_file)
+            else:
+                names = subdir_names.get(parent)
+                if names is None:
+                    try:
+                        with os.scandir(parent) as entries:
+                            names = {e.name for e in entries if e.is_dir()}
+                    except OSError:
+                        names = set()
+                    subdir_names[parent] = names
+                current_fp = (
+                    subagents_fingerprint(jsonl_file)
+                    if jsonl_file.stem in names
+                    else ""
+                )
+
+            # Same NULL-fingerprint rule as is_file_cached(): pre-007
+            # rows are accepted only while the file has no sidecars.
+            cached_fp = row["subagents_fingerprint"]
+            if cached_fp is None:
+                if current_fp != "":
+                    modified.append(jsonl_file)
+            elif cached_fp != current_fp:
+                modified.append(jsonl_file)
+
+        return modified
 
     def get_cached_project_data(self) -> Optional[ProjectCache]:
         """Get the cached project data if available."""
@@ -923,19 +1010,11 @@ class CacheManager:
 
             cached_files: Dict[str, CachedFileInfo] = {}
             for row in file_rows:
-                # Get session IDs for this file from messages
-                session_rows = conn.execute(
-                    "SELECT DISTINCT session_id FROM messages WHERE file_id = ? AND session_id IS NOT NULL",
-                    (row["id"],),
-                ).fetchall()
-                session_ids = [r["session_id"] for r in session_rows]
-
                 cached_files[row["file_name"]] = CachedFileInfo(
                     file_path=row["file_path"],
                     source_mtime=row["source_mtime"],
                     cached_mtime=row["cached_mtime"],
                     message_count=row["message_count"],
-                    session_ids=session_ids,
                 )
 
             # Get sessions
@@ -961,6 +1040,10 @@ class CacheManager:
                     team_name=row["team_name"] if "team_name" in row.keys() else None,
                 )
 
+            # On the same connection: calling the public method here
+            # would open a second connection per call.
+            working_directories = self._get_working_directories(conn)
+
         return ProjectCache(
             version=project_row["version"],
             cache_created=project_row["cache_created"],
@@ -973,7 +1056,7 @@ class CacheManager:
             total_cache_creation_tokens=project_row["total_cache_creation_tokens"],
             total_cache_read_tokens=project_row["total_cache_read_tokens"],
             sessions=sessions,
-            working_directories=self.get_working_directories(),
+            working_directories=working_directories,
             earliest_timestamp=project_row["earliest_timestamp"],
             latest_timestamp=project_row["latest_timestamp"],
         )

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -10,7 +10,7 @@ import zlib
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Callable, Dict, Generator, List, Optional
 
 from packaging import version
 from pydantic import BaseModel
@@ -257,6 +257,32 @@ def subagents_fingerprint(jsonl_path: Path) -> str:
         # check re-reads (an always-mismatching fingerprint is safe).
         return f"{len(metas)}:unstable"
     return f"{len(metas)}:{newest}"
+
+
+def _cache_row_is_fresh(
+    row: sqlite3.Row, source_mtime: float, current_fp: Callable[[], str]
+) -> bool:
+    """Decide whether a cached_files row is still fresh.
+
+    Single source of truth for the freshness rule shared by
+    is_file_cached() and get_modified_files(). current_fp is a callable
+    so callers only pay for the sidecar fingerprint scan when the mtime
+    check passes (and get_modified_files() can plug in its
+    scandir-optimized variant).
+
+    Cache is valid if modification times match (within 1 second
+    tolerance) and the sidecar inputs of spawn discovery (#213) match
+    too — new agent-*.meta.json files appear without touching the
+    source jsonl. Pre-007 rows carry NULL: accept those only when the
+    file has no sidecars today (nothing to miss), so legacy caches
+    don't mass-invalidate while sessions WITH sidecars reparse once.
+    """
+    if abs(source_mtime - row["source_mtime"]) >= 1.0:
+        return False
+    cached_fp = row["subagents_fingerprint"]
+    if cached_fp is None:
+        return current_fp() == ""
+    return cached_fp == current_fp()
 
 
 def get_cache_db_path(projects_dir: Path) -> Path:
@@ -610,23 +636,11 @@ class CacheManager:
         if not row:
             return False
 
-        source_mtime = jsonl_path.stat().st_mtime
-        cached_mtime = row["source_mtime"]
-
-        # Cache is valid if modification times match (within 1 second tolerance)
-        if abs(source_mtime - cached_mtime) >= 1.0:
-            return False
-
-        # The sidecar inputs of spawn discovery (#213) must match too —
-        # new agent-*.meta.json files appear without touching the source
-        # jsonl. Pre-007 rows carry NULL: accept those only when the file
-        # has no sidecars today (nothing to miss), so legacy caches don't
-        # mass-invalidate while sessions WITH sidecars reparse once.
-        cached_fp = row["subagents_fingerprint"]
-        current_fp = subagents_fingerprint(jsonl_path)
-        if cached_fp is None:
-            return current_fp == ""
-        return cached_fp == current_fp
+        return _cache_row_is_fresh(
+            row,
+            jsonl_path.stat().st_mtime,
+            lambda: subagents_fingerprint(jsonl_path),
+        )
 
     def load_cached_entries(self, jsonl_path: Path) -> Optional[List[TranscriptEntry]]:
         """Load cached transcript entries for a JSONL file."""
@@ -937,6 +951,22 @@ class CacheManager:
         # non-empty fingerprint without any per-file stat probes.
         subdir_names: Dict[Path, set[str]] = {}
 
+        def current_fp(jsonl_file: Path) -> str:
+            parent = jsonl_file.parent
+            if parent.name == "subagents":
+                # Agent file in a subagents dir: its sidecars sit next to
+                # it, so the full fingerprint scan is required.
+                return subagents_fingerprint(jsonl_file)
+            names = subdir_names.get(parent)
+            if names is None:
+                try:
+                    with os.scandir(parent) as entries:
+                        names = {e.name for e in entries if e.is_dir()}
+                except OSError:
+                    names = set[str]()
+                subdir_names[parent] = names
+            return subagents_fingerprint(jsonl_file) if jsonl_file.stem in names else ""
+
         modified: List[Path] = []
         for jsonl_file in jsonl_files:
             row = cached.get(jsonl_file.name)
@@ -952,39 +982,9 @@ class CacheManager:
                 modified.append(jsonl_file)
                 continue
 
-            # Cache is valid if modification times match (within 1 second
-            # tolerance)
-            if abs(source_mtime - row["source_mtime"]) >= 1.0:
-                modified.append(jsonl_file)
-                continue
-
-            parent = jsonl_file.parent
-            if parent.name == "subagents":
-                # Agent file in a subagents dir: its sidecars sit next to
-                # it, so the full fingerprint scan is required.
-                current_fp = subagents_fingerprint(jsonl_file)
-            else:
-                names = subdir_names.get(parent)
-                if names is None:
-                    try:
-                        with os.scandir(parent) as entries:
-                            names = {e.name for e in entries if e.is_dir()}
-                    except OSError:
-                        names = set[str]()
-                    subdir_names[parent] = names
-                current_fp = (
-                    subagents_fingerprint(jsonl_file)
-                    if jsonl_file.stem in names
-                    else ""
-                )
-
-            # Same NULL-fingerprint rule as is_file_cached(): pre-007
-            # rows are accepted only while the file has no sidecars.
-            cached_fp = row["subagents_fingerprint"]
-            if cached_fp is None:
-                if current_fp != "":
-                    modified.append(jsonl_file)
-            elif cached_fp != current_fp:
+            if not _cache_row_is_fresh(
+                row, source_mtime, lambda file=jsonl_file: current_fp(file)
+            ):
                 modified.append(jsonl_file)
 
         return modified

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -135,6 +135,13 @@ per-file load loop, per-session generation) in `CacheManager.batch()`:
 one shared connection reused for the scope and closed on exit (including
 on exception). `batch()` nesting is a no-op reuse, so the wraps compose.
 
+Freshness checks are batched too (issue #12): `get_modified_files()`
+fetches every cached row for the project in one query (one connection
+open, or zero extra inside a `batch()` scope) and rules out
+subagent-sidecar fingerprints with one scandir per parent directory,
+instead of a per-file query + `is_dir()` probes. This is what makes
+TUI startup near-instant on multi-thousand-file archives.
+
 For the operations / recovery side (archived sessions, manual
 deletion, `cleanupPeriodDays`), see
 [`docs/restoring-archived-sessions.md`](../docs/restoring-archived-sessions.md).
@@ -145,8 +152,9 @@ deletion, `cleanupPeriodDays`), see
 small migration system. Each migration is a `NNN_description.sql` file
 applied in numeric order by `migrations/runner.py`. The schema-version
 table tracks which migrations have run; `cache.py` invokes the runner
-on every connection open, so a fresh checkout running against an old
-cache DB transparently upgrades.
+the first time a given cache DB is opened in a process (memoised per
+DB path, re-checked if the file disappears), so a fresh checkout
+running against an old cache DB transparently upgrades.
 
 Current migrations:
 


### PR DESCRIPTION
# Speed up cache freshness checks 13–54× on large archives (#12)

Even with a fully warm cache, launching the TUI on a big archive spent seconds
re-verifying freshness. This PR attacks the check itself, benchmarked against a
real 2 GB / 5,381-item copy of `~/.claude/projects` (63 projects, ~1,830
session JSONLs, 1,603 sessions).

## Results

Warm cache, best of 3, before → after on current `main` (which already
includes #251):

| Scenario | main | this PR | speed-up |
|---|---|---|---|
| TUI launch, one project (453 files) | 646 ms | 12 ms | **54×** |
| TUI project selector (all 63 projects) | 1,190 ms | 276 ms | **4×** |
| Full-archive freshness scan | 4,652 ms | 358 ms | **13×** |

The `--tui` launch path runs the freshness check twice (once in
`_launch_tui_with_cache_check`, again in `SessionBrowser.load_sessions`), so
the user-visible launch delay was ~1.3 s and is now ~25 ms.

## What was actually slow

The file stats were never the problem — stat'ing all 1,830 files takes ~5 ms,
and even a full recursive walk of the 2 GB tree is ~150 ms. The measured costs:

1. **A SQLite connection per file.** `get_modified_files()` called
   `is_file_cached()` per file, each opening a fresh connection (~40× the cost
   of the query it runs). #251 fixed this pattern for cache *builds* via
   `batch()`, but the freshness-check paths don't run inside a batch.
2. **Per-file sidecar probes.** `subagents_fingerprint()` (#213) does an
   `is_dir()` probe + glob per file, ~160 ms across the archive — almost all
   for files that can't have sidecars.
3. **A dead query.** `get_cached_project_data()` ran
   `SELECT DISTINCT session_id FROM messages WHERE file_id = ?` per cached
   file to fill `CachedFileInfo.session_ids` — a field nothing reads
   (production code, tests, or docs). This is what made the project selector
   slow.
4. **Migration re-checks.** Every `CacheManager` construction re-ran the
   migration check (~2 ms); the TUI selector constructs one per project row,
   on every resize.

## Changes (all in `cache.py`)

- **Batched `get_modified_files()`** — one query fetches every cached row for
  the project (one connection open; zero extra inside a `batch()` scope), and
  one `os.scandir` per parent directory determines which files even *can*
  have sidecars, so the fingerprint scan only runs for those (~154 of 1,830
  here). Semantics are identical to the per-file path — verified below.
- **Dropped `CachedFileInfo.session_ids`** and its N-queries-per-call.
  (Measured alternatives: single `GROUP BY` query = 209 ms, per-file lookups
  on a shared connection = 131 ms, not doing it = 4 ms.)
- **`get_cached_project_data()` fetches `working_directories` on the same
  connection** instead of opening a second one per call.
- **Memoised the migration check** per DB path per process, with an
  `exists()` guard so `--clear-cache`'s DB deletion still re-migrates.

Connection lifecycle is untouched: connection-per-call stays the default
(the Windows-safe behaviour pinned by #251's integrity tests), and the new
code composes with `batch()`.

## Approaches considered and rejected

- **Directory-mtime fast path** (from the issue): unsound as a freshness
  check — appending to a JSONL doesn't update the directory mtime, so it can
  only detect create/delete/rename. And since per-file stats cost ~5 ms
  total, it would save nothing meaningful.
- **Hash-based / probabilistic checking**: both optimise the stats, which
  were never the bottleneck; probabilistic is also non-deterministic.
- **Parallel scanning / lazy validation**: unnecessary at 12 ms; parallelism
  could still help the one-time initial parse (~400 s for the full 2 GB),
  but that's a rare event and separate from this issue.

## Verification

- End-to-end change detection on the real archive: touched file detected,
  new sidecar detected (including for a session with no pre-existing
  `<stem>/` dir — the case the scandir shortcut could plausibly have
  broken), new file detected, and full parity with per-file
  `is_file_cached()` both outside and inside a `batch()` scope.
- 2,323 unit tests + 68 TUI tests pass (including #251's connection-
  lifecycle integrity tests); `ruff check` and `ty check` clean.

Numbers above are from a Linux dev container; absolute values will differ on
macOS but the ratios should hold, since the fix removes work rather than
speeding it up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Significantly faster TUI startup on large archives via batched cache freshness checks and fewer filesystem probes.
  * More efficient cache validation for file updates, including sidecar fingerprint handling.
  * Reduced repeated cache migration work during a single process run.
* **Bug Fixes**
  * Improved cache metadata rebuilding so changes in project files are reflected more reliably, minimizing stale results.
* **Documentation**
  * Updated developer documentation to describe the improved cache freshness and cache migration upgrade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->