### PR TITLE
Render steering from queued_command attachments; fix empty steering cards

### DIFF
--- a/claude_code_log/factories/attachment_factory.py
+++ b/claude_code_log/factories/attachment_factory.py
@@ -9,16 +9,25 @@ which left the user unable to inspect any hook output even at
 full-detail.
 
 This factory promotes the *hook* flavours into a renderable
-``HookAttachmentMessage``; non-hook flavours still return ``None`` so
-they keep the historical "structural in DAG, hidden from rendering"
-behaviour. New attachment flavours can grow their own factory branch
-here as needed.
+``HookAttachmentMessage`` and ``queued_command`` (modern steering
+deliveries) into a ``UserSteeringMessage``; the remaining non-hook
+flavours still return ``None`` so they keep the historical "structural
+in DAG, hidden from rendering" behaviour. New attachment flavours can
+grow their own factory branch here as needed.
 """
 
 from typing import Any, Optional, cast
 
-from ..models import AttachmentTranscriptEntry, HookAttachmentMessage
+from ..models import (
+    AttachmentTranscriptEntry,
+    HookAttachmentMessage,
+    MessageContent,
+    TextContent,
+    UserSteeringMessage,
+    UserTextMessage,
+)
 from .meta_factory import create_meta
+from .user_factory import create_user_message
 
 
 # Attachment ``type`` values produced when a Claude Code hook fires.
@@ -61,9 +70,51 @@ def _coerce_int(value: Any) -> Optional[int]:
     return None
 
 
+def _create_queued_command_message(
+    transcript: AttachmentTranscriptEntry,
+    payload: dict[str, Any],
+) -> Optional[MessageContent]:
+    """Promote a ``queued_command`` attachment to a steering message.
+
+    Modern Claude Code (≳2.1.101) writes a ``queued_command`` attachment
+    for every steering delivery — an in-DAG, uuid'd record that is
+    strictly better than the chain-less legacy queue-operation
+    ``remove`` (which we suppress per-version in the renderer once a
+    ``queued_command`` is seen). The steering text lives in
+    ``payload["prompt"]``.
+
+    The text is routed through :func:`create_user_message` so it gets
+    the same classification + plugin-transformer pass as an
+    idle-delivered user prompt: a ``[monitor] …`` steering injection
+    renders as the same demoted marker as its non-steering siblings. If
+    no transformer rewrites it (the result is a *plain*
+    ``UserTextMessage``), it is wrapped as ``UserSteeringMessage`` to
+    keep the ``user steering`` CSS treatment; a transformed/other
+    classification is returned unchanged.
+    """
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return None
+
+    meta = create_meta(transcript)
+    chunk: list[Any] = [TextContent(type="text", text=prompt)]
+    result = create_user_message(meta, chunk, prompt, is_slash_command=False)
+    if result is None:
+        return None
+
+    # Only a plain, untransformed UserTextMessage becomes steering. An
+    # exact-type check mirrors the legacy-path hardening in renderer.py:
+    # a transformer may return a UserTextMessage *subclass* carrying its
+    # content in own fields with ``items=[]`` — rebuilding steering from
+    # its ``items`` would blank the card.
+    if type(result) is UserTextMessage:
+        return UserSteeringMessage(items=result.items, meta=meta)
+    return result
+
+
 def create_attachment_message(
     transcript: AttachmentTranscriptEntry,
-) -> Optional[HookAttachmentMessage]:
+) -> Optional[MessageContent]:
     """Build a renderable MessageContent from an attachment entry.
 
     Returns ``None`` for attachment flavours we don't surface yet — the
@@ -76,11 +127,17 @@ def create_attachment_message(
         transcript: Parsed attachment entry from the JSONL file.
 
     Returns:
-        HookAttachmentMessage for hook flavours; ``None`` otherwise.
+        A renderable content model (``HookAttachmentMessage`` for hook
+        flavours, a steering message for ``queued_command``); ``None``
+        otherwise.
     """
     payload = transcript.attachment or {}
 
     attachment_type = payload.get("type")
+
+    if attachment_type == "queued_command":
+        return _create_queued_command_message(transcript, payload)
+
     kind = (
         _HOOK_KINDS.get(attachment_type) if isinstance(attachment_type, str) else None
     )

--- a/claude_code_log/factories/attachment_factory.py
+++ b/claude_code_log/factories/attachment_factory.py
@@ -99,6 +99,11 @@ def _create_queued_command_message(
     meta = create_meta(transcript)
     chunk: list[Any] = [TextContent(type="text", text=prompt)]
     result = create_user_message(meta, chunk, prompt, is_slash_command=False)
+    # Defensive only: create_user_message never returns None for a non-empty
+    # text chunk (it returns None solely on an empty content_list / the empty
+    # is_slash_command path, neither reachable here). Kept to guard against a
+    # future change to its contract — the effective render condition upstream
+    # is exactly this ``prompt.strip()``, so pre-pass and factory can't drift.
     if result is None:
         return None
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3730,6 +3730,23 @@ def _queue_op_content_as_list(
     return []
 
 
+def _steering_match_text(content: Optional[list[ContentItem] | str]) -> str:
+    """Normalized text used to pair a steering ``remove`` with its
+    ``queued_command``.
+
+    Both records carry the same human prompt (``remove.content`` ==
+    ``queued_command.prompt``), so suppression matches on this text rather
+    than on arrival order. Order-based matching loses/duplicates content
+    when the 1:1 pairing is imperfect and an orphan ``remove`` (no paired
+    ``queued_command``) precedes a paired one.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        return extract_text_content(content).strip()
+    return ""
+
+
 def _filter_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntry]:
     """Filter messages to those that should be rendered.
 
@@ -4547,17 +4564,20 @@ def _render_messages(
     # from the map and skipped by the scan.
     uuid_to_entry: dict[str, TranscriptEntry] = {}
     # Pass 1 for legacy steering-``remove`` suppression: per ``(session,
-    # version)``, the count of *renderable* ``queued_command`` attachments.
-    # Modern Claude Code (≳2.1.101) writes an in-DAG ``queued_command`` for
-    # every steering delivery, 1:1 with the chain-less legacy ``remove`` op;
-    # once we render the former we must suppress the latter to avoid a duplicate
-    # card. Keyed per session (session HTML is cached individually — cross-
-    # session state would break incremental-cache correctness) and per version
-    # (a resumed session can span a harness upgrade, so neither a session-level
-    # boolean nor hard-coded version knowledge is correct — learn it from the
-    # file). A count (not a bare set) so pass 2 can warn if it suppresses more
-    # removes than there are cards to replace them. See pass 2 below.
-    renderable_qc_count: dict[tuple[str, str], int] = {}
+    # version, prompt-text)``, the count of *renderable* ``queued_command``
+    # attachments. Modern Claude Code (≳2.1.101) writes an in-DAG
+    # ``queued_command`` for every steering delivery, 1:1 with the chain-less
+    # legacy ``remove`` op; once we render the former we must suppress the
+    # latter to avoid a duplicate card. Keyed per session (session HTML is
+    # cached individually — cross-session state would break incremental-cache
+    # correctness), per version (a resumed session can span a harness upgrade,
+    # so learn it from the file rather than assume), AND per prompt text: a
+    # ``remove`` is paired to a ``queued_command`` by content, not arrival
+    # order, so an orphan ``remove`` (no paired card) can't consume a different
+    # remove's budget and get dropped. ``qc_versions`` records which
+    # ``(session, version)`` had any card, to scope the imbalance warning.
+    renderable_qc_count: dict[tuple[str, str, str], int] = {}
+    qc_versions: set[tuple[str, str]] = set()
     for entry in messages:
         entry_uuid = getattr(entry, "uuid", "")
         if entry_uuid:
@@ -4566,15 +4586,17 @@ def _render_messages(
             isinstance(entry, AttachmentTranscriptEntry)
             and (entry.attachment or {}).get("type") == "queued_command"
         ):
-            # Only count a version whose ``queued_command`` will actually
-            # render — i.e. it carries a usable prompt (mirrors the guard in
+            # Only count a ``queued_command`` that will actually render — i.e.
+            # it carries a usable prompt (mirrors the guard in
             # ``attachment_factory._create_queued_command_message``). Otherwise
-            # a promptless attachment would seed the suppression set and drop
-            # the paired ``remove`` that still holds the steering text.
+            # a promptless attachment would seed the budget and drop the paired
+            # ``remove`` that still holds the steering text.
             qc_prompt = (entry.attachment or {}).get("prompt")
             if isinstance(qc_prompt, str) and qc_prompt.strip():
-                key = (entry.sessionId, entry.version)
+                text = _steering_match_text(qc_prompt)
+                key = (entry.sessionId, entry.version, text)
                 renderable_qc_count[key] = renderable_qc_count.get(key, 0) + 1
+                qc_versions.add((entry.sessionId, entry.version))
 
     # Track which sessions have had headers added.
     seen_sessions: set[str] = set()
@@ -4585,14 +4607,14 @@ def _render_messages(
     # harness restart, so the most recent version in its session is its version.
     last_version_by_session: dict[str, str] = {}
     # Decrementing budget of renderable ``queued_command`` cards per ``(session,
-    # version)``, seeded from the pass-1 count. Each suppressed ``remove`` spends
-    # one unit; once a key's budget is exhausted, further removes under that key
-    # are *rendered* as legacy steering rather than dropped. This makes
-    # suppression LOSSLESS: we hide exactly ``min(#removes, #renderable_qc)`` per
-    # version (no duplicate cards), and any orphan removes (the 1:1 pairing does
-    # break in real archives — e.g. a 2.1.160 file with 34 removes / 29 qc)
-    # still render their steering text.
-    qc_budget: dict[tuple[str, str], int] = dict(renderable_qc_count)
+    # version, prompt-text)``, seeded from the pass-1 count. Each suppressed
+    # ``remove`` spends one unit under ITS OWN text key; once a text's budget is
+    # exhausted (or absent), further removes with that text are *rendered* as
+    # legacy steering rather than dropped. This makes suppression LOSSLESS and
+    # order-independent: we hide exactly the removes that have a matching card
+    # (no duplicate), and any orphan removes — the 1:1 pairing does break in
+    # real archives, e.g. a 2.1.160 file with 34 removes / 29 qc — still render.
+    qc_budget: dict[tuple[str, str, str], int] = dict(renderable_qc_count)
     # (session, version) keys already warned about, so the imbalance is logged
     # at most once per key rather than per orphan remove.
     warned_qc_imbalance: set[tuple[str, str]] = set()
@@ -4611,11 +4633,12 @@ def _render_messages(
             last_version_by_session[msg_session_id] = msg_version
 
         # Suppress the legacy steering ``remove`` when its session still has an
-        # unspent ``queued_command`` under the same (inferred) harness version:
-        # the modern in-DAG attachment is rendered instead, 1:1. Old transcripts
-        # (no ``queued_command`` anywhere) have no budget → removes render as
-        # before. ``remove`` ops are uuid-less (no DAG role), so suppression is
-        # plain skipping with no dangling-anchor risk.
+        # unspent ``queued_command`` with the SAME prompt text under the same
+        # (inferred) harness version: the modern in-DAG attachment is rendered
+        # instead, 1:1. Old transcripts (no ``queued_command`` anywhere) have no
+        # budget → removes render as before. ``remove`` ops are uuid-less (no
+        # DAG role), so suppression is plain skipping with no dangling-anchor
+        # risk.
         if (
             isinstance(message, QueueOperationTranscriptEntry)
             and message.operation == "remove"
@@ -4625,29 +4648,30 @@ def _render_messages(
             # version-bearing entry preceded this remove, so we can't confirm a
             # same-version ``queued_command`` — render the remove (safe default)
             # rather than risk suppressing a real steering card.
-            key = (message.sessionId, inferred_version)
+            remove_text = _steering_match_text(message.content)
+            key = (message.sessionId, inferred_version, remove_text)
             if inferred_version and qc_budget.get(key, 0) > 0:
-                qc_budget[key] -= 1  # spend one paired card; hide this remove
+                qc_budget[key] -= 1  # spend the matching card; hide this remove
                 continue
-            # Budget exhausted for a version that DID have queued_commands →
-            # this is an orphan remove (more removes than cards). Fall through
-            # to render it (lossless), and flag the broken 1:1 invariant once.
+            # No matching queued_command (or its budget is spent) → this is an
+            # orphan remove. Fall through to render it (lossless). If the session
+            # DID have cards under this version, the 1:1 pairing broke — flag it
+            # once per (session, version).
+            version_key = (message.sessionId, inferred_version)
             if (
                 inferred_version
-                and key in renderable_qc_count
-                and key not in warned_qc_imbalance
+                and version_key in qc_versions
+                and version_key not in warned_qc_imbalance
             ):
-                warned_qc_imbalance.add(key)
-                session_id, version = key
+                warned_qc_imbalance.add(version_key)
                 logger.warning(
                     "steering suppression imbalance in session %s under version "
-                    "%s: more 'remove' ops than renderable queued_command cards "
-                    "(%d card(s)) — rendering the surplus remove(s) as legacy "
-                    "steering (content preserved). The remove↔queued_command "
-                    "1:1 pairing appears violated (seen in real archives).",
-                    session_id,
-                    version,
-                    renderable_qc_count.get(key, 0),
+                    "%s: a 'remove' op has no matching queued_command card — "
+                    "rendering it as legacy steering (content preserved). The "
+                    "remove↔queued_command 1:1 pairing appears violated (seen in "
+                    "real archives).",
+                    message.sessionId,
+                    inferred_version,
                 )
 
         # Pre-D11 inline derivation (``current_render_session`` +

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3764,10 +3764,11 @@ def _filter_messages(messages: list[TranscriptEntry]) -> list[TranscriptEntry]:
 
         # Attachment entries (issue #128): include — pass-2 walker will
         # call ``create_attachment_message`` to surface hook payloads at
-        # full detail. Non-hook attachment flavours produce ``None`` and
-        # are silently dropped at registration time, mirroring the
-        # pre-#128 PassthroughTranscriptEntry behaviour. Detail-level
-        # filtering happens later: ``_ghost_template_by_detail`` drops
+        # full detail (and ``queued_command`` as a steering message).
+        # The remaining non-hook flavours produce ``None`` and are
+        # silently dropped at registration time, mirroring the pre-#128
+        # PassthroughTranscriptEntry behaviour. Detail-level filtering
+        # happens later: ``_ghost_template_by_detail`` drops
         # ``HookAttachmentMessage`` at HIGH and below.
         if isinstance(message, AttachmentTranscriptEntry):
             filtered.append(message)
@@ -4561,9 +4562,16 @@ def _render_messages(
             isinstance(entry, AttachmentTranscriptEntry)
             and (entry.attachment or {}).get("type") == "queued_command"
         ):
-            versions_with_queued_command.setdefault(entry.sessionId, set()).add(
-                entry.version
-            )
+            # Only count a version whose ``queued_command`` will actually
+            # render — i.e. it carries a usable prompt (mirrors the guard in
+            # ``attachment_factory._create_queued_command_message``). Otherwise
+            # a promptless attachment would seed the suppression set and drop
+            # the paired ``remove`` that still holds the steering text.
+            qc_prompt = (entry.attachment or {}).get("prompt")
+            if isinstance(qc_prompt, str) and qc_prompt.strip():
+                versions_with_queued_command.setdefault(entry.sessionId, set()).add(
+                    entry.version
+                )
 
     # Track which sessions have had headers added.
     seen_sessions: set[str] = set()
@@ -4598,8 +4606,14 @@ def _render_messages(
             and message.operation == "remove"
         ):
             inferred_version = last_version_by_session.get(message.sessionId, "")
-            if inferred_version in versions_with_queued_command.get(
-                message.sessionId, set()
+            # A non-empty inferred version is required: an empty string means no
+            # version-bearing entry preceded this remove, so we can't confirm a
+            # same-version ``queued_command`` — render the remove (safe default)
+            # rather than risk suppressing a real steering card.
+            if (
+                inferred_version
+                and inferred_version
+                in versions_with_queued_command.get(message.sessionId, set())
             ):
                 continue
 

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 from dataclasses import dataclass, field, replace
@@ -89,6 +90,8 @@ from .utils import (
 from .renderer_timings import (
     log_timing,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # -- Rendering Context --------------------------------------------------------
@@ -4543,17 +4546,18 @@ def _render_messages(
     # list; entries removed by structural filtering are simply absent
     # from the map and skipped by the scan.
     uuid_to_entry: dict[str, TranscriptEntry] = {}
-    # Pass 1 for legacy steering-``remove`` suppression: per session, the set
-    # of harness ``version`` values under which a ``queued_command`` attachment
-    # appears. Modern Claude Code (≳2.1.101) writes an in-DAG ``queued_command``
-    # for every steering delivery, 1:1 with the chain-less legacy ``remove`` op;
+    # Pass 1 for legacy steering-``remove`` suppression: per ``(session,
+    # version)``, the count of *renderable* ``queued_command`` attachments.
+    # Modern Claude Code (≳2.1.101) writes an in-DAG ``queued_command`` for
+    # every steering delivery, 1:1 with the chain-less legacy ``remove`` op;
     # once we render the former we must suppress the latter to avoid a duplicate
-    # card. Scoped per session (session HTML is cached individually — cross-
+    # card. Keyed per session (session HTML is cached individually — cross-
     # session state would break incremental-cache correctness) and per version
     # (a resumed session can span a harness upgrade, so neither a session-level
     # boolean nor hard-coded version knowledge is correct — learn it from the
-    # file). See ``_render_messages`` pass 2 below for the inference.
-    versions_with_queued_command: dict[str, set[str]] = {}
+    # file). A count (not a bare set) so pass 2 can warn if it suppresses more
+    # removes than there are cards to replace them. See pass 2 below.
+    renderable_qc_count: dict[tuple[str, str], int] = {}
     for entry in messages:
         entry_uuid = getattr(entry, "uuid", "")
         if entry_uuid:
@@ -4569,9 +4573,8 @@ def _render_messages(
             # the paired ``remove`` that still holds the steering text.
             qc_prompt = (entry.attachment or {}).get("prompt")
             if isinstance(qc_prompt, str) and qc_prompt.strip():
-                versions_with_queued_command.setdefault(entry.sessionId, set()).add(
-                    entry.version
-                )
+                key = (entry.sessionId, entry.version)
+                renderable_qc_count[key] = renderable_qc_count.get(key, 0) + 1
 
     # Track which sessions have had headers added.
     seen_sessions: set[str] = set()
@@ -4581,6 +4584,18 @@ def _render_messages(
     # ``version``; a ``remove`` happens mid-turn and a turn cannot span a
     # harness restart, so the most recent version in its session is its version.
     last_version_by_session: dict[str, str] = {}
+    # Decrementing budget of renderable ``queued_command`` cards per ``(session,
+    # version)``, seeded from the pass-1 count. Each suppressed ``remove`` spends
+    # one unit; once a key's budget is exhausted, further removes under that key
+    # are *rendered* as legacy steering rather than dropped. This makes
+    # suppression LOSSLESS: we hide exactly ``min(#removes, #renderable_qc)`` per
+    # version (no duplicate cards), and any orphan removes (the 1:1 pairing does
+    # break in real archives — e.g. a 2.1.160 file with 34 removes / 29 qc)
+    # still render their steering text.
+    qc_budget: dict[tuple[str, str], int] = dict(renderable_qc_count)
+    # (session, version) keys already warned about, so the imbalance is logged
+    # at most once per key rather than per orphan remove.
+    warned_qc_imbalance: set[tuple[str, str]] = set()
 
     for message in messages:
         message_type = message.type
@@ -4595,10 +4610,10 @@ def _render_messages(
         if msg_version:
             last_version_by_session[msg_session_id] = msg_version
 
-        # Suppress the legacy steering ``remove`` when its session has learned a
-        # ``queued_command`` under the same (inferred) harness version: the
-        # modern in-DAG attachment is rendered instead, 1:1. Old transcripts
-        # (no ``queued_command`` anywhere) have an empty set → removes render as
+        # Suppress the legacy steering ``remove`` when its session still has an
+        # unspent ``queued_command`` under the same (inferred) harness version:
+        # the modern in-DAG attachment is rendered instead, 1:1. Old transcripts
+        # (no ``queued_command`` anywhere) have no budget → removes render as
         # before. ``remove`` ops are uuid-less (no DAG role), so suppression is
         # plain skipping with no dangling-anchor risk.
         if (
@@ -4610,12 +4625,30 @@ def _render_messages(
             # version-bearing entry preceded this remove, so we can't confirm a
             # same-version ``queued_command`` — render the remove (safe default)
             # rather than risk suppressing a real steering card.
+            key = (message.sessionId, inferred_version)
+            if inferred_version and qc_budget.get(key, 0) > 0:
+                qc_budget[key] -= 1  # spend one paired card; hide this remove
+                continue
+            # Budget exhausted for a version that DID have queued_commands →
+            # this is an orphan remove (more removes than cards). Fall through
+            # to render it (lossless), and flag the broken 1:1 invariant once.
             if (
                 inferred_version
-                and inferred_version
-                in versions_with_queued_command.get(message.sessionId, set())
+                and key in renderable_qc_count
+                and key not in warned_qc_imbalance
             ):
-                continue
+                warned_qc_imbalance.add(key)
+                session_id, version = key
+                logger.warning(
+                    "steering suppression imbalance in session %s under version "
+                    "%s: more 'remove' ops than renderable queued_command cards "
+                    "(%d card(s)) — rendering the surplus remove(s) as legacy "
+                    "steering (content preserved). The remove↔queued_command "
+                    "1:1 pairing appears violated (seen in real archives).",
+                    session_id,
+                    version,
+                    renderable_qc_count.get(key, 0),
+                )
 
         # Pre-D11 inline derivation (``current_render_session`` +
         # agent-parent resolution) collapsed into one map lookup.

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4542,18 +4542,66 @@ def _render_messages(
     # list; entries removed by structural filtering are simply absent
     # from the map and skipped by the scan.
     uuid_to_entry: dict[str, TranscriptEntry] = {}
+    # Pass 1 for legacy steering-``remove`` suppression: per session, the set
+    # of harness ``version`` values under which a ``queued_command`` attachment
+    # appears. Modern Claude Code (≳2.1.101) writes an in-DAG ``queued_command``
+    # for every steering delivery, 1:1 with the chain-less legacy ``remove`` op;
+    # once we render the former we must suppress the latter to avoid a duplicate
+    # card. Scoped per session (session HTML is cached individually — cross-
+    # session state would break incremental-cache correctness) and per version
+    # (a resumed session can span a harness upgrade, so neither a session-level
+    # boolean nor hard-coded version knowledge is correct — learn it from the
+    # file). See ``_render_messages`` pass 2 below for the inference.
+    versions_with_queued_command: dict[str, set[str]] = {}
     for entry in messages:
         entry_uuid = getattr(entry, "uuid", "")
         if entry_uuid:
             uuid_to_entry.setdefault(entry_uuid, entry)
+        if (
+            isinstance(entry, AttachmentTranscriptEntry)
+            and (entry.attachment or {}).get("type") == "queued_command"
+        ):
+            versions_with_queued_command.setdefault(entry.sessionId, set()).add(
+                entry.version
+            )
 
     # Track which sessions have had headers added.
     seen_sessions: set[str] = set()
+
+    # Pass 2 state for steering-``remove`` suppression: the last version-bearing
+    # entry seen per session, in file order. Queue-op entries carry no
+    # ``version``; a ``remove`` happens mid-turn and a turn cannot span a
+    # harness restart, so the most recent version in its session is its version.
+    last_version_by_session: dict[str, str] = {}
 
     for message in messages:
         message_type = message.type
         msg_session_id = getattr(message, "sessionId", "") or ""
         message_uuid = getattr(message, "uuid", "") or ""
+
+        # Track the harness version per session in file order (pass 2 of the
+        # steering-``remove`` suppression). Version-bearing entries carry a
+        # non-empty ``version``; queue-op / summary entries don't and leave the
+        # last value in place.
+        msg_version = getattr(message, "version", "") or ""
+        if msg_version:
+            last_version_by_session[msg_session_id] = msg_version
+
+        # Suppress the legacy steering ``remove`` when its session has learned a
+        # ``queued_command`` under the same (inferred) harness version: the
+        # modern in-DAG attachment is rendered instead, 1:1. Old transcripts
+        # (no ``queued_command`` anywhere) have an empty set → removes render as
+        # before. ``remove`` ops are uuid-less (no DAG role), so suppression is
+        # plain skipping with no dangling-anchor risk.
+        if (
+            isinstance(message, QueueOperationTranscriptEntry)
+            and message.operation == "remove"
+        ):
+            inferred_version = last_version_by_session.get(message.sessionId, "")
+            if inferred_version in versions_with_queued_command.get(
+                message.sessionId, set()
+            ):
+                continue
 
         # Pre-D11 inline derivation (``current_render_session`` +
         # agent-parent resolution) collapsed into one map lookup.
@@ -4786,11 +4834,19 @@ def _render_messages(
                         chunk_meta, chunk, chunk_usage
                     )
 
-                # Convert to UserSteeringMessage for queue-operation 'remove' messages
+                # Convert to UserSteeringMessage for queue-operation 'remove'
+                # messages. Exact-type check (not ``isinstance``): a plugin
+                # transformer may have rewritten the text into a
+                # ``UserTextMessage`` *subclass* that carries its content in
+                # own fields with ``items=[]`` (e.g. hook-demotion). Rebuilding
+                # ``UserSteeringMessage(items=content_model.items)`` from such a
+                # subclass would clobber the transformed content back into an
+                # empty-items steering card. Only the plain, untransformed
+                # ``UserTextMessage`` is promoted to steering here.
                 if (
                     isinstance(message, QueueOperationTranscriptEntry)
                     and message.operation == "remove"
-                    and isinstance(content_model, UserTextMessage)
+                    and type(content_model) is UserTextMessage
                 ):
                     content_model = UserSteeringMessage(
                         items=content_model.items, meta=chunk_meta

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -251,9 +251,15 @@ class CompactedSummaryMessage(MessageContent):
     summary_text: str  # The compacted conversation summary
 ```
 
-### User Steering (Queue Remove)
+### User Steering (Queue Remove / queued_command)
 
-- **Condition**: `QueueOperationTranscriptEntry` with `operation: "remove"`
+- **Condition** (two sources, by harness era):
+  - Modern (Claude Code ≳2.1.101): a `type: "attachment"` /
+    `attachment.type: "queued_command"` entry — the preferred record, as
+    it is in-DAG and carries `uuid`/`parentUuid` (a debug line the legacy
+    `remove` lacks). Promoted in `factories/attachment_factory.py`.
+  - Legacy (≤~2.1.29): a `QueueOperationTranscriptEntry` with
+    `operation: "remove"` — chain-less, uuid-less.
 - **Content Model**: `UserSteeringMessage` (extends `UserTextMessage`)
 - **CSS Class**: `user steering`
 - **Title**: "User (steering)"
@@ -265,7 +271,30 @@ class UserSteeringMessage(UserTextMessage):
     pass  # Inherits items from UserTextMessage
 ```
 
-Steering messages represent user interrupts that cancel queued operations.
+Steering messages represent user input injected mid-turn to steer an
+ongoing assistant response.
+
+**De-duplication (modern transcripts).** Every steering delivery writes
+*both* a `queued_command` attachment and a legacy `remove` op, 1:1. To
+avoid a duplicate card, `_render_messages` suppresses the `remove`
+per-session, per inferred harness version: a pre-pass collects the set of
+`version` values under which a `queued_command` appears (queue-op entries
+carry no `version`, so a `remove`'s version is inferred from the last
+version-bearing entry in file order — a turn cannot span a harness
+restart). A `remove` is skipped iff its inferred version is in that set.
+Per-session scoping keeps per-session HTML caching correct; the 1:1
+pairing makes it sufficient. Old transcripts (empty set) render `remove`
+exactly as before.
+
+**Transformer pass.** The `queued_command` prompt is routed through the
+same `create_user_message` classification + plugin-transformer pass as an
+idle-delivered prompt, so e.g. a `[monitor] …` steering injection renders
+as the same demoted marker as its non-steering siblings. Only a plain,
+untransformed `UserTextMessage` is (re)wrapped as `UserSteeringMessage`
+— an exact-type (`type(x) is UserTextMessage`) check, mirrored in the
+legacy steering conversion in `renderer.py`, prevents a transformer's
+`UserTextMessage` *subclass* (which may carry its text in own fields with
+`items=[]`) from being rebuilt into an empty-items steering card.
 
 ### User Memory
 
@@ -750,7 +779,10 @@ The `leafUuid` links the summary to the last message of the session.
 ## 4.2 Queue Operation (QueueOperationTranscriptEntry)
 
 - **Purpose**: User interrupts and steering during assistant responses
-- **Rendered**: Only `remove` operations (as `UserSteeringContent`)
+- **Rendered**: Only `remove` operations (as `UserSteeringMessage`), and
+  only on legacy transcripts — on modern transcripts (≳2.1.101) the paired
+  `queued_command` attachment is rendered instead and the `remove` is
+  suppressed. See "User Steering (Queue Remove / queued_command)" above.
 - **CSS Class**: `user steering`
 - **Files**: [queue_operation.json](messages/system/queue_operation.json)
 

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -275,16 +275,32 @@ Steering messages represent user input injected mid-turn to steer an
 ongoing assistant response.
 
 **De-duplication (modern transcripts).** Every steering delivery writes
-*both* a `queued_command` attachment and a legacy `remove` op, 1:1. To
-avoid a duplicate card, `_render_messages` suppresses the `remove`
-per-session, per inferred harness version: a pre-pass collects the set of
-`version` values under which a `queued_command` appears (queue-op entries
-carry no `version`, so a `remove`'s version is inferred from the last
-version-bearing entry in file order — a turn cannot span a harness
-restart). A `remove` is skipped iff its inferred version is in that set.
-Per-session scoping keeps per-session HTML caching correct; the 1:1
-pairing makes it sufficient. Old transcripts (empty set) render `remove`
-exactly as before.
+*both* a `queued_command` attachment and a legacy `remove` op, normally
+1:1. To avoid a duplicate card, `_render_messages` suppresses the `remove`
+whose steering text is already covered by a rendered `queued_command`. A
+pass-1 pre-pass counts *renderable* `queued_command`s keyed by `(session,
+version, prompt-text)`; pass 2 spends a decrementing budget under the
+matching key. (Queue-op entries carry no `version`, so a `remove`'s
+version is inferred from the last version-bearing entry in file order — a
+turn cannot span a harness restart.)
+
+The keying matters on two axes:
+
+- **Per `(session, version)`** — session HTML is cached individually, so
+  cross-session state would break incremental-cache correctness; and a
+  resumed session can span a harness upgrade, so the version is learned
+  from the file rather than assumed.
+- **Per prompt-text** — a `remove` is paired to a `queued_command` by
+  *content*, not arrival order. The 1:1 pairing is **not** airtight in
+  real archives (observed: a 2.1.160 file with 34 removes / 29
+  `queued_command`s). Content-keying makes suppression **lossless and
+  order-independent**: exactly the removes with a matching card are hidden,
+  and any orphan `remove` (no matching card, or one arriving before its
+  paired sibling) still renders as legacy steering rather than being
+  dropped. Rendering an orphan under a version that *did* have cards logs a
+  one-shot WARNING (content preserved, invariant-break made visible). Old
+  transcripts (no `queued_command`, empty budget) render `remove` exactly
+  as before.
 
 **Transformer pass.** The `queued_command` prompt is routed through the
 same `create_user_message` classification + plugin-transformer pass as an
@@ -779,10 +795,12 @@ The `leafUuid` links the summary to the last message of the session.
 ## 4.2 Queue Operation (QueueOperationTranscriptEntry)
 
 - **Purpose**: User interrupts and steering during assistant responses
-- **Rendered**: Only `remove` operations (as `UserSteeringMessage`), and
-  only on legacy transcripts — on modern transcripts (≳2.1.101) the paired
-  `queued_command` attachment is rendered instead and the `remove` is
-  suppressed. See "User Steering (Queue Remove / queued_command)" above.
+- **Rendered**: Only `remove` operations (as `UserSteeringMessage`). On
+  modern transcripts (≳2.1.101) a `remove` is suppressed when a paired
+  `queued_command` attachment covers its steering text (rendered instead);
+  a `remove` with no matching card — legacy transcripts, or an orphan when
+  the 1:1 pairing breaks — still renders. See "User Steering (Queue Remove
+  / queued_command)" above.
 - **CSS Class**: `user steering`
 - **Files**: [queue_operation.json](messages/system/queue_operation.json)
 

--- a/test/test_hook_attachment_rendering.py
+++ b/test/test_hook_attachment_rendering.py
@@ -3,7 +3,8 @@
 Covers:
 - Pydantic parse of the issue's example payload (anchored on ``parentUuid``).
 - Factory dispatch to ``HookAttachmentMessage`` for each hook flavour.
-- Non-hook attachment types stay structural (factory returns ``None``).
+- Non-hook attachment types stay structural (factory returns ``None``),
+  except ``queued_command``, which is promoted to a steering message.
 - Full-detail HTML rendering surfaces the hook payload.
 - HIGH and below detail levels drop hook attachments.
 - Parent-anchor: the rendered attachment's parent_uuid matches the
@@ -23,6 +24,7 @@ from claude_code_log.models import (
     DetailLevel,
     HookAttachmentMessage,
     TranscriptEntry,
+    UserSteeringMessage,
 )
 
 
@@ -182,15 +184,35 @@ class TestNonHookAttachments:
         assert isinstance(entry, AttachmentTranscriptEntry)
         assert create_attachment_message(entry) is None
 
-    def test_queued_command_returns_none(self) -> None:
+    def test_queued_command_promoted_to_steering(self) -> None:
+        """``queued_command`` is no longer structural-only: it is promoted
+        to a steering message anchored on its uuid/parentUuid (spec:
+        ``work/steering-queued-command.md``). A plain prompt (no
+        transformer match) becomes a ``UserSteeringMessage``."""
         raw = _make_attachment(
             uuid="aaaaaaaa-0000-4000-8000-000000000002",
-            parent_uuid=None,
+            parent_uuid="bbbbbbbb-0000-4000-8000-000000000002",
             payload={
                 "type": "queued_command",
                 "prompt": "follow-up",
                 "commandMode": "prompt",
             },
+        )
+        entry = create_transcript_entry(raw)
+        assert isinstance(entry, AttachmentTranscriptEntry)
+        result = create_attachment_message(entry)
+        assert isinstance(result, UserSteeringMessage)
+        assert result.meta.uuid == "aaaaaaaa-0000-4000-8000-000000000002"
+        assert result.meta.parent_uuid == "bbbbbbbb-0000-4000-8000-000000000002"
+        assert any(getattr(item, "text", "") == "follow-up" for item in result.items)
+
+    def test_queued_command_without_prompt_returns_none(self) -> None:
+        """A ``queued_command`` with no usable prompt text stays
+        structural (``None``) — nothing to render."""
+        raw = _make_attachment(
+            uuid="aaaaaaaa-0000-4000-8000-000000000009",
+            parent_uuid=None,
+            payload={"type": "queued_command", "commandMode": "prompt"},
         )
         entry = create_transcript_entry(raw)
         assert isinstance(entry, AttachmentTranscriptEntry)

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -302,13 +302,24 @@ class TestMixedVersion:
         # the legacy one is the uuid-less remove (no debug line for it).
         assert "qc1 &rarr; u2" in html
 
+    @staticmethod
+    def _imbalance_warnings(caplog):
+        import logging
+
+        return [
+            rec
+            for rec in caplog.records
+            if "steering suppression imbalance" in rec.message
+            and rec.levelno == logging.WARNING
+        ]
+
     def test_orphan_removes_render_losslessly(self, caplog):
         """The remove↔queued_command 1:1 pairing is not airtight in real
         archives (observed: a 2.1.160 file with 34 removes / 29 qc). When a
         (session, version) has MORE removes than renderable queued_command
-        cards, suppression must be lossless: hide exactly one remove per
-        card (no duplicate), and RENDER the orphan removes rather than drop
-        their steering text. The broken invariant is logged once."""
+        cards, suppression must be lossless: hide exactly the removes with a
+        matching card (no duplicate), and RENDER the orphan removes rather
+        than drop their steering text. The broken invariant is logged once."""
         import logging
 
         with caplog.at_level(logging.WARNING, logger="claude_code_log.renderer"):
@@ -330,14 +341,44 @@ class TestMixedVersion:
         # Both texts survive; nothing silently dropped.
         assert "first-steer" in html
         assert "second-steer-ORPHAN" in html
-        # The broken 1:1 invariant is surfaced (once) so it's not silent.
-        imbalance_warnings = [
-            rec
-            for rec in caplog.records
-            if "steering suppression imbalance" in rec.message
-            and rec.levelno == logging.WARNING
-        ]
-        assert len(imbalance_warnings) == 1, (
-            "expected exactly one imbalance WARNING when removes > "
-            f"renderable queued_commands; got {len(imbalance_warnings)}"
-        )
+        # The paired text renders exactly once (via the qc card), NOT twice.
+        # Each rendered message text appears twice in the HTML (card body +
+        # timeline data), so a single render == 2 occurrences; a duplicate
+        # (paired remove ALSO rendered) would be 4.
+        assert html.count("first-steer") == 2
+        assert len(self._imbalance_warnings(caplog)) == 1
+
+    def test_orphan_remove_before_paired_remove_is_lossless(self, caplog):
+        """Order-independence (CodeRabbit #284): suppression must pair a
+        ``remove`` to its ``queued_command`` by PROMPT CONTENT, not arrival
+        order. With an order-only budget, an orphan ``remove`` arriving
+        BEFORE the paired one wrongly spends the budget → the orphan's text
+        is dropped and the paired text is duplicated (rendered by both the
+        qc card and the un-suppressed paired remove).
+
+        Mutation-check: key the budget on ``(session, version)`` only
+        (drop ``remove_text`` from the key in renderer.py) and this test
+        goes RED — ``orphan-first-STEER`` disappears and ``paired-STEER``
+        renders twice (verified against this fixture)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="claude_code_log.renderer"):
+            html = _render(
+                [
+                    _user("u1", None, "start"),
+                    _assistant("a1", "u1", "working"),
+                    _remove("orphan-first-STEER"),  # orphan, arrives FIRST
+                    _remove("paired-STEER"),  # paired (qc below has this text)
+                    _user("u2", "a1", "next"),
+                    _queued_command("qc1", "u2", "paired-STEER"),
+                    _assistant("a2", "qc1", "ok"),
+                ]
+            )
+
+        # Two cards: the qc (paired-STEER) + the orphan remove (rendered).
+        assert html.count("User (steering)") == 2
+        # The orphan survives — NOT consumed by the paired card's budget.
+        assert "orphan-first-STEER" in html
+        # The paired text renders exactly once (via the qc), NOT duplicated.
+        assert html.count("paired-STEER") == 2
+        assert len(self._imbalance_warnings(caplog)) == 1

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Steering messages: render from ``queued_command`` attachments.
+
+Modern Claude Code (≳2.1.101) writes an in-DAG ``queued_command``
+attachment for every steering delivery, 1:1 with the chain-less legacy
+queue-operation ``remove``. This suite covers the three-part rework
+(spec: ``work/steering-queued-command.md``):
+
+(a) ``queued_command`` promoted to a steering card in
+    ``attachment_factory``, routed through the user-message
+    classification + plugin-transformer pass;
+(b) the paired legacy ``remove`` suppressed per inferred harness
+    version (per-session scoped);
+(c) exact-type hardening of the legacy steering conversion so a
+    transformer-demoted ``UserTextMessage`` subclass is never rebuilt
+    into an empty-items steering card (defect 1).
+
+The demotion cases exercise the in-repo reference plugin's
+``[testhook]`` hook-demotion transformer (``test/_plugins/clmail/``),
+so they skip when it isn't installed.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.plugins import reset_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_cache():
+    """Load the real entry-point transformers fresh for each test.
+
+    Other suites inject fakes into ``plugins._cached_transformers``;
+    resetting guards against cross-file ordering under xdist.
+    """
+    reset_cache()
+    yield
+    reset_cache()
+
+
+def _have_embedded_plugin() -> bool:
+    try:
+        import claude_code_log_clmail_test  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+reference_plugin_required = pytest.mark.skipif(
+    not _have_embedded_plugin(),
+    reason="test-embedded reference plugin not installed; run `uv sync`",
+)
+
+
+# --------------------------------------------------------------------------
+# Synthetic transcript builders (no private data — see spec)
+# --------------------------------------------------------------------------
+_SID = "sess-1"
+_MODERN = "2.1.207"  # a version that writes queued_command
+_LEGACY = "2.1.29"  # a version that predates queued_command
+
+
+def _user(uuid, parent, text, *, version=_MODERN, sid=_SID):
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": sid,
+        "version": version,
+        "timestamp": "2026-07-11T07:00:00.000Z",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant(uuid, parent, text, *, version=_MODERN, sid=_SID):
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": sid,
+        "version": version,
+        "timestamp": "2026-07-11T07:00:01.000Z",
+        "message": {
+            "id": "msg-" + uuid,
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4",
+            "content": [{"type": "text", "text": text}],
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }
+
+
+def _remove(text, *, sid=_SID):
+    """Legacy queue-operation 'remove' — chain-less, uuid-less."""
+    return {
+        "type": "queue-operation",
+        "operation": "remove",
+        "timestamp": "2026-07-11T07:00:02.000Z",
+        "content": text,
+        "sessionId": sid,
+    }
+
+
+def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID):
+    """Modern in-DAG queued_command attachment paired with a 'remove'."""
+    return {
+        "type": "attachment",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": sid,
+        "version": version,
+        "timestamp": "2026-07-11T07:00:03.000Z",
+        "attachment": {
+            "type": "queued_command",
+            "prompt": prompt,
+            "commandMode": "prompt",
+            "origin": {"kind": "human"},
+            "timestamp": "2026-07-11T07:00:00.000Z",
+        },
+    }
+
+
+def _render(entries, title="Steering Test"):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+        path = Path(f.name)
+    try:
+        messages = load_transcript(path)
+        return generate_html(messages, title)
+    finally:
+        path.unlink()
+
+
+# --------------------------------------------------------------------------
+# (a)+(b) Modern transcripts: promote queued_command, suppress the remove
+# --------------------------------------------------------------------------
+class TestModernQueuedCommand:
+    def test_plain_prompt_renders_as_steering_and_remove_suppressed(self):
+        """A paired remove + queued_command yields exactly ONE steering
+        card (from the attachment), carrying a uuid → parentUuid debug
+        line the chain-less remove could never have."""
+        html = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _remove("please focus on the parser"),
+                _user("u2", "a1", "next real prompt"),
+                _queued_command("qc1", "u2", "please focus on the parser"),
+                _assistant("a2", "qc1", "ok"),
+            ]
+        )
+
+        # Exactly one steering card (the remove is suppressed, not
+        # rendered alongside the attachment → no duplicate).
+        assert html.count("User (steering)") == 1
+        assert "please focus on the parser" in html
+        # Anchored in the DAG: the promoted card carries the attachment's
+        # uuid → parentUuid debug line (the legacy remove is uuid-less).
+        assert "qc1 &rarr; u2" in html
+
+    @reference_plugin_required
+    def test_demoted_prompt_renders_marker_not_empty_card(self):
+        """A ``[testhook]`` steering injection is demoted by the plugin
+        transformer to the same marker as its idle-delivered siblings —
+        NOT an empty steering card (defect 1, dissolved on modern
+        transcripts by promoting the attachment)."""
+        html = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _remove("[testhook] monk blocked — permission prompt"),
+                _user("u2", "a1", "next real prompt"),
+                _queued_command(
+                    "qc1", "u2", "[testhook] monk blocked — permission prompt"
+                ),
+                _assistant("a2", "qc1", "ok"),
+            ]
+        )
+
+        # Demoted → rendered as the marker, present exactly once, and NOT
+        # promoted to a (would-be empty) steering card.
+        assert "monk blocked — permission prompt" in html
+        assert html.count("User (steering)") == 0
+
+
+# --------------------------------------------------------------------------
+# (b) Legacy transcripts (no queued_command anywhere): unchanged behaviour
+# --------------------------------------------------------------------------
+class TestLegacyRemove:
+    def test_remove_without_attachment_still_renders_as_steering(self):
+        """Old transcripts (≤2.1.29) have no queued_command → the
+        version set is empty → removes render exactly as before."""
+        html = _render(
+            [
+                _user("u1", None, "start", version=_LEGACY),
+                _assistant("a1", "u1", "working", version=_LEGACY),
+                _remove("steer the ongoing turn"),
+                _assistant("a2", "a1", "ok", version=_LEGACY),
+            ]
+        )
+
+        assert html.count("User (steering)") == 1
+        assert "steer the ongoing turn" in html
+
+    @reference_plugin_required
+    def test_legacy_demoted_remove_is_not_empty_card(self):
+        """Defect-1 hardening (c): a legacy remove whose single-line text
+        is demoted by a transformer must render the marker, NOT be
+        rebuilt into an empty steering card.
+
+        Mutation-check (feedback_test_must_reach_its_target_guard):
+        reverting the ``type(...) is UserTextMessage`` guard at
+        ``renderer.py`` to ``isinstance(...)`` makes this RED — the
+        marker text disappears and a bare ``User (steering)`` card with
+        no body appears (verified manually against this fixture)."""
+        html = _render(
+            [
+                _user("u1", None, "start", version=_LEGACY),
+                _assistant("a1", "u1", "working", version=_LEGACY),
+                _remove("[testhook] steering injection body"),
+                _assistant("a2", "a1", "ok", version=_LEGACY),
+            ]
+        )
+
+        # The demoted marker text survives (the guard did NOT clobber it).
+        assert "steering injection body" in html
+        # And it was not turned into a steering card at all.
+        assert html.count("User (steering)") == 0
+
+
+# --------------------------------------------------------------------------
+# (b) Mixed-version session (spans a harness upgrade)
+# --------------------------------------------------------------------------
+class TestMixedVersion:
+    def test_only_versions_with_queued_command_suppress_removes(self):
+        """A resumed session can span an upgrade: a remove under a
+        version that never wrote queued_command must still render, while
+        a remove under a version that did is suppressed (its attachment
+        renders instead). Version is inferred from the last
+        version-bearing entry in file order."""
+        html = _render(
+            [
+                _user("u1", None, "start", version=_LEGACY),
+                _assistant("a1", "u1", "working", version=_LEGACY),
+                _remove("legacy-steer"),  # infers 2.1.29 (no qc) → renders
+                _assistant("a2", "a1", "upgraded", version=_MODERN),
+                _remove("modern-steer"),  # infers 2.1.207 (qc set) → suppressed
+                _user("u2", "a2", "next", version=_MODERN),
+                _queued_command("qc1", "u2", "modern-steer", version=_MODERN),
+                _assistant("a3", "qc1", "ok", version=_MODERN),
+            ]
+        )
+
+        # Two steering cards: the legacy remove + the modern attachment
+        # (NOT three — the modern remove is suppressed, not duplicated).
+        assert html.count("User (steering)") == 2
+        assert "legacy-steer" in html
+        assert "modern-steer" in html
+        # The modern steering card is the attachment (has a debug line);
+        # the legacy one is the uuid-less remove (no debug line for it).
+        assert "qc1 &rarr; u2" in html

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -301,3 +301,43 @@ class TestMixedVersion:
         # The modern steering card is the attachment (has a debug line);
         # the legacy one is the uuid-less remove (no debug line for it).
         assert "qc1 &rarr; u2" in html
+
+    def test_orphan_removes_render_losslessly(self, caplog):
+        """The remove↔queued_command 1:1 pairing is not airtight in real
+        archives (observed: a 2.1.160 file with 34 removes / 29 qc). When a
+        (session, version) has MORE removes than renderable queued_command
+        cards, suppression must be lossless: hide exactly one remove per
+        card (no duplicate), and RENDER the orphan removes rather than drop
+        their steering text. The broken invariant is logged once."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="claude_code_log.renderer"):
+            html = _render(
+                [
+                    _user("u1", None, "start"),
+                    _assistant("a1", "u1", "working"),
+                    _remove("first-steer"),  # paired → suppressed (spends the card)
+                    _remove("second-steer-ORPHAN"),  # orphan → rendered, not dropped
+                    _user("u2", "a1", "next"),
+                    _queued_command("qc1", "u2", "first-steer"),  # only ONE card
+                    _assistant("a2", "qc1", "ok"),
+                ]
+            )
+
+        # Lossless: exactly two steering cards — the qc card + the orphan
+        # remove — with NO duplicate for the paired one.
+        assert html.count("User (steering)") == 2
+        # Both texts survive; nothing silently dropped.
+        assert "first-steer" in html
+        assert "second-steer-ORPHAN" in html
+        # The broken 1:1 invariant is surfaced (once) so it's not silent.
+        imbalance_warnings = [
+            rec
+            for rec in caplog.records
+            if "steering suppression imbalance" in rec.message
+            and rec.levelno == logging.WARNING
+        ]
+        assert len(imbalance_warnings) == 1, (
+            "expected exactly one imbalance WARNING when removes > "
+            f"renderable queued_commands; got {len(imbalance_warnings)}"
+        )

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -114,7 +114,19 @@ def _remove(text, *, sid=_SID):
 
 
 def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID):
-    """Modern in-DAG queued_command attachment paired with a 'remove'."""
+    """Modern in-DAG queued_command attachment paired with a 'remove'.
+
+    ``prompt=None`` omits the prompt key entirely (a promptless, non-
+    renderable attachment).
+    """
+    attachment = {
+        "type": "queued_command",
+        "commandMode": "prompt",
+        "origin": {"kind": "human"},
+        "timestamp": "2026-07-11T07:00:00.000Z",
+    }
+    if prompt is not None:
+        attachment["prompt"] = prompt
     return {
         "type": "attachment",
         "uuid": uuid,
@@ -125,13 +137,7 @@ def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID):
         "sessionId": sid,
         "version": version,
         "timestamp": "2026-07-11T07:00:03.000Z",
-        "attachment": {
-            "type": "queued_command",
-            "prompt": prompt,
-            "commandMode": "prompt",
-            "origin": {"kind": "human"},
-            "timestamp": "2026-07-11T07:00:00.000Z",
-        },
+        "attachment": attachment,
     }
 
 
@@ -197,6 +203,26 @@ class TestModernQueuedCommand:
         # promoted to a (would-be empty) steering card.
         assert "monk blocked — permission prompt" in html
         assert html.count("User (steering)") == 0
+
+    def test_promptless_queued_command_does_not_suppress_remove(self):
+        """A queued_command with no usable prompt renders nothing, so it
+        must NOT seed the version-suppression set — otherwise the paired
+        `remove` (which still carries the steering text) would be dropped
+        and the steering content lost entirely."""
+        html = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _remove("do not lose this steering text"),
+                _user("u2", "a1", "next real prompt"),
+                _queued_command("qc1", "u2", None),  # promptless → renders nothing
+                _assistant("a2", "qc1", "ok"),
+            ]
+        )
+
+        # The remove is the only carrier of the text → it must still render.
+        assert "do not lose this steering text" in html
+        assert html.count("User (steering)") == 1
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #283.

## Problem

Modern Claude Code (≳2.1.101) writes a `type:"attachment"` /
`attachment.type:"queued_command"` entry for every steering delivery, 1:1
with the chain-less legacy queue-operation `remove`. We were **ghosting the
good record and rendering the legacy one** — and a plugin-transformer
interaction rendered some steering cards **empty** (#283): a `remove` whose
content is a single-line `[monitor] …` notification gets classified as a
`UserTextMessage`, a transformer (e.g. ClMail hook-demotion) rewrites it into
a subclass that carries its text in own fields with `items=[]`, and the
steering conversion rebuilt `UserSteeringMessage(items=[])` → empty card.

## Fix

**(a) Promote `queued_command` to the steering renderer** (`attachment_factory`).
Build the steering content from `payload["prompt"]`, routed through the same
`create_user_message` classification + plugin-transformer pass as an
idle-delivered prompt — so a `[monitor] …` injection renders as the same
demoted marker as its non-steering siblings. Only a plain, untransformed
`UserTextMessage` is wrapped as `UserSteeringMessage`. Proper uuid/parent
anchoring via `create_meta` (gives steering cards the `uuid → parentUuid`
debug line the legacy `remove` never had).

**(b) Suppress the paired legacy `remove`** (`_render_messages`), per session
and per **inferred harness version** (a resumed session can span an upgrade,
so neither a session-level boolean nor hard-coded version knowledge is
correct — learn it from the file). Pass 1 counts *renderable* `queued_command`s
per `(session, version)`; pass 2 spends a decrementing budget. Suppression is
**lossless**: it hides exactly `min(#removes, #renderable_qc)` per version, so
paired removes are hidden (no duplicate) and any orphan removes (the 1:1
pairing does break in real archives) still render their steering text. The
broken invariant is logged once per key. Per-session scoping keeps
per-session HTML caching correct.

**(c) Exact-type hardening** of the legacy steering conversion
(`type(x) is UserTextMessage`, not `isinstance`) so a transformer's
`UserTextMessage` subclass is never rebuilt into an empty-items steering card.
Belt-and-braces for the legacy (pre-`queued_command`) path.

## Tests

`test/test_steering_queued_command.py` (new) covers: modern plain + demoted,
legacy, mixed-version, promptless `queued_command`, and the removes>qc
lossless case. The exact-type guards and the promptless guard are
mutation-verified (reverting each turns a named test RED). Updated the
now-obsolete `queued_command → None` assertion in
`test_hook_attachment_rendering.py`. `dev-docs/messages.md` updated in-tree.

Full `just ci` green (unit / TUI / browser / integration / benchmark, pyright + ty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modern `queued_command` attachments now render as user steering messages when they include usable prompt text.
* **Bug Fixes**
  * Improved de-duplication between modern `queued_command` cards and legacy `remove` operations to prevent duplicate steering cards.
  * Prevented empty or incorrectly formed steering messages from transformed/promptless content.
  * Added clearer warning behavior when suppression counts don’t balance across transcript versions.
* **Documentation**
  * Updated guidance on steering behavior for both modern and legacy transcript formats.
* **Tests**
  * Expanded coverage for promptful vs promptless `queued_command`, ordering independence, and suppression/imbalance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->