### PR TITLE
Fix ty possibly-missing-attribute warnings in tests

### DIFF
--- a/test/test_dag_integration.py
+++ b/test/test_dag_integration.py
@@ -856,7 +856,7 @@ class TestAgentDagIntegration:
         header_session_ids = {
             m.content.session_id
             for m in context.messages
-            if isinstance(m.content, SessionHeaderMessage)
+            if m is not None and isinstance(m.content, SessionHeaderMessage)
         }
         assert header_session_ids == {"s1"}
 
@@ -1025,7 +1025,9 @@ class TestAgentDagIntegration:
 
         # Verify message ordering: agent messages should be in the branch
         # block (after b1_u anchor, before branch 2's b2_u)
-        msg_uuids = {m.meta.uuid: m.message_index for m in context.messages}
+        msg_uuids = {
+            m.meta.uuid: m.message_index for m in context.messages if m is not None
+        }
         assert "ag1" in msg_uuids
         assert "b1_u" in msg_uuids
         assert "b2_u" in msg_uuids
@@ -1154,7 +1156,9 @@ class TestRenderSessionResetAcrossSessions:
         _, _, ctx = generate_template_messages(messages, session_tree=session_tree)
 
         # Find messages from session s2 by UUID
-        s2_msgs = [m for m in ctx.messages if m.meta.uuid in ("u3", "a3")]
+        s2_msgs = [
+            m for m in ctx.messages if m is not None and m.meta.uuid in ("u3", "a3")
+        ]
         assert len(s2_msgs) == 2, f"Expected 2 s2 messages, got {len(s2_msgs)}"
 
         for msg in s2_msgs:
@@ -1579,7 +1583,9 @@ class TestPassthroughDagChain:
         _, _, ctx = generate_template_messages(messages, session_tree=session_tree)
 
         # No message should have uuid "att1"
-        rendered_uuids = [m.meta.uuid for m in ctx.messages if m.meta.uuid]
+        rendered_uuids = [
+            m.meta.uuid for m in ctx.messages if m is not None and m.meta.uuid
+        ]
         assert "att1" not in rendered_uuids
         # But user and assistant should be rendered
         assert "u1" in rendered_uuids

--- a/test/test_hook_attachment_rendering.py
+++ b/test/test_hook_attachment_rendering.py
@@ -397,7 +397,9 @@ class TestEndToEndDetailLevels:
         del roots, _nav  # only inspect ctx.messages
 
         attachments = [
-            m for m in ctx.messages if isinstance(m.content, HookAttachmentMessage)
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, HookAttachmentMessage)
         ]
         assert len(attachments) == 1
         msg = attachments[0]
@@ -507,7 +509,9 @@ class TestHookAttachmentHierarchy:
         del _roots, _nav
 
         hook = next(
-            m for m in ctx.messages if isinstance(m.content, HookAttachmentMessage)
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, HookAttachmentMessage)
         )
         # No pair links on either side — the hook stands alone.
         assert hook.pair_first is None
@@ -549,14 +553,20 @@ class TestHookAttachmentHierarchy:
         del _roots, _nav
 
         hook = next(
-            m for m in ctx.messages if isinstance(m.content, HookAttachmentMessage)
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, HookAttachmentMessage)
         )
         # Filter to user-content SystemMessages (the "/color" + "Session
         # color set" entries) — exclude SessionHeaderMessage which also
         # carries msg_type "system".
         from claude_code_log.models import SystemMessage
 
-        system_infos = [m for m in ctx.messages if isinstance(m.content, SystemMessage)]
+        system_infos = [
+            m
+            for m in ctx.messages
+            if m is not None and isinstance(m.content, SystemMessage)
+        ]
 
         # Hook should NOT have any system_info as immediate child.
         assert hook.immediate_children_count == 0, (

--- a/test/test_skill_pairing.py
+++ b/test/test_skill_pairing.py
@@ -759,21 +759,21 @@ class TestSkillFoldOnFork:
         # long as the fork anchor itself wasn't ghosted (it wasn't —
         # the trunk-side anchor is never a Skill-fold target).
         branch_headers = [
-            m
+            m.content
             for m in survivors
             if isinstance(m.content, SessionHeaderMessage) and m.content.is_branch
         ]
         # The Skill-bearing branch is the one rooted at 'a-skill'.
         # (Branch sids are ``{trunk}@{first_uuid12}`` per dag.py.)
         skill_branches = [
-            m for m in branch_headers if m.content.session_id.endswith("@a-skill")
+            h for h in branch_headers if h.session_id.endswith("@a-skill")
         ]
         assert len(skill_branches) == 1, (
             f"expected exactly one branch header rooted at 'a-skill'; got "
-            f"{[m.content.session_id for m in branch_headers]}"
+            f"{[h.session_id for h in branch_headers]}"
         )
         skill_branch = skill_branches[0]
-        parent_idx = skill_branch.content.parent_message_index
+        parent_idx = skill_branch.parent_message_index
         assert parent_idx is not None, (
             "skill-bearing branch header's parent_message_index is None — "
             "expected it to resolve to the fork anchor 'c'."


### PR DESCRIPTION
ctx.messages is list[Optional[TemplateMessage]] (ghost slots are None), so comprehensions iterating it directly need an 'm is not None' guard. In test_skill_pairing, collect the narrowed SessionHeaderMessage contents instead of the wrapper messages so the isinstance narrowing survives into the follow-up comprehensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Hardened several test assertions to safely ignore `None` entries while scanning message lists.
  * Improved message lookups for session headers, UUID ordering, session filtering, and rendered output checks.
  * Simplified one branch-header assertion by reading header details directly from the surviving session header objects.
  * No user-facing behavior or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->