### PR TITLE
feat: add claude-history-mcp to community extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,8 @@ Projects built on top of `claude-code-log`:
   - Caches data in a local SQLite database with incremental mtime tracking
   - Exposes 7 MCP tools and 2 resources via FastMCP (stdio transport)
   - Natural language date filtering ("yesterday", "last week", etc.)
-  - Install: `claude mcp add claude-history --scope user -- uvx --from git+https://github.com/sydasif/claude-history-mcp claude-history-mcp`
+  - Install: `claude mcp add claude-history --scope user -- uvx --from git+https://github.com/sydasif/claude-history-mcp@79c7803312ee8242d1d8b83d25d8aaba6cb6b62a claude-history-mcp`
+  - ⚠️ **Trust & Privacy Note**: This MCP server reads your local Claude Code session transcripts and command history. Review the source at `github.com/sydasif/claude-history-mcp` before installing. It runs locally via stdio and does not send data externally.
 
 ## TODO
 
@@ -304,7 +305,7 @@ Projects built on top of `claude-code-log`:
 - convert images to WebP as screenshots are often huge PNGs – this might be time consuming to keep redoing (so would also need some caching) and need heavy dependencies with compilation (unless there are fast pure Python conversation libraries? Or WASM?)
 - add special formatting for built-in tools: Glob, Grep, LS, MultiEdit, NotebookRead, NotebookEdit, WebFetch, TodoRead, WebSearch
 - add `ccusage` like daily summary and maybe some textual summary too based on Claude generate session summaries?
-  – import logs from @claude Github Actions
+  - import logs from @claude GitHub Actions
 - stream logs from @claude Github Actions, see [octotail](https://github.com/getbettr/octotail)
 - wrap up CLI as Github Action to run after Cladue Github Action and process [output](https://github.com/anthropics/claude-code-base-action?tab=readme-ov-file#outputs)
 - feed the filtered user messages to headless claude CLI to distill the user intent from the session

--- a/README.md
+++ b/README.md
@@ -287,7 +287,15 @@ Projects built on top of `claude-code-log`:
   - a Claude Code slash [Command](https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/commands/archive-session.md) `/archive-session` for explicit in-chat invocation
   - a Claude Code PreCompact [Hook](https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/hooks/pre-compact-archive.sh) that auto-archives transcripts and subagent logs right before context compaction
 
-Cross-platform (macOS and Windows/MSYS).
+  Cross-platform (macOS and Windows/MSYS).
+
+- **[claude-history-mcp](https://github.com/sydasif/claude-history-mcp)** by [@sydasif](https://github.com/sydasif). MCP server that lets Claude Code query its own session history — search messages, list sessions, retrieve transcripts, and analyze usage patterns across all your projects.
+
+  - Reads from `~/.claude/projects/**/*.jsonl` (session transcripts) and `~/.claude/history.jsonl` (command history)
+  - Caches data in a local SQLite database with incremental mtime tracking
+  - Exposes 7 MCP tools and 2 resources via FastMCP (stdio transport)
+  - Natural language date filtering ("yesterday", "last week", etc.)
+  - Install: `claude mcp add claude-history --scope user -- uvx --from git+https://github.com/sydasif/claude-history-mcp claude-history-mcp`
 
 ## TODO
 
@@ -296,7 +304,7 @@ Cross-platform (macOS and Windows/MSYS).
 - convert images to WebP as screenshots are often huge PNGs – this might be time consuming to keep redoing (so would also need some caching) and need heavy dependencies with compilation (unless there are fast pure Python conversation libraries? Or WASM?)
 - add special formatting for built-in tools: Glob, Grep, LS, MultiEdit, NotebookRead, NotebookEdit, WebFetch, TodoRead, WebSearch
 - add `ccusage` like daily summary and maybe some textual summary too based on Claude generate session summaries?
-– import logs from @claude Github Actions
+  – import logs from @claude Github Actions
 - stream logs from @claude Github Actions, see [octotail](https://github.com/getbettr/octotail)
 - wrap up CLI as Github Action to run after Cladue Github Action and process [output](https://github.com/anthropics/claude-code-base-action?tab=readme-ov-file#outputs)
 - feed the filtered user messages to headless claude CLI to distill the user intent from the session

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and archi
 
 ## Community Extensions
 
-Projects built on top of `claude-code-log`:
+Projects that wrap or extend the `claude-code-log` CLI:
 
 - **[archive-session](https://github.com/lifeinchords/claude-code-skills#archive-session-skill--slash-command--optional-hook)** by [@lifeinchords](https://github.com/lifeinchords). Wraps the CLI as three integration surfaces:
   - a Claude Code [Skill](https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/skills/archive-session/SKILL.md)
@@ -289,14 +289,11 @@ Projects built on top of `claude-code-log`:
 
   Cross-platform (macOS and Windows/MSYS).
 
-- **[claude-history-mcp](https://github.com/sydasif/claude-history-mcp)** by [@sydasif](https://github.com/sydasif). MCP server that lets Claude Code query its own session history — search messages, list sessions, retrieve transcripts, and analyze usage patterns across all your projects.
+## Related Projects
 
-  - Reads from `~/.claude/projects/**/*.jsonl` (session transcripts) and `~/.claude/history.jsonl` (command history)
-  - Caches data in a local SQLite database with incremental mtime tracking
-  - Exposes 7 MCP tools and 2 resources via FastMCP (stdio transport)
-  - Natural language date filtering ("yesterday", "last week", etc.)
-  - Install: `claude mcp add claude-history --scope user -- uvx --from git+https://github.com/sydasif/claude-history-mcp@79c7803312ee8242d1d8b83d25d8aaba6cb6b62a claude-history-mcp`
-  - ⚠️ **Trust & Privacy Note**: This MCP server reads your local Claude Code session transcripts and command history. Review the source at `github.com/sydasif/claude-history-mcp` before installing. It runs locally via stdio and does not send data externally.
+Tools that read the same `~/.claude` transcript data for different interfaces:
+
+- **[claude-history-mcp](https://github.com/sydasif/claude-history-mcp)** by [@sydasif](https://github.com/sydasif). Agent-facing MCP server for programmatic history queries — search messages, list sessions, retrieve transcripts, and analyze usage patterns. Reads from `~/.claude/projects/**/*.jsonl` and `~/.claude/history.jsonl`, caches in SQLite, exposes 7 MCP tools + 2 resources via FastMCP (stdio transport).
 
 ## TODO
 


### PR DESCRIPTION
Adds [claude-history-mcp](https://github.com/sydasif/claude-history-mcp) as a community extension in the README.

This MCP server lets Claude Code query its own session history — search messages, list sessions, retrieve transcripts, and analyze usage patterns across all your projects.

Key features:
- Reads from `~/.claude/projects/**/*.jsonl` (session transcripts) and `~/.claude/history.jsonl` (command history)
- Caches data in a local SQLite database with incremental mtime tracking
- Exposes 7 MCP tools and 2 resources via FastMCP (stdio transport)
- Natural language date filtering ("yesterday", "last week", etc.)
- Install: `claude mcp add claude-history --scope user -- uvx --from git+https://github.com/sydasif/claude-history-mcp claude-history-mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Community Extensions section to include `claude-history-mcp`.
  * Added details on its transcript/history input locations, local SQLite caching with incremental tracking, and the number of FastMCP tools and resources available.
  * Adjusted the related projects listing formatting and updated the TODO item formatting for GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->