### PR TITLE
fix: gate project staleness check on requested outputs

### DIFF
--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2853,6 +2853,7 @@ def _plan_project(
     filter_path: Optional[str],
     write_combined: bool,
     page_size: int,
+    generate_individual_sessions: bool = True,
 ) -> Optional[_ProjectPlan]:
     """Resolve destination and staleness for one project (no rendering).
 
@@ -2948,20 +2949,21 @@ def _plan_project(
     else:
         combined_stale = True
 
-    # Determine if we need to do any work. With
-    # `write_combined=False`, the combined-transcript file
-    # isn't produced — its staleness / on-disk presence is
-    # irrelevant; only modified sources / stale per-session
-    # files matter.
+    # Determine if we need to do any work, gated on the artifacts that
+    # were actually requested. With `write_combined=False` the combined
+    # transcript isn't produced, so its staleness / on-disk presence is
+    # irrelevant; with `generate_individual_sessions=False` the
+    # per-session files aren't produced, so their staleness is too.
+    # Without a cache there is nothing that could have produced the
+    # requested outputs on an earlier run, so any request needs work —
+    # empty `modified_files` / `stale_sessions` must not read as
+    # "nothing to do" (that skipped every per-session file and left the
+    # index pointing at paths that were never written).
+    needs_work = bool(modified_files)
+    if generate_individual_sessions:
+        needs_work = needs_work or bool(stale_sessions) or cache_manager is None
     if write_combined:
-        needs_work = (
-            bool(modified_files)
-            or bool(stale_sessions)
-            or combined_stale
-            or not output_path.exists()
-        )
-    else:
-        needs_work = bool(modified_files) or bool(stale_sessions)
+        needs_work = needs_work or combined_stale or not output_path.exists()
 
     if needs_work:
         stats.files_updated = len(modified_files) if modified_files else 0
@@ -3174,6 +3176,7 @@ def process_projects_hierarchy(
                 filter_path=filter_path,
                 write_combined=write_combined,
                 page_size=page_size,
+                generate_individual_sessions=generate_individual_sessions,
             )
         except Exception as e:
             stats = GenerationStats()

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2468,6 +2468,11 @@ def _generate_individual_session_files(
             session_data = {s.session_id: s for s in project_cache.sessions.values()}
         # Get working directories for project title
         working_directories = cache_manager.get_working_directories()
+    else:
+        # No cache: derive session data from the messages themselves, so the
+        # no-cache path actually generates the requested session files
+        # instead of intersecting down to the empty set (issue #274).
+        session_data = _build_session_data_from_messages(messages)
 
     # Only generate HTML for sessions that are tracked in the sessions table
     # (filters out warmup-only and sessions without user messages)
@@ -2976,10 +2981,17 @@ def _plan_project(
             # every source file as (re)processed rather than as a cache hit.
             stats.files_updated = len(jsonl_files)
             stats.files_loaded_from_cache = 0
+            # Without a cache every requested session output is (re)generated
+            # (stale_sessions is always empty when there is no cache), so
+            # report the corresponding sessions as regenerated rather than
+            # zero. valid_session_ids is the plan-time estimate: in real
+            # usage the JSONL file stems are the session IDs.
+            if generate_individual_sessions:
+                stats.sessions_regenerated = len(valid_session_ids)
         else:
             stats.files_updated = len(modified_files) if modified_files else 0
             stats.files_loaded_from_cache = len(jsonl_files) - stats.files_updated
-        stats.sessions_regenerated = len(stale_sessions)
+            stats.sessions_regenerated = len(stale_sessions)
     else:
         # Fast path: nothing to do, just collect stats for index
         stats.files_loaded_from_cache = len(jsonl_files)

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2913,6 +2913,9 @@ def _plan_project(
     # _generate_individual_session_files writes, or every
     # session reads as "not_cached" and the project takes the
     # slow path on every run.
+    # Combined-only runs generate no per-session files, so skip their
+    # staleness query entirely (CodeRabbit review on #297): the I/O is
+    # wasted, and the rows would otherwise inflate stats below.
     stale_sessions = (
         cache_manager.get_stale_sessions(
             valid_session_ids,
@@ -2920,7 +2923,7 @@ def _plan_project(
             ext=combined_ext,
             output_dir=dest_dir,
         )
-        if cache_manager
+        if cache_manager and generate_individual_sessions
         else []
     )
     # Count archived sessions (cached but JSONL deleted)

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2928,26 +2928,31 @@ def _plan_project(
     # Check combined_stale using the appropriate cache:
     # - Paginated projects store data in html_pages table (via save_page_cache)
     # - Non-paginated projects store data in html_cache table (via update_html_cache)
-    if cache_manager is not None:
-        existing_page_count = cache_manager.get_page_count(variant)
-        if existing_page_count > 0:
-            # Paginated project: check page 1 staleness for the
-            # current --format/--detail/--compact variant, resolving
-            # the page file against dest_dir (--output) like the
-            # non-paginated branch below.
-            combined_stale = cache_manager.is_page_stale(
-                1, page_size, variant, output_dir=dest_dir
-            )[0]
+    # Skip the combined-cache queries entirely when the combined output isn't
+    # requested: individual-only runs shouldn't do combined I/O or fail on
+    # unrelated combined-cache state.
+    combined_stale = False
+    if write_combined:
+        if cache_manager is not None:
+            existing_page_count = cache_manager.get_page_count(variant)
+            if existing_page_count > 0:
+                # Paginated project: check page 1 staleness for the
+                # current --format/--detail/--compact variant, resolving
+                # the page file against dest_dir (--output) like the
+                # non-paginated branch below.
+                combined_stale = cache_manager.is_page_stale(
+                    1, page_size, variant, output_dir=dest_dir
+                )[0]
+            else:
+                # Non-paginated project: check html_cache for the
+                # variant-specific filename (e.g.
+                # `combined_transcripts.low.compact.md`), not the
+                # default `combined_transcripts.html`.
+                combined_stale = cache_manager.is_transcript_stale(
+                    output_path.name, None, output_dir=dest_dir
+                )[0]
         else:
-            # Non-paginated project: check html_cache for the
-            # variant-specific filename (e.g.
-            # `combined_transcripts.low.compact.md`), not the
-            # default `combined_transcripts.html`.
-            combined_stale = cache_manager.is_transcript_stale(
-                output_path.name, None, output_dir=dest_dir
-            )[0]
-    else:
-        combined_stale = True
+            combined_stale = True
 
     # Determine if we need to do any work, gated on the artifacts that
     # were actually requested. With `write_combined=False` the combined
@@ -2966,8 +2971,14 @@ def _plan_project(
         needs_work = needs_work or combined_stale or not output_path.exists()
 
     if needs_work:
-        stats.files_updated = len(modified_files) if modified_files else 0
-        stats.files_loaded_from_cache = len(jsonl_files) - stats.files_updated
+        if cache_manager is None:
+            # No cache: nothing could have been loaded from it, so report
+            # every source file as (re)processed rather than as a cache hit.
+            stats.files_updated = len(jsonl_files)
+            stats.files_loaded_from_cache = 0
+        else:
+            stats.files_updated = len(modified_files) if modified_files else 0
+            stats.files_loaded_from_cache = len(jsonl_files) - stats.files_updated
         stats.sessions_regenerated = len(stale_sessions)
     else:
         # Fast path: nothing to do, just collect stats for index

--- a/test/test_parallel_processing.py
+++ b/test/test_parallel_processing.py
@@ -158,3 +158,44 @@ def test_pool_failure_falls_back_to_sequential(
     out = capsys.readouterr().out
     assert "falling back to sequential processing" in out
     _assert_all_outputs_exist(projects_dir)
+
+
+def _plan(project_dir: Path, **overrides) -> converter._ProjectPlan:
+    kwargs = dict(
+        use_cache=True,
+        library_version="0.0.0",
+        variant="",
+        combined_ext="html",
+        combined_name="combined_transcripts.html",
+        output_dir=None,
+        expand_paths=False,
+        filter_path=None,
+        write_combined=True,
+        page_size=0,
+    )
+    kwargs.update(overrides)
+    plan = converter._plan_project(project_dir, **kwargs)
+    assert plan is not None
+    return plan
+
+
+def test_plan_needs_work_without_cache_for_individual_sessions(
+    tmp_path: Path,
+) -> None:
+    """Individual-session-only run with no cache must still be planned as work.
+
+    With `use_cache=False` there is no cache manager, so `modified_files`
+    and `stale_sessions` are always empty; treating that as "nothing to
+    do" skipped every per-session file while the index still linked to
+    them (issue #274).
+    """
+    project_dir = _build_projects_dir(tmp_path, "no-cache") / "-proj-alpha"
+
+    plan = _plan(
+        project_dir,
+        use_cache=False,
+        write_combined=False,
+        generate_individual_sessions=True,
+    )
+
+    assert plan.needs_work is True

--- a/test/test_parallel_processing.py
+++ b/test/test_parallel_processing.py
@@ -249,3 +249,60 @@ def test_no_cache_run_generates_individual_session_files(tmp_path: Path) -> None
     session_files = sorted(project_dir.glob("session-*.html"))
     assert len(session_files) > 0
     assert report.sessions_regenerated == len(session_files)
+
+
+def test_plan_combined_only_run_reports_no_sessions_regenerated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Combined-only plan must not query or count stale sessions.
+
+    On a combined-only run (`generate_individual_sessions=False`) no
+    per-session files are generated, so the plan must skip the
+    per-session staleness query entirely and report zero regenerated
+    sessions even when the cache holds stale session rows (CodeRabbit
+    review on #297). Counting them would also leak into the progress
+    line via `stats.sessions_regenerated`.
+    """
+    project_dir = _build_projects_dir(tmp_path, "combined-only") / "-proj-alpha"
+    monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "cache.db"))
+
+    # Seed the cache with a full run.
+    report = converter.RegenerationReport()
+    converter.convert_jsonl_to(
+        "html",
+        project_dir,
+        None,
+        use_cache=True,
+        silent=True,
+        report=report,
+    )
+
+    # Make one session stale (rendered file deleted -> "file_missing")
+    # and the combined output missing so the combined-only plan has
+    # work to do.
+    stale_session_file = next(project_dir.glob("session-*.html"))
+    stale_session_file.unlink()
+    (project_dir / "combined_transcripts.html").unlink()
+
+    stale_queries: list[int] = []
+    real_get_stale_sessions = converter.CacheManager.get_stale_sessions
+
+    def spy_get_stale_sessions(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        stale_queries.append(1)
+        return real_get_stale_sessions(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        converter.CacheManager, "get_stale_sessions", spy_get_stale_sessions
+    )
+
+    plan = _plan(
+        project_dir,
+        use_cache=True,
+        library_version=converter.get_library_version(),
+        write_combined=True,
+        generate_individual_sessions=False,
+    )
+
+    assert plan.needs_work is True
+    assert stale_queries == []
+    assert plan.stats.sessions_regenerated == 0

--- a/test/test_parallel_processing.py
+++ b/test/test_parallel_processing.py
@@ -199,3 +199,53 @@ def test_plan_needs_work_without_cache_for_individual_sessions(
     )
 
     assert plan.needs_work is True
+
+
+def test_plan_stats_without_cache_report_all_files_and_sessions(tmp_path: Path) -> None:
+    """No-cache plan stats must not report cache hits or zero regenerated sessions.
+
+    With `use_cache=False` every source file is (re)processed and every
+    requested session output is (re)generated, so the summary must count all
+    requested source files as processed and the corresponding sessions as
+    regenerated (CodeRabbit review on #297).
+    """
+    project_dir = _build_projects_dir(tmp_path, "no-cache-stats") / "-proj-alpha"
+
+    plan = _plan(
+        project_dir,
+        use_cache=False,
+        write_combined=False,
+        generate_individual_sessions=True,
+    )
+
+    assert plan.needs_work is True
+    assert plan.stats.files_updated == 1
+    assert plan.stats.files_loaded_from_cache == 0
+    assert plan.stats.sessions_regenerated == 1
+
+
+def test_no_cache_run_generates_individual_session_files(tmp_path: Path) -> None:
+    """End-to-end: a no-cache individual-sessions-only run writes session files.
+
+    Regression test for issue #274: `_generate_individual_session_files`
+    intersected the trunk session IDs with the cache-derived session data,
+    which is empty without a cache, so zero session files were ever written
+    while the index still linked to them (404 links).
+    """
+    project_dir = _build_projects_dir(tmp_path, "no-cache-run") / "-proj-alpha"
+
+    report = converter.RegenerationReport()
+    converter.convert_jsonl_to(
+        "html",
+        project_dir,
+        None,
+        generate_individual_sessions=True,
+        write_combined=False,
+        use_cache=False,
+        silent=True,
+        report=report,
+    )
+
+    session_files = sorted(project_dir.glob("session-*.html"))
+    assert len(session_files) > 0
+    assert report.sessions_regenerated == len(session_files)


### PR DESCRIPTION
Closes #274

`_plan_project` decided whether a project needed (re)conversion without looking at which artifacts were actually requested. With `use_cache=False` there is no cache manager, so `modified_files` and `stale_sessions` are always empty and `needs_work` came out `False` unconditionally for an individual-sessions-only run — no per-session files were written while the index still linked to `session-{id}` paths, producing 404 links. Symmetrically, per-session staleness could force work on combined-only runs where those files aren't produced.

`needs_work` is now composed from the requested outputs: session staleness (and the no-cache case) counts only when `generate_individual_sessions` is set, and combined staleness/on-disk presence only when `write_combined` is set. New test `test_plan_needs_work_without_cache_for_individual_sessions` fails on the old code and passes with the fix; `test/test_parallel_processing.py` is green (5 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed individual session generation when caching is disabled or unavailable.
  * Ensured conversion planning correctly identifies work required for individual-session output.
  * Corrected no-cache reporting so regenerated sessions are counted accurately.
  * Ensured requested session files are generated instead of being skipped during no-cache conversions.
  * Improved combined-only conversions so they avoid unnecessary individual-session checks and report regeneration status accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->