### PR TITLE
Codex provider rendering across all CLI modalities

### DIFF
--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -218,18 +218,23 @@ def _run_provider_wholesale(
     ``sessions_root`` None walks the provider's own data dir; a directory
     (an INPUT_PATH dir, or ``--projects-dir``) selects a mini sessions root.
 
-    ``--clear-cache`` / ``--clear-output`` are standalone cleanup ops (clear
-    then exit, mirroring the Claude path), scoped to the provider output root so
-    the pristine sessions tree is never touched (DECIDED #4).
+    ``--clear-cache`` / ``--clear-output`` are scoped to the provider output
+    root so the pristine sessions tree is never touched (DECIDED #4). Mirroring
+    the Claude path, they clear-and-exit on their own, but when a date filter is
+    also given they clear then fall through to REGENERATE the filtered view
+    (else ``--clear-output --from-date`` would leave an empty directory).
     """
     output_root = _resolve_provider_output_root(provider_name, output)
 
+    dated = from_date is not None or to_date is not None
     if clear_cache:
         _clear_provider_cache(output_root)
-        return
+        if not dated:
+            return
     if clear_output:
         _clear_provider_output(output_root, output_format)
-        return
+        if not dated:
+            return
 
     index_path = render_provider_wholesale(
         provider_name,
@@ -1094,6 +1099,17 @@ def main(
         and (input_path is None or input_path.is_dir())
     )
     if provider is not None:
+        # Validate the provider name up front so an unknown one is a clean
+        # UsageError (exit 2), consistent with the other flag errors, instead of
+        # surfacing later as a broad-except "Error converting file" (exit 1).
+        from .providers import discover_providers as _discover_providers
+
+        _known = _discover_providers().get_all_providers()
+        if provider not in _known:
+            raise click.UsageError(
+                f"Unknown provider: {provider}. Available providers: "
+                f"{', '.join(_known) or 'none'}."
+            )
         if input_path is not None and session_id is not None:
             raise click.UsageError(
                 "--provider with an INPUT_PATH renders that path; drop "

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -112,6 +112,15 @@ def _render_provider_input_file(
     from .providers import discover_providers
     from .utils import output_path_is_file
 
+    # Directory rendering (a mini sessions root) lands with the wholesale
+    # walker; until then a claimed directory errors loudly rather than falling
+    # through to the empty Claude parse (interim; the matrix must not lie).
+    if input_path.is_dir():
+        raise click.UsageError(
+            f"{input_path} is a {provider_name} sessions directory; directory "
+            "rendering lands with the wholesale walker. For now point at a single "
+            f"rollout file, or use --provider {provider_name} --session-id <id>."
+        )
     selected = discover_providers().get_provider(provider_name)
     if selected is None:
         raise click.UsageError(f"Unknown provider: {provider_name}")
@@ -1516,12 +1525,12 @@ def main(
                 click.launch(str(output_path))
             return
 
-        # Provider auto-detection (silent-empty pin): a Codex rollout handed as
-        # an INPUT_PATH must route to the provider pipeline, not the Claude
-        # parser, which skips every record and renders a near-empty page. A bare
-        # rollout FILE with no --provider is auto-detected here; --provider and
-        # rollout DIRECTORIES arrive with the wholesale slice.
-        if provider is None and input_path.is_file():
+        # Provider auto-detection (silent-empty pin): a rollout handed as an
+        # INPUT_PATH must route to the provider pipeline, not the Claude parser,
+        # which skips every record and renders a near-empty page. Files render;
+        # a rollout DIRECTORY errors loudly for now (the wholesale walker lands
+        # directory rendering) — either way it never falls to the empty parse.
+        if provider is None and input_path.exists():
             from .providers import discover_providers
 
             detected = discover_providers().detect_provider_for_path(input_path)

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1422,6 +1422,67 @@ def main(
                 click.launch(str(output_path))
             return
 
+        # Provider auto-detection (silent-empty pin): a Codex rollout handed as
+        # an INPUT_PATH must route to the provider pipeline, not the Claude
+        # parser, which skips every record and renders a near-empty page. A bare
+        # rollout FILE with no --provider is auto-detected here; --provider and
+        # rollout DIRECTORIES arrive with the wholesale slice.
+        if provider is None and input_path.is_file():
+            from .providers import discover_providers
+
+            registry = discover_providers()
+            detected = registry.detect_provider_for_path(input_path)
+            if detected is not None:
+                selected = registry.get_provider(detected)
+                assert selected is not None
+                detected_messages = list(selected.load_session_from_path(input_path))
+                if not detected_messages:
+                    raise click.UsageError(
+                        f"{input_path} was detected as a {detected} session but "
+                        "produced no renderable messages; it may be truncated or "
+                        "malformed."
+                    )
+                # generate_session filters entries by sessionId, so the render
+                # key MUST be the session's own id (the thread id carried on the
+                # entries), not the filename stem — a mismatch silently drops
+                # every message, i.e. the exact empty-page bug this branch fixes.
+                session_key = detected_messages[0].sessionId or input_path.stem
+                detected_title = f"{detected.title()}: {session_key}"
+
+                def render_detected(destination: Path) -> Path:
+                    return render_normalized_session_file(
+                        detected_messages,
+                        session_key,
+                        destination,
+                        output_format,
+                        detected_title,
+                        image_export_mode,
+                        depth_level,
+                        compact,
+                        no_timestamps,
+                        no_recaps,
+                    )
+
+                extension = get_file_extension(output_format)
+                if _is_stdout_target(output):
+                    _render_to_stdout(
+                        input_path,
+                        lambda tmpdir: render_detected(tmpdir / f"session.{extension}"),
+                    )
+                    return
+                filename = f"session-{session_key}.{extension}"
+                if output is None:
+                    destination = Path.cwd() / filename
+                elif _output_path_is_file(output):
+                    destination = output
+                else:
+                    destination = output / filename
+                output_path = render_detected(destination)
+                click.echo(f"Successfully rendered {detected} session to {output_path}")
+                if open_browser:
+                    click.launch(str(output_path))
+                return
+
         # Original single file/directory processing logic
         should_convert = False
 

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -19,6 +19,7 @@ from .converter import (
     ensure_fresh_cache,
     generate_single_session_file,
     render_normalized_session_file,
+    render_provider_wholesale,
     get_file_extension,
     get_index_filename,
     process_projects_hierarchy,
@@ -112,15 +113,9 @@ def _render_provider_input_file(
     from .providers import discover_providers
     from .utils import output_path_is_file
 
-    # Directory rendering (a mini sessions root) lands with the wholesale
-    # walker; until then a claimed directory errors loudly rather than falling
-    # through to the empty Claude parse (interim; the matrix must not lie).
-    if input_path.is_dir():
-        raise click.UsageError(
-            f"{input_path} is a {provider_name} sessions directory; directory "
-            "rendering lands with the wholesale walker. For now point at a single "
-            f"rollout file, or use --provider {provider_name} --session-id <id>."
-        )
+    # A directory INPUT_PATH is a mini sessions root and is routed to the
+    # wholesale walker by the dispatcher before it reaches here, so this helper
+    # only ever sees a single rollout file.
     selected = discover_providers().get_provider(provider_name)
     if selected is None:
         raise click.UsageError(f"Unknown provider: {provider_name}")
@@ -168,6 +163,77 @@ def _render_provider_input_file(
     click.echo(f"Successfully rendered {provider_name} session to {output_path}")
     if open_browser:
         click.launch(str(output_path))
+
+
+def _resolve_provider_output_root(provider_name: str, output: "Optional[Path]") -> Path:
+    """Resolve where a provider wholesale run writes its project hierarchy.
+
+    An explicit ``-o DIR`` wins (a file-shaped ``-o`` is rejected — wholesale
+    writes many files). Otherwise the default is ``<provider_home>/claude-code-log/``
+    (DECIDED #4: the sessions tree stays pristine, so output never lands inside
+    it). If the provider has no discoverable home, there is nowhere to default
+    to — fail loudly asking for ``-o``.
+    """
+    from .providers import discover_providers
+    from .utils import output_path_is_file
+
+    if output is not None:
+        if output_path_is_file(output):
+            raise click.UsageError(
+                f"provider wholesale rendering writes many files; pass -o as a "
+                f"directory, not a file ({output})."
+            )
+        return output
+    provider = discover_providers().get_provider(provider_name)
+    data_dir = provider.get_data_dir() if provider is not None else None
+    if data_dir is None:
+        raise click.UsageError(
+            f"no {provider_name} home found to place output; pass -o DIR to "
+            "choose an output directory."
+        )
+    return data_dir / "claude-code-log"
+
+
+def _run_provider_wholesale(
+    provider_name: str,
+    sessions_root: "Optional[Path]",
+    output: "Optional[Path]",
+    output_format: str,
+    image_export_mode: "Optional[str]",
+    depth: RenderingDepth,
+    compact: bool,
+    no_timestamps: bool,
+    no_recaps: bool,
+    write_combined: bool,
+    write_individual: bool,
+    from_date: "Optional[str]",
+    to_date: "Optional[str]",
+    open_browser: bool,
+) -> None:
+    """Render a whole provider sessions tree into a project hierarchy.
+
+    ``sessions_root`` None walks the provider's own data dir; a directory
+    (an INPUT_PATH dir, or ``--projects-dir``) selects a mini sessions root.
+    """
+    output_root = _resolve_provider_output_root(provider_name, output)
+    index_path = render_provider_wholesale(
+        provider_name,
+        sessions_root,
+        output_root,
+        from_date=from_date,
+        to_date=to_date,
+        output_format=output_format,
+        image_export_mode=image_export_mode,
+        depth=depth,
+        compact=compact,
+        no_timestamps=no_timestamps,
+        no_recaps=no_recaps,
+        write_combined=write_combined,
+        write_individual=write_individual,
+        silent=False,
+    )
+    if open_browser:
+        click.launch(str(index_path))
 
 
 def _install_stack_dump_signal() -> None:
@@ -953,47 +1019,84 @@ def main(
     # Configure logging to show warnings and above
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
-    # Provider mode currently renders ONE session — by --session-id (export) or
-    # by INPUT_PATH (a rollout file). Wholesale, cache, and Claude-only flags are
-    # not supported yet and are rejected loudly (never a silent no-op).
+    # Provider mode has three sub-modes:
+    #   * export     — `--session-id <id>`: render one session by id
+    #   * single-file — INPUT_PATH is a rollout FILE: render that one session
+    #   * wholesale  — no id, and no INPUT_PATH (or an INPUT_PATH directory):
+    #                  walk the whole sessions tree into a project hierarchy
+    # Each rejects the flags that don't apply to it LOUDLY (never a silent
+    # no-op); the matrix in test_codex_cli.py pins which combos are legal.
+    provider_wholesale = (
+        provider is not None
+        and session_id is None
+        and (input_path is None or input_path.is_dir())
+    )
     if provider is not None:
         if input_path is not None and session_id is not None:
             raise click.UsageError(
                 "--provider with an INPUT_PATH renders that path; drop "
                 "--session-id (or drop the INPUT_PATH to export a session by id)."
             )
-        if input_path is None and session_id is None:
-            raise click.UsageError("--provider requires --session-id or an INPUT_PATH.")
+        # Always illegal in provider mode: Claude-only projection semantics and
+        # the TUI (provider TUI support is out of scope, tracked in the backlog).
         conflicts: list[str] = []
         for enabled, flag in (
-            (all_projects, "--all-projects"),
             (tui, "--tui"),
-            (projects_dir is not None, "--projects-dir"),
             (expand_paths, "--expand-paths"),
             (filter_path is not None, "--filter-path"),
-            (no_individual_sessions, "--no-individual-sessions"),
-            (from_date is not None, "--from-date"),
-            (to_date is not None, "--to-date"),
+        ):
+            if enabled:
+                conflicts.append(flag)
+        # Cache flags: provider wholesale does not yet participate in the cache
+        # (separate milestone); reject rather than silently ignore.
+        for enabled, flag in (
             (no_cache, "--no-cache"),
             (clear_cache, "--clear-cache"),
             (clear_output, "--clear-output"),
         ):
             if enabled:
                 conflicts.append(flag)
-        for parameter, flag in (
-            ("combined", "--combined"),
-            ("page_size", "--page-size"),
-        ):
+        if provider_wholesale:
+            # Wholesale honors --combined, date range, -o/-f, --open-browser.
+            # Pagination (--page-size) and job-parallelism (--jobs) ride on the
+            # cache machinery that lands in a later milestone, so reject them
+            # loudly rather than accept-and-silently-ignore (no silent no-ops).
+            if jobs is not None:
+                conflicts.append("--jobs")
             if (
-                ctx.get_parameter_source(parameter)
+                ctx.get_parameter_source("page_size")
                 is not click.core.ParameterSource.DEFAULT
             ):
-                conflicts.append(flag)
+                conflicts.append("--page-size")
+        else:
+            # export / single-file render one session; the wholesale-only flags
+            # (multi-project hierarchy, pagination, date range) don't apply.
+            for enabled, flag in (
+                (all_projects, "--all-projects"),
+                (projects_dir is not None, "--projects-dir"),
+                (no_individual_sessions, "--no-individual-sessions"),
+                (from_date is not None, "--from-date"),
+                (to_date is not None, "--to-date"),
+            ):
+                if enabled:
+                    conflicts.append(flag)
+            for parameter, flag in (
+                ("combined", "--combined"),
+                ("page_size", "--page-size"),
+            ):
+                if (
+                    ctx.get_parameter_source(parameter)
+                    is not click.core.ParameterSource.DEFAULT
+                ):
+                    conflicts.append(flag)
         if conflicts:
+            detail = (
+                "provider wholesale rendering"
+                if provider_wholesale
+                else "provider single-session rendering (--session-id / a rollout file)"
+            )
             raise click.UsageError(
-                f"--provider does not yet support {', '.join(conflicts)}; "
-                "provider mode currently renders one session "
-                "(by --session-id or INPUT_PATH)."
+                f"--provider does not support {', '.join(conflicts)} with {detail}."
             )
 
     # Resolve --combined default and back-compat with --no-individual-sessions.
@@ -1168,9 +1271,38 @@ def main(
         if provider is not None:
             from .providers import SessionInfo, discover_providers
 
-            # Explicit --provider with an INPUT_PATH renders that file directly
-            # (distinct from --session-id export below). The fence guarantees not
-            # both are set.
+            # Wholesale: no --session-id, and either no INPUT_PATH (walk the
+            # provider's data dir) or an INPUT_PATH directory / --projects-dir
+            # (a mini sessions root). Renders the whole project hierarchy.
+            if provider_wholesale:
+                sessions_root = (
+                    input_path
+                    if input_path is not None
+                    else projects_dir
+                    if projects_dir is not None
+                    else None
+                )
+                _run_provider_wholesale(
+                    provider,
+                    sessions_root,
+                    output,
+                    output_format,
+                    image_export_mode,
+                    depth_level,
+                    compact,
+                    no_timestamps,
+                    no_recaps,
+                    write_combined,
+                    write_individual,
+                    from_date,
+                    to_date,
+                    open_browser,
+                )
+                return
+
+            # Explicit --provider with an INPUT_PATH FILE renders that file
+            # directly (distinct from --session-id export below). The fence
+            # guarantees not both id and INPUT_PATH are set.
             if input_path is not None:
                 _render_provider_input_file(
                     provider,
@@ -1527,14 +1659,32 @@ def main(
 
         # Provider auto-detection (silent-empty pin): a rollout handed as an
         # INPUT_PATH must route to the provider pipeline, not the Claude parser,
-        # which skips every record and renders a near-empty page. Files render;
-        # a rollout DIRECTORY errors loudly for now (the wholesale walker lands
-        # directory rendering) — either way it never falls to the empty parse.
+        # which skips every record and renders a near-empty page. A single file
+        # renders that session; a DIRECTORY of rollouts renders the whole tree
+        # via the wholesale walker — either way it never falls to the empty parse.
         if provider is None and input_path.exists():
             from .providers import discover_providers
 
             detected = discover_providers().detect_provider_for_path(input_path)
             if detected is not None:
+                if input_path.is_dir():
+                    _run_provider_wholesale(
+                        detected,
+                        input_path,
+                        output,
+                        output_format,
+                        image_export_mode,
+                        depth_level,
+                        compact,
+                        no_timestamps,
+                        no_recaps,
+                        write_combined,
+                        write_individual,
+                        from_date,
+                        to_date,
+                        open_browser,
+                    )
+                    return
                 _render_provider_input_file(
                     detected,
                     input_path,

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -30,6 +30,7 @@ from .cache import (
     get_cache_db_path,
     get_library_version,
 )
+from .models import RenderingDepth
 
 
 # Output values that mean "stream the rendered document to stdout" (issue
@@ -87,6 +88,77 @@ def _render_to_stdout(
         # Fallback (e.g. a text-only stdout shim): decode best-effort.
         sys.stdout.write(content.decode("utf-8", errors="replace"))
     click.echo(f"Successfully converted {input_path} to stdout", err=True)
+
+
+def _render_provider_input_file(
+    provider_name: str,
+    input_path: Path,
+    output: "Optional[Path]",
+    output_format: str,
+    image_export_mode: "Optional[str]",
+    depth: RenderingDepth,
+    compact: bool,
+    no_timestamps: bool,
+    no_recaps: bool,
+    open_browser: bool,
+) -> None:
+    """Render a single provider session file handed in as an INPUT_PATH.
+
+    Shared by the explicit ``--provider <p> <file>`` path and the no-flag
+    auto-detected-rollout path. Fails LOUDLY if a provider claimed the file but
+    it yields no renderable messages, so a rollout can never fall through to a
+    near-empty page (the silent-empty gap).
+    """
+    from .providers import discover_providers
+    from .utils import output_path_is_file
+
+    selected = discover_providers().get_provider(provider_name)
+    if selected is None:
+        raise click.UsageError(f"Unknown provider: {provider_name}")
+    messages = list(selected.load_session_from_path(input_path))
+    if not messages:
+        raise click.UsageError(
+            f"{input_path} was detected as a {provider_name} session but produced "
+            "no renderable messages; it may be truncated or malformed."
+        )
+    # generate_session filters entries by sessionId, so the render key MUST be
+    # the session's own id (the thread id carried on the entries), not the
+    # filename stem — a mismatch silently drops every message (the empty-page bug).
+    session_key = messages[0].sessionId or input_path.stem
+    title = f"{provider_name.title()}: {session_key}"
+
+    def render(destination: Path) -> Path:
+        return render_normalized_session_file(
+            messages,
+            session_key,
+            destination,
+            output_format,
+            title,
+            image_export_mode,
+            depth,
+            compact,
+            no_timestamps,
+            no_recaps,
+        )
+
+    extension = get_file_extension(output_format)
+    if _is_stdout_target(output):
+        _render_to_stdout(
+            input_path,
+            lambda tmpdir: render(tmpdir / f"session.{extension}"),
+        )
+        return
+    filename = f"session-{session_key}.{extension}"
+    if output is None:
+        destination = Path.cwd() / filename
+    elif output_path_is_file(output):
+        destination = output
+    else:
+        destination = output / filename
+    output_path = render(destination)
+    click.echo(f"Successfully rendered {provider_name} session to {output_path}")
+    if open_browser:
+        click.launch(str(output_path))
 
 
 def _install_stack_dump_signal() -> None:
@@ -872,15 +944,18 @@ def main(
     # Configure logging to show warnings and above
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
-    # Provider sessions are an intentionally narrow first slice. Keep them
-    # away from the Claude project/cache pipeline and reject options whose
-    # meaning would otherwise be silently ambiguous.
+    # Provider mode currently renders ONE session — by --session-id (export) or
+    # by INPUT_PATH (a rollout file). Wholesale, cache, and Claude-only flags are
+    # not supported yet and are rejected loudly (never a silent no-op).
     if provider is not None:
-        if session_id is None:
-            raise click.UsageError("--provider requires --session-id.")
+        if input_path is not None and session_id is not None:
+            raise click.UsageError(
+                "--provider with an INPUT_PATH renders that path; drop "
+                "--session-id (or drop the INPUT_PATH to export a session by id)."
+            )
+        if input_path is None and session_id is None:
+            raise click.UsageError("--provider requires --session-id or an INPUT_PATH.")
         conflicts: list[str] = []
-        if input_path is not None:
-            conflicts.append("INPUT_PATH")
         for enabled, flag in (
             (all_projects, "--all-projects"),
             (tui, "--tui"),
@@ -907,8 +982,9 @@ def main(
                 conflicts.append(flag)
         if conflicts:
             raise click.UsageError(
-                f"--provider does not support {', '.join(conflicts)}; "
-                "provider mode exports one session only."
+                f"--provider does not yet support {', '.join(conflicts)}; "
+                "provider mode currently renders one session "
+                "(by --session-id or INPUT_PATH)."
             )
 
     # Resolve --combined default and back-compat with --no-individual-sessions.
@@ -1083,7 +1159,25 @@ def main(
         if provider is not None:
             from .providers import SessionInfo, discover_providers
 
-            assert session_id is not None  # enforced by provider-mode validation
+            # Explicit --provider with an INPUT_PATH renders that file directly
+            # (distinct from --session-id export below). The fence guarantees not
+            # both are set.
+            if input_path is not None:
+                _render_provider_input_file(
+                    provider,
+                    input_path,
+                    output,
+                    output_format,
+                    image_export_mode,
+                    depth_level,
+                    compact,
+                    no_timestamps,
+                    no_recaps,
+                    open_browser,
+                )
+                return
+
+            assert session_id is not None  # fence guarantees this in export mode
             provider_session_id = session_id
             registry = discover_providers()
             selected = registry.get_provider(provider)
@@ -1430,57 +1524,20 @@ def main(
         if provider is None and input_path.is_file():
             from .providers import discover_providers
 
-            registry = discover_providers()
-            detected = registry.detect_provider_for_path(input_path)
+            detected = discover_providers().detect_provider_for_path(input_path)
             if detected is not None:
-                selected = registry.get_provider(detected)
-                assert selected is not None
-                detected_messages = list(selected.load_session_from_path(input_path))
-                if not detected_messages:
-                    raise click.UsageError(
-                        f"{input_path} was detected as a {detected} session but "
-                        "produced no renderable messages; it may be truncated or "
-                        "malformed."
-                    )
-                # generate_session filters entries by sessionId, so the render
-                # key MUST be the session's own id (the thread id carried on the
-                # entries), not the filename stem — a mismatch silently drops
-                # every message, i.e. the exact empty-page bug this branch fixes.
-                session_key = detected_messages[0].sessionId or input_path.stem
-                detected_title = f"{detected.title()}: {session_key}"
-
-                def render_detected(destination: Path) -> Path:
-                    return render_normalized_session_file(
-                        detected_messages,
-                        session_key,
-                        destination,
-                        output_format,
-                        detected_title,
-                        image_export_mode,
-                        depth_level,
-                        compact,
-                        no_timestamps,
-                        no_recaps,
-                    )
-
-                extension = get_file_extension(output_format)
-                if _is_stdout_target(output):
-                    _render_to_stdout(
-                        input_path,
-                        lambda tmpdir: render_detected(tmpdir / f"session.{extension}"),
-                    )
-                    return
-                filename = f"session-{session_key}.{extension}"
-                if output is None:
-                    destination = Path.cwd() / filename
-                elif _output_path_is_file(output):
-                    destination = output
-                else:
-                    destination = output / filename
-                output_path = render_detected(destination)
-                click.echo(f"Successfully rendered {detected} session to {output_path}")
-                if open_browser:
-                    click.launch(str(output_path))
+                _render_provider_input_file(
+                    detected,
+                    input_path,
+                    output,
+                    output_format,
+                    image_export_mode,
+                    depth_level,
+                    compact,
+                    no_timestamps,
+                    no_recaps,
+                    open_browser,
+                )
                 return
 
         # Original single file/directory processing logic

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -208,14 +208,29 @@ def _run_provider_wholesale(
     write_individual: bool,
     from_date: "Optional[str]",
     to_date: "Optional[str]",
+    no_cache: bool,
+    clear_cache: bool,
+    clear_output: bool,
     open_browser: bool,
 ) -> None:
     """Render a whole provider sessions tree into a project hierarchy.
 
     ``sessions_root`` None walks the provider's own data dir; a directory
     (an INPUT_PATH dir, or ``--projects-dir``) selects a mini sessions root.
+
+    ``--clear-cache`` / ``--clear-output`` are standalone cleanup ops (clear
+    then exit, mirroring the Claude path), scoped to the provider output root so
+    the pristine sessions tree is never touched (DECIDED #4).
     """
     output_root = _resolve_provider_output_root(provider_name, output)
+
+    if clear_cache:
+        _clear_provider_cache(output_root)
+        return
+    if clear_output:
+        _clear_provider_output(output_root, output_format)
+        return
+
     index_path = render_provider_wholesale(
         provider_name,
         sessions_root,
@@ -230,10 +245,57 @@ def _run_provider_wholesale(
         no_recaps=no_recaps,
         write_combined=write_combined,
         write_individual=write_individual,
+        use_cache=not no_cache,
         silent=False,
     )
     if open_browser:
         click.launch(str(index_path))
+
+
+def _clear_provider_cache(output_root: Path) -> None:
+    """Delete the provider wholesale cache DB (and its WAL/SHM sidecars) under
+    the output root. Never touches the sessions tree — the DB lives beside the
+    generated output, not inside the sources."""
+    from .cache import get_cache_db_path
+
+    db = get_cache_db_path(output_root)
+    removed = False
+    for path in (db, db.with_name(db.name + "-wal"), db.with_name(db.name + "-shm")):
+        if path.exists():
+            try:
+                path.unlink()
+                removed = True
+            except OSError as exc:
+                click.echo(f"  Warning: failed to delete {path}: {exc}")
+    click.echo(
+        f"Cleared provider cache database: {db}"
+        if removed
+        else f"No provider cache database at {db}."
+    )
+
+
+def _clear_provider_output(output_root: Path, output_format: str) -> None:
+    """Remove generated output files under the provider output root only.
+
+    Scoped by known generated filenames (index + per-project
+    ``combined_transcripts*`` / ``session-*``), so unrelated files — and every
+    file in the sessions tree, which lives elsewhere — are left untouched."""
+    file_ext = get_file_extension(output_format)
+    removed = 0
+    if output_root.is_dir():
+        index_file = output_root / get_index_filename(output_format)
+        if index_file.exists():
+            index_file.unlink()
+            removed += 1
+        for project_dir in output_root.iterdir():
+            if not project_dir.is_dir():
+                continue
+            for generated in _list_generated_outputs(project_dir, file_ext):
+                generated.unlink()
+                removed += 1
+    click.echo(
+        f"Cleared {removed} generated {file_ext.upper()} file(s) under {output_root}."
+    )
 
 
 def _install_stack_dump_signal() -> None:
@@ -1047,20 +1109,11 @@ def main(
         ):
             if enabled:
                 conflicts.append(flag)
-        # Cache flags: provider wholesale does not yet participate in the cache
-        # (separate milestone); reject rather than silently ignore.
-        for enabled, flag in (
-            (no_cache, "--no-cache"),
-            (clear_cache, "--clear-cache"),
-            (clear_output, "--clear-output"),
-        ):
-            if enabled:
-                conflicts.append(flag)
         if provider_wholesale:
-            # Wholesale honors --combined, date range, -o/-f, --open-browser.
-            # Pagination (--page-size) and job-parallelism (--jobs) ride on the
-            # cache machinery that lands in a later milestone, so reject them
-            # loudly rather than accept-and-silently-ignore (no silent no-ops).
+            # Wholesale honors --combined, date range, -o/-f, --open-browser, and
+            # the cache flags (--no-cache/--clear-cache/--clear-output). Only
+            # pagination (--page-size) and job-parallelism (--jobs) remain
+            # deferred, so reject those loudly rather than accept-and-ignore.
             if jobs is not None:
                 conflicts.append("--jobs")
             if (
@@ -1070,13 +1123,16 @@ def main(
                 conflicts.append("--page-size")
         else:
             # export / single-file render one session; the wholesale-only flags
-            # (multi-project hierarchy, pagination, date range) don't apply.
+            # (multi-project hierarchy, pagination, date range, cache) don't apply.
             for enabled, flag in (
                 (all_projects, "--all-projects"),
                 (projects_dir is not None, "--projects-dir"),
                 (no_individual_sessions, "--no-individual-sessions"),
                 (from_date is not None, "--from-date"),
                 (to_date is not None, "--to-date"),
+                (no_cache, "--no-cache"),
+                (clear_cache, "--clear-cache"),
+                (clear_output, "--clear-output"),
             ):
                 if enabled:
                     conflicts.append(flag)
@@ -1296,6 +1352,9 @@ def main(
                     write_individual,
                     from_date,
                     to_date,
+                    no_cache,
+                    clear_cache,
+                    clear_output,
                     open_browser,
                 )
                 return
@@ -1682,6 +1741,9 @@ def main(
                         write_individual,
                         from_date,
                         to_date,
+                        no_cache,
+                        clear_cache,
+                        clear_output,
                         open_browser,
                     )
                     return

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -37,6 +37,7 @@ from .cache import (
     CacheManager,
     SessionCacheData,
     get_all_cached_projects,
+    get_cache_db_path,
     get_library_version,
 )
 from .parser import parse_timestamp
@@ -2816,6 +2817,32 @@ def _first_user_text(messages: List[TranscriptEntry]) -> Optional[str]:
     return None
 
 
+def _wholesale_should_render(
+    cache: Optional[CacheManager],
+    output_name: str,
+    session_id: Optional[str],
+    dest_dir: Path,
+    source_changed: bool,
+) -> bool:
+    """Whether a wholesale output file must be (re)written.
+
+    Conservative render-skip: with no cache, always render. Otherwise render on
+    ANY staleness signal — the source rollout changed since the last run, or
+    ``is_transcript_stale`` reports the on-disk file missing / version-stale /
+    message-count-drifted. Skip only when both agree the file is current; a skip
+    leaves the byte-identical file in place (rendering is deterministic, so
+    warm output equals cold output either way).
+    """
+    if cache is None:
+        return True
+    if source_changed:
+        return True
+    stale, _reason = cache.is_transcript_stale(
+        output_name, session_id=session_id, output_dir=dest_dir
+    )
+    return stale
+
+
 def render_provider_wholesale(
     provider_name: str,
     sessions_root: Optional[Path],
@@ -2830,6 +2857,7 @@ def render_provider_wholesale(
     no_recaps: bool = False,
     write_combined: bool = True,
     write_individual: bool = True,
+    use_cache: bool = True,
     silent: bool = False,
 ) -> Path:
     """Render every session of one provider under ``sessions_root`` into a
@@ -2844,9 +2872,14 @@ def render_provider_wholesale(
     INPUT_PATH). Output lands under ``output_root`` (the caller resolves the
     default ``<provider_home>/claude-code-log/`` and any ``-o`` override).
 
-    Cache participation and paginated combined pages are intentionally out of
-    this milestone — the combined page is a single unpaginated document, like
-    :func:`render_normalized_session_file` (both pass ``cache_manager=None``).
+    With ``use_cache`` the run participates in a SQLite cache under
+    ``output_root`` (``claude-code-log-cache.db``, honoring
+    ``CLAUDE_CODE_LOG_CACHE_PATH``): unchanged sessions/combined pages are
+    skipped by source mtime + output staleness, keyed on the synthetic output
+    project dir so the pristine sessions tree is never touched. Paginated
+    combined pages remain out of scope (the combined page is a single
+    unpaginated document); byte-stability across warm/cold runs is guaranteed
+    by deterministic rendering regardless.
     """
     from .providers import SessionInfo, discover_providers
 
@@ -2876,6 +2909,11 @@ def render_provider_wholesale(
 
     ext = get_file_extension(output_format)
     suffix = _variant_suffix(depth, compact, output_format, no_timestamps, no_recaps)
+    library_version = get_library_version()
+    cache_db_path = get_cache_db_path(output_root) if use_cache else None
+    # The cache DB lives directly under output_root, so the root must exist
+    # before the first CacheManager opens it (also where the index is written).
+    output_root.mkdir(parents=True, exist_ok=True)
 
     project_summaries: list[dict[str, Any]] = []
 
@@ -2887,34 +2925,96 @@ def render_provider_wholesale(
         working_directories = [group_key] if group_key is not None else []
         project_title = get_project_display_name(project_dirname, working_directories)
 
-        session_dicts: list[dict[str, Any]] = []
-        combined_messages: list[TranscriptEntry] = []
-        last_modified = 0.0
-
+        # Phase 1 — load every session in the project fresh. v1 always re-parses
+        # rollouts (cache-backed load is a documented deferral); only rendering
+        # is skipped when unchanged.
+        loaded: list[tuple[SessionInfo, list[TranscriptEntry]]] = []
         for info in group_infos:
             messages = list(provider.load_session_under(sessions_root, info.session_id))
             if from_date or to_date:
                 messages = filter_messages_by_date(messages, from_date, to_date)
-            if not messages:
-                continue
+            if messages:
+                loaded.append((info, messages))
 
+        if not loaded:
+            continue  # everything in this project was empty / filtered out
+
+        combined_messages: list[TranscriptEntry] = [
+            m for _info, msgs in loaded for m in msgs
+        ]
+
+        # Phase 2 — populate the cache and capture the pre-render modified set.
+        cache: Optional[CacheManager] = None
+        modified_sources: set[Path] = set()
+        session_counts: dict[str, int] = {}
+        if use_cache:
+            cache = CacheManager(dest_dir, library_version, db_path=cache_db_path)
+            source_paths = [
+                info.source_path for info, _ in loaded if info.source_path is not None
+            ]
+            with cache.batch():
+                # get_modified_files reads the PRIOR run's mtimes, so it must run
+                # before save_cached_entries overwrites them.
+                modified_sources = {
+                    p.resolve() for p in cache.get_modified_files(source_paths)
+                }
+                merged_session_data: dict[str, SessionCacheData] = {}
+                for info, messages in loaded:
+                    if info.source_path is not None:
+                        # DEFERRED (tracked in work/codex-backlog.md): populating
+                        # the messages table gives schema uniformity and a future
+                        # cache-backed-load flip. v1 never LOADS from it — the
+                        # walker always re-parses rollouts (cheap, and it avoids a
+                        # serialization round-trip fidelity risk). subagents_fp=""
+                        # because codex has no sidecar tree, so the fingerprint
+                        # stays stable across runs.
+                        cache.save_cached_entries(
+                            info.source_path, messages, subagents_fp=""
+                        )
+                    merged_session_data.update(compute_session_data(messages))
+                cache.update_session_cache(merged_session_data)
+                cache.update_project_aggregates(
+                    **compute_project_aggregates(combined_messages)
+                )
+            session_counts = {
+                sid: sd.message_count for sid, sd in merged_session_data.items()
+            }
+
+        # Phase 3 — build index cards and render per-session pages (skipping
+        # unchanged ones).
+        session_dicts: list[dict[str, Any]] = []
+        last_modified = 0.0
+        for info, messages in loaded:
             session_key = info.session_id
             session_title = info.title or f"{provider_name.title()}: {session_key}"
             if write_individual:
-                render_normalized_session_file(
-                    messages,
-                    session_key,
-                    dest_dir / f"session-{session_key}{suffix}.{ext}",
-                    output_format,
-                    session_title,
-                    image_export_mode,
-                    depth,
-                    compact,
-                    no_timestamps,
-                    no_recaps,
-                    suppress_combined_link=not write_combined,
+                output_name = f"session-{session_key}{suffix}.{ext}"
+                source_changed = (
+                    info.source_path is not None
+                    and info.source_path.resolve() in modified_sources
                 )
-            combined_messages.extend(messages)
+                if _wholesale_should_render(
+                    cache, output_name, session_key, dest_dir, source_changed
+                ):
+                    render_normalized_session_file(
+                        messages,
+                        session_key,
+                        dest_dir / output_name,
+                        output_format,
+                        session_title,
+                        image_export_mode,
+                        depth,
+                        compact,
+                        no_timestamps,
+                        no_recaps,
+                        suppress_combined_link=not write_combined,
+                    )
+                    if cache is not None:
+                        cache.update_html_cache(
+                            output_name,
+                            session_key,
+                            session_counts.get(session_key, len(messages)),
+                        )
 
             first_ts, last_ts = _entry_timestamp_range(messages)
             first_user = _first_user_text(messages)
@@ -2942,29 +3042,32 @@ def render_provider_wholesale(
                 }
             )
 
-        if not session_dicts:
-            continue  # everything in this project was empty / filtered out
-
         combined_name = f"combined_transcripts{suffix}.{ext}"
         if write_combined:
-            combined_renderer = get_renderer(
-                output_format,
-                image_export_mode,
-                depth=depth,
-                compact=compact,
-                no_timestamps=no_timestamps,
-                no_recaps=no_recaps,
-            )
-            combined_content = combined_renderer.generate(
-                combined_messages,
-                project_title,
-                output_dir=dest_dir,
-            )
-            assert combined_content is not None
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            (dest_dir / combined_name).write_text(
-                combined_content, encoding="utf-8", errors="replace"
-            )
+            # Any changed session in the project invalidates the combined page.
+            if _wholesale_should_render(
+                cache, combined_name, None, dest_dir, bool(modified_sources)
+            ):
+                combined_renderer = get_renderer(
+                    output_format,
+                    image_export_mode,
+                    depth=depth,
+                    compact=compact,
+                    no_timestamps=no_timestamps,
+                    no_recaps=no_recaps,
+                )
+                combined_content = combined_renderer.generate(
+                    combined_messages,
+                    project_title,
+                    output_dir=dest_dir,
+                )
+                assert combined_content is not None
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                (dest_dir / combined_name).write_text(
+                    combined_content, encoding="utf-8", errors="replace"
+                )
+                if cache is not None:
+                    cache.update_html_cache(combined_name, None, len(combined_messages))
 
         first_ts_all, last_ts_all = _entry_timestamp_range(combined_messages)
         project_summaries.append(

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2898,6 +2898,16 @@ def render_provider_wholesale(
         sessions_root = data_dir / "sessions"
 
     infos = list(provider.discover_sessions_under(sessions_root))
+    if not infos:
+        # No sessions discovered under an explicitly-targeted root. Fail LOUDLY
+        # rather than write an empty index and exit 0 — a silent empty-success
+        # here is indistinguishable from "rendered a rollout as nothing", the
+        # exact gap the modalities work closes. (A non-empty tree that is merely
+        # filtered to nothing by --from/--to still renders an empty index; that
+        # is a deliberate, legible filter result, not this.)
+        raise FileNotFoundError(
+            f"No {provider_name} sessions found under {sessions_root}."
+        )
 
     # Group by cwd (DECIDED #3). The no-cwd bucket (key None) sorts last.
     groups: dict[Optional[str], list[SessionInfo]] = {}

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 import traceback
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
@@ -2748,12 +2749,17 @@ def render_normalized_session_file(
     compact: bool = False,
     no_timestamps: bool = False,
     no_recaps: bool = False,
+    suppress_combined_link: bool = False,
 ) -> Path:
     """Render already-normalized provider entries to one output file.
 
     Unlike :func:`generate_single_session_file`, this helper has no Claude
     project-directory or cache assumptions. Providers own discovery and
     normalization; the shared renderer only needs transcript entries.
+
+    ``suppress_combined_link`` omits the per-session "Back to combined
+    transcript" affordance — set it when no combined page is written for the
+    project (``--combined no``) so the back-link can't 404.
     """
     renderer = get_renderer(
         format,
@@ -2769,11 +2775,240 @@ def render_normalized_session_file(
         title or f"Session {session_id[:8]}",
         cache_manager=None,
         output_dir=output.parent,
+        suppress_combined_link=suppress_combined_link,
     )
     assert content is not None
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(content, encoding="utf-8", errors="replace")
     return output
+
+
+def _provider_project_dirname(cwd: Optional[Path]) -> str:
+    """Stable per-cwd output subdir name, mirroring Claude's dashed encoding
+    (``/proj/a`` → ``-proj-a``). Sessions without a cwd share one bucket so the
+    index always has a home for them (DECIDED #3)."""
+    if cwd is None:
+        return "no-project"
+    return str(cwd).replace("/", "-").replace("\\", "-")
+
+
+def _entry_timestamp_range(
+    messages: List[TranscriptEntry],
+) -> tuple[Optional[str], Optional[str]]:
+    """Earliest/latest ISO timestamp across entries (ignoring blanks)."""
+    stamps = sorted(ts for m in messages if (ts := getattr(m, "timestamp", None)))
+    return (stamps[0], stamps[-1]) if stamps else (None, None)
+
+
+def _first_user_text(messages: List[TranscriptEntry]) -> Optional[str]:
+    """First user message's text, for the index card summary/preview."""
+    for message in messages:
+        if getattr(message, "type", None) != "user":
+            continue
+        content = getattr(getattr(message, "message", None), "content", None)
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            for item in cast(List[Any], content):
+                text = getattr(item, "text", None)
+                if isinstance(text, str) and text:
+                    return text
+    return None
+
+
+def render_provider_wholesale(
+    provider_name: str,
+    sessions_root: Optional[Path],
+    output_root: Path,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    output_format: str = "html",
+    image_export_mode: Optional[str] = None,
+    depth: RenderingDepth = DEFAULT_DEPTH,
+    compact: bool = False,
+    no_timestamps: bool = False,
+    no_recaps: bool = False,
+    write_combined: bool = True,
+    write_individual: bool = True,
+    silent: bool = False,
+) -> Path:
+    """Render every session of one provider under ``sessions_root`` into a
+    project hierarchy — per-session pages, a per-project combined page, and a
+    master index — reusing the shared renderers.
+
+    Provider-neutral: discovery and loading come from the provider's
+    root-scoped seams (:meth:`BaseProvider.discover_sessions_under` /
+    :meth:`load_session_under`); sessions are grouped into "projects" by their
+    ``cwd`` (DECIDED #3). ``sessions_root`` ``None`` walks the provider's own
+    data-dir sessions root; a directory selects a mini sessions root (an
+    INPUT_PATH). Output lands under ``output_root`` (the caller resolves the
+    default ``<provider_home>/claude-code-log/`` and any ``-o`` override).
+
+    Cache participation and paginated combined pages are intentionally out of
+    this milestone — the combined page is a single unpaginated document, like
+    :func:`render_normalized_session_file` (both pass ``cache_manager=None``).
+    """
+    from .providers import SessionInfo, discover_providers
+
+    registry = discover_providers()
+    provider = registry.get_provider(provider_name)
+    if provider is None:
+        raise ValueError(f"Unknown provider: {provider_name}")
+
+    if sessions_root is None:
+        data_dir = provider.get_data_dir()
+        if data_dir is None:
+            raise FileNotFoundError(
+                f"No {provider_name} data directory found; set the provider home "
+                "or pass a directory to render."
+            )
+        sessions_root = data_dir / "sessions"
+
+    infos = list(provider.discover_sessions_under(sessions_root))
+
+    # Group by cwd (DECIDED #3). The no-cwd bucket (key None) sorts last.
+    groups: dict[Optional[str], list[SessionInfo]] = {}
+    for info in infos:
+        key = str(info.project_path) if info.project_path is not None else None
+        groups.setdefault(key, []).append(info)
+
+    from .utils import variant_suffix as _variant_suffix
+
+    ext = get_file_extension(output_format)
+    suffix = _variant_suffix(depth, compact, output_format, no_timestamps, no_recaps)
+
+    project_summaries: list[dict[str, Any]] = []
+
+    for group_key in sorted(groups, key=lambda k: (k is None, k or "")):
+        group_infos = sorted(groups[group_key], key=lambda i: i.session_id)
+        cwd = Path(group_key) if group_key is not None else None
+        project_dirname = _provider_project_dirname(cwd)
+        dest_dir = output_root / project_dirname
+        working_directories = [group_key] if group_key is not None else []
+        project_title = get_project_display_name(project_dirname, working_directories)
+
+        session_dicts: list[dict[str, Any]] = []
+        combined_messages: list[TranscriptEntry] = []
+        last_modified = 0.0
+
+        for info in group_infos:
+            messages = list(provider.load_session_under(sessions_root, info.session_id))
+            if from_date or to_date:
+                messages = filter_messages_by_date(messages, from_date, to_date)
+            if not messages:
+                continue
+
+            session_key = info.session_id
+            session_title = info.title or f"{provider_name.title()}: {session_key}"
+            if write_individual:
+                render_normalized_session_file(
+                    messages,
+                    session_key,
+                    dest_dir / f"session-{session_key}{suffix}.{ext}",
+                    output_format,
+                    session_title,
+                    image_export_mode,
+                    depth,
+                    compact,
+                    no_timestamps,
+                    no_recaps,
+                    suppress_combined_link=not write_combined,
+                )
+            combined_messages.extend(messages)
+
+            first_ts, last_ts = _entry_timestamp_range(messages)
+            first_user = _first_user_text(messages)
+            if info.updated_at:
+                try:
+                    last_modified = max(
+                        last_modified,
+                        datetime.fromisoformat(info.updated_at).timestamp(),
+                    )
+                except ValueError:
+                    pass
+            session_dicts.append(
+                {
+                    "id": session_key,
+                    "summary": info.title or first_user or session_key,
+                    "timestamp_range": format_timestamp_range(
+                        first_ts or "", last_ts or ""
+                    ),
+                    "first_timestamp": first_ts,
+                    "last_timestamp": last_ts,
+                    "message_count": len(messages),
+                    "first_user_message": first_user
+                    or "[No user message found in session.]",
+                    "file": f"{project_dirname}/session-{session_key}{suffix}.{ext}",
+                }
+            )
+
+        if not session_dicts:
+            continue  # everything in this project was empty / filtered out
+
+        combined_name = f"combined_transcripts{suffix}.{ext}"
+        if write_combined:
+            combined_renderer = get_renderer(
+                output_format,
+                image_export_mode,
+                depth=depth,
+                compact=compact,
+                no_timestamps=no_timestamps,
+                no_recaps=no_recaps,
+            )
+            combined_content = combined_renderer.generate(
+                combined_messages,
+                project_title,
+                output_dir=dest_dir,
+            )
+            assert combined_content is not None
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            (dest_dir / combined_name).write_text(
+                combined_content, encoding="utf-8", errors="replace"
+            )
+
+        first_ts_all, last_ts_all = _entry_timestamp_range(combined_messages)
+        project_summaries.append(
+            {
+                "name": project_dirname,
+                "path": dest_dir,
+                "html_file": f"{project_dirname}/{combined_name}",
+                "html_variants": [],
+                "jsonl_count": len(session_dicts),
+                "message_count": len(combined_messages),
+                "last_modified": last_modified,
+                # Codex has no token accounting yet; emit zero totals so the
+                # index-summary dict is shape-identical to the Claude path
+                # (the contract the drift pin locks) rather than relying on the
+                # renderer's ``.get(..., 0)`` fallbacks.
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_cache_creation_tokens": 0,
+                "total_cache_read_tokens": 0,
+                "latest_timestamp": last_ts_all or "",
+                "earliest_timestamp": first_ts_all or "",
+                "working_directories": working_directories,
+                "is_archived": False,
+                "combined_suppressed": not write_combined,
+                "sessions": session_dicts,
+                "team_names": [],
+            }
+        )
+
+    renderer = get_renderer(output_format, image_export_mode)
+    index_content = renderer.generate_projects_index(
+        project_summaries, from_date, to_date
+    )
+    assert index_content is not None
+    index_path = output_root / get_index_filename(output_format)
+    output_root.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(index_content, encoding="utf-8", errors="replace")
+
+    if not silent:
+        print(
+            f"Processed {len(project_summaries)} {provider_name} project(s) "
+            f"and created index at {index_path}"
+        )
+    return index_path
 
 
 def _get_cleanup_period_days() -> Optional[int]:

--- a/claude_code_log/providers/base.py
+++ b/claude_code_log/providers/base.py
@@ -28,6 +28,9 @@ class SessionInfo:
     project_path: Optional[Path] = None
     message_count: int = 0
     total_tokens: int = 0
+    # Absolute path to the session's source file, when it has a single one.
+    # The wholesale walker keys source-mtime cache staleness off this.
+    source_path: Optional[Path] = None
 
 
 def extract_text(content: Any) -> str:

--- a/claude_code_log/providers/base.py
+++ b/claude_code_log/providers/base.py
@@ -233,5 +233,18 @@ class BaseProvider(ABC):
         """
         return False
 
+    def load_session_from_path(
+        self, path: Path, max_messages: Optional[int] = None
+    ) -> Iterator[TranscriptEntry]:
+        """Load a single session file handed in directly as an INPUT_PATH.
+
+        Only providers that participate in INPUT_PATH detection (``detect_path``)
+        need this. The default raises: a provider that never claims a path will
+        never be asked to load one.
+        """
+        raise NotImplementedError(
+            f"{self.get_provider_name()} cannot load a session directly by path"
+        )
+
     def get_session_stats(self, session_id: str) -> dict[str, Any]:
         return {}

--- a/claude_code_log/providers/base.py
+++ b/claude_code_log/providers/base.py
@@ -246,5 +246,35 @@ class BaseProvider(ABC):
             f"{self.get_provider_name()} cannot load a session directly by path"
         )
 
+    def discover_sessions_under(self, root: Path) -> Iterator[SessionInfo]:
+        """Discover sessions within an arbitrary *root* directory.
+
+        The wholesale walker calls this for both the provider's own data dir
+        and a directory handed in as an INPUT_PATH (a mini sessions root).
+        Unlike :meth:`discover_sessions` (which is pinned to ``get_data_dir``),
+        the root is explicit, so one code path serves both. Sibling context
+        within *root* (e.g. fork-prefix stripping) is honored, unlike the
+        standalone :meth:`load_session_from_path`.
+
+        Default raises: only providers that support wholesale rendering
+        override this.
+        """
+        raise NotImplementedError(
+            f"{self.get_provider_name()} does not support wholesale rendering"
+        )
+
+    def load_session_under(
+        self, root: Path, session_id: str, max_messages: Optional[int] = None
+    ) -> Iterator[TranscriptEntry]:
+        """Load one session by id within an explicit *root* (see
+        :meth:`discover_sessions_under`), with sibling context.
+
+        Default raises: only providers that support wholesale rendering
+        override this.
+        """
+        raise NotImplementedError(
+            f"{self.get_provider_name()} does not support wholesale rendering"
+        )
+
     def get_session_stats(self, session_id: str) -> dict[str, Any]:
         return {}

--- a/claude_code_log/providers/base.py
+++ b/claude_code_log/providers/base.py
@@ -222,5 +222,16 @@ class BaseProvider(ABC):
         data_dir = self.get_data_dir()
         return data_dir is not None and data_dir.exists()
 
+    def detect_path(self, path: Path) -> bool:
+        """Cheaply decide whether an INPUT_PATH belongs to this provider.
+
+        Default: no auto-detection. A provider that can recognize its own
+        session files by a cheap check (a filename pattern or a first-line
+        sniff) overrides this so an INPUT_PATH routes to the provider pipeline
+        instead of the Claude parser (which would silently skip the records and
+        emit a near-empty page). Implementations MUST NOT fully parse the file.
+        """
+        return False
+
     def get_session_stats(self, session_id: str) -> dict[str, Any]:
         return {}

--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -288,6 +288,7 @@ class CodexProvider(BaseProvider):
                 created_at=identity.created_at or file_mtime_iso(identity.path),
                 updated_at=file_mtime_iso(identity.path),
                 project_path=identity.cwd,
+                source_path=identity.path,
                 parent_thread_id=identity.parent_thread_id,
                 forked_from_id=identity.forked_from_id,
                 spawn_call_id=identity.spawn_call_id,

--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -217,6 +217,13 @@ def _contained_rollouts(root: Path) -> Iterator[Path]:
 class CodexProvider(BaseProvider):
     """Read active Codex rollout files from ``$CODEX_HOME/sessions``."""
 
+    def __init__(self) -> None:
+        # Memoize the thread-id → paths index per resolved sessions root so a
+        # wholesale run (discovery + per-session loads) reads each rollout's
+        # header once instead of O(sessions) times. Safe within a single CLI
+        # run — the sessions tree does not change mid-render.
+        self._index_cache: dict[Path, dict[str, list[Path]]] = {}
+
     def detect_path(self, path: Path) -> bool:
         """A Codex rollout file, or a directory containing at least one."""
         if path.is_file():
@@ -241,17 +248,28 @@ class CodexProvider(BaseProvider):
         sessions_dir = codex_home / "sessions"
         return codex_home if sessions_dir.is_dir() else None
 
-    def discover_sessions(self) -> Iterator[SessionInfo]:
+    def _sessions_root(self) -> Optional[Path]:
         data_dir = self.get_data_dir()
-        if data_dir is None:
-            return
+        return data_dir / "sessions" if data_dir is not None else None
 
+    def discover_sessions(self) -> Iterator[SessionInfo]:
+        sessions_root = self._sessions_root()
+        if sessions_root is None:
+            return
+        yield from self._discover_in(sessions_root)
+
+    def discover_sessions_under(self, root: Path) -> Iterator[SessionInfo]:
+        """Discover sessions within an arbitrary root (INPUT_PATH dir or the
+        data dir), honoring sibling fork-prefix context within *root*."""
+        yield from self._discover_in(root)
+
+    def _discover_in(self, sessions_root: Path) -> Iterator[SessionInfo]:
         # A duplicated thread id is corrupt/ambiguous.  Discovery remains
         # useful and deterministic by retaining the lexicographically first
         # path; loading that id reports the ambiguity instead of guessing.
         identities: dict[str, CodexSessionIdentity] = {}
-        index = self._session_index(data_dir)
-        for path in self._rollout_paths(data_dir):
+        index = self._session_index(sessions_root)
+        for path in self._rollout_paths(sessions_root):
             identity = self._read_identity(path)
             if identity.thread_id in identities:
                 logger.warning(
@@ -280,16 +298,27 @@ class CodexProvider(BaseProvider):
     def load_session(
         self, session_id: str, max_messages: Optional[int] = None
     ) -> Iterator[TranscriptEntry]:
+        sessions_root = self._sessions_root()
+        if sessions_root is None:
+            raise ValueError("Codex data directory not found")
+        yield from self._load_in(sessions_root, session_id, max_messages)
+
+    def load_session_under(
+        self, root: Path, session_id: str, max_messages: Optional[int] = None
+    ) -> Iterator[TranscriptEntry]:
+        """Load one session by id within an explicit *root* (a mini sessions
+        tree or the data dir), with sibling fork-prefix stripping."""
+        yield from self._load_in(root, session_id, max_messages)
+
+    def _load_in(
+        self, sessions_root: Path, session_id: str, max_messages: Optional[int]
+    ) -> Iterator[TranscriptEntry]:
         if not session_id or _SESSION_ID_RE.fullmatch(session_id) is None:
             raise ValueError(f"Invalid session_id: {session_id}")
         if max_messages is not None and max_messages <= 0:
             return
 
-        data_dir = self.get_data_dir()
-        if data_dir is None:
-            raise ValueError("Codex data directory not found")
-
-        index = self._session_index(data_dir)
+        index = self._session_index(sessions_root)
         if session_id not in index:
             raise FileNotFoundError(f"Codex session {session_id} not found")
         paths = index[session_id]
@@ -321,26 +350,37 @@ class CodexProvider(BaseProvider):
         records = list(self._decode_records(path))
         yield from self._normalize_records(identity, records, max_messages)
 
-    def _rollout_paths(self, data_dir: Path) -> list[Path]:
+    def _rollout_paths(self, sessions_root: Path) -> list[Path]:
         # Recursive discovery supports both current date shards and old flat
         # layouts.  archived_sessions is deliberately outside this v1 root.
-        sessions_dir = data_dir / "sessions"
-        sessions_root = sessions_dir.resolve()
+        # ``sessions_root`` is the directory to walk directly: the data dir's
+        # ``sessions/`` subdir, or a directory handed in as an INPUT_PATH.
+        resolved_root = sessions_root.resolve()
         paths: set[Path] = set()
-        for path in sessions_dir.rglob(_ROLLOUT_GLOB):
+        for path in sessions_root.rglob(_ROLLOUT_GLOB):
             try:
                 resolved = path.resolve()
-                if path.is_file() and resolved.is_relative_to(sessions_root):
+                if path.is_file() and resolved.is_relative_to(resolved_root):
                     paths.add(resolved)
             except OSError:
                 continue
         return sorted(paths)
 
-    def _session_index(self, data_dir: Path) -> dict[str, list[Path]]:
+    def _session_index(self, sessions_root: Path) -> dict[str, list[Path]]:
+        # Memoized per resolved root: discovery and every per-session load in a
+        # wholesale run share one index build (see ``_index_cache``).
+        try:
+            cache_key = sessions_root.resolve()
+        except OSError:
+            cache_key = sessions_root
+        cached = self._index_cache.get(cache_key)
+        if cached is not None:
+            return cached
         index: dict[str, list[Path]] = {}
-        for path in self._rollout_paths(data_dir):
+        for path in self._rollout_paths(sessions_root):
             identity = self._read_identity(path)
             index.setdefault(identity.thread_id, []).append(path)
+        self._index_cache[cache_key] = index
         return index
 
     def _with_inherited_prefix(

--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -201,14 +201,24 @@ def _looks_like_rollout_file(path: Path) -> bool:
 
 
 def _contained_rollouts(root: Path) -> Iterator[Path]:
-    """Yield ``rollout-*.jsonl`` files under *root*, resolving symlinks but
-    keeping containment (mirrors ``_rollout_paths``): a symlink escaping *root*
-    is skipped, so an INPUT_PATH directory can't pull in outside files."""
+    """Yield rollout files under *root*, resolving symlinks but keeping
+    containment (mirrors ``_rollout_paths``): a symlink escaping *root* is
+    skipped, so an INPUT_PATH directory can't pull in outside files.
+
+    A file counts as a rollout by the SAME rule ``_looks_like_rollout_file``
+    applies to a single file — the ``rollout-*.jsonl`` name, else a first-line
+    ``session_meta`` sniff — so a directory of sniff-only-named rollouts is
+    discovered exactly as the equivalent standalone file is, never silently
+    dropped to an empty Claude parse."""
     resolved_root = root.resolve()
-    for candidate in root.rglob(_ROLLOUT_GLOB):
+    for candidate in root.rglob("*.jsonl"):
         try:
             resolved = candidate.resolve()
-            if candidate.is_file() and resolved.is_relative_to(resolved_root):
+            if (
+                candidate.is_file()
+                and resolved.is_relative_to(resolved_root)
+                and _looks_like_rollout_file(candidate)
+            ):
                 yield resolved
         except OSError:
             continue
@@ -356,12 +366,20 @@ class CodexProvider(BaseProvider):
         # layouts.  archived_sessions is deliberately outside this v1 root.
         # ``sessions_root`` is the directory to walk directly: the data dir's
         # ``sessions/`` subdir, or a directory handed in as an INPUT_PATH.
+        # Match by ``_looks_like_rollout_file`` (name OR first-line sniff), the
+        # same rule single-file detection uses, so a sniff-only-named rollout in
+        # a directory is discovered — not silently dropped. Real data dirs hold
+        # only ``rollout-*.jsonl``, which short-circuits on the name (no read).
         resolved_root = sessions_root.resolve()
         paths: set[Path] = set()
-        for path in sessions_root.rglob(_ROLLOUT_GLOB):
+        for path in sessions_root.rglob("*.jsonl"):
             try:
                 resolved = path.resolve()
-                if path.is_file() and resolved.is_relative_to(resolved_root):
+                if (
+                    path.is_file()
+                    and resolved.is_relative_to(resolved_root)
+                    and _looks_like_rollout_file(path)
+                ):
                     paths.add(resolved)
             except OSError:
                 continue

--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -303,6 +303,24 @@ class CodexProvider(BaseProvider):
         )
         yield from self._normalize_records(identity, records, max_messages)
 
+    def load_session_from_path(
+        self, path: Path, max_messages: Optional[int] = None
+    ) -> Iterator[TranscriptEntry]:
+        """Load a single rollout file directly by path (an INPUT_PATH),
+        independent of the configured data dir.
+
+        There is no sibling index, so inherited-prefix stripping is a no-op and
+        the file renders standalone — the right behavior for "render that one
+        rollout" without discovering an ambient sessions tree around it.
+        """
+        if max_messages is not None and max_messages <= 0:
+            return
+        if not path.is_file():
+            raise FileNotFoundError(f"Codex rollout not found: {path}")
+        identity = self._read_identity(path)
+        records = list(self._decode_records(path))
+        yield from self._normalize_records(identity, records, max_messages)
+
     def _rollout_paths(self, data_dir: Path) -> list[Path]:
         # Recursive discovery supports both current date shards and old flat
         # layouts.  archived_sessions is deliberately outside this v1 root.

--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
+from fnmatch import fnmatch
 import json
 import logging
 import mimetypes
@@ -167,8 +168,62 @@ class _SessionMarkerProgram:
     output_mode: str
 
 
+def _looks_like_rollout_file(path: Path) -> bool:
+    """Cheap check: does *path* look like a Codex rollout JSONL file?
+
+    A positive filename match (``rollout-*.jsonl``) short-circuits; otherwise a
+    single first-line sniff for the ``session_meta`` header (modern ``type``
+    field, or the legacy no-``type``/``id`` flat header). Never parses the body.
+    """
+    if not path.is_file():
+        return False
+    if fnmatch(path.name, _ROLLOUT_GLOB):
+        return True
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    raw = json.loads(stripped)
+                except json.JSONDecodeError:
+                    return False
+                if not isinstance(raw, dict):
+                    return False
+                raw_dict = cast("dict[str, Any]", raw)
+                return raw_dict.get("type") == "session_meta" or (
+                    "type" not in raw_dict and bool(raw_dict.get("id"))
+                )
+    except OSError:
+        return False
+    return False
+
+
+def _contained_rollouts(root: Path) -> Iterator[Path]:
+    """Yield ``rollout-*.jsonl`` files under *root*, resolving symlinks but
+    keeping containment (mirrors ``_rollout_paths``): a symlink escaping *root*
+    is skipped, so an INPUT_PATH directory can't pull in outside files."""
+    resolved_root = root.resolve()
+    for candidate in root.rglob(_ROLLOUT_GLOB):
+        try:
+            resolved = candidate.resolve()
+            if candidate.is_file() and resolved.is_relative_to(resolved_root):
+                yield resolved
+        except OSError:
+            continue
+
+
 class CodexProvider(BaseProvider):
     """Read active Codex rollout files from ``$CODEX_HOME/sessions``."""
+
+    def detect_path(self, path: Path) -> bool:
+        """A Codex rollout file, or a directory containing at least one."""
+        if path.is_file():
+            return _looks_like_rollout_file(path)
+        if path.is_dir():
+            return any(True for _ in _contained_rollouts(path))
+        return False
 
     def get_provider_name(self) -> str:
         return "codex"

--- a/claude_code_log/providers/registry.py
+++ b/claude_code_log/providers/registry.py
@@ -1,6 +1,7 @@
 """Provider registry for auto-discovery and management."""
 
 import logging
+from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Type
 
 from .base import BaseProvider, SessionInfo
@@ -78,6 +79,27 @@ class ProviderRegistry:
         provider = self._providers.get(provider_name)
         if provider and provider.is_available():
             yield from provider.discover_sessions()
+
+    def detect_provider_for_path(self, path: Path) -> Optional[str]:
+        """Return the single provider name that recognizes *path* via its cheap
+        ``detect_path`` sniff, or ``None`` if none do.
+
+        Detection is independent of ``is_available`` — an INPUT_PATH rollout may
+        be handed in even when the provider's own data dir is absent. If more
+        than one provider claims the path the choice is ambiguous, so raise and
+        tell the caller to disambiguate with ``--provider`` (DECIDED #2).
+        """
+        matches = [
+            name
+            for name, provider in sorted(self._providers.items())
+            if provider.detect_path(path)
+        ]
+        if len(matches) > 1:
+            raise ValueError(
+                "INPUT_PATH matches multiple providers "
+                f"({', '.join(matches)}); pass --provider to disambiguate"
+            )
+        return matches[0] if matches else None
 
     def load_session(
         self, provider_name: str, session_id: str, max_messages: Optional[int] = None

--- a/test/test_codex_cli.py
+++ b/test/test_codex_cli.py
@@ -127,7 +127,9 @@ def test_provider_directory_output_creates_nested_destination(
 @pytest.mark.parametrize(
     ("args", "message"),
     [
-        (["--provider", "codex"], "requires --session-id"),
+        # NB: bare ``--provider codex`` (no id, no INPUT_PATH) is no longer
+        # rejected — it now runs the wholesale walker (see the walker CLI tests).
+        # These rows are the combos that stay illegal in single-session mode.
         (
             ["some-project", "--provider", "codex", "--session-id", "0123"],
             "INPUT_PATH",

--- a/test/test_codex_cli.py
+++ b/test/test_codex_cli.py
@@ -51,6 +51,11 @@ class FakeRegistry:
     def get_provider(self, name: str):
         return self.provider if name == "codex" else None
 
+    def get_all_providers(self) -> list[str]:
+        # The CLI validates --provider against this up front (clean UsageError
+        # for an unknown name). The stub only knows "codex" when it has one.
+        return ["codex"] if self.provider is not None else []
+
 
 @pytest.fixture
 def provider(monkeypatch: pytest.MonkeyPatch) -> FakeProvider:

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -110,10 +110,12 @@ def test_base_provider_default_is_no_detection(tmp_path: Path) -> None:
         def get_data_dir(self) -> Path | None:
             return None
 
-        def discover_sessions(self):  # type: ignore[no-untyped-def]
+        def discover_sessions(self) -> Iterator[SessionInfo]:
             return iter(())
 
-        def load_session(self, session_id, max_messages=None):  # type: ignore[no-untyped-def]
+        def load_session(
+            self, session_id: str, max_messages: Optional[int] = None
+        ) -> Iterator[TranscriptEntry]:
             return iter(())
 
     path = _write(tmp_path / "rollout-x.jsonl", [_SESSION_META])
@@ -250,27 +252,36 @@ def test_explicit_provider_renders_rollout_file(tmp_path: Path) -> None:
     assert "synthetic files" in out.read_text(encoding="utf-8")
 
 
-def test_rollout_directory_errors_loudly_until_walker_lands(tmp_path: Path) -> None:
-    """Interim guard: a directory of rollouts must NOT fall through to the empty
-    Claude parse before the wholesale walker lands. Both auto-detect and
-    explicit --provider error loudly (the matrix must not silently lie)."""
+def test_rollout_directory_renders_via_walker(tmp_path: Path) -> None:
+    """A directory of rollouts must NOT fall through to the empty Claude parse:
+    both auto-detect and explicit --provider now render the whole tree via the
+    wholesale walker (an index + per-session pages), never a near-empty page."""
     from click.testing import CliRunner
 
     from claude_code_log.cli import main
 
-    nested = tmp_path / "sessions" / "2026" / "01"
-    nested.mkdir(parents=True)
-    _write(nested / "rollout-abcd.jsonl", [_SESSION_META, {"type": "message"}])
-
-    auto = CliRunner().invoke(main, [str(tmp_path), "-o", str(tmp_path / "a.html")])
-    assert auto.exit_code != 0
-    assert "sessions directory" in auto.output and "wholesale walker" in auto.output
-
-    explicit = CliRunner().invoke(
-        main, ["--provider", "codex", str(tmp_path), "-o", str(tmp_path / "e.html")]
+    tree = tmp_path / "sessions" / "2026" / "01"
+    tree.mkdir(parents=True)
+    _write(
+        tree / "rollout-abcd.jsonl",
+        [
+            _SESSION_META,
+            {"type": "event_msg", "payload": {"type": "user_message", "message": "hi"}},
+        ],
     )
-    assert explicit.exit_code != 0
-    assert "sessions directory" in explicit.output
+
+    auto_out = tmp_path / "auto"
+    auto = CliRunner().invoke(main, [str(tmp_path / "sessions"), "-o", str(auto_out)])
+    assert auto.exit_code == 0, auto.output
+    assert (auto_out / "index.html").exists()
+
+    explicit_out = tmp_path / "explicit"
+    explicit = CliRunner().invoke(
+        main,
+        ["--provider", "codex", str(tmp_path / "sessions"), "-o", str(explicit_out)],
+    )
+    assert explicit.exit_code == 0, explicit.output
+    assert (explicit_out / "index.html").exists()
 
 
 def test_non_rollout_file_is_left_to_the_claude_path(tmp_path: Path) -> None:

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -10,9 +10,14 @@ directory containment) on synthetic fixtures — no real transcript content.
 
 import json
 from pathlib import Path
+from typing import Iterator, Optional
 
-from claude_code_log.providers.base import BaseProvider
+import pytest
+
+from claude_code_log.models import TranscriptEntry
+from claude_code_log.providers.base import BaseProvider, SessionInfo
 from claude_code_log.providers.codex import CodexProvider
+from claude_code_log.providers.registry import ProviderRegistry
 
 _SESSION_META = {
     "type": "session_meta",
@@ -113,3 +118,74 @@ def test_base_provider_default_is_no_detection(tmp_path: Path) -> None:
 
     path = _write(tmp_path / "rollout-x.jsonl", [_SESSION_META])
     assert _Dummy().detect_path(path) is False
+
+
+# --------------------------------------------------------------------------
+# Registry routing + standalone-path load.
+# --------------------------------------------------------------------------
+class _AlwaysDetects(BaseProvider):
+    """A stub provider that claims every path (to force an ambiguous match)."""
+
+    def get_provider_name(self) -> str:
+        return "stub"
+
+    def get_session_format(self) -> str:
+        return "stub"
+
+    def get_data_dir(self) -> Optional[Path]:
+        return None
+
+    def discover_sessions(self) -> Iterator[SessionInfo]:
+        return iter(())
+
+    def load_session(
+        self, session_id: str, max_messages: Optional[int] = None
+    ) -> Iterator[TranscriptEntry]:
+        return iter(())
+
+    def detect_path(self, path: Path) -> bool:
+        return True
+
+
+def _registry(*providers: BaseProvider) -> ProviderRegistry:
+    registry = ProviderRegistry()
+    for provider in providers:
+        registry.register(provider)
+    return registry
+
+
+def test_registry_detects_codex_for_rollout(tmp_path: Path) -> None:
+    registry = _registry(CodexProvider())
+    path = _write(tmp_path / "rollout-x.jsonl", [_SESSION_META])
+    assert registry.detect_provider_for_path(path) == "codex"
+
+
+def test_registry_returns_none_for_claude_transcript(tmp_path: Path) -> None:
+    # Detection is independent of is_available; a non-rollout still yields None
+    # (falls through to the Claude default path).
+    registry = _registry(CodexProvider())
+    path = _write(tmp_path / "session.jsonl", [{"type": "user"}])
+    assert registry.detect_provider_for_path(path) is None
+
+
+def test_registry_raises_on_ambiguous_match(tmp_path: Path) -> None:
+    registry = _registry(CodexProvider(), _AlwaysDetects())
+    path = _write(tmp_path / "rollout-x.jsonl", [_SESSION_META])
+    with pytest.raises(ValueError, match="multiple providers"):
+        registry.detect_provider_for_path(path)
+
+
+def test_load_session_from_path_loads_standalone_rollout() -> None:
+    fixture = Path(
+        "test/test_data/codex/sessions/2026/01/02/"
+        "rollout-2026-01-02T03-04-05-11111111-1111-4111-8111-111111111111.jsonl"
+    )
+    entries = list(CodexProvider().load_session_from_path(fixture))
+    assert entries, "standalone rollout should yield entries, not an empty page"
+    roles = {getattr(getattr(e, "message", None), "role", None) for e in entries}
+    assert "user" in roles and "assistant" in roles
+
+
+def test_load_session_from_path_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        list(CodexProvider().load_session_from_path(tmp_path / "nope.jsonl"))

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -189,3 +189,71 @@ def test_load_session_from_path_loads_standalone_rollout() -> None:
 def test_load_session_from_path_missing_file_raises(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         list(CodexProvider().load_session_from_path(tmp_path / "nope.jsonl"))
+
+
+# --------------------------------------------------------------------------
+# CLI dispatch: a rollout INPUT_PATH renders via the provider, never empty.
+# --------------------------------------------------------------------------
+_FIXTURE_ROLLOUT = Path(
+    "test/test_data/codex/sessions/2026/01/02/"
+    "rollout-2026-01-02T03-04-05-11111111-1111-4111-8111-111111111111.jsonl"
+)
+
+
+@pytest.mark.parametrize(
+    ("fmt", "ext"), [("html", "html"), ("md", "md"), ("json", "json")]
+)
+def test_rollout_input_path_renders_via_codex(
+    tmp_path: Path, fmt: str, ext: str
+) -> None:
+    """A bare rollout INPUT_PATH (no --provider) auto-detects to codex and
+    renders the actual conversation — asserting CONTENT, not just a non-empty
+    file, because a wrong render key silently produced a full-size-but-empty
+    page (regression pin)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    out = tmp_path / f"rollout.{ext}"
+    result = CliRunner().invoke(
+        main, [str(_FIXTURE_ROLLOUT), "-o", str(out), "--format", fmt]
+    )
+    assert result.exit_code == 0, result.output
+    assert "synthetic files" in out.read_text(encoding="utf-8")
+
+
+def test_rollout_that_yields_no_messages_errors_loudly(tmp_path: Path) -> None:
+    """A detected rollout that produces no renderable messages must fail LOUDLY,
+    never fall through to a near-empty page (the worst gap)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    rollout = _write(tmp_path / "rollout-empty.jsonl", [_SESSION_META])
+    result = CliRunner().invoke(main, [str(rollout), "-o", str(tmp_path / "e.html")])
+    assert result.exit_code != 0
+    assert "no renderable messages" in result.output
+
+
+def test_non_rollout_file_is_left_to_the_claude_path(tmp_path: Path) -> None:
+    """A non-rollout .jsonl is NOT hijacked by auto-detection — it must reach
+    the Claude parser unchanged (byte-stability of the default path)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    claude = _write(
+        tmp_path / "session.jsonl",
+        [
+            {
+                "type": "user",
+                "uuid": "u1",
+                "sessionId": "s1",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "message": {"role": "user", "content": "hello claude"},
+            }
+        ],
+    )
+    result = CliRunner().invoke(main, [str(claude), "-o", str(tmp_path / "c.html")])
+    # It reaches the Claude path (no provider hijack, no loud provider error).
+    assert "no renderable messages" not in result.output

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -235,6 +235,21 @@ def test_rollout_that_yields_no_messages_errors_loudly(tmp_path: Path) -> None:
     assert "no renderable messages" in result.output
 
 
+def test_explicit_provider_renders_rollout_file(tmp_path: Path) -> None:
+    """`--provider codex <rollout>` renders that file directly (fence relaxed
+    from the old blanket INPUT_PATH rejection), asserting real content."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    out = tmp_path / "explicit.html"
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", str(_FIXTURE_ROLLOUT), "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "synthetic files" in out.read_text(encoding="utf-8")
+
+
 def test_non_rollout_file_is_left_to_the_claude_path(tmp_path: Path) -> None:
     """A non-rollout .jsonl is NOT hijacked by auto-detection — it must reach
     the Claude parser unchanged (byte-stability of the default path)."""

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -250,6 +250,29 @@ def test_explicit_provider_renders_rollout_file(tmp_path: Path) -> None:
     assert "synthetic files" in out.read_text(encoding="utf-8")
 
 
+def test_rollout_directory_errors_loudly_until_walker_lands(tmp_path: Path) -> None:
+    """Interim guard: a directory of rollouts must NOT fall through to the empty
+    Claude parse before the wholesale walker lands. Both auto-detect and
+    explicit --provider error loudly (the matrix must not silently lie)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    nested = tmp_path / "sessions" / "2026" / "01"
+    nested.mkdir(parents=True)
+    _write(nested / "rollout-abcd.jsonl", [_SESSION_META, {"type": "message"}])
+
+    auto = CliRunner().invoke(main, [str(tmp_path), "-o", str(tmp_path / "a.html")])
+    assert auto.exit_code != 0
+    assert "sessions directory" in auto.output and "wholesale walker" in auto.output
+
+    explicit = CliRunner().invoke(
+        main, ["--provider", "codex", str(tmp_path), "-o", str(tmp_path / "e.html")]
+    )
+    assert explicit.exit_code != 0
+    assert "sessions directory" in explicit.output
+
+
 def test_non_rollout_file_is_left_to_the_claude_path(tmp_path: Path) -> None:
     """A non-rollout .jsonl is NOT hijacked by auto-detection — it must reach
     the Claude parser unchanged (byte-stability of the default path)."""

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -1,0 +1,115 @@
+"""INPUT_PATH auto-detection for the Codex provider (modalities M1).
+
+The worst gap the modalities work closes: a Codex rollout handed to the CLI as
+an INPUT_PATH used to fall through to the Claude parser, which skips every
+record and emits a near-empty page. ``CodexProvider.detect_path`` is the cheap
+sniff that routes such a path to the Codex pipeline instead. These tests pin the
+sniff itself (filename pattern, first-line ``session_meta``, legacy header,
+directory containment) on synthetic fixtures — no real transcript content.
+"""
+
+import json
+from pathlib import Path
+
+from claude_code_log.providers.base import BaseProvider
+from claude_code_log.providers.codex import CodexProvider
+
+_SESSION_META = {
+    "type": "session_meta",
+    "payload": {"id": "0123abcd-0000-4000-8000-000000000001", "cwd": "/workspace"},
+}
+
+
+def _write(path: Path, records: list[dict[str, object]]) -> Path:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+def test_detects_rollout_by_filename(tmp_path: Path) -> None:
+    # Filename pattern alone is a positive signal (body not consulted).
+    path = _write(tmp_path / "rollout-2026-07-24T10-00-00-abcd.jsonl", [{"x": 1}])
+    assert CodexProvider().detect_path(path) is True
+
+
+def test_detects_rollout_by_session_meta_first_line(tmp_path: Path) -> None:
+    # A non-rollout filename still detects via the first-line session_meta sniff.
+    path = _write(tmp_path / "export.jsonl", [_SESSION_META, {"type": "message"}])
+    assert CodexProvider().detect_path(path) is True
+
+
+def test_detects_legacy_flat_header(tmp_path: Path) -> None:
+    # Legacy rollouts: no ``type`` but a top-level ``id`` header.
+    path = _write(tmp_path / "old.jsonl", [{"id": "abc", "cwd": "/w"}, {"x": 1}])
+    assert CodexProvider().detect_path(path) is True
+
+
+def test_does_not_detect_claude_transcript(tmp_path: Path) -> None:
+    # A Claude-style transcript (no rollout name, no session_meta) is NOT a
+    # rollout — it must keep flowing to the Claude parser, not be hijacked.
+    path = _write(
+        tmp_path / "session.jsonl",
+        [{"type": "user", "message": {"role": "user", "content": "hi"}}],
+    )
+    assert CodexProvider().detect_path(path) is False
+
+
+def test_does_not_detect_garbage_or_empty(tmp_path: Path) -> None:
+    garbage = tmp_path / "notes.jsonl"
+    garbage.write_text("this is not json\n", encoding="utf-8")
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    assert CodexProvider().detect_path(garbage) is False
+    assert CodexProvider().detect_path(empty) is False
+
+
+def test_detects_directory_containing_a_rollout(tmp_path: Path) -> None:
+    nested = tmp_path / "sessions" / "2026" / "07"
+    nested.mkdir(parents=True)
+    _write(nested / "rollout-abcd.jsonl", [_SESSION_META])
+    assert CodexProvider().detect_path(tmp_path) is True
+
+
+def test_does_not_detect_directory_without_rollouts(tmp_path: Path) -> None:
+    (tmp_path / "sub").mkdir()
+    _write(tmp_path / "sub" / "plain.jsonl", [{"type": "user"}])
+    assert CodexProvider().detect_path(tmp_path) is False
+
+
+def test_directory_discovery_keeps_symlink_containment(tmp_path: Path) -> None:
+    # A rollout reachable only via a symlink escaping the root must not count —
+    # mirrors the loader's containment rule so an INPUT_PATH dir can't pull in
+    # outside files.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _write(outside / "rollout-escape.jsonl", [_SESSION_META])
+    root = tmp_path / "root"
+    root.mkdir()
+    link = root / "link"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return  # platform without symlink support — skip the containment check
+    assert CodexProvider().detect_path(root) is False
+
+
+def test_base_provider_default_is_no_detection(tmp_path: Path) -> None:
+    # The base contract opts out — only providers that override detect_path
+    # participate in auto-detection.
+    class _Dummy(BaseProvider):
+        def get_provider_name(self) -> str:
+            return "dummy"
+
+        def get_session_format(self) -> str:
+            return "dummy"
+
+        def get_data_dir(self) -> Path | None:
+            return None
+
+        def discover_sessions(self):  # type: ignore[no-untyped-def]
+            return iter(())
+
+        def load_session(self, session_id, max_messages=None):  # type: ignore[no-untyped-def]
+            return iter(())
+
+    path = _write(tmp_path / "rollout-x.jsonl", [_SESSION_META])
+    assert _Dummy().detect_path(path) is False

--- a/test/test_codex_detection.py
+++ b/test/test_codex_detection.py
@@ -80,6 +80,16 @@ def test_does_not_detect_directory_without_rollouts(tmp_path: Path) -> None:
     assert CodexProvider().detect_path(tmp_path) is False
 
 
+def test_detects_directory_with_sniff_only_named_rollout(tmp_path: Path) -> None:
+    # A rollout recognised only by the session_meta sniff (non-rollout name)
+    # inside a directory must be detected — symmetric with the single-file sniff,
+    # so a directory of such files can't silent-empty through the Claude parser.
+    nested = tmp_path / "sub"
+    nested.mkdir()
+    _write(nested / "codex-session.jsonl", [_SESSION_META, {"type": "message"}])
+    assert CodexProvider().detect_path(tmp_path) is True
+
+
 def test_directory_discovery_keeps_symlink_containment(tmp_path: Path) -> None:
     # A rollout reachable only via a symlink escaping the root must not count —
     # mirrors the loader's containment rule so an INPUT_PATH dir can't pull in

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -372,3 +372,229 @@ def test_cli_provider_wholesale_rejects_pagination_and_jobs_for_now(
     result = CliRunner().invoke(main, ["--provider", "codex", "-o", str(out), *extra])
     assert result.exit_code != 0
     assert "does not support" in result.output and extra[0] in result.output
+
+
+# --------------------------------------------------------------------------
+# M3 cache participation: render-skip, byte-stability, --no-cache.
+#
+# These use a content-TAMPER probe rather than mtimes: after a render we
+# overwrite each page with a sentinel, render again, and check which sentinels
+# survive. A surviving sentinel == the page was skipped; a replaced sentinel ==
+# the page was re-rendered. This is robust against coarse filesystem mtime
+# resolution and parallel-run timing.
+# --------------------------------------------------------------------------
+_TAMPER = "<!-- TAMPERED-SENTINEL -->"
+
+
+def _tamper_all(out: Path) -> list[Path]:
+    # Append (don't overwrite): the version marker lives in the first few lines
+    # and drives the staleness check — clobbering it would force a re-render and
+    # defeat the probe. Appending leaves the marker intact, so a skipped page
+    # keeps the sentinel while a re-rendered page (full overwrite) loses it.
+    pages = sorted(out.rglob("*.html"))
+    for page in pages:
+        with page.open("a", encoding="utf-8") as handle:
+            handle.write("\n" + _TAMPER + "\n")
+    return pages
+
+
+def _survived(page: Path) -> bool:
+    return _TAMPER in page.read_text(encoding="utf-8")
+
+
+def test_walker_cache_db_lives_under_output_root(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, silent=True)
+    assert (out / "claude-code-log-cache.db").exists()
+    # DECIDED #4: nothing is written into the sessions tree.
+    assert not list(SESSIONS_ROOT.rglob("claude-code-log-cache.db"))
+
+
+def test_walker_warm_run_is_byte_stable(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, silent=True)
+    cold = {
+        str(p.relative_to(out)): p.read_bytes() for p in sorted(out.rglob("*.html"))
+    }
+
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, silent=True)
+    warm = {
+        str(p.relative_to(out)): p.read_bytes() for p in sorted(out.rglob("*.html"))
+    }
+
+    assert set(cold) == set(warm)
+    assert all(cold[k] == warm[k] for k in cold)  # byte-stable warm vs cold
+
+
+def test_walker_warm_run_skips_unchanged_pages(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, silent=True)
+    _tamper_all(out)
+
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, silent=True)
+
+    for page in sorted(out.rglob("*.html")):
+        rel = str(page.relative_to(out))
+        if rel == "index.html":
+            assert not _survived(page), "index must always be regenerated"
+        else:
+            assert _survived(page), f"{rel} should have been skipped (cache hit)"
+
+
+def test_walker_cache_rerenders_only_changed_session(tmp_path: Path) -> None:
+    tree = tmp_path / "sessions"
+    a = _rollout(tree, "a.jsonl", "10000000-0000-4000-8000-000000000001", "/proj/a")
+    _rollout(tree, "b.jsonl", "20000000-0000-4000-8000-000000000002", "/proj/b")
+    out = tmp_path / "ccl"
+
+    render_provider_wholesale("codex", tree, out, silent=True)
+    _tamper_all(out)
+
+    # Grow session A's transcript (a new visible message → message-count drift,
+    # which the cache detects regardless of the 1s mtime tolerance window).
+    records = a.read_text(encoding="utf-8").rstrip("\n").split("\n")
+    records.append(
+        json.dumps(
+            {
+                "timestamp": "2026-01-02T00:00:03Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "one more turn"},
+            }
+        )
+    )
+    a.write_text("\n".join(records) + "\n", encoding="utf-8")
+
+    render_provider_wholesale("codex", tree, out, silent=True)
+
+    a_page = out / "-proj-a/session-10000000-0000-4000-8000-000000000001.html"
+    b_page = out / "-proj-b/session-20000000-0000-4000-8000-000000000002.html"
+    assert not _survived(a_page)  # changed session was re-rendered
+    assert _survived(b_page)  # untouched session was skipped
+    # A's project combined page also re-renders; B's does not.
+    assert not _survived(out / "-proj-a/combined_transcripts.html")
+    assert _survived(out / "-proj-b/combined_transcripts.html")
+
+
+def test_walker_no_cache_rewrites_every_run(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, use_cache=False, silent=True)
+    _tamper_all(out)
+    render_provider_wholesale("codex", SESSIONS_ROOT, out, use_cache=False, silent=True)
+
+    # No cache DB is created, and every page is rewritten (no sentinel survives).
+    assert not (out / "claude-code-log-cache.db").exists()
+    for page in sorted(out.rglob("*.html")):
+        assert not _survived(page), f"{page.relative_to(out)} should be rewritten"
+
+
+# --------------------------------------------------------------------------
+# M3 CLI flag flips: --no-cache / --clear-cache / --clear-output.
+# --------------------------------------------------------------------------
+def _snapshot_tree(root: Path) -> dict[str, bytes]:
+    return {
+        str(p.relative_to(root)): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def test_cli_provider_no_cache_renders_without_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", "--no-cache", "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert (out / "index.html").exists()
+    assert not (out / "claude-code-log-cache.db").exists()
+
+
+def test_cli_provider_clear_cache_removes_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    CliRunner().invoke(main, ["--provider", "codex", "-o", str(out)])
+    assert (out / "claude-code-log-cache.db").exists()
+
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", "--clear-cache", "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert not (out / "claude-code-log-cache.db").exists()
+    assert "Cleared provider cache" in result.output
+
+
+def test_cli_provider_clear_output_removes_generated_files_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    CliRunner().invoke(main, ["--provider", "codex", "-o", str(out)])
+    assert (out / "index.html").exists()
+    assert list(out.rglob("session-*.html"))
+
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", "--clear-output", "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert not (out / "index.html").exists()
+    assert not list(out.rglob("session-*.html"))
+    assert not list(out.rglob("combined_transcripts*.html"))
+
+
+def test_cli_provider_clear_output_never_touches_sessions_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DECIDED #4 pin: --clear-output removes generated files under the output
+    root only; the pristine sessions tree is byte-identical afterwards and every
+    rollout still present."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    home = _codex_home_with_sessions(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    sessions = home / "sessions"
+    before = _snapshot_tree(sessions)
+    assert before  # sanity: the tree has rollouts
+
+    # Default output root is <codex_home>/claude-code-log/ (no -o).
+    CliRunner().invoke(main, ["--provider", "codex"])
+    result = CliRunner().invoke(main, ["--provider", "codex", "--clear-output"])
+    assert result.exit_code == 0, result.output
+
+    after = _snapshot_tree(sessions)
+    assert after == before  # sessions tree byte-identical, every rollout intact
+
+
+def test_cli_single_session_still_rejects_cache_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cache flags remain illegal in single-session mode (they only apply to
+    the wholesale hierarchy)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    result = CliRunner().invoke(
+        main,
+        ["--provider", "codex", "--session-id", "10000000", "--no-cache"],
+    )
+    assert result.exit_code != 0
+    assert "does not support" in result.output and "--no-cache" in result.output

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -587,13 +587,21 @@ def test_cli_wholesale_for_provider_without_support_errors_loudly(
 ) -> None:
     """A provider that doesn't implement the wholesale seams (agy) must fail
     LOUDLY, never crash or silently render nothing — the base default raises and
-    the CLI surfaces it."""
+    the CLI surfaces it.
+
+    --projects-dir supplies an explicit sessions root so the walker reaches
+    discover_sessions_under (the NotImplementedError) deterministically, rather
+    than short-circuiting on whether an agy data dir happens to exist in the
+    environment (it does on a dev box, not on CI)."""
     from click.testing import CliRunner
 
     from claude_code_log.cli import main
 
+    root = tmp_path / "sessions"
+    root.mkdir()
     result = CliRunner().invoke(
-        main, ["--provider", "agy", "-o", str(tmp_path / "out")]
+        main,
+        ["--provider", "agy", "--projects-dir", str(root), "-o", str(tmp_path / "out")],
     )
     assert result.exit_code != 0
     assert "does not support wholesale rendering" in result.output

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -729,6 +729,51 @@ def test_cli_clear_output_without_date_clears_and_exits(
     assert not list(out.rglob("session-*.html"))
 
 
+def test_cli_all_projects_flag_runs_wholesale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--provider codex --all-projects` is an accepted synonym for bare
+    wholesale — it walks the data dir into the project hierarchy, identically to
+    bare `--provider codex` (was execution-verified only)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", "--all-projects", "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert (out / "index.html").exists()
+    assert (out / "-proj-a" / "combined_transcripts.html").exists()
+    assert (out / "-proj-b" / "combined_transcripts.html").exists()
+
+
+def test_cli_nonexistent_input_path_with_provider_errors_loudly(
+    tmp_path: Path,
+) -> None:
+    """A nonexistent INPUT_PATH + --provider routes to single-file mode (a
+    nonexistent path is not a directory) and errors loudly with rollout-not-found
+    — never a silent empty render (was execution-verified only)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "--provider",
+            "codex",
+            str(tmp_path / "does-not-exist"),
+            "-o",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Codex rollout not found" in result.output
+
+
 def test_cli_unknown_provider_is_clean_usage_error(tmp_path: Path) -> None:
     """An unknown --provider is a clean UsageError (exit 2), not a broad-except
     'Error converting file' (exit 1)."""

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -582,6 +582,23 @@ def test_cli_provider_clear_output_never_touches_sessions_tree(
     assert after == before  # sessions tree byte-identical, every rollout intact
 
 
+def test_cli_wholesale_for_provider_without_support_errors_loudly(
+    tmp_path: Path,
+) -> None:
+    """A provider that doesn't implement the wholesale seams (agy) must fail
+    LOUDLY, never crash or silently render nothing — the base default raises and
+    the CLI surfaces it."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    result = CliRunner().invoke(
+        main, ["--provider", "agy", "-o", str(tmp_path / "out")]
+    )
+    assert result.exit_code != 0
+    assert "does not support wholesale rendering" in result.output
+
+
 def test_cli_single_session_still_rejects_cache_flags(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -599,6 +599,150 @@ def test_cli_wholesale_for_provider_without_support_errors_loudly(
     assert "does not support wholesale rendering" in result.output
 
 
+# --------------------------------------------------------------------------
+# Review round: silent-divergence edges (monk MOD/LOW findings).
+# --------------------------------------------------------------------------
+def _sniff_only_rollout(path: Path, thread_id: str, cwd: str) -> Path:
+    """A rollout whose NAME does not match rollout-*.jsonl but whose first line
+    is a session_meta header (detected by sniff, not glob)."""
+    records = [
+        {
+            "timestamp": "2026-01-02T00:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": thread_id, "cwd": cwd},
+        },
+        {
+            "timestamp": "2026-01-02T00:00:01Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "sniff-only hello"},
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+def test_cli_sniff_only_directory_renders_not_silent_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory whose rollouts are recognised only by the session_meta sniff
+    (non-rollout filenames) must render via the walker, NOT fall through to an
+    empty Claude parse — symmetric with the single-file sniff path. Covers both
+    auto-detect and explicit --provider."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    tree = tmp_path / "tree"
+    _sniff_only_rollout(
+        tree / "codex-session.jsonl", "10000000-0000-4000-8000-000000000001", "/proj/s"
+    )
+
+    auto_out = tmp_path / "auto"
+    auto = CliRunner().invoke(main, [str(tree), "-o", str(auto_out)])
+    assert auto.exit_code == 0, auto.output
+    assert "sniff-only hello" in (
+        auto_out / "-proj-s" / "combined_transcripts.html"
+    ).read_text(encoding="utf-8")
+
+    explicit_out = tmp_path / "explicit"
+    explicit = CliRunner().invoke(
+        main, ["--provider", "codex", str(tree), "-o", str(explicit_out)]
+    )
+    assert explicit.exit_code == 0, explicit.output
+    assert (explicit_out / "-proj-s" / "combined_transcripts.html").exists()
+
+
+def test_cli_empty_provider_directory_errors_loudly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory with no discoverable sessions must fail LOUDLY, never write
+    an empty index and exit 0 (silent empty-success)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    # A plain (non-rollout, non-sniff) .jsonl must not count.
+    (empty / "notes.jsonl").write_text(
+        json.dumps({"type": "user", "message": "hi"}) + "\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", str(empty), "-o", str(tmp_path / "out")]
+    )
+    assert result.exit_code != 0
+    assert "No codex sessions found" in result.output
+
+
+def test_cli_provider_clear_output_with_date_regenerates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--clear-output WITH a date filter clears then REGENERATES the filtered
+    view (mirroring the Claude path), rather than clearing and leaving an empty
+    directory."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    CliRunner().invoke(main, ["--provider", "codex", "-o", str(out)])
+    assert list(out.rglob("session-*.html"))
+
+    # A from-date that includes all fixture content: clear + rebuild.
+    result = CliRunner().invoke(
+        main,
+        [
+            "--provider",
+            "codex",
+            "--clear-output",
+            "--from-date",
+            "2020-01-01",
+            "-o",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (out / "index.html").exists()
+    assert list(out.rglob("session-*.html"))  # regenerated, not left empty
+
+
+def test_cli_clear_output_without_date_clears_and_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contrast: with NO date filter, --clear-output clears and exits (no
+    regeneration), so the directory is left empty."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    CliRunner().invoke(main, ["--provider", "codex", "-o", str(out)])
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", "--clear-output", "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert not (out / "index.html").exists()
+    assert not list(out.rglob("session-*.html"))
+
+
+def test_cli_unknown_provider_is_clean_usage_error(tmp_path: Path) -> None:
+    """An unknown --provider is a clean UsageError (exit 2), not a broad-except
+    'Error converting file' (exit 1)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    result = CliRunner().invoke(
+        main, ["--provider", "bogus", "-o", str(tmp_path / "out")]
+    )
+    assert result.exit_code == 2
+    assert "Unknown provider: bogus" in result.output
+
+
 def test_cli_single_session_still_rejects_cache_flags(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -223,7 +223,7 @@ def test_index_summary_dict_shape_matches_claude_path(
     captured: list[list[dict[str, object]]] = []
     original = HtmlRenderer.generate_projects_index
 
-    def _spy(self: HtmlRenderer, project_summaries, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def _spy(self, project_summaries, *args, **kwargs):
         captured.append(project_summaries)
         return original(self, project_summaries, *args, **kwargs)
 
@@ -250,10 +250,125 @@ def test_index_summary_dict_shape_matches_claude_path(
         f"walker-only={walker_keys - claude_keys}"
     )
 
-    claude_session_keys = set(claude_summaries[0]["sessions"][0])  # type: ignore[index]
-    walker_session_keys = set(walker_summaries[0]["sessions"][0])  # type: ignore[index]
+    claude_session_keys = set(claude_summaries[0]["sessions"][0])
+    walker_session_keys = set(walker_summaries[0]["sessions"][0])
     assert claude_session_keys == walker_session_keys, (
         "session-summary dict drift — "
         f"claude-only={claude_session_keys - walker_session_keys}, "
         f"walker-only={walker_session_keys - claude_session_keys}"
     )
+
+
+# --------------------------------------------------------------------------
+# CLI dispatch: --provider wholesale reaches the walker; output-root rules.
+# --------------------------------------------------------------------------
+def _codex_home_with_sessions(tmp_path: Path) -> Path:
+    """A throwaway CODEX_HOME whose sessions/ tree holds two cwd-projects."""
+    home = tmp_path / "codex-home"
+    sessions = home / "sessions" / "2026" / "01"
+    _rollout(sessions, "a.jsonl", "10000000-0000-4000-8000-000000000001", "/proj/a")
+    _rollout(sessions, "b.jsonl", "20000000-0000-4000-8000-000000000002", "/proj/b")
+    return home
+
+
+def test_cli_bare_provider_runs_wholesale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    result = CliRunner().invoke(main, ["--provider", "codex", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert (out / "index.html").exists()
+    assert (out / "-proj-a" / "combined_transcripts.html").exists()
+    assert (out / "-proj-b" / "combined_transcripts.html").exists()
+
+
+def test_cli_provider_projects_dir_overrides_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--projects-dir selects the sessions root to walk (a subset/copy)."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    # No CODEX_HOME needed — the explicit root is the fixture sessions tree.
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    out = tmp_path / "out"
+    result = CliRunner().invoke(
+        main,
+        ["--provider", "codex", "--projects-dir", str(SESSIONS_ROOT), "-o", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert (out / SYNTHETIC_PROJECT_DIR / "combined_transcripts.html").exists()
+
+
+def test_cli_provider_default_output_root_is_under_codex_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DECIDED #4: with no -o, output lands at <codex_home>/claude-code-log/,
+    never inside the pristine sessions tree."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    home = _codex_home_with_sessions(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    result = CliRunner().invoke(main, ["--provider", "codex"])
+    assert result.exit_code == 0, result.output
+    assert (home / "claude-code-log" / "index.html").exists()
+    # The sessions tree itself is untouched.
+    assert not list((home / "sessions").rglob("index.html"))
+
+
+def test_cli_provider_wholesale_rejects_file_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wholesale run writes many files; a file-shaped -o is a loud error."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    result = CliRunner().invoke(
+        main, ["--provider", "codex", "-o", str(tmp_path / "one.html")]
+    )
+    assert result.exit_code != 0
+    assert "directory, not a file" in result.output
+
+
+def test_cli_provider_wholesale_rejects_claude_only_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Claude-only projection flags stay illegal in provider mode — loudly."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    for flag in ("--expand-paths", "--tui"):
+        result = CliRunner().invoke(main, ["--provider", "codex", flag, "-o", str(out)])
+        assert result.exit_code != 0, f"{flag} should be rejected"
+        assert "does not support" in result.output and flag in result.output
+
+
+@pytest.mark.parametrize("extra", [["--page-size", "5"], ["--jobs", "2"]])
+def test_cli_provider_wholesale_rejects_pagination_and_jobs_for_now(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, extra: list[str]
+) -> None:
+    """Pagination and job-parallelism ride on cache machinery not yet wired for
+    the provider walker, so they must be rejected loudly — never accepted and
+    silently ignored."""
+    from click.testing import CliRunner
+
+    from claude_code_log.cli import main
+
+    monkeypatch.setenv("CODEX_HOME", str(_codex_home_with_sessions(tmp_path)))
+    out = tmp_path / "out"
+    result = CliRunner().invoke(main, ["--provider", "codex", "-o", str(out), *extra])
+    assert result.exit_code != 0
+    assert "does not support" in result.output and extra[0] in result.output

--- a/test/test_codex_walker.py
+++ b/test/test_codex_walker.py
@@ -1,0 +1,259 @@
+"""Wholesale walker for the Codex provider (modalities M2).
+
+``render_provider_wholesale`` renders every session of one provider under a
+root into a project hierarchy (per-session pages + per-project combined page +
+master index), grouping sessions by cwd. These tests exercise the walker
+end-to-end on the synthetic fixture tree and pin the index-summary dict shape
+against the Claude path so a key rename on either side goes RED rather than
+silently producing an empty provider index.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import (
+    process_projects_hierarchy,
+    render_provider_wholesale,
+)
+
+FIXTURES = Path(__file__).parent / "test_data" / "codex"
+SESSIONS_ROOT = FIXTURES / "sessions"
+SYNTHETIC_PROJECT_DIR = "-workspace-synthetic-project"
+
+
+def _rollout(tmp: Path, rel: str, thread_id: str, cwd: str | None) -> Path:
+    payload: dict[str, object] = {"id": thread_id, "timestamp": "2026-01-02T00:00:00Z"}
+    if cwd is not None:
+        payload["cwd"] = cwd
+    records = [
+        {
+            "timestamp": "2026-01-02T00:00:00Z",
+            "type": "session_meta",
+            "payload": payload,
+        },
+        {
+            "timestamp": "2026-01-02T00:00:01Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": f"hi {thread_id[:4]}"},
+        },
+        {
+            "timestamp": "2026-01-02T00:00:02Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": f"bye {thread_id[:4]}"},
+        },
+    ]
+    rel_path = Path(rel)
+    path = tmp / rel_path.parent / f"rollout-{rel_path.name}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+def _make_claude_session(path: Path, sid: str) -> None:
+    """A minimal two-message Claude transcript (the default, non-provider path)."""
+    entries = [
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T10:00:00Z",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/tmp",
+            "sessionId": sid,
+            "version": "1.0.0",
+            "uuid": f"{sid}-0",
+            "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T10:01:00Z",
+            "parentUuid": f"{sid}-0",
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/tmp",
+            "sessionId": sid,
+            "version": "1.0.0",
+            "uuid": f"{sid}-1",
+            "message": {
+                "id": f"{sid}-1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-sonnet",
+                "content": [{"type": "text", "text": "hi there"}],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+    ]
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# End-to-end: index + per-project combined + per-session pages.
+# --------------------------------------------------------------------------
+def test_walker_renders_index_combined_and_sessions(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    index = render_provider_wholesale("codex", SESSIONS_ROOT, out, silent=True)
+
+    assert index == out / "index.html"
+    assert index.exists()
+    # Two cwd-projects: the synthetic-project (root + parent + child threads)
+    # and the no-cwd legacy session bucket. The archived session lives outside
+    # the sessions root and must not be discovered.
+    proj = out / SYNTHETIC_PROJECT_DIR
+    assert (proj / "combined_transcripts.html").exists()
+    assert (proj / "session-11111111-1111-4111-8111-111111111111.html").exists()
+    assert (out / "no-project" / "combined_transcripts.html").exists()
+
+    index_text = index.read_text(encoding="utf-8")
+    # The index links to each project's combined page.
+    assert f"{SYNTHETIC_PROJECT_DIR}/combined_transcripts.html" in index_text
+    assert "no-project/combined_transcripts.html" in index_text
+
+
+@pytest.mark.parametrize(
+    ("fmt", "index_name", "combined_name"),
+    [
+        ("html", "index.html", "combined_transcripts.html"),
+        ("md", "index.md", "combined_transcripts.md"),
+        ("json", "all-projects-summary.json", "combined_transcripts.json"),
+    ],
+)
+def test_walker_all_three_formats(
+    tmp_path: Path, fmt: str, index_name: str, combined_name: str
+) -> None:
+    out = tmp_path / "ccl"
+    index = render_provider_wholesale(
+        "codex", SESSIONS_ROOT, out, output_format=fmt, silent=True
+    )
+    assert index == out / index_name
+    assert index.exists()
+    assert (out / SYNTHETIC_PROJECT_DIR / combined_name).exists()
+
+
+def test_walker_groups_by_cwd(tmp_path: Path) -> None:
+    tree = tmp_path / "sessions"
+    _rollout(tree, "a/one.jsonl", "10000000-0000-4000-8000-000000000001", "/proj/a")
+    _rollout(tree, "a/two.jsonl", "10000000-0000-4000-8000-000000000002", "/proj/a")
+    _rollout(tree, "b/one.jsonl", "20000000-0000-4000-8000-000000000001", "/proj/b")
+    _rollout(tree, "c/orphan.jsonl", "30000000-0000-4000-8000-000000000001", None)
+
+    out = tmp_path / "ccl"
+    render_provider_wholesale("codex", tree, out, silent=True)
+
+    assert (out / "-proj-a" / "combined_transcripts.html").exists()
+    assert (out / "-proj-b" / "combined_transcripts.html").exists()
+    assert (out / "no-project" / "combined_transcripts.html").exists()
+    # /proj/a has two sessions, both rendered.
+    a_sessions = list((out / "-proj-a").glob("session-*.html"))
+    assert len(a_sessions) == 2
+
+
+def test_walker_combined_no_suppresses_combined_page(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    render_provider_wholesale(
+        "codex", SESSIONS_ROOT, out, write_combined=False, silent=True
+    )
+    proj = out / SYNTHETIC_PROJECT_DIR
+    # No combined page is written…
+    assert not (proj / "combined_transcripts.html").exists()
+    # …but per-session pages are, and they carry no dangling back-link to the
+    # (absent) combined transcript.
+    session = proj / "session-11111111-1111-4111-8111-111111111111.html"
+    assert session.exists()
+    assert "combined_transcripts.html" not in session.read_text(encoding="utf-8")
+
+
+def test_walker_no_individual_still_writes_combined_and_index(tmp_path: Path) -> None:
+    out = tmp_path / "ccl"
+    render_provider_wholesale(
+        "codex", SESSIONS_ROOT, out, write_individual=False, silent=True
+    )
+    proj = out / SYNTHETIC_PROJECT_DIR
+    assert (proj / "combined_transcripts.html").exists()
+    assert not list(proj.glob("session-*.html"))
+    assert (out / "index.html").exists()
+
+
+def test_walker_is_deterministic(tmp_path: Path) -> None:
+    first = tmp_path / "one"
+    second = tmp_path / "two"
+    render_provider_wholesale("codex", SESSIONS_ROOT, first, silent=True)
+    render_provider_wholesale("codex", SESSIONS_ROOT, second, silent=True)
+
+    for rel in (
+        "index.html",
+        f"{SYNTHETIC_PROJECT_DIR}/combined_transcripts.html",
+        f"{SYNTHETIC_PROJECT_DIR}/session-11111111-1111-4111-8111-111111111111.html",
+    ):
+        assert (first / rel).read_bytes() == (second / rel).read_bytes()
+
+
+def test_walker_date_filter_excludes_out_of_range_sessions(tmp_path: Path) -> None:
+    tree = tmp_path / "sessions"
+    # One 2026-01 session, one 2020-01 session under distinct cwds.
+    _rollout(tree, "new/s.jsonl", "10000000-0000-4000-8000-000000000001", "/proj/new")
+    old = _rollout(
+        tree, "old/s.jsonl", "20000000-0000-4000-8000-000000000002", "/proj/old"
+    )
+    # Rewrite the old session's timestamps into 2020.
+    old.write_text(
+        old.read_text(encoding="utf-8").replace("2026-01-02", "2020-01-02"),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "ccl"
+    render_provider_wholesale("codex", tree, out, from_date="2025-01-01", silent=True)
+    assert (out / "-proj-new").exists()
+    # The 2020 session is filtered out → its project renders nothing → no dir.
+    assert not (out / "-proj-old").exists()
+
+
+# --------------------------------------------------------------------------
+# REQUIRED drift pin: the walker's index-summary dict must be shape-identical
+# to the Claude path's, so a key rename on either side goes RED instead of
+# silently rendering an empty provider index.
+# --------------------------------------------------------------------------
+def test_index_summary_dict_shape_matches_claude_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from claude_code_log.html.renderer import HtmlRenderer
+
+    captured: list[list[dict[str, object]]] = []
+    original = HtmlRenderer.generate_projects_index
+
+    def _spy(self: HtmlRenderer, project_summaries, *args, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(project_summaries)
+        return original(self, project_summaries, *args, **kwargs)
+
+    monkeypatch.setattr(HtmlRenderer, "generate_projects_index", _spy)
+
+    # Claude path: a minimal projects root with one project + one session.
+    claude_root = tmp_path / "claude"
+    project = claude_root / "-work-x"
+    project.mkdir(parents=True)
+    _make_claude_session(project / "sess.jsonl", "sess-1")
+    process_projects_hierarchy(claude_root, silent=True)
+    claude_summaries = captured[-1]
+
+    # Walker path over the codex fixture tree.
+    render_provider_wholesale("codex", SESSIONS_ROOT, tmp_path / "out", silent=True)
+    walker_summaries = captured[-1]
+
+    assert claude_summaries and walker_summaries
+    claude_keys = set(claude_summaries[0])
+    walker_keys = set(walker_summaries[0])
+    assert claude_keys == walker_keys, (
+        "project-summary dict drift — "
+        f"claude-only={claude_keys - walker_keys}, "
+        f"walker-only={walker_keys - claude_keys}"
+    )
+
+    claude_session_keys = set(claude_summaries[0]["sessions"][0])  # type: ignore[index]
+    walker_session_keys = set(walker_summaries[0]["sessions"][0])  # type: ignore[index]
+    assert claude_session_keys == walker_session_keys, (
+        "session-summary dict drift — "
+        f"claude-only={claude_session_keys - walker_session_keys}, "
+        f"walker-only={walker_session_keys - claude_session_keys}"
+    )

--- a/test/test_codex_wholesale.py
+++ b/test/test_codex_wholesale.py
@@ -1,0 +1,201 @@
+"""Root-scoped wholesale primitives for the Codex provider (modalities M2).
+
+The wholesale walker needs to discover and load every session under an
+arbitrary root — the provider's own data dir, or a directory handed in as an
+INPUT_PATH — while keeping sibling context (fork-prefix stripping) that the
+standalone ``load_session_from_path`` deliberately drops. These tests pin the
+two new provider-neutral seams (``discover_sessions_under`` /
+``load_session_under``) and the index memoization that keeps a wholesale run
+from re-reading every rollout header once per session (O(n²)).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.models import (
+    AssistantTranscriptEntry,
+    UserTranscriptEntry,
+)
+from claude_code_log.providers.agy import AgyProvider
+from claude_code_log.providers.codex import CodexProvider
+
+FIXTURES = Path(__file__).parent / "test_data" / "codex"
+SESSIONS_ROOT = FIXTURES / "sessions"
+PARENT_ID = "22222222-2222-4222-8222-222222222222"
+CHILD_ID = "33333333-3333-4333-8333-333333333333"
+
+
+def _visible_text(entries: list[object]) -> list[str]:
+    texts: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, (UserTranscriptEntry, AssistantTranscriptEntry)):
+            continue
+        for item in entry.message.content:
+            text = getattr(item, "text", None)
+            if isinstance(text, str):
+                texts.append(text)
+    return texts
+
+
+def _rollout(tmp: Path, rel: str, thread_id: str, cwd: str | None) -> Path:
+    payload: dict[str, object] = {"id": thread_id, "timestamp": "2026-01-02T00:00:00Z"}
+    if cwd is not None:
+        payload["cwd"] = cwd
+    records = [
+        {
+            "timestamp": "2026-01-02T00:00:00Z",
+            "type": "session_meta",
+            "payload": payload,
+        },
+        {
+            "timestamp": "2026-01-02T00:00:01Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": f"hi from {thread_id[:4]}"},
+        },
+        {
+            "timestamp": "2026-01-02T00:00:02Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "agent_message",
+                "message": f"bye from {thread_id[:4]}",
+            },
+        },
+    ]
+    # Discovery only walks ``rollout-*.jsonl`` — prefix the basename so the
+    # synthetic tree is found the same way a real sessions tree is.
+    rel_path = Path(rel)
+    path = tmp / rel_path.parent / f"rollout-{rel_path.name}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------
+# discover_sessions_under
+# --------------------------------------------------------------------------
+def test_discover_under_matches_data_dir_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovering the fixture ``sessions/`` root directly must reproduce
+    exactly what ``discover_sessions`` (pinned to CODEX_HOME) yields, including
+    the child's inherited-prefix lineage — sibling context is honored under an
+    explicit root."""
+    monkeypatch.setenv("CODEX_HOME", str(FIXTURES))
+    provider = CodexProvider()
+
+    via_data_dir = {s.session_id: s.project_path for s in provider.discover_sessions()}
+    via_root = {
+        s.session_id: s.project_path
+        for s in CodexProvider().discover_sessions_under(SESSIONS_ROOT)
+    }
+    assert via_root == via_data_dir
+
+    child = next(
+        s
+        for s in CodexProvider().discover_sessions_under(SESSIONS_ROOT)
+        if s.session_id == CHILD_ID
+    )
+    # The frozen lineage fields only populate when the parent is a discoverable
+    # sibling within the walked root.
+    assert getattr(child, "parent_thread_id") == PARENT_ID
+    assert getattr(child, "inherited_prefix_records") == 2
+
+
+def test_discover_under_groups_by_cwd(tmp_path: Path) -> None:
+    """A mini sessions root of 2 cwds × 2 sessions + 1 no-cwd — the walker's
+    grouping input: each session carries its cwd as ``project_path`` (None for
+    the no-cwd bucket)."""
+    _rollout(tmp_path, "a/one.jsonl", "10000000-0000-4000-8000-000000000001", "/proj/a")
+    _rollout(tmp_path, "a/two.jsonl", "10000000-0000-4000-8000-000000000002", "/proj/a")
+    _rollout(tmp_path, "b/one.jsonl", "20000000-0000-4000-8000-000000000001", "/proj/b")
+    _rollout(tmp_path, "b/two.jsonl", "20000000-0000-4000-8000-000000000002", "/proj/b")
+    _rollout(tmp_path, "c/orphan.jsonl", "30000000-0000-4000-8000-000000000001", None)
+
+    infos = list(CodexProvider().discover_sessions_under(tmp_path))
+    by_cwd: dict[str | None, int] = {}
+    for info in infos:
+        key = str(info.project_path) if info.project_path is not None else None
+        by_cwd[key] = by_cwd.get(key, 0) + 1
+
+    assert by_cwd == {"/proj/a": 2, "/proj/b": 2, None: 1}
+
+
+def test_discover_under_is_deterministic(tmp_path: Path) -> None:
+    _rollout(tmp_path, "x/one.jsonl", "10000000-0000-4000-8000-000000000001", "/p")
+    _rollout(tmp_path, "x/two.jsonl", "10000000-0000-4000-8000-000000000002", "/p")
+    _rollout(tmp_path, "y/three.jsonl", "20000000-0000-4000-8000-000000000003", "/q")
+
+    first = [s.session_id for s in CodexProvider().discover_sessions_under(tmp_path)]
+    second = [s.session_id for s in CodexProvider().discover_sessions_under(tmp_path)]
+    assert first == second
+    assert first == sorted(first)  # discovery is a deterministic sorted walk
+
+
+# --------------------------------------------------------------------------
+# load_session_under
+# --------------------------------------------------------------------------
+def test_load_under_round_trips(tmp_path: Path) -> None:
+    tid = "10000000-0000-4000-8000-000000000001"
+    _rollout(tmp_path, "a/one.jsonl", tid, "/proj/a")
+    entries = list(CodexProvider().load_session_under(tmp_path, tid))
+    assert _visible_text(entries) == ["hi from 1000", "bye from 1000"]
+
+
+def test_load_under_strips_inherited_prefix_vs_standalone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reason ``load_session_under`` exists: within a root it strips the
+    child's inherited prefix (present as a sibling parent), whereas the
+    standalone ``load_session_from_path`` renders the file verbatim. The rooted
+    load must therefore yield strictly fewer entries."""
+    monkeypatch.setenv("CODEX_HOME", str(FIXTURES))
+    provider = CodexProvider()
+    child_file = next(SESSIONS_ROOT.rglob(f"*{CHILD_ID}.jsonl"))
+
+    rooted = list(provider.load_session_under(SESSIONS_ROOT, CHILD_ID))
+    standalone = list(CodexProvider().load_session_from_path(child_file))
+    assert 0 < len(rooted) < len(standalone)
+
+
+def test_load_under_missing_id_raises(tmp_path: Path) -> None:
+    _rollout(tmp_path, "a/one.jsonl", "10000000-0000-4000-8000-000000000001", "/p")
+    with pytest.raises(FileNotFoundError):
+        list(CodexProvider().load_session_under(tmp_path, "deadbeef-dead-4dead-8dead"))
+
+
+# --------------------------------------------------------------------------
+# index memoization (perf guard: one index build per root per run)
+# --------------------------------------------------------------------------
+def test_session_index_is_memoized_per_root(tmp_path: Path) -> None:
+    _rollout(tmp_path, "a/one.jsonl", "10000000-0000-4000-8000-000000000001", "/p")
+    provider = CodexProvider()
+
+    walked: list[Path] = []
+    original = provider._rollout_paths
+
+    def _spy(root: Path) -> list[Path]:
+        walked.append(root)
+        return original(root)
+
+    # Swap the bound method on this throwaway instance to count tree walks.
+    provider._rollout_paths = _spy  # type: ignore[method-assign]
+
+    first = provider._session_index(tmp_path)
+    second = provider._session_index(tmp_path)
+    assert first is second  # same cached object
+    assert len(walked) == 1  # the second lookup did not re-walk the tree
+
+
+# --------------------------------------------------------------------------
+# base default: providers that don't support wholesale rendering opt out loudly
+# --------------------------------------------------------------------------
+def test_wholesale_default_raises_for_non_participating_provider(
+    tmp_path: Path,
+) -> None:
+    provider = AgyProvider()
+    with pytest.raises(NotImplementedError):
+        list(provider.discover_sessions_under(tmp_path))
+    with pytest.raises(NotImplementedError):
+        list(provider.load_session_under(tmp_path, "some-id"))

--- a/test/test_codex_wholesale.py
+++ b/test/test_codex_wholesale.py
@@ -117,7 +117,10 @@ def test_discover_under_groups_by_cwd(tmp_path: Path) -> None:
     infos = list(CodexProvider().discover_sessions_under(tmp_path))
     by_cwd: dict[str | None, int] = {}
     for info in infos:
-        key = str(info.project_path) if info.project_path is not None else None
+        # as_posix() so the grouping key is separator-stable across platforms
+        # (str(WindowsPath("/proj/a")) is "\\proj\\a"); the recorded cwds are
+        # POSIX paths and the counts are what this pins.
+        key = info.project_path.as_posix() if info.project_path is not None else None
         by_cwd[key] = by_cwd.get(key, 0) + 1
 
     assert by_cwd == {"/proj/a": 2, "/proj/b": 2, None: 1}

--- a/test/test_codex_wholesale.py
+++ b/test/test_codex_wholesale.py
@@ -16,6 +16,7 @@ import pytest
 
 from claude_code_log.models import (
     AssistantTranscriptEntry,
+    TranscriptEntry,
     UserTranscriptEntry,
 )
 from claude_code_log.providers.agy import AgyProvider
@@ -27,7 +28,7 @@ PARENT_ID = "22222222-2222-4222-8222-222222222222"
 CHILD_ID = "33333333-3333-4333-8333-333333333333"
 
 
-def _visible_text(entries: list[object]) -> list[str]:
+def _visible_text(entries: list[TranscriptEntry]) -> list[str]:
     texts: list[str] = []
     for entry in entries:
         if not isinstance(entry, (UserTranscriptEntry, AssistantTranscriptEntry)):

--- a/work/codex-backlog.md
+++ b/work/codex-backlog.md
@@ -70,6 +70,12 @@ families and the provider contract are in
   lineage and strips inherited history but `load_session()` emits one thread.
 - Decide how native image-view results should render, independently of the
   already-supported user-message image references.
+- Codex token accounting → index totals. The wholesale walker emits zero
+  input/output/cache token totals per project because Codex rollouts carry no
+  token accounting the provider currently surfaces; the index token summary is
+  therefore always blank for Codex projects. If/when token counts are extracted
+  from rollout records, thread them into the walker's project summaries so the
+  index totals populate like the Claude path.
 
 ## Tool and static-analysis candidates
 

--- a/work/codex-backlog.md
+++ b/work/codex-backlog.md
@@ -76,6 +76,14 @@ families and the provider contract are in
   therefore always blank for Codex projects. If/when token counts are extracted
   from rollout records, thread them into the walker's project summaries so the
   index totals populate like the Claude path.
+- Cache-backed load + paginated combined for the wholesale walker. v1
+  participates in the SQLite cache for render-SKIP only: `render_provider_wholesale`
+  populates the messages table via `save_cached_entries` for schema uniformity
+  but never LOADS from it — every run re-parses rollouts (cheap, and it avoids a
+  serialization round-trip fidelity risk). Flip to cache-backed load once the
+  round-trip is proven byte-stable for Codex entries. The combined page is also
+  a single unpaginated document; wire `_generate_paginated_html` (cache-coupled)
+  and flip `--page-size`/`--jobs` from loud-rejected to honored at the same time.
 
 ## Tool and static-analysis candidates
 


### PR DESCRIPTION
## Provider rendering across all CLI modalities

Extends provider-based rendering (notably `codex`) from the narrow
`--provider codex --session-id <id>` single-session export to the **whole CLI
surface** — wholesale runs, `--projects-dir`, an INPUT_PATH that is a rollout
file *or* a directory, `--combined`/`--page-size`/date filters, and the SQLite
cache. The Claude default path (no `--provider`) is byte-stable throughout.

The design goal is a **no-gaps modality matrix**: every modality × flag
combination either works with the provider or fails **loudly** — nothing
silently bypasses the provider or renders a Codex rollout as an empty Claude
transcript (previously the worst gap: a rollout handed to the CLI fell through
to the Claude parser, which skipped every record and emitted a near-empty page).

### Target matrix

| Modality | Behavior |
|---|---|
| default run, no `--provider` | unchanged Claude wholesale (byte-stable) |
| `--provider codex` (no INPUT_PATH) / `--all-projects` | wholesale render of the provider data dir: per-session pages + per-project combined pages + master index |
| `--provider codex --projects-dir DIR` | same wholesale, `DIR` overrides the sessions root |
| INPUT_PATH = single `rollout-*.jsonl` (or a `session_meta`-sniffed file) | render that one session via the provider; auto-detected when `--provider` is omitted |
| INPUT_PATH = directory of rollouts | mini sessions root → wholesale (same recursive, symlink-contained discovery), incl. sniff-only-named files |
| `--session-id` (+ `--provider`) | single-session export, prefix match, all formats — unchanged |
| `--combined yes/no/only` | honored in wholesale |
| `--format html/md/json`, `-o` file/dir | honored; a file-shaped `-o` for a multi-file wholesale run errors loudly |
| `--from-date` / `--to-date` | honored (filter on normalized timestamps) |
| `--no-cache` / `--clear-cache` / `--clear-output` | wholesale participates in a SQLite cache under the output root; clears are scoped there |
| `--expand-paths` / `--filter-path` / `--tui` | Claude-only — rejected loudly in provider mode |

### Key decisions

- **One provider per wholesale run** — no unified multi-provider index; `--provider NAME` selects the single provider.
- **Auto-detection** only for an INPUT_PATH, only for Codex rollouts, via cheap checks (filename `rollout-*.jsonl`, else a first-line `session_meta` sniff); ambiguity errors and asks for `--provider`.
- **Codex "projects" = group sessions by cwd**; sessions without a cwd share a catch-all bucket.
- **Output root** = `<codex_home>/claude-code-log/` (created on demand, `-o` overrides); the cache DB lives there and the date-sharded sessions tree is never written into.
- The single-session index-summary dict is shape-identical to the Claude path, pinned so a key rename on either side fails RED rather than silently rendering an empty provider index.

### Cache

Reuses `CacheManager` with an explicit `db_path` + `output_dir` and a synthetic
per-cwd output project dir as the project identity, so none of its
write-next-to-source assumptions apply. v1 caches for **render-skip** only
(unchanged sessions/combined pages are skipped by source mtime + output
staleness); warm/cold runs are byte-stable by deterministic rendering. A
`--clear-output` run is pinned to leave the sessions tree byte-identical.

### Deferred (loud-rejected, tracked in `work/codex-backlog.md`)

- Paginated combined pages + `--page-size` / `--jobs` (ride on cache-coupled machinery).
- Cache-backed message *load* (the walker re-parses rollouts each run — cheap, avoids a serialization round-trip fidelity risk).
- Codex token totals in the index (rollouts carry no token accounting yet → blank token summary).
- TUI provider awareness; multi-provider unified index; `archived_sessions`.

### Testing

Detection primitives, root-scoped discovery/loading, the wholesale walker e2e
across all three formats (grouping, `--combined` variants, determinism, date
filtering), the required Claude-vs-walker index-contract drift pin, cache
warm/cold byte-stability + render-skip + change-detection, the CLI flag flips
and the loud-error rejection matrix, and the DECIDED sessions-tree-untouched
invariant. Full `just ci` green; the Claude snapshot suite is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider “wholesale” rendering for single rollout files and provider session directories, generating project-based output with index and combined transcript pages.
  * Added automatic provider detection for rollout inputs when no provider is specified.
  * Extended provider rendering output support (HTML/Markdown/JSON) with provider-scoped caching and regeneration controls.
* **Bug Fixes**
  * Prevented rollout/provider detection from producing near-empty renders.
  * Improved Codex rollout discovery to recognize additional filename/header patterns while keeping root boundaries safe.
  * Strengthened validation and clearer errors for provider-mode flag combinations.
* **Tests**
  * Added extensive end-to-end and unit coverage for detection, wholesale walking, rendering determinism, caching, and cache/output clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->