### PR TITLE
Fix ty on Windows (#276)

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -100,7 +100,7 @@ def _install_stack_dump_signal() -> None:
     if sigusr1 is None:
         return
     try:
-        faulthandler.register(sigusr1, all_threads=True, chain=False)
+        faulthandler.register(sigusr1, all_threads=True, chain=False)  # ty: ignore[possibly-missing-attribute]
     except (RuntimeError, ValueError, OSError):
         # E.g. signal already taken, no-tty environments, or platforms
         # where faulthandler.register raises. Diagnostics shouldn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,13 @@ markers = [
 [tool.ty.environment]
 # Use custom stubs for untyped libraries
 extra-paths = ["stubs"]
+# Check against all platforms (mirrors pyright's pythonPlatform = "All") rather
+# than the host, so ty is deterministic regardless of who runs it. POSIX-only
+# stdlib members used behind runtime guards (faulthandler.register,
+# signal.SIGUSR1, os.mkfifo) then read as "possibly missing on win32" and carry
+# a targeted `# ty: ignore[possibly-missing-attribute]` at each guarded site,
+# instead of being hard `unresolved-attribute` errors on a Windows host (#276).
+python-platform = "all"
 
 [tool.ty.src]
 # docs/gen_pages.py is a build-time mkdocs-gen-files script: it imports

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -649,7 +649,7 @@ class TestStackDumpSignal:
             line = proc.stdout.readline()
             assert line.strip() == b"ready"
 
-            os.kill(proc.pid, signal.SIGUSR1)
+            os.kill(proc.pid, signal.SIGUSR1)  # ty: ignore[possibly-missing-attribute]
 
             # Poll for traceback markers up to a generous deadline. The
             # handler usually fires within a few ms; we allow much more

--- a/test/test_output_explicit.py
+++ b/test/test_output_explicit.py
@@ -168,19 +168,19 @@ class TestIsOutdatedNonRegularFileGuard:
     @_requires_mkfifo
     def test_markdown_is_outdated_on_fifo_returns_true(self, tmp_path: Path):
         fifo = tmp_path / "f"
-        os.mkfifo(fifo)
+        os.mkfifo(fifo)  # ty: ignore[possibly-missing-attribute]
         assert self._call_with_timeout(MarkdownRenderer().is_outdated, fifo) is True
 
     @_requires_mkfifo
     def test_json_is_outdated_on_fifo_returns_true(self, tmp_path: Path):
         fifo = tmp_path / "f"
-        os.mkfifo(fifo)
+        os.mkfifo(fifo)  # ty: ignore[possibly-missing-attribute]
         assert self._call_with_timeout(JsonRenderer().is_outdated, fifo) is True
 
     @_requires_mkfifo
     def test_check_html_version_on_fifo_returns_none(self, tmp_path: Path):
         fifo = tmp_path / "f"
-        os.mkfifo(fifo)
+        os.mkfifo(fifo)  # ty: ignore[possibly-missing-attribute]
         assert self._call_with_timeout(check_html_version, fifo) is None
 
     def test_markdown_is_outdated_on_directory_returns_true(self, tmp_path: Path):


### PR DESCRIPTION
## Problem

`uv run ty check` (`just ty`) infers the **host** platform, so on Windows it raised hard `unresolved-attribute` errors for POSIX-only stdlib members that the code already guards at runtime:

- `faulthandler.register` — guarded in `_install_stack_dump_signal` (`getattr(signal, "SIGUSR1", None)` + `try/except`; POSIX-only, no-op on Windows)
- `signal.SIGUSR1` — behind `@pytest.mark.skipif(not hasattr(signal, "SIGUSR1"), ...)`
- `os.mkfifo` (×3) — behind `@_requires_mkfifo`

CI never caught this because it runs on Linux, where all three resolve. Otherwise `just ci` is green (reported on `d2a1b66`).

## Fix

Set `[tool.ty.environment] python-platform = "all"` so ty is deterministic regardless of who runs it, mirroring the existing pyright `pythonPlatform = "All"`. This keeps ty validating **both** platforms rather than blinding it to Windows.

Under `"all"` these members read as *possibly missing on win32*, so each of the five guarded call sites carries a targeted `# ty: ignore[possibly-missing-attribute]`. The suppressions are stable on every host (the warning always fires under `"all"`, so they never become "unused").

## Verification

- `just ty` → **All checks passed!** (was 5 diagnostics on Windows)
- `just typecheck` (pyright) → 0 errors, 0 warnings
- `ruff format --check` / `ruff check` → clean
- Edited test files still collect

Fixes #276.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform static type-checking configuration.
  * Added targeted typing annotations for platform-specific signal and FIFO operations.

* **Tests**
  * Updated platform-specific test cases to satisfy static analysis without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->