### PR TITLE
Parallelise per-project processing in --all-projects mode

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -717,7 +717,7 @@ def _validate_git_link_template(template: str) -> None:
 @click.option(
     "--jobs",
     "-j",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help=(
         "Worker processes for converting projects in --all-projects mode "

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -715,6 +715,17 @@ def _validate_git_link_template(template: str) -> None:
     help="Maximum messages per page for combined transcript (default: 2000). Sessions are never split across pages.",
 )
 @click.option(
+    "--jobs",
+    "-j",
+    type=int,
+    default=None,
+    help=(
+        "Worker processes for converting projects in --all-projects mode "
+        "(default: CPU count; 1 disables parallelism). Peak memory scales "
+        "with jobs × the largest stale project."
+    ),
+)
+@click.option(
     "--session-id",
     default=None,
     help="Export a single session by ID (full ID or prefix). Project path is optional — looks up the session globally via cache.",
@@ -804,6 +815,7 @@ def main(
     output_format: str,
     image_export_mode: Optional[str],
     page_size: int,
+    jobs: Optional[int],
     session_id: Optional[str],
     detail: str,
     compact: bool,
@@ -1224,6 +1236,7 @@ def main(
                 write_combined=write_combined,
                 no_timestamps=no_timestamps,
                 no_recaps=no_recaps,
+                jobs=jobs,
             )
 
             # Count processed projects

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -5,8 +5,12 @@ import contextlib
 import itertools
 import json
 import logging
+import multiprocessing
+import os
 import re
+import time
 from collections.abc import Iterator
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 import traceback
@@ -2768,6 +2772,212 @@ def _print_archived_sessions_note(total_archived: int) -> None:
     )
 
 
+@dataclass
+class _ProjectPlan:
+    """Work plan for one project, computed by the sequential planning pass.
+
+    Splitting plan (staleness check) from execute (conversion) lets the
+    execute phase run in a process pool: the plan carries everything the
+    parent needs to report progress and build the index afterwards, while
+    workers re-derive their own state from the project path alone.
+    """
+
+    project_dir: Path
+    dest_dir: Path
+    cache_manager: Optional["CacheManager"]
+    output_path: Path
+    needs_work: bool
+    archived_count: int
+    stats: GenerationStats
+    source_bytes: int
+    error: Optional[str] = None
+
+
+def _plan_project(
+    project_dir: Path,
+    *,
+    use_cache: bool,
+    library_version: str,
+    variant: str,
+    combined_ext: str,
+    combined_name: str,
+    output_dir: Optional[Path],
+    expand_paths: bool,
+    filter_path: Optional[str],
+    write_combined: bool,
+    page_size: int,
+) -> Optional[_ProjectPlan]:
+    """Resolve destination and staleness for one project (no rendering).
+
+    Returns None when ``--filter-path`` excludes the project. Runs in
+    the parent before any pool worker starts, which also guarantees the
+    shared cache DB's schema/migrations and this project's row exist
+    before concurrent workers touch the DB.
+    """
+    from .utils import project_destination
+
+    plan_start = time.time()
+    stats = GenerationStats()
+    cache_manager: Optional[CacheManager] = None
+    if use_cache:
+        try:
+            cache_manager = CacheManager(project_dir, library_version)
+        except Exception as e:
+            stats.add_warning(f"Failed to initialize cache: {e}")
+
+    # Per-project destination (#151). When `output_dir` /
+    # `expand_paths` / `filter_path` are unset this returns
+    # `project_dir` (legacy in-place behaviour). When the
+    # filter excludes this project, returns None.
+    cached_working_dirs: Optional[list[str]] = None
+    if cache_manager is not None:
+        try:
+            cached_working_dirs = cache_manager.get_working_directories()
+        except Exception:
+            cached_working_dirs = None
+    dest_dir = project_destination(
+        project_dir,
+        output_dir=output_dir,
+        expand_paths=expand_paths,
+        filter_path=filter_path,
+        cached_working_directories=cached_working_dirs,
+    )
+    if dest_dir is None:
+        return None
+
+    # Fast staleness check (mtime comparison only). Exclude agent
+    # files - they are loaded via session references, not directly.
+    jsonl_files = [
+        f for f in project_dir.glob("*.jsonl") if not f.name.startswith("agent-")
+    ]
+    # Valid session IDs are from existing JSONL files (file stem = session ID)
+    valid_session_ids = {f.stem for f in jsonl_files}
+    modified_files = (
+        cache_manager.get_modified_files(jsonl_files) if cache_manager else []
+    )
+    # Pass valid_session_ids to skip archived sessions (JSONL
+    # deleted). The variant/ext/output_dir must mirror what
+    # _generate_individual_session_files writes, or every
+    # session reads as "not_cached" and the project takes the
+    # slow path on every run.
+    stale_sessions = (
+        cache_manager.get_stale_sessions(
+            valid_session_ids,
+            variant=variant,
+            ext=combined_ext,
+            output_dir=dest_dir,
+        )
+        if cache_manager
+        else []
+    )
+    # Count archived sessions (cached but JSONL deleted)
+    archived_count = (
+        cache_manager.get_archived_session_count(valid_session_ids)
+        if cache_manager
+        else 0
+    )
+    output_path = dest_dir / combined_name
+    # Check combined_stale using the appropriate cache:
+    # - Paginated projects store data in html_pages table (via save_page_cache)
+    # - Non-paginated projects store data in html_cache table (via update_html_cache)
+    if cache_manager is not None:
+        existing_page_count = cache_manager.get_page_count(variant)
+        if existing_page_count > 0:
+            # Paginated project: check page 1 staleness for the
+            # current --format/--detail/--compact variant, resolving
+            # the page file against dest_dir (--output) like the
+            # non-paginated branch below.
+            combined_stale = cache_manager.is_page_stale(
+                1, page_size, variant, output_dir=dest_dir
+            )[0]
+        else:
+            # Non-paginated project: check html_cache for the
+            # variant-specific filename (e.g.
+            # `combined_transcripts.low.compact.md`), not the
+            # default `combined_transcripts.html`.
+            combined_stale = cache_manager.is_transcript_stale(
+                output_path.name, None, output_dir=dest_dir
+            )[0]
+    else:
+        combined_stale = True
+
+    # Determine if we need to do any work. With
+    # `write_combined=False`, the combined-transcript file
+    # isn't produced — its staleness / on-disk presence is
+    # irrelevant; only modified sources / stale per-session
+    # files matter.
+    if write_combined:
+        needs_work = (
+            bool(modified_files)
+            or bool(stale_sessions)
+            or combined_stale
+            or not output_path.exists()
+        )
+    else:
+        needs_work = bool(modified_files) or bool(stale_sessions)
+
+    if needs_work:
+        stats.files_updated = len(modified_files) if modified_files else 0
+        stats.files_loaded_from_cache = len(jsonl_files) - stats.files_updated
+        stats.sessions_regenerated = len(stale_sessions)
+    else:
+        # Fast path: nothing to do, just collect stats for index
+        stats.files_loaded_from_cache = len(jsonl_files)
+    stats.total_time = time.time() - plan_start
+
+    return _ProjectPlan(
+        project_dir=project_dir,
+        dest_dir=dest_dir,
+        cache_manager=cache_manager,
+        output_path=output_path,
+        needs_work=needs_work,
+        archived_count=archived_count,
+        stats=stats,
+        source_bytes=sum(f.stat().st_size for f in jsonl_files),
+    )
+
+
+def _convert_project_worker(
+    worker_args: Dict[str, Any],
+) -> "tuple[str, float, Optional[str]]":
+    """Convert one project inside a pool worker process.
+
+    Module-level, with dict-of-picklables in and primitives out, so it
+    works under the ``spawn`` start method. Failures are returned as a
+    formatted traceback instead of raised so the parent can attribute
+    them to the right project and keep processing the rest.
+    """
+    start = time.time()
+    error: Optional[str] = None
+    try:
+        convert_jsonl_to(
+            worker_args["format"],
+            Path(worker_args["project_dir"]),
+            None,
+            worker_args["from_date"],
+            worker_args["to_date"],
+            worker_args["generate_individual_sessions"],
+            worker_args["use_cache"],
+            # Workers always run silent: per-file progress lines from N
+            # concurrent processes would interleave illegibly. The
+            # parent prints one line per project as results arrive.
+            silent=True,
+            image_export_mode=worker_args["image_export_mode"],
+            page_size=worker_args["page_size"],
+            detail=worker_args["detail"],
+            compact=worker_args["compact"],
+            output_root=(
+                Path(worker_args["output_root"]) if worker_args["output_root"] else None
+            ),
+            write_combined=worker_args["write_combined"],
+            no_timestamps=worker_args["no_timestamps"],
+            no_recaps=worker_args["no_recaps"],
+        )
+    except Exception:
+        error = traceback.format_exc()
+    return (worker_args["project_dir"], time.time() - start, error)
+
+
 def process_projects_hierarchy(
     projects_path: Path,
     from_date: Optional[str] = None,
@@ -2786,6 +2996,7 @@ def process_projects_hierarchy(
     write_combined: bool = True,
     no_timestamps: bool = False,
     no_recaps: bool = False,
+    jobs: Optional[int] = None,
 ) -> Path:
     """Process the entire ~/.claude/projects/ hierarchy and create linked output files.
 
@@ -2807,6 +3018,13 @@ def process_projects_hierarchy(
             under ``output_dir``.
         filter_path: When set, restrict to projects matching the prefix.
             See ``utils.project_destination`` for the matching semantics.
+        jobs: Worker processes for the per-project conversion phase.
+            ``None`` (default) uses the CPU count; ``1`` processes
+            projects inline in this process (historical behaviour).
+            Parallel workers run silent — the parent prints one
+            progress line per project as results arrive. Peak memory
+            scales with roughly ``jobs ×`` the largest stale project,
+            so lower it on memory-constrained machines.
     """
     import time
 
@@ -2891,178 +3109,199 @@ def process_projects_hierarchy(
             rel = p
         return rel.as_posix()
 
+    # ---- Phase 1 (plan): sequential, cheap staleness/destination pass.
+    # Runs in the parent so the shared cache DB's schema/migrations and
+    # every project row exist before any pool worker opens the DB.
+    plans: list[_ProjectPlan] = []
     for project_dir in sorted(project_dirs):
-        project_start_time = time.time()
-        stats = GenerationStats()
-
         try:
-            # Initialize cache manager for this project
-            cache_manager = None
-            if use_cache:
-                try:
-                    cache_manager = CacheManager(project_dir, library_version)
-                except Exception as e:
-                    stats.add_warning(f"Failed to initialize cache: {e}")
-
-            # Per-project destination (#151). When `output_dir` /
-            # `expand_paths` / `filter_path` are unset this returns
-            # `project_dir` (legacy in-place behaviour). When the
-            # filter excludes this project, returns None.
-            cached_working_dirs: Optional[list[str]] = None
-            if cache_manager is not None:
-                try:
-                    cached_working_dirs = cache_manager.get_working_directories()
-                except Exception:
-                    cached_working_dirs = None
-            dest_dir = project_destination(
+            plan = _plan_project(
                 project_dir,
+                use_cache=use_cache,
+                library_version=library_version,
+                variant=variant,
+                combined_ext=combined_ext,
+                combined_name=combined_name,
                 output_dir=output_dir,
                 expand_paths=expand_paths,
                 filter_path=filter_path,
-                cached_working_directories=cached_working_dirs,
+                write_combined=write_combined,
+                page_size=page_size,
             )
-            if dest_dir is None:
-                # Filter-out: don't process this project at all.
-                if not silent:
-                    print(f"  {project_dir.name}: skipped (filter)")
-                continue
+        except Exception as e:
+            stats = GenerationStats()
+            stats.add_error(str(e))
+            project_stats.append((project_dir.name, stats))
+            print(
+                f"Warning: Failed to process {project_dir}: {e}\n"
+                f"{traceback.format_exc()}"
+            )
+            continue
+        if plan is None:
+            # Filter-out: don't process this project at all.
+            if not silent:
+                print(f"  {project_dir.name}: skipped (filter)")
+            continue
+        total_archived += plan.archived_count
+        plans.append(plan)
 
-            # Phase 1: Fast check if anything needs updating (mtime comparison only)
-            # Exclude agent files - they are loaded via session references, not directly
-            jsonl_files = [
-                f
-                for f in project_dir.glob("*.jsonl")
-                if not f.name.startswith("agent-")
-            ]
-            # Valid session IDs are from existing JSONL files (file stem = session ID)
-            valid_session_ids = {f.stem for f in jsonl_files}
-            modified_files = (
-                cache_manager.get_modified_files(jsonl_files) if cache_manager else []
-            )
-            # Pass valid_session_ids to skip archived sessions (JSONL
-            # deleted). The variant/ext/output_dir must mirror what
-            # _generate_individual_session_files writes, or every
-            # session reads as "not_cached" and the project takes the
-            # slow path on every run.
-            stale_sessions = (
-                cache_manager.get_stale_sessions(
-                    valid_session_ids,
-                    variant=variant,
-                    ext=combined_ext,
-                    output_dir=dest_dir,
-                )
-                if cache_manager
-                else []
-            )
-            # Count archived sessions (cached but JSONL deleted)
-            archived_count = (
-                cache_manager.get_archived_session_count(valid_session_ids)
-                if cache_manager
-                else 0
-            )
-            total_archived += archived_count
-            # Output destination — `dest_dir` for #151's `--output` /
-            # `--expand-paths` / `--filter-path`, falling back to the
-            # source project_dir for legacy in-place behaviour. Filename
-            # uses the same {variant}.{ext} convention as
-            # `convert_jsonl_to`.
-            output_path = dest_dir / combined_name
-            # Check combined_stale using the appropriate cache:
-            # - Paginated projects store data in html_pages table (via save_page_cache)
-            # - Non-paginated projects store data in html_cache table (via update_html_cache)
-            if cache_manager is not None:
-                existing_page_count = cache_manager.get_page_count(variant)
-                if existing_page_count > 0:
-                    # Paginated project: check page 1 staleness for the
-                    # current --format/--detail/--compact variant, resolving
-                    # the page file against dest_dir (--output) like the
-                    # non-paginated branch below.
-                    combined_stale = cache_manager.is_page_stale(
-                        1, page_size, variant, output_dir=dest_dir
-                    )[0]
-                else:
-                    # Non-paginated project: check html_cache for the
-                    # variant-specific filename (e.g.
-                    # `combined_transcripts.low.compact.md`), not the
-                    # default `combined_transcripts.html`.
-                    combined_stale = cache_manager.is_transcript_stale(
-                        output_path.name, None, output_dir=dest_dir
-                    )[0]
-            else:
-                combined_stale = True
+    to_convert = [p for p in plans if p.needs_work]
+    projects_with_updates = sum(1 for p in to_convert if p.stats.files_updated > 0)
 
-            # Determine if we need to do any work. With
-            # `write_combined=False`, the combined-transcript file
-            # isn't produced — its staleness / on-disk presence is
-            # irrelevant; only modified sources / stale per-session
-            # files matter.
-            if write_combined:
-                needs_work = (
-                    bool(modified_files)
-                    or bool(stale_sessions)
-                    or combined_stale
-                    or not output_path.exists()
-                )
-            else:
-                needs_work = bool(modified_files) or bool(stale_sessions)
+    def _archived_suffix(plan: _ProjectPlan) -> str:
+        return f", {plan.archived_count} archived" if plan.archived_count > 0 else ""
 
-            # Build archived suffix for output (shown on both cached and work paths)
-            archived_suffix = (
-                f", {archived_count} archived" if archived_count > 0 else ""
+    def _print_project_done(plan: _ProjectPlan, elapsed: float) -> None:
+        plan.stats.total_time = elapsed
+        progress_parts: List[str] = []
+        if plan.stats.files_updated > 0:
+            progress_parts.append(f"{plan.stats.files_updated} files updated")
+        if plan.stats.sessions_regenerated > 0:
+            progress_parts.append(f"{plan.stats.sessions_regenerated} sessions")
+        progress_detail = ", ".join(progress_parts) if progress_parts else "regenerated"
+        print(
+            f"  {plan.project_dir.name}: {progress_detail}{_archived_suffix(plan)} ({elapsed:.1f}s)"
+        )
+
+    def _print_project_failed(plan: _ProjectPlan, error: str) -> None:
+        plan.error = error
+        last_line = error.strip().splitlines()[-1] if error.strip() else error
+        plan.stats.add_error(last_line)
+        print(f"Warning: Failed to process {plan.project_dir}:\n{error}")
+
+    # Cached (no-work) projects are reported first, in stable
+    # alphabetical order; regenerated projects follow as they finish.
+    for plan in plans:
+        if not plan.needs_work:
+            print(
+                f"  {plan.project_dir.name}: cached{_archived_suffix(plan)} "
+                f"({plan.stats.total_time:.1f}s)"
             )
 
-            if not needs_work:
-                # Fast path: nothing to do, just collect stats for index
-                stats.files_loaded_from_cache = len(jsonl_files)
-                stats.total_time = time.time() - project_start_time
-                # Show progress
-                print(
-                    f"  {project_dir.name}: cached{archived_suffix} ({stats.total_time:.1f}s)"
-                )
-            else:
-                # Slow path: update cache and regenerate output
-                stats.files_updated = len(modified_files) if modified_files else 0
-                stats.files_loaded_from_cache = len(jsonl_files) - stats.files_updated
-                stats.sessions_regenerated = len(stale_sessions)
+    # ---- Phase 2 (execute): (re)generate stale projects. Rendering is
+    # CPU-bound pure Python and projects are independent — each
+    # conversion touches only its own project dir and its own rows in
+    # the (WAL-mode) cache DB — so stale projects fan out over a
+    # process pool. `jobs=1` keeps the historical inline path.
+    resolved_jobs = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
+    resolved_jobs = max(1, min(resolved_jobs, len(to_convert)))
 
-                if modified_files:
-                    projects_with_updates += 1
+    def _convert_plan_inline(plan: _ProjectPlan) -> None:
+        """Convert one project in this process, reporting progress/failure."""
+        project_start_time = time.time()
+        try:
+            # Generate output for this project (handles cache updates internally)
+            convert_jsonl_to(
+                output_format,
+                plan.project_dir,
+                None,
+                from_date,
+                to_date,
+                generate_individual_sessions,
+                use_cache,
+                silent=silent,
+                image_export_mode=image_export_mode,
+                page_size=page_size,
+                detail=detail,
+                compact=compact,
+                output_root=(
+                    plan.dest_dir if plan.dest_dir != plan.project_dir else None
+                ),
+                write_combined=write_combined,
+                no_timestamps=no_timestamps,
+                no_recaps=no_recaps,
+            )
+        except Exception:
+            _print_project_failed(plan, traceback.format_exc())
+            return
+        _print_project_done(plan, time.time() - project_start_time)
 
-                # Generate output for this project (handles cache updates internally)
-                output_path = convert_jsonl_to(
-                    output_format,
-                    project_dir,
-                    None,
-                    from_date,
-                    to_date,
-                    generate_individual_sessions,
-                    use_cache,
-                    silent=silent,
-                    image_export_mode=image_export_mode,
-                    page_size=page_size,
-                    detail=detail,
-                    compact=compact,
-                    output_root=(dest_dir if dest_dir != project_dir else None),
-                    write_combined=write_combined,
-                    no_timestamps=no_timestamps,
-                    no_recaps=no_recaps,
-                )
+    if resolved_jobs <= 1:
+        for plan in to_convert:
+            _convert_plan_inline(plan)
+    elif to_convert:
+        # Largest projects first: with N workers the wall clock is
+        # bounded by the biggest single project, so don't leave it
+        # queued behind small ones at the tail.
+        by_size = sorted(to_convert, key=lambda p: p.source_bytes, reverse=True)
+        settled: set[int] = set()
+        try:
+            # `spawn` on every platform: fork is officially unsafe with
+            # threads and inherits arbitrary parent state; macOS/Windows
+            # default to spawn already. Workers re-import the package once
+            # each and are reused across projects, so the overhead is a
+            # one-off ~1s per worker.
+            ctx = multiprocessing.get_context("spawn")
+            with ProcessPoolExecutor(max_workers=resolved_jobs, mp_context=ctx) as pool:
+                future_to_plan = {
+                    pool.submit(
+                        _convert_project_worker,
+                        {
+                            "format": output_format,
+                            "project_dir": str(plan.project_dir),
+                            "from_date": from_date,
+                            "to_date": to_date,
+                            "generate_individual_sessions": generate_individual_sessions,
+                            "use_cache": use_cache,
+                            "image_export_mode": image_export_mode,
+                            "page_size": page_size,
+                            "detail": detail,
+                            "compact": compact,
+                            "output_root": (
+                                str(plan.dest_dir)
+                                if plan.dest_dir != plan.project_dir
+                                else None
+                            ),
+                            "write_combined": write_combined,
+                            "no_timestamps": no_timestamps,
+                            "no_recaps": no_recaps,
+                        },
+                    ): plan
+                    for plan in by_size
+                }
+                for future in as_completed(future_to_plan):
+                    plan = future_to_plan[future]
+                    _dir, elapsed, error = future.result()
+                    settled.add(id(plan))
+                    if error is not None:
+                        _print_project_failed(plan, error)
+                    else:
+                        _print_project_done(plan, elapsed)
+        except Exception as e:
+            # Pool-level failure — e.g. BrokenProcessPool when workers
+            # can't bootstrap because a library caller's script lacks the
+            # `if __name__ == "__main__"` guard `spawn` requires. The
+            # conversions are idempotent (staleness is re-derived from
+            # the cache), so degrade to inline processing of whatever
+            # hasn't completed rather than aborting the whole run.
+            print(
+                f"Warning: parallel processing failed ({e.__class__.__name__}: {e}); "
+                f"falling back to sequential processing. If you are calling "
+                f"this as a library, run it under `if __name__ == '__main__':` "
+                f"or pass jobs=1."
+            )
+            for plan in to_convert:
+                if id(plan) not in settled:
+                    _convert_plan_inline(plan)
 
-                # Track timing
-                stats.total_time = time.time() - project_start_time
-                # Show progress
-                progress_parts: List[str] = []
-                if stats.files_updated > 0:
-                    progress_parts.append(f"{stats.files_updated} files updated")
-                if stats.sessions_regenerated > 0:
-                    progress_parts.append(f"{stats.sessions_regenerated} sessions")
-                progress_detail = (
-                    ", ".join(progress_parts) if progress_parts else "regenerated"
-                )
-                print(
-                    f"  {project_dir.name}: {progress_detail}{archived_suffix} ({stats.total_time:.1f}s)"
-                )
+    # ---- Phase 3 (collect): aggregate per-project index data from the
+    # now-fresh cache. Sequential — cheap cache reads (the no-cache
+    # fallback is the rare exception) — and iteration order follows the
+    # sorted `plans` list, so the index and summary output don't depend
+    # on worker completion order.
+    for plan in plans:
+        if plan.error is not None:
+            # Conversion failed (already reported). Match the historical
+            # behaviour: record stats, leave the project out of the index.
+            project_stats.append((plan.project_dir.name, plan.stats))
+            continue
+        project_dir = plan.project_dir
+        cache_manager = plan.cache_manager
+        dest_dir = plan.dest_dir
+        output_path = plan.output_path
+        stats = plan.stats
 
+        try:
             # Get project info for index - use cached data if available
             # Exclude agent files (they are loaded via session references)
             jsonl_files = [

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -78,6 +78,8 @@ single transcript or directory. Major flags:
   output, packing whole sessions into pages of up to N messages each
   (sessions are never split across pages, so individual pages may
   overflow). Per-session HTML files are not paginated.
+- `--jobs N` / `-j N` — worker processes for the all-projects
+  conversion phase (default: CPU count; `1` disables parallelism).
 
 CLI orchestration delegates to `converter.py` (which owns the
 high-level "load + render + write" flow) and never touches `renderer.py`
@@ -85,6 +87,21 @@ directly. Output paths follow a stable convention so the cache and
 re-renders can find existing files: `combined_transcripts.html`,
 `session-{id}.html`, `index.html`, with `--detail` and `--compact`
 adding suffixes per `utils.variant_suffix`.
+
+For the all-projects invocation, `process_projects_hierarchy` runs in
+three phases: **plan** (sequential, cheap — per-project staleness via
+cache mtimes, also ensures DB schema/migrations exist), **execute**
+(stale projects fan out over a `ProcessPoolExecutor` with the `spawn`
+start method, largest-first; rendering is CPU-bound pure Python and
+projects are independent, so this scales near-linearly with cores),
+and **collect** (sequential — per-project index data is read back from
+the cache and the cross-project `index.html` is written last). Workers
+run silent; the parent prints one progress line per project as results
+arrive. All workers share the WAL-mode SQLite cache DB — each writes
+only its own project's rows, and WAL serialises the short write
+transactions. A pool-level failure (e.g. a library caller without the
+`if __name__ == "__main__"` guard `spawn` needs) degrades to inline
+sequential processing with a warning rather than aborting.
 
 ### 2.2 TUI
 

--- a/test/test_parallel_processing.py
+++ b/test/test_parallel_processing.py
@@ -2,20 +2,25 @@
 
 The hierarchy pass fans stale projects out over a process pool (see
 `_convert_project_worker` / the plan→execute→collect phases in
-converter.py). These tests pin the two properties that make that safe:
+converter.py). These tests pin the properties that make that safe:
 
 - Determinism: `jobs=2` produces byte-identical output to `jobs=1`.
 - Warm-cache behaviour: a second run takes the fast path (no pool, all
   projects reported as cached) and still rewrites the index.
+- Worker count is clamped to the number of stale projects.
+- Pool-level failure degrades to the sequential inline path.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
+from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 
 import pytest
 
+from claude_code_log import converter
 from claude_code_log.converter import process_projects_hierarchy
 
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
@@ -23,6 +28,14 @@ TEST_DATA_DIR = Path(__file__).parent / "test_data"
 # Small-but-real transcripts; stems become session IDs, so each project
 # gets distinct filenames.
 SAMPLE_FILES = ["edge_cases.jsonl", "sidechain.jsonl", "edit_tool.jsonl"]
+
+# Fixed, distinct source mtimes. The projects index orders cards by
+# each project's newest source mtime (`last_modified`), so the copies
+# must carry identical mtimes in every tree the tests build. Relying on
+# copy-time mtimes is flaky on Windows: the filesystem clock ticks
+# ~15.6ms, so back-to-back copies can tie (or not) per run, flipping
+# the card order between otherwise-identical trees.
+_MTIME_BASE = 1_600_000_000
 
 
 def _build_projects_dir(root: Path, name: str) -> Path:
@@ -33,7 +46,10 @@ def _build_projects_dir(root: Path, name: str) -> Path:
         project_dir.mkdir(parents=True)
         for j, sample in enumerate(SAMPLE_FILES[: i + 1]):
             # Unique stem per (project, file) pair — stems are session IDs.
-            shutil.copy(TEST_DATA_DIR / sample, project_dir / f"session-{i}-{j}.jsonl")
+            dest = project_dir / f"session-{i}-{j}.jsonl"
+            shutil.copy(TEST_DATA_DIR / sample, dest)
+            mtime = _MTIME_BASE + i * 100 + j * 10
+            os.utime(dest, (mtime, mtime))
     return projects_dir
 
 
@@ -43,6 +59,12 @@ def _snapshot_outputs(projects_dir: Path) -> dict[str, bytes]:
         str(f.relative_to(projects_dir)): f.read_bytes()
         for f in sorted(projects_dir.rglob("*.html"))
     }
+
+
+def _assert_all_outputs_exist(projects_dir: Path) -> None:
+    assert (projects_dir / "index.html").exists()
+    for project in ["-proj-alpha", "-proj-beta", "-proj-gamma"]:
+        assert (projects_dir / project / "combined_transcripts.html").exists()
 
 
 def test_parallel_output_matches_sequential(
@@ -82,7 +104,9 @@ def test_parallel_second_run_takes_cached_fast_path(
 
     index_path = projects_dir / "index.html"
     assert index_path.exists()
-    index_mtime = index_path.stat().st_mtime
+    # Sentinel: prove the second run rewrites the index (mtime
+    # comparison is unreliable on coarse-granularity filesystems).
+    index_path.write_text("SENTINEL — must be replaced", encoding="utf-8")
 
     process_projects_hierarchy(projects_dir, jobs=2)
     second_run = capsys.readouterr().out
@@ -91,17 +115,46 @@ def test_parallel_second_run_takes_cached_fast_path(
     # archived-sessions footer note)
     assert second_run.count(": cached") == 3
     # ...and the index is still (unconditionally) regenerated.
-    assert index_path.stat().st_mtime >= index_mtime
+    assert "SENTINEL" not in index_path.read_text(encoding="utf-8")
 
 
-def test_jobs_exceeding_project_count(
+def test_jobs_clamped_to_stale_project_count(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Worker count is clamped to the number of stale projects."""
+    """jobs=64 with three stale projects spawns a pool of exactly 3."""
     projects_dir = _build_projects_dir(tmp_path, "projects")
     monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "cache.db"))
 
+    recorded_max_workers: list[int | None] = []
+    real_pool = converter.ProcessPoolExecutor
+
+    class RecordingPool(real_pool):
+        def __init__(self, max_workers: int | None = None, **kwargs: object) -> None:
+            recorded_max_workers.append(max_workers)
+            super().__init__(max_workers=max_workers, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(converter, "ProcessPoolExecutor", RecordingPool)
+
     process_projects_hierarchy(projects_dir, jobs=64)
-    assert (projects_dir / "index.html").exists()
-    for project in ["-proj-alpha", "-proj-beta", "-proj-gamma"]:
-        assert (projects_dir / project / "combined_transcripts.html").exists()
+    assert recorded_max_workers == [3]
+    _assert_all_outputs_exist(projects_dir)
+
+
+def test_pool_failure_falls_back_to_sequential(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A pool that can't start degrades to inline processing, not a crash."""
+    projects_dir = _build_projects_dir(tmp_path, "projects")
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "cache.db"))
+
+    def broken_pool(*args: object, **kwargs: object) -> None:
+        raise BrokenProcessPool("simulated pool bootstrap failure")
+
+    monkeypatch.setattr(converter, "ProcessPoolExecutor", broken_pool)
+
+    process_projects_hierarchy(projects_dir, jobs=2)
+    out = capsys.readouterr().out
+    assert "falling back to sequential processing" in out
+    _assert_all_outputs_exist(projects_dir)

--- a/test/test_parallel_processing.py
+++ b/test/test_parallel_processing.py
@@ -1,0 +1,107 @@
+"""Tests for parallel per-project processing in process_projects_hierarchy.
+
+The hierarchy pass fans stale projects out over a process pool (see
+`_convert_project_worker` / the plan→execute→collect phases in
+converter.py). These tests pin the two properties that make that safe:
+
+- Determinism: `jobs=2` produces byte-identical output to `jobs=1`.
+- Warm-cache behaviour: a second run takes the fast path (no pool, all
+  projects reported as cached) and still rewrites the index.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import process_projects_hierarchy
+
+TEST_DATA_DIR = Path(__file__).parent / "test_data"
+
+# Small-but-real transcripts; stems become session IDs, so each project
+# gets distinct filenames.
+SAMPLE_FILES = ["edge_cases.jsonl", "sidechain.jsonl", "edit_tool.jsonl"]
+
+
+def _build_projects_dir(root: Path, name: str) -> Path:
+    """Create a projects dir with three projects of 1-3 sessions each."""
+    projects_dir = root / name
+    for i, project in enumerate(["-proj-alpha", "-proj-beta", "-proj-gamma"]):
+        project_dir = projects_dir / project
+        project_dir.mkdir(parents=True)
+        for j, sample in enumerate(SAMPLE_FILES[: i + 1]):
+            # Unique stem per (project, file) pair — stems are session IDs.
+            shutil.copy(TEST_DATA_DIR / sample, project_dir / f"session-{i}-{j}.jsonl")
+    return projects_dir
+
+
+def _snapshot_outputs(projects_dir: Path) -> dict[str, bytes]:
+    """Relative path → content for every generated output file."""
+    return {
+        str(f.relative_to(projects_dir)): f.read_bytes()
+        for f in sorted(projects_dir.rglob("*.html"))
+    }
+
+
+def test_parallel_output_matches_sequential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seq_dir = _build_projects_dir(tmp_path, "sequential")
+    par_dir = _build_projects_dir(tmp_path, "parallel")
+
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "seq-cache.db"))
+    process_projects_hierarchy(seq_dir, jobs=1)
+
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "par-cache.db"))
+    process_projects_hierarchy(par_dir, jobs=2)
+
+    seq_outputs = _snapshot_outputs(seq_dir)
+    par_outputs = _snapshot_outputs(par_dir)
+
+    assert seq_outputs.keys() == par_outputs.keys()
+    assert len(seq_outputs) > 3  # index + combined + per-session files
+    for rel_path, seq_content in seq_outputs.items():
+        assert par_outputs[rel_path] == seq_content, (
+            f"{rel_path} differs between jobs=1 and jobs=2"
+        )
+
+
+def test_parallel_second_run_takes_cached_fast_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    projects_dir = _build_projects_dir(tmp_path, "projects")
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "cache.db"))
+
+    process_projects_hierarchy(projects_dir, jobs=2)
+    first_run = capsys.readouterr().out
+    assert "cached" not in first_run
+
+    index_path = projects_dir / "index.html"
+    assert index_path.exists()
+    index_mtime = index_path.stat().st_mtime
+
+    process_projects_hierarchy(projects_dir, jobs=2)
+    second_run = capsys.readouterr().out
+    # All three projects hit the fast path... (": cached" is the
+    # per-project progress line; bare "cached" also appears in the
+    # archived-sessions footer note)
+    assert second_run.count(": cached") == 3
+    # ...and the index is still (unconditionally) regenerated.
+    assert index_path.stat().st_mtime >= index_mtime
+
+
+def test_jobs_exceeding_project_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Worker count is clamped to the number of stale projects."""
+    projects_dir = _build_projects_dir(tmp_path, "projects")
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "cache.db"))
+
+    process_projects_hierarchy(projects_dir, jobs=64)
+    assert (projects_dir / "index.html").exists()
+    for project in ["-proj-alpha", "-proj-beta", "-proj-gamma"]:
+        assert (projects_dir / project / "combined_transcripts.html").exists()


### PR DESCRIPTION
process_projects_hierarchy previously converted projects one at a time on a single core, even though rendering is CPU-bound pure Python (~97% of one core) and projects are fully independent. The loop is now split into three phases:

- plan (sequential): per-project staleness/destination via cache mtimes; also ensures the shared DB schema and project rows exist before any worker opens the DB, so migrations can't race.
- execute: stale projects fan out over a ProcessPoolExecutor (spawn start method, largest project first to minimise the straggler tail). Workers run silent; the parent prints one progress line per project as results arrive. Pool-level failures (e.g. a library caller without spawn's __main__ guard) degrade to inline sequential processing with a warning instead of aborting.
- collect (sequential): index aggregation reads the now-fresh cache in sorted order, so index.html and the summary are deterministic regardless of worker completion order.

New --jobs/-j flag (default: CPU count; 1 restores the old inline path). Warm runs skip the pool entirely — an all-cached hierarchy pass is unchanged at ~sub-second.

Benchmarked on a 16-project / 221 MB real-data subset (4 cores, cold cache): 38.7s → 13.2s (2.9×, 310% CPU), output byte-identical to the sequential run. Concurrent workers share the WAL-mode SQLite cache DB safely: each writes only its own project's rows in short committed transactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--jobs`/`-j` option to control parallel project conversion.
  * All-project processing now supports concurrent conversion with progress across phases.
  * `--jobs 1` disables parallel execution.
* **Bug Fixes**
  * Output remains deterministic between sequential and parallel runs.
  * `jobs` is clamped to the number of stale projects to avoid wasted workers.
  * If worker pool startup fails, conversion falls back to sequential processing without aborting outputs.
* **Documentation**
  * Updated CLI documentation to describe the new planning/execution/collection workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->