### PR TITLE
Document tool-renderer coverage + fix docs-build dependency-group install

### DIFF
--- a/.claude/skills/update-tools-coverage/SKILL.md
+++ b/.claude/skills/update-tools-coverage/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: update-tools-coverage
+description: Refresh dev-docs/tools-coverage.md against the upstream Claude Code tools reference. Use when checkpointing tool-renderer coverage, after adding/removing a tool renderer, or when the upstream tools list may have changed.
+---
+
+# Update Tool Coverage
+
+Keeps [`dev-docs/tools-coverage.md`](../../../dev-docs/tools-coverage.md) in
+sync with two sources of truth:
+
+1. **Upstream** — the documented tool list at
+   <https://code.claude.com/docs/en/tools-reference>.
+2. **Us** — `TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` in
+   [`claude_code_log/factories/tool_factory.py`](../../../claude_code_log/factories/tool_factory.py).
+
+The doc grades each documented tool **Full** (typed input + typed output),
+**Input only** (typed input, generic output), or **Generic** (no registry
+entry → params-table + raw-`<pre>` fallback), and separately lists tools we
+support that upstream no longer documents (renames like `Task`→`Agent`,
+supersessions like `MultiEdit`, legacy aliases, undocumented features).
+
+## Procedure
+
+1. **Fetch the upstream tool names.** WebFetch the reference and ask only
+   for the tool-table names (the page is ~80 KB; a targeted prompt keeps it
+   manageable):
+
+   > WebFetch `https://code.claude.com/docs/en/tools-reference` —
+   > "List the exact tool names in the main tools table, one per line.
+   > Names only, no descriptions."
+
+   Note any tool the page marks deprecated/renamed — that's a candidate for
+   the second table.
+
+2. **Compute the truth mechanically.** Feed those names to the bundled
+   helper (run from the repo root; `uv run` is required so `pydantic`
+   resolves — bare `python3` fails with `ModuleNotFoundError: pydantic`):
+
+   ```bash
+   printf 'Agent Artifact AskUserQuestion ... Write' \
+     | uv run python .claude/skills/update-tools-coverage/check_coverage.py
+   ```
+
+   It prints each tool's support level, the totals, the "we register but
+   upstream doesn't document" set, and — if the doc exists — a **drift
+   report** (missing / mismatched / stale rows). If it says `in sync [OK]` and
+   the upstream name set is unchanged, there is nothing to do.
+
+3. **Reconcile the doc.** Apply the helper's output to
+   `dev-docs/tools-coverage.md`:
+   - Move rows between the two tables as tools enter/leave the upstream list —
+     **never delete** a row for a tool we still register. A tool leaving the
+     reference moves to the "no longer documented" table (it's history a
+     transcript viewer must still render); it does not lose support.
+   - Fix any support-level the drift report flags.
+   - Update the **totals line** and the **snapshot date** in the intro
+     (`snapshot YYYY-MM-DD`).
+   - The **Notes column is hand-maintained** — carry notes forward; only the
+     support level is machine-derived.
+
+4. **Re-run the helper** to confirm `in sync [OK]`.
+
+## Guardrails
+
+- **Generic is a feature, not a gap.** Unknown / `mcp__*` / plugin tools
+  *should* fall back to generic rendering. Only type a tool when it's common
+  or carries structure worth surfacing — see
+  [`implementing-a-tool-renderer.md`](../../../dev-docs/implementing-a-tool-renderer.md)
+  (or the `tool-renderer` skill) to actually add one.
+- **Undocumented ≠ obsolete.** The reference table isn't a full census of
+  what lands in a JSONL file (e.g. `TeamCreate`/`TeamDelete` are typed both
+  sides but never appeared upstream). Keep those under "no longer /never
+  documented" with a note, not removed.
+- **Dead models.** `GlobOutput` / `GrepOutput` exist in `models.py` but no
+  parser constructs them, so `Glob`/`Grep` are **Input only**. If a future
+  change wires up a parser, they graduate to Full automatically — the helper
+  will show the flip.

--- a/.claude/skills/update-tools-coverage/check_coverage.py
+++ b/.claude/skills/update-tools-coverage/check_coverage.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Compute tool-coverage status from the live factory registries.
+
+Run from the repo root via ``uv run`` (needs pydantic on the path):
+
+    # Feed the upstream documented tool names (whitespace/newline separated)
+    printf 'Agent Artifact ... Write' | uv run python .claude/skills/update-tools-coverage/check_coverage.py
+
+Emits, for the given upstream tool set:
+  * per-tool support level (Full / Input only / Generic),
+  * totals,
+  * tools we register that upstream does NOT list (obsolete / undocumented),
+  * drift vs. the committed dev-docs/tools-coverage.md table, if present.
+
+The classification here is the *source of truth*; the doc's Notes column is
+hand-maintained, so reconcile prose by hand after reading this output.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+from claude_code_log.factories.tool_factory import (
+    TOOL_INPUT_MODELS,
+    TOOL_OUTPUT_PARSERS,
+)
+
+DOC = Path("dev-docs/tools-coverage.md")
+
+
+def support(tool: str) -> str:
+    has_in = tool in TOOL_INPUT_MODELS
+    has_out = tool in TOOL_OUTPUT_PARSERS
+    if has_in and has_out:
+        return "Full"
+    if has_in:
+        return "Input only"
+    return "Generic"
+
+
+def read_upstream() -> list[str]:
+    raw = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else sys.stdin.read()
+    tools = raw.split()
+    if not tools:
+        sys.exit(
+            "No upstream tool names given.\n"
+            "Pass them as args or on stdin (whitespace/newline separated).\n"
+            "Get them by fetching https://code.claude.com/docs/en/tools-reference"
+        )
+    # de-dupe, preserve order
+    seen: dict[str, None] = {}
+    for t in tools:
+        seen.setdefault(t, None)
+    return list(seen)
+
+
+def main() -> None:
+    upstream = read_upstream()
+    print(f"UPSTREAM documented tools: {len(upstream)}\n")
+
+    print("=== Support level (source of truth) ===")
+    width = max(len(t) for t in upstream)
+    for t in sorted(upstream):
+        print(f"  {t:<{width}}  {support(t)}")
+
+    counts = Counter(support(t) for t in upstream)
+    print(
+        f"\n=== Totals === "
+        f"Full: {counts['Full']}  "
+        f"Input only: {counts['Input only']}  "
+        f"Generic: {counts['Generic']}"
+    )
+
+    registered = set(TOOL_INPUT_MODELS) | set(TOOL_OUTPUT_PARSERS)
+    extra = sorted(registered - set(upstream))
+    print("\n=== We register but upstream does NOT document ===")
+    print("(obsolete renames/supersessions, legacy aliases, or undocumented features)")
+    for t in extra:
+        sides = []
+        if t in TOOL_INPUT_MODELS:
+            sides.append("input")
+        if t in TOOL_OUTPUT_PARSERS:
+            sides.append("output")
+        print(f"  {t:<20} typed: {', '.join(sides)}")
+
+    # --- Drift check against the committed doc, if present ------------------
+    if not DOC.exists():
+        print(f"\n(no {DOC} yet — nothing to diff)")
+        return
+
+    doc_rows = dict(
+        re.findall(
+            r"^\| `(\w+)` \| (Full|Input only|Generic) \|",
+            DOC.read_text(encoding="utf-8"),
+            re.M,
+        )
+    )
+    print(f"\n=== Drift vs {DOC} ===")
+    problems = False
+    for t in upstream:
+        want, have = support(t), doc_rows.get(t)
+        if have is None:
+            print(f"  MISSING from doc: {t} (should be {want})")
+            problems = True
+        elif have != want:
+            print(f"  MISMATCH: {t} — doc says {have!r}, code says {want!r}")
+            problems = True
+    for t in doc_rows.keys() - set(upstream):
+        print(f"  STALE in doc (not in upstream list): {t}")
+        problems = True
+    if not problems:
+        print("  in sync [OK]")
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ with pointers to the deep-dive docs:
 - [dev-docs/teammates.md](dev-docs/teammates.md) - Teammates feature deep-dive
 - [dev-docs/message-hierarchy.md](dev-docs/message-hierarchy.md) - Fold/unfold state machine
 - [dev-docs/implementing-a-tool-renderer.md](dev-docs/implementing-a-tool-renderer.md) - How-to: add a new tool
+- [dev-docs/tools-coverage.md](dev-docs/tools-coverage.md) - Which tools are typed vs. generic, vs. upstream reference
 - [dev-docs/plugins.md](dev-docs/plugins.md) - Plugin system reference + author guide
 
 User-facing docs live in [docs/](docs/); plans and TODOs live in [work/](work/).

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -37,6 +37,7 @@ for user-facing operations docs see [`docs/`](../docs/).
 | Performance profiling | [`renderer_timings.py`](../claude_code_log/renderer_timings.py) | inlined below (§ 2.8) |
 | Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.9) |
 | Adding a new tool renderer | [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), `html/tool_formatters.py` | [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md) (how-to) |
+| Which tools have a specialized renderer | `TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` in [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py) | [tools-coverage.md](tools-coverage.md) (status vs. upstream reference) |
 | Plugin system (third-party message transformers) | [`plugins.py`](../claude_code_log/plugins.py), [`factories/priorities.py`](../claude_code_log/factories/priorities.py), `Renderer._dispatch_format` | [plugins.md](plugins.md) |
 
 A note on cross-cutting concerns: some behaviour spans several rows

--- a/dev-docs/tools-coverage.md
+++ b/dev-docs/tools-coverage.md
@@ -1,0 +1,136 @@
+# Tool Coverage
+
+> See [application_model.md](application_model.md) for the system overview,
+> and [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md) for
+> the how-to when closing a gap listed here.
+
+Which Claude Code tools get a specialized renderer, and which fall back
+to the generic one. Checked against the upstream
+[Tools reference](https://code.claude.com/docs/en/tools-reference)
+(42 documented tools, snapshot 2026-07-15).
+
+## Three levels of support
+
+Coverage is not binary — a tool can be typed on one side and generic on
+the other:
+
+1. **Typed input** — an entry in `TOOL_INPUT_MODELS`
+   (`factories/tool_factory.py`) parses `tool_use.input` into a Pydantic
+   model, which `_dispatch_format` routes to `format_<Model>` /
+   `title_<Model>` methods in `html/renderer.py` and `markdown/renderer.py`.
+2. **Typed output** — an entry in `TOOL_OUTPUT_PARSERS` turns the raw
+   `tool_result` (and, for members of `PARSERS_WITH_TOOL_USE_RESULT`, the
+   structured `toolUseResult`) into a dataclass with its own formatters.
+3. **Generic fallback** — no registry entry. Input renders as a
+   `<table class="params">` key/value dump (`format_ToolUseContent`),
+   output as a raw `<pre>` block (`format_ToolResultContent`), and the
+   header shows the bare tool name, HTML-escaped
+   (`title_ToolUseMessage`, see #245).
+
+The fallback is a genuine feature, not a hole: it means an unknown tool —
+a brand-new built-in, an `mcp__*` tool, a plugin's tool — always renders
+something faithful. Typing a tool buys a compact title, structured
+formatting, and correct Markdown/JSON export; it is worth doing for tools
+that appear often or carry structure worth surfacing.
+
+**JSON export needs no per-tool work.** `json/renderer.py` serialises
+whatever the factory produced via `dataclasses.asdict`, so a tool's JSON
+representation improves for free the moment it gets typed models.
+
+## Documented tools
+
+Legend: **Full** = typed input + typed output · **Input only** = typed
+input, generic output · **Generic** = no registry entry, fallback
+rendering.
+
+| Tool | Support | Notes |
+| :--- | :--- | :--- |
+| `Agent` | Full | Aliased to `TaskInput` / `parse_task_output`; see [agents.md](agents.md) |
+| `Artifact` | Full | #257 |
+| `AskUserQuestion` | Full | Input card elides when the paired answer re-renders the questions |
+| `Bash` | Full | `minted_background_task_id` hoisted from output (#158) |
+| `CronCreate` | Full | |
+| `CronDelete` | Full | |
+| `CronList` | Full | |
+| `Edit` | Full | |
+| `EnterPlanMode` | Generic | |
+| `EnterWorktree` | Generic | |
+| `ExitPlanMode` | Full | |
+| `ExitWorktree` | Generic | |
+| `Glob` | Input only | `GlobOutput` model exists but no parser registers it — see "Dead models" below |
+| `Grep` | Input only | |
+| `ListMcpResourcesTool` | Generic | |
+| `LSP` | Generic | |
+| `Monitor` | Full | |
+| `NotebookEdit` | Generic | |
+| `PowerShell` | Generic | Windows sessions only; shape is close to `Bash` |
+| `PushNotification` | Generic | |
+| `Read` | Full | |
+| `ReadMcpResourceTool` | Generic | |
+| `RemoteTrigger` | Generic | |
+| `ReportFindings` | Generic | Structured findings list — a good typing candidate |
+| `ScheduleWakeup` | Full | |
+| `SendMessage` | Full | See [teammates.md](teammates.md) |
+| `SendUserFile` | Generic | |
+| `ShareOnboardingGuide` | Generic | |
+| `Skill` | Input only | Body folded in from the paired `isMeta` entry (#93) |
+| `TaskCreate` | Full | |
+| `TaskGet` | Generic | Only `TaskGet` of the `Task*` family is untyped |
+| `TaskList` | Full | |
+| `TaskOutput` | Full | Back-links to the spawning call (#90, #154) |
+| `TaskStop` | Full | #158 follow-up |
+| `TaskUpdate` | Full | |
+| `TodoWrite` | Input only | Disabled by default upstream since v2.1.142, but ubiquitous in older transcripts |
+| `ToolSearch` | Generic | |
+| `WaitForMcpServers` | Generic | |
+| `WebFetch` | Full | |
+| `WebSearch` | Full | |
+| `Workflow` | Input only | Input `script` is JS; #174 |
+| `Write` | Full | |
+
+**Totals:** 21 full · 5 input only · 16 generic.
+
+## Tools we support that upstream no longer documents
+
+A transcript viewer reads *history*. These entries look obsolete against
+today's reference but are load-bearing for archived transcripts, so
+**none of them should be dropped** — a removal silently degrades old
+logs to generic rendering.
+
+| Tool | Why it's gone upstream | Why we keep it |
+| :--- | :--- | :--- |
+| `Task` | Renamed to `Agent` | Every subagent spawn in pre-rename transcripts |
+| `MultiEdit` | Removed; superseded by `Edit` | Common in older transcripts; has input model + title, no output parser |
+| `ask_user_question` | Legacy snake_case name of `AskUserQuestion` | Aliased to the same input model |
+| `TeamCreate` | Never in the reference table | Agent-teams feature; fully typed both sides |
+| `TeamDelete` | Never in the reference table | Ditto |
+
+`TeamCreate` / `TeamDelete` are the inverse case: emitted by the
+agent-teams feature but absent from the public table. Undocumented is
+not the same as obsolete — the reference table is not a complete census
+of what lands in a JSONL file.
+
+## Dead models
+
+`GlobOutput` and `GrepOutput` are declared in `models.py` and
+`GlobOutput` even has a `format_GlobOutput` in `markdown/renderer.py`,
+but neither is registered in `TOOL_OUTPUT_PARSERS`, so nothing ever
+constructs them — `ToolOutput` carries an explicit
+`# TODO: Add as parsers are implemented` for both. Either wire up the
+parsers or drop the models; right now they read as coverage that isn't
+there.
+
+## MCP and plugin tools
+
+`mcp__<server>__<tool>` names never appear in the reference table and are
+unbounded by definition, so they always take the generic path. Plugins
+can register their own formatters — see [plugins.md](plugins.md).
+
+## Keeping this page current
+
+The upstream reference changes with most Claude Code releases. When
+revisiting: re-fetch the reference, diff its tool names against
+`TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` keys, and move rows between
+the two tables above rather than deleting them — a tool leaving the
+reference means it moves to "no longer documented", never that support
+gets removed.

--- a/justfile
+++ b/justfile
@@ -85,12 +85,15 @@ docs-gen:
     uv run python scripts/generate_tui_screenshots.py docs/assets/tui
 
 # Serve the documentation site locally with live reload (http://127.0.0.1:8000)
+# `--group docs` pulls in the docs-only deps (mkdocs et al.) on demand — the
+# group is not synced by a plain `uv run`, so run it here rather than relying
+# on a prior `uv sync --group docs`.
 docs-serve:
-    DISABLE_MKDOCS_2_WARNING=true uv run mkdocs serve
+    DISABLE_MKDOCS_2_WARNING=true uv run --group docs mkdocs serve
 
 # Build the documentation site (strict: fails on broken links/nav)
 docs-build:
-    DISABLE_MKDOCS_2_WARNING=true uv run mkdocs build --strict
+    DISABLE_MKDOCS_2_WARNING=true uv run --group docs mkdocs build --strict
 
 build:
     -rm dist/*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Workflows: development/workflows.md
       - CSS classes: development/css-classes.md
       - Implementing a tool renderer: development/implementing-a-tool-renderer.md
+      - Tool coverage: development/tools-coverage.md
       - Plugins: development/plugins.md
   - Contributing: contributing.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

Two related documentation-tooling changes:

- **Tool-renderer coverage doc** (`55feaeb`, `3db695a`): adds `dev-docs/tools-coverage.md` mapping which Claude Code tools have typed renderers vs. fall back to generic rendering, cross-referenced against the upstream tools reference, plus a `/update-tools-coverage` skill to refresh it.
- **docs-build dependency fix** (`8bf360e`): `just docs-serve`/`docs-build` now pass `--group docs` to `uv run`. The `docs` group is a non-default PEP 735 dependency-group, so a plain `uv run mkdocs` didn't include it — the recipe only worked after a prior `uv sync --group docs`. Now the docs deps install on demand, matching the env CI builds.

## Test plan

- `just docs-build` — strict build passes from a clean env (auto-installs the docs group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Tool Coverage reference describing tool rendering support levels and coverage status.
  * Added the Tool Coverage page to the developer documentation navigation and architecture references.
  * Documented which tools have specialized renderers.

* **Developer Tools**
  * Added a coverage checker to identify missing, outdated, or mismatched tool support documentation.
  * Updated documentation build and preview commands for reliable dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->