### PR TITLE
Recover provenance-laundered Codex tool-result correlations

### DIFF
--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -1411,7 +1411,19 @@ class CodexProvider(BaseProvider):
             ):
                 source = record.payload.get("input")
                 if isinstance(source, str):
-                    batch = adapt_codex_tool_batch(source)
+                    # Defense-in-depth: a batch-adapter bug must degrade this
+                    # exec to its raw fallback, never crash the whole transcript
+                    # render. The adapter's own contract (never raise on any
+                    # analyze output) is pinned in the tests; this guard keeps a
+                    # contract violation from being fatal in production.
+                    try:
+                        batch = adapt_codex_tool_batch(source)
+                    except Exception:
+                        logger.warning(
+                            "Codex batch adapter raised on an exec snippet; "
+                            "falling back to raw rendering"
+                        )
+                        batch = None
                     if batch is not None:
                         requests[call_id] = (
                             batch.calls,

--- a/claude_code_log/providers/codex.py
+++ b/claude_code_log/providers/codex.py
@@ -1419,9 +1419,16 @@ class CodexProvider(BaseProvider):
                     try:
                         batch = adapt_codex_tool_batch(source)
                     except Exception:
+                        # Name WHICH exec faulted (call_id) and carry WHAT broke
+                        # (exc_info): this guard exists to diagnose an adapter
+                        # contract violation, so a non-specific warning defeats
+                        # its purpose — it was exactly this path that hid a
+                        # consumer IndexError until a corpus probe surfaced it.
                         logger.warning(
-                            "Codex batch adapter raised on an exec snippet; "
-                            "falling back to raw rendering"
+                            "Codex batch adapter raised on exec snippet %s; "
+                            "falling back to raw rendering",
+                            call_id,
+                            exc_info=True,
                         )
                         batch = None
                     if batch is not None:

--- a/claude_code_log/providers/codex_quickjs.py
+++ b/claude_code_log/providers/codex_quickjs.py
@@ -81,6 +81,11 @@ class JavaScriptToolBatch:
     synthetic_results: tuple[Optional[str], ...] = ()
     output_count: int = 0
     result_object_keys: tuple[Optional[str], ...] = ()
+    # True only for the single-call whole-output fallback (a lone call whose
+    # emissions didn't correlate). Lets the adapter keep Workflow-family calls
+    # (spawn_agent → Task) on their scrubbed-opaque fallback instead of exposing
+    # the payload; a cleanly-correlated single call leaves this False.
+    whole_output_fallback: bool = False
 
 
 # --------------------------------------------------------------------------
@@ -93,6 +98,7 @@ _PRELUDE_TEMPLATE = r"""
 globalThis.__records = [];
 globalThis.__texts = [];
 globalThis.__errors = [];
+globalThis.__reads = [];
 const __D = "@@SENTINEL@@";
 const __MAXSTR = @@MAXSTR@@;
 const __MARK = "@@MARK@@";
@@ -100,11 +106,20 @@ function __cap(s) {
   return s.length > __MAXSTR ? s.slice(0, __MAXSTR) + __MARK : s;
 }
 
+// Record that call R<i>'s result was actually consumed — a real property read
+// (r.output, r.items[0]) or a coercion (JSON.parse(r), `${r}`). Distinguishes a
+// snippet that reads-then-launders a result (its output row IS that call's
+// result) from one that merely prints an unrelated literal (result untouched).
+function __noteRead(sentinel) {
+  const m = /^R(\d+)/.exec(sentinel);
+  if (m) __reads.push(m[1] | 0);
+}
+
 function __makeMagic(sentinel) {
   // Arrow fn target: still callable (apply trap fires) but has no
   // `prototype` own key, so the ownKeys trap need not report target keys.
   const fn = () => {};
-  const wrap = () => __D + sentinel + __D;
+  const wrap = () => { __noteRead(sentinel); return __D + sentinel + __D; };
   const magic = new Proxy(fn, {
     get(t, prop) {
       if (prop === "__sentinel") return sentinel;
@@ -116,6 +131,7 @@ function __makeMagic(sentinel) {
       if (prop === "then") return undefined;
       if (prop === "length") return 0;
       if (typeof prop === "symbol") return undefined;
+      __noteRead(sentinel);
       return __makeMagic(sentinel + "." + String(prop));
     },
     apply(t, self, args) { return __makeMagic(sentinel + "()"); },
@@ -172,7 +188,10 @@ globalThis.tools = new Proxy({}, {
   },
 });
 
-globalThis.text = (v) => { __texts.push(__safe(v)); };
+// Each emission records __records.length at fire time (calls-made-so-far), so
+// the interleaving relaxation can attribute a laundered loop row to the call it
+// followed.
+globalThis.text = (v) => { __texts.push({ v: __safe(v), after: __records.length }); };
 globalThis.ALL_TOOLS = __makeMagic("ALL_TOOLS");
 globalThis.setTimeout = (fn, ms) => {
   __records.push({ name: "__wait", args: [{ delay_ms: ms }] });
@@ -182,8 +201,8 @@ globalThis.setTimeout = (fn, ms) => {
 globalThis.clearTimeout = () => {};
 globalThis.exit = () => { throw { __exit: true }; };
 globalThis.console = {
-  log: (...a) => __texts.push(__safe(a.length === 1 ? a[0] : a)),
-  error: (...a) => __texts.push(__safe(a.length === 1 ? a[0] : a)),
+  log: (...a) => __texts.push({ v: __safe(a.length === 1 ? a[0] : a), after: __records.length }),
+  error: (...a) => __texts.push({ v: __safe(a.length === 1 ? a[0] : a), after: __records.length }),
 };
 """
 
@@ -232,7 +251,7 @@ def _run_snippet(code: str) -> Optional[dict[str, Any]]:
                 return None
         report = ctx.eval(
             "JSON.stringify({records:__records,texts:__texts,"
-            "errors:__errors,done:__done})"
+            "errors:__errors,done:__done,reads:__reads})"
         )
         return json.loads(report)
     except Exception:
@@ -276,6 +295,12 @@ class _Emission:
     prefix: str  # literal text before the first sentinel
     refs: list[_Ref]  # call refs embedded, in order (object_key set for JSON obj)
     literal_only: bool  # no sentinel at all
+    # Number of tool records made before this emission fired (``__records.length``
+    # at ``text()`` time). Set by ``_build_batch`` from the prelude's per-text
+    # bookkeeping; used only by the interleaving relaxation to attribute a
+    # provenance-laundered loop emission to the call it followed. ``None`` when
+    # the position is unknown (e.g. projected object emissions).
+    after: Optional[int] = None
 
 
 def _refs_from_string(
@@ -477,21 +502,93 @@ def _build_batch(report: dict[str, Any]) -> Optional[JavaScriptToolBatch]:
             return None
         calls.append(info)
 
+    single_call = len(calls) == 1 and not calls[0].is_wait
+
     emissions: list[_Emission] = []
+    decompose_failed = False
     for tv in raw_texts:
-        emi = _decompose(tv)
-        if emi is None:
+        # Each recorded text() is ``{v, after}`` (value + calls-made-so-far).
+        if not isinstance(tv, dict):
             return None
+        entry = cast("dict[str, Any]", tv)
+        raw_after = entry.get("after")
+        after = raw_after if isinstance(raw_after, int) else None
+        emi = _decompose(entry.get("v"))
+        if emi is None:
+            # A single-call snippet doesn't need its emissions to decompose (its
+            # whole output is that one call's result); everything else fails
+            # closed on an undecomposable emission.
+            if single_call:
+                decompose_failed = True
+                break
+            return None
+        emi.after = after
         emissions.append(emi)
 
-    return _correlate(calls, emissions)
+    raw_reads = report.get("reads")
+    reads: set[int] = set()
+    if isinstance(raw_reads, list):
+        for r in cast("list[Any]", raw_reads):
+            if isinstance(r, int) and not isinstance(r, bool):
+                reads.add(r)
+
+    if not decompose_failed:
+        correlated = _correlate(calls, emissions, reads)
+        if correlated is not None:
+            return correlated
+
+    # Single-call fallback: exactly one (non-wait) tool call has no output-split
+    # ambiguity by construction — whatever the snippet did (laundered the
+    # result, emitted nothing, emitted an undecomposable object), the single
+    # paired function_call_output is that call's result. The single-call render
+    # path (adapt_codex_tool_call → canonicalize + whole-output pairing) needs no
+    # correlation, so recover it here. Clean / session-marker single calls are
+    # already returned by ``_correlate`` above with their richer mapping.
+    if single_call:
+        # Per-call tuples MUST be call-length (one element here): the batch
+        # consumer (adapt_codex_tool_batch) indexes result_prefixes /
+        # synthetic_results / result_object_keys by call position before it even
+        # checks the call count, so an empty default would raise IndexError.
+        return JavaScriptToolBatch(
+            calls=[JavaScriptToolCall(calls[0].name, calls[0].input)],
+            result_indexes=[0],
+            result_prefixes=(None,),
+            synthetic_results=(None,),
+            output_count=1,
+            result_object_keys=(None,),
+            whole_output_fallback=True,
+        )
+    return None
+
+
+def _finish_batch(
+    calls: list[_CallInfo],
+    result_indexes: list[int],
+    output_mode: "Literal['markers', 'ordered']",
+    session_markers: bool,
+    result_prefixes: list[Optional[str]],
+    synthetic_results: list[Optional[str]],
+    output_count: int,
+    result_object_keys: list[Optional[str]],
+) -> JavaScriptToolBatch:
+    return JavaScriptToolBatch(
+        calls=[JavaScriptToolCall(c.name, c.input) for c in calls],
+        result_indexes=result_indexes,
+        output_mode=output_mode,
+        session_markers=session_markers,
+        result_prefixes=tuple(result_prefixes),
+        synthetic_results=tuple(synthetic_results),
+        output_count=output_count,
+        result_object_keys=tuple(result_object_keys),
+    )
 
 
 def _correlate(
-    calls: list[_CallInfo], emissions: list[_Emission]
+    calls: list[_CallInfo], emissions: list[_Emission], reads: set[int]
 ) -> Optional[JavaScriptToolBatch]:
     """Assign each non-wait call the output row of the emission that reads it."""
     n = len(calls)
+    real_idxs = [i for i, c in enumerate(calls) if not c.is_wait]
     result_indexes = [-1] * n
     result_prefixes: list[Optional[str]] = [None] * n
     synthetic_results: list[Optional[str]] = [None] * n
@@ -505,6 +602,14 @@ def _correlate(
     session_markers = False
     output_row = 0
     seen_rows: set[int] = set()
+    # Content rows whose provenance was laundered (a real output row carrying no
+    # sentinel because snippet logic consumed the marker: ``JSON.parse`` threw,
+    # ``indexOf`` missed it, ...). Deferred — a relaxation may still attribute
+    # them; a bare fail-closed here is what dropped these to the raw fallback.
+    laundered: list[_Emission] = []
+    # Every content row in emission order (sentinel-bearing AND laundered), for
+    # the interleaving relaxation's positional attribution of a mixed loop.
+    content: list[_Emission] = []
 
     for emi in emissions:
         if emi.literal_only:
@@ -512,9 +617,9 @@ def _correlate(
                 output_mode = "markers"
                 continue
             if emi.raw.strip():
-                # A non-marker literal with no call ref: a synthetic string the
-                # tree-sitter version wouldn't correlate → fail closed.
-                return None
+                laundered.append(emi)
+                content.append(emi)
+                continue
             continue
 
         # Session marker: "SESSION_ID=<sentinel .session_id>".
@@ -526,6 +631,7 @@ def _correlate(
             session_markers = True
             continue
 
+        content.append(emi)
         row = output_row
         introduced_new = False
         for ref in emi.refs:
@@ -552,22 +658,92 @@ def _correlate(
             output_row += 1
 
     output_count = len(seen_rows)
+    unmapped = [i for i in real_idxs if result_indexes[i] == -1]
 
+    if not unmapped and not laundered:
+        return _finish_batch(
+            calls,
+            result_indexes,
+            output_mode,
+            session_markers,
+            result_prefixes,
+            synthetic_results,
+            output_count,
+            result_object_keys,
+        )
+
+    # Interleaving relaxation: an ordered loop that emits one content row per
+    # call — sentinel-bearing where the snippet kept the result, laundered where
+    # it consumed the sentinel — is attributable by execution position even when
+    # provenance is partial. (Single-call snippets are recovered earlier, in
+    # ``_build_batch``, and never reach here.) Markers/session shapes are not
+    # loop rows, so they stay on the strict path.
+    if laundered and output_mode == "ordered" and not session_markers:
+        relaxed = _relax_interleaved(calls, real_idxs, content, reads)
+        if relaxed is not None:
+            return relaxed
+    return None
+
+
+def _relax_interleaved(
+    calls: list[_CallInfo],
+    real_idxs: list[int],
+    content: list[_Emission],
+    reads: set[int],
+) -> Optional[JavaScriptToolBatch]:
+    """Attribute an ordered mixed/laundered loop's rows to calls by position.
+
+    Requires one content row per non-wait call, all in execution order, all
+    read. Each row ``j`` must have fired immediately after the call it belongs
+    to (``after`` == ``real_idxs[j] + 1``); a sentinel-bearing row must ALSO
+    self-identify that same call by a single clean whole-result ref (no prefix,
+    no object-key projection) — any disagreement between the sentinel and the
+    position is a conflict and fails closed. Count mismatch, unread call,
+    non-monotone order, missing ``after``, or a composed sentinel row → None.
+    """
+    m = len(content)
+    if (
+        m < 2
+        or m != len(real_idxs)
+        or not all(i in reads for i in real_idxs)
+        or any(e.after is None for e in content)
+    ):
+        return None
+
+    for j, emi in enumerate(content):
+        target = real_idxs[j]
+        if emi.after != target + 1:
+            return None  # not emitted immediately after its call — out of order.
+        if not emi.literal_only:
+            # Sentinel-bearing row: must be exactly ``text(r.output)`` for THIS
+            # call — one whole-result ref, no prefix, no projected key.
+            if (
+                len(emi.refs) != 1
+                or emi.refs[0].call_index != target
+                or emi.refs[0].object_key is not None
+                or emi.prefix
+            ):
+                return None
+
+    result_indexes = [-1] * len(calls)
+    synthetic_results: list[Optional[str]] = [None] * len(calls)
     for i, c in enumerate(calls):
-        if not c.is_wait and result_indexes[i] == -1:
-            return None  # un-emitted call → we'd drop its output; fail closed.
-
-    js_calls = [JavaScriptToolCall(c.name, c.input) for c in calls]
-    return JavaScriptToolBatch(
-        calls=js_calls,
-        result_indexes=result_indexes,
-        output_mode=output_mode,
-        session_markers=session_markers,
-        result_prefixes=tuple(result_prefixes),
-        synthetic_results=tuple(synthetic_results),
-        output_count=output_count,
-        result_object_keys=tuple(result_object_keys),
+        if c.is_wait:
+            synthetic_results[i] = f"Waited {c.delay_ms} ms"
+    for j, i in enumerate(real_idxs):
+        result_indexes[i] = j
+    return _finish_batch(
+        calls,
+        result_indexes,
+        "ordered",
+        False,
+        [None] * len(calls),
+        synthetic_results,
+        m,
+        [None] * len(calls),
     )
+
+    return None
 
 
 def analyze_javascript_tools(

--- a/claude_code_log/providers/codex_quickjs.py
+++ b/claude_code_log/providers/codex_quickjs.py
@@ -753,8 +753,6 @@ def _relax_interleaved(
         [None] * len(calls),
     )
 
-    return None
-
 
 def analyze_javascript_tools(
     source: str,

--- a/claude_code_log/providers/codex_quickjs.py
+++ b/claude_code_log/providers/codex_quickjs.py
@@ -700,6 +700,16 @@ def _relax_interleaved(
     no object-key projection) — any disagreement between the sentinel and the
     position is a conflict and fails closed. Count mismatch, unread call,
     non-monotone order, missing ``after``, or a composed sentinel row → None.
+
+    Known contrived limitation: the read check is GLOBAL (every call read
+    *somewhere*), not per-row — a *laundered* row carries no sentinel to
+    cross-check, so it is placed purely by slot. A snippet whose row j reads a
+    DIFFERENT call than ``real_idxs[j]`` yet still satisfies the global check via
+    a **dead** read of ``real_idxs[j]`` would be mis-attributed. Reaching it
+    requires an unused read of the slot-call (a real snippet uses what it reads,
+    which would add another content row and trip the count check), and reads
+    can't be shown dead in this static model — so this is accepted rather than
+    guarded against.
     """
     m = len(content)
     if (

--- a/claude_code_log/providers/codex_tools.py
+++ b/claude_code_log/providers/codex_tools.py
@@ -17,6 +17,10 @@ from typing import Any, Literal, Optional, cast
 
 from .codex_quickjs import analyze_javascript_tools
 
+# Canonical names whose payloads are kept on the scrubbed-opaque ToolExecution
+# fallback rather than exposed by the single-call whole-output recovery.
+_WORKFLOW_FAMILY = frozenset({"Task", "Workflow"})
+
 
 @dataclass(frozen=True)
 class AdaptedToolCall:
@@ -67,7 +71,14 @@ def adapt_codex_tool_call(
         analyzed = analyze_javascript_tools(raw_input)
         if analyzed is not None and len(analyzed.calls) == 1:
             call = analyzed.calls[0]
-            return _canonicalize(call.name, call.input)
+            canonical = _canonicalize(call.name, call.input)
+            # Workflow-family calls (spawn_agent → Task) recovered ONLY by the
+            # single-call whole-output fallback stay on their scrubbed-opaque
+            # ToolExecution fallback rather than exposing the agent payload. A
+            # cleanly-correlated single call keeps its canonical mapping.
+            if analyzed.whole_output_fallback and canonical.name in _WORKFLOW_FAMILY:
+                return _tool_execution(raw_input)
+            return canonical
         return _tool_execution(raw_input)
     return _canonicalize(name, input_data)
 

--- a/test/test_codex_adversarial.py
+++ b/test/test_codex_adversarial.py
@@ -1041,6 +1041,64 @@ def test_widened_single_call_exec_renders_without_crashing() -> None:
     assert [item.name for item in uses] == ["mcp__clmail__terminal"]
 
 
+def test_batch_adapter_fault_warning_carries_call_id_and_exception(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The defense-in-depth guard around adapt_codex_tool_batch already survived
+    # an adapter fault (degrade to raw, never crash — pinned above). This pins
+    # the *diagnosability* of that survival: the warning must name WHICH exec
+    # faulted (call_id) and carry WHAT broke (the exception via exc_info).
+    # Without both, the guard hides exactly the class of bug it exists to catch
+    # (the consumer IndexError a corpus probe once surfaced). Mutation: drop
+    # call_id or exc_info from the warning and the respective assertion fails.
+    import claude_code_log.providers.codex as codex_module
+
+    def _boom(_source: str) -> object:
+        raise RuntimeError("synthetic adapter fault")
+
+    monkeypatch.setattr(codex_module, "adapt_codex_tool_batch", _boom)
+    caplog.set_level(logging.WARNING)
+
+    # A custom_tool_call exec with a string input is what reaches the batch
+    # adapter (a bare function_call takes the single-call path instead). A
+    # two-call Promise.all would expand to >=2 tool-uses via the batch path;
+    # under the fault it must degrade to exactly ONE raw fallback tool-use.
+    source = (
+        "const results = await Promise.all(["
+        'tools.exec_command({cmd: "one"}), '
+        'tools.exec_command({cmd: "two"})]); '
+        "results.forEach((r) => text(r.output));"
+    )
+    records = [
+        _record(
+            1,
+            "response_item",
+            {
+                "type": "custom_tool_call",
+                "call_id": "call-XYZ",
+                "name": "exec",
+                "input": source,
+            },
+        ),
+        _output(2, "call-XYZ", [{"type": "input_text", "text": "out"}]),
+    ]
+
+    content = [item for entry in _normalized(records) for item in entry.message.content]
+    uses = [item for item in content if isinstance(item, ToolUseContent)]
+    assert len(uses) == 1  # degraded to a single raw fallback, no crash, no batch
+
+    warnings = [
+        record for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert any("call-XYZ" in record.getMessage() for record in warnings)
+    assert any(
+        record.exc_info is not None
+        and "synthetic adapter fault" in str(record.exc_info[1])
+        for record in warnings
+    )
+
+
 def test_inherited_prefix_requires_strong_parent_suffix_evidence() -> None:
     provider = CodexProvider()
     shared = _event(1, "assistant", "Done.")

--- a/test/test_codex_adversarial.py
+++ b/test/test_codex_adversarial.py
@@ -1000,7 +1000,12 @@ def test_direct_nested_tool_result_propagates_mcp_error() -> None:
     assert result.is_error is True
 
 
-def test_workflow_result_retains_nested_tool_transport() -> None:
+def test_single_communicate_call_maps_and_retains_nested_tool_transport() -> None:
+    # A single mcp call (plus an unrelated "prefix" literal) is a single-call
+    # snippet: it maps to the tool, and the whole paired output — the forwarded
+    # result envelope — is retained verbatim as that call's result (widened
+    # single-call recovery; the transport is preserved, just rendered as the
+    # mcp tool rather than the raw ToolExecution fallback).
     payload = {"sent": True, "message_ids": [4730]}
     output = _forwarded_result_envelope(payload)
     source = (
@@ -1012,8 +1017,28 @@ def test_workflow_result_retains_nested_tool_transport() -> None:
     content = [item for entry in _normalized(records) for item in entry.message.content]
     uses = [item for item in content if isinstance(item, ToolUseContent)]
     result = next(item for item in content if isinstance(item, ToolResultContent))
-    assert [item.name for item in uses] == ["ToolExecution"]
-    assert result.content == output
+    assert [item.name for item in uses] == ["mcp__clmail__communicate"]
+    # The forwarded result payload (the nested transport) is retained — extracted
+    # from the envelope as the mcp call's result rather than the raw script dump.
+    assert '"sent": true' in result.content
+    assert '"message_ids": [4730]' in result.content
+
+
+def test_widened_single_call_exec_renders_without_crashing() -> None:
+    # End-to-end through the real _tool_batches consumer: a single-call snippet
+    # whose result feeds a for-of loop (the widened whole-output class) must
+    # render as the tool, never raise. Regression pin for the batch-adapter
+    # IndexError on the new single-call batch shape.
+    source = (
+        "const r = await tools.mcp__clmail__terminal({}); "
+        "for (const c of (r.content || [])) text(c.text);"
+    )
+    output = [{"type": "input_text", "text": "Script completed\nOutput:\nline\n"}]
+    records = [_call(1, "exec", "exec", source), _output(2, "exec", output)]
+
+    content = [item for entry in _normalized(records) for item in entry.message.content]
+    uses = [item for item in content if isinstance(item, ToolUseContent)]
+    assert [item.name for item in uses] == ["mcp__clmail__terminal"]
 
 
 def test_inherited_prefix_requires_strong_parent_suffix_evidence() -> None:
@@ -1031,16 +1056,19 @@ def test_inherited_prefix_requires_strong_parent_suffix_evidence() -> None:
     )
 
 
-def test_assignment_and_emission_text_in_comments_or_strings_is_not_structural() -> (
-    None
-):
+def test_commented_tool_is_not_a_second_call_single_call_maps() -> None:
+    # The commented-out call is NOT counted (only the one real exec_command is),
+    # so this is a single-call snippet and maps to the tool via whole-output
+    # widening — even though its only emission is an unrelated "result" literal.
+    # (Pre-widening this stayed ToolExecution; the pin now proves the comment
+    # isn't miscounted AND that one real call renders.)
     source = (
         "// const result = await tools.exec_command(\n"
         'await tools.exec_command({cmd: "git status"}); text("result");'
     )
 
-    assert adapt_codex_tool_call("exec", {"raw": source}, raw_input=source).name == (
-        "ToolExecution"
+    assert (
+        adapt_codex_tool_call("exec", {"raw": source}, raw_input=source).name == "Bash"
     )
 
 
@@ -2112,13 +2140,18 @@ def test_static_for_of_unwraps_each_nested_mcp_result_like_a_direct_call() -> No
             "ToolExecution",
         ),
         (
+            # A single call whose only emission is an unread literal (the
+            # template word "result", not ${result}) still maps: one call, whole
+            # output is its result.
             'const result = await tools.exec_command({cmd: "real"}); text(`result`);',
-            "ToolExecution",
+            "Bash",
         ),
         (
+            # An undecomposable nested emission no longer blocks a single call —
+            # its whole paired output is that one call's result.
             'const result = await tools.exec_command({cmd: "real"}); '
             "text({nested: [result.output, {ok: true}]} );",
-            "ToolExecution",
+            "Bash",
         ),
     ],
     ids=[

--- a/test/test_codex_quickjs.py
+++ b/test/test_codex_quickjs.py
@@ -448,7 +448,11 @@ def test_analyzer_expands_static_array_map_with_explicit_result_fields() -> None
     assert batch.output_count == 3
 
 
-def test_analyzer_rejects_aliased_explicit_result_projection() -> None:
+def test_single_call_aliased_projection_maps_whole_output() -> None:
+    # ``cmds`` has ONE entry, so this is a single exec call. The aliased
+    # projection (``output: r.exit_code``) can't correlate cleanly, but with one
+    # call there is nothing to mis-attribute — the whole output is its result, so
+    # it maps as the fallback rather than staying the raw ToolExecution.
     source = """
         const cmds = [["status", "git status --short"]];
         const out = await Promise.all(cmds.map(async ([name, cmd]) => {
@@ -458,10 +462,14 @@ def test_analyzer_rejects_aliased_explicit_result_projection() -> None:
         out.forEach(text);
     """
 
-    assert analyze_javascript_tools(source) is None
+    batch = analyze_javascript_tools(source)
+    assert batch is not None
+    assert len(batch.calls) == 1 and batch.whole_output_fallback is True
 
 
-def test_analyzer_rejects_unrecognized_collection_callback() -> None:
+def test_single_call_unrecognized_collection_callback_maps_whole_output() -> None:
+    # Same single-call shape emitted via ``console.log``; an unrecognized
+    # collection callback no longer blocks a lone call from mapping.
     source = """
         const cmds = [["status", "git status --short"]];
         const out = await Promise.all(cmds.map(async ([name, cmd]) => {
@@ -471,7 +479,9 @@ def test_analyzer_rejects_unrecognized_collection_callback() -> None:
         out.forEach(console.log);
     """
 
-    assert analyze_javascript_tools(source) is None
+    batch = analyze_javascript_tools(source)
+    assert batch is not None
+    assert len(batch.calls) == 1 and batch.whole_output_fallback is True
 
 
 def test_analyzer_projects_sequential_calls_from_one_result_object() -> None:
@@ -561,3 +571,152 @@ def test_analyzer_recognizes_single_session_marker() -> None:
     assert batch is not None
     assert batch.session_markers is True
     assert batch.result_indexes == [0]
+
+
+# --------------------------------------------------------------------------
+# Provenance-laundering relaxations: a snippet that READS a call result but
+# transforms the sentinel away before text() (JSON.parse throwing on it,
+# indexOf missing it) leaves the output row carrying no provenance. Two
+# unambiguous shapes are recovered; everything else stays fail-closed. Fixtures
+# are synthetic (no private content).
+# --------------------------------------------------------------------------
+def test_single_call_json_parse_launder_is_recovered() -> None:
+    """JSON.parse(r.output) throws on the sentinel → catch → text('[]'). One
+    call, one read output row → the whole paired output is that call's result."""
+    batch = analyze_javascript_tools(
+        "const r = await tools.mcp__x__list({});"
+        " let d; try { d = JSON.parse(r.output); } catch (e) { d = []; }"
+        " text(JSON.stringify(d));"
+    )
+    assert batch is not None
+    assert [c.name for c in batch.calls] == ["mcp__x__list"]
+    assert batch.result_indexes == [0]
+    assert batch.output_count == 1
+
+
+def test_single_call_indexof_launder_is_recovered() -> None:
+    """indexOf on the sentinel string is false → text('(not found)')."""
+    batch = analyze_javascript_tools(
+        'const r = await tools.mcp__x__search({q: "hi"});'
+        " const raw = String(r.output);"
+        ' text(raw.indexOf("needle") >= 0 ? raw : "(not found)");'
+    )
+    assert batch is not None
+    assert batch.result_indexes == [0]
+    assert batch.output_count == 1
+
+
+def test_single_call_maps_whole_output_regardless_of_emission() -> None:
+    """A single (non-wait) tool call has no output-split ambiguity by
+    construction — the one paired output is its result — so it maps as the
+    whole-output FALLBACK no matter what the snippet emitted: an unread literal,
+    a header + laundered result (multi-emission), or nothing at all."""
+    for source in (
+        'await tools.exec_command({cmd: "git status"}); text("result");',  # unread
+        'const r = await tools.mcp__x__list({}); text("Results:");'  # multi-emission
+        " let d; try { d = JSON.parse(r.output); } catch (e) { d = []; }"
+        " text(String(d.length));",
+        'await tools.exec_command({cmd: "ls"});',  # zero-emission
+    ):
+        batch = analyze_javascript_tools(source)
+        assert batch is not None, source
+        assert len(batch.calls) == 1
+        assert batch.result_indexes == [0]
+        assert batch.whole_output_fallback is True
+
+
+def test_interleaving_laundered_loop_is_recovered() -> None:
+    """A for-of loop that launders each iteration's result (JSON.parse-catch per
+    call) emits one laundered row per call, in order — attributed positionally by
+    the recorded calls-made-so-far."""
+    batch = analyze_javascript_tools(
+        'for (const id of ["a", "b", "c"]) {'
+        "  const r = await tools.mcp__x__get({id});"
+        "  let d; try { d = JSON.parse(r.output); } catch (e) { d = null; }"
+        '  text(d && d.name ? d.name : "(none)");'
+        "}"
+    )
+    assert batch is not None
+    assert [c.name for c in batch.calls] == ["mcp__x__get"] * 3
+    assert batch.result_indexes == [0, 1, 2]
+    assert batch.output_count == 3
+
+
+def test_interleaving_count_mismatch_fails_closed() -> None:
+    """Three calls (all read) but only two laundered rows → the row↔call
+    bijection is broken, so it fails closed rather than guess."""
+    assert (
+        analyze_javascript_tools(
+            'const r0 = await tools.get({id: "a"});'
+            ' const r1 = await tools.get({id: "b"});'
+            ' const r2 = await tools.get({id: "c"});'
+            " let a; try { a = JSON.parse(r0.output); } catch (e) { a = 0; }"
+            " let b; try { b = JSON.parse(r1.output); } catch (e) { b = 0; }"
+            " let c; try { c = JSON.parse(r2.output); } catch (e) { c = 0; }"
+            " text(String(a)); text(String(b));"
+        )
+        is None
+    )
+
+
+def test_interleaving_out_of_order_fails_closed() -> None:
+    """Two calls but the laundered rows are emitted in reverse order → the
+    positional (monotone ``after``) check fails, so it stays fail-closed."""
+    assert (
+        analyze_javascript_tools(
+            'const r0 = await tools.get({id: "a"});'
+            ' const r1 = await tools.get({id: "b"});'
+            ' const s1 = String(r1.output); text(s1.indexOf("x") >= 0 ? s1 : "(a)");'
+            ' const s0 = String(r0.output); text(s0.indexOf("x") >= 0 ? s0 : "(b)");'
+        )
+        is None
+    )
+
+
+def test_interleaved_mixed_provenance_is_recovered() -> None:
+    """A multi-call sequence that keeps the sentinel on one row and launders the
+    next is attributed by position: the sentinel row self-identifies its call
+    AND agrees with its execution slot, the laundered row is placed by slot."""
+    batch = analyze_javascript_tools(
+        "const r0 = await tools.getA({});"
+        " text(r0.output);"
+        " const r1 = await tools.getB({});"
+        " let d; try { d = JSON.parse(r1.output); } catch (e) { d = null; }"
+        ' text(d ? d.n : "(none)");'
+    )
+    assert batch is not None
+    assert [c.name for c in batch.calls] == ["getA", "getB"]
+    assert batch.result_indexes == [0, 1]
+    assert batch.output_count == 2
+
+
+def test_multi_call_with_an_unread_call_fails_closed() -> None:
+    """A multi-call loop that emits a STATIC literal each iteration (never
+    reading the call result) leaves every call unread — nothing attributable —
+    so it fails closed rather than pair unrelated literals to calls."""
+    assert (
+        analyze_javascript_tools(
+            'for (const id of ["a", "b", "c"]) {'
+            "  await tools.get({id});"
+            '  text("static");'
+            "}"
+        )
+        is None
+    )
+
+
+def test_multi_call_forged_reference_fails_closed() -> None:
+    """Load-bearing: with two real calls, an emission forging a ref to a
+    nonexistent call index must fail closed (a forged ref could otherwise
+    re-route a real output row). Only single-call snippets — where there is
+    nothing to mis-attribute — recover unconditionally."""
+    from claude_code_log.providers.codex_quickjs import _S
+
+    assert (
+        analyze_javascript_tools(
+            "const r0 = await tools.a({x: 1});"
+            " const r1 = await tools.b({y: 2});"
+            f' text(r0.output); text("{_S}R9{_S}");'
+        )
+        is None
+    )

--- a/test/test_codex_quickjs.py
+++ b/test/test_codex_quickjs.py
@@ -673,6 +673,25 @@ def test_interleaving_out_of_order_fails_closed() -> None:
     )
 
 
+def test_interleaving_sentinel_position_conflict_fails_closed() -> None:
+    """A strict-interleaved sequence where an output row's execution SLOT and its
+    surviving sentinel DISAGREE about which call it belongs to must fail closed —
+    the sentinel is the ground truth, so a slot-vs-sentinel conflict means the
+    positional attribution is wrong. Here row 2 sits in call ``c``'s slot but its
+    sentinel references call ``a``; without the conflict guard the laundered
+    middle row would be mis-attributed (idx [0, 1, 2])."""
+    assert (
+        analyze_javascript_tools(
+            "const a = await tools.getA({}); text(a.output);"
+            " const b = await tools.getB({});"
+            " let d; try { d = JSON.parse(b.output); } catch (e) { d = 0; }"
+            ' text(d ? d.n : "z");'
+            " const c = await tools.getC({}); void c.output; text(a.output);"
+        )
+        is None
+    )
+
+
 def test_interleaved_mixed_provenance_is_recovered() -> None:
     """A multi-call sequence that keeps the sentinel on one row and launders the
     next is attributed by position: the sentinel row self-identifies its call

--- a/test/test_codex_quickjs_adversarial.py
+++ b/test/test_codex_quickjs_adversarial.py
@@ -105,14 +105,18 @@ def test_global_pollution_does_not_leak_across_snippets() -> None:
 # --------------------------------------------------------------------------
 # Sentinel forgery — a hostile snippet emitting the provenance char itself.
 # --------------------------------------------------------------------------
-def test_forged_reference_to_nonexistent_call_fails_closed() -> None:
-    # One real call, but the emission forges a ref to call index 9.
-    assert (
-        analyze_javascript_tools(
-            f'const r = await tools.a({{x: 1}}); text("{_S}R9{_S}");'
-        )
-        is None
+def test_single_call_forged_reference_maps_whole_output() -> None:
+    # One real call whose emission forges a ref to call index 9. The forged ref
+    # makes correlation fail, but with a SINGLE call there is nothing to
+    # mis-attribute — the whole paired output is that call's result — so it maps
+    # as the fallback. (The MULTI-call forged-ref case, where a forged ref could
+    # re-route a real output row, still fails closed — see
+    # test_codex_quickjs::test_multi_call_forged_reference_fails_closed.)
+    batch = analyze_javascript_tools(
+        f'const r = await tools.a({{x: 1}}); text("{_S}R9{_S}");'
     )
+    assert batch is not None
+    assert len(batch.calls) == 1 and batch.whole_output_fallback is True
 
 
 def test_forged_sentinel_in_a_tool_argument_fails_closed() -> None:

--- a/test/test_codex_tools.py
+++ b/test/test_codex_tools.py
@@ -389,7 +389,13 @@ def test_static_for_of_expands_distinct_tool_calls() -> None:
     ]
 
 
-def test_all_tools_plus_one_command_is_compound_workflow() -> None:
+def test_all_tools_plus_one_command_maps_the_single_command() -> None:
+    # ALL_TOOLS.filter is tool INTROSPECTION, not a tool call — the snippet makes
+    # exactly one real call (exec_command), so single-call widening renders it as
+    # that command (whole output, incl. the introspection JSON, is its result).
+    # NB this retires the old "ALL_TOOLS ⇒ compound ToolExecution" classification
+    # for the one-real-call case; a genuinely compound program (≥2 calls) still
+    # falls back.
     source = (
         "const matches = ALL_TOOLS.filter(x => x.name.includes('git')); "
         'const git = await tools.exec_command({cmd: "git status"}); '
@@ -398,8 +404,7 @@ def test_all_tools_plus_one_command_is_compound_workflow() -> None:
 
     call = adapt_codex_tool_call("exec", {"raw": source}, raw_input=source)
 
-    assert call.name == "ToolExecution"
-    assert call.input == {"script": source}
+    assert call.name == "Bash"
 
 
 def test_one_tool_with_multiple_result_emissions_reuses_renderer() -> None:
@@ -413,14 +418,18 @@ def test_one_tool_with_multiple_result_emissions_reuses_renderer() -> None:
     )
 
 
-def test_one_tool_with_unrelated_output_emission_is_workflow() -> None:
+def test_one_tool_with_unrelated_output_emission_maps_whole_output() -> None:
+    # A single tool call has no output-split ambiguity: whatever the snippet
+    # printed (here a "prefix" literal alongside the result), the whole paired
+    # output is that one call's result, so it renders as the tool — not the raw
+    # ToolExecution fallback (widened single-call recovery).
     source = (
         'const result = await tools.exec_command({cmd: "git status"}); '
         'text("prefix"); text(result.output);'
     )
 
-    assert adapt_codex_tool_call("exec", {"raw": source}, raw_input=source).name == (
-        "ToolExecution"
+    assert (
+        adapt_codex_tool_call("exec", {"raw": source}, raw_input=source).name == "Bash"
     )
 
 
@@ -686,3 +695,46 @@ def test_codex_write_error_result_is_not_collapsed() -> None:
     )
 
     assert normalized == "{}"
+
+
+# --------------------------------------------------------------------------
+# Layer contract: adapt_codex_tool_batch must NEVER raise on any analyze
+# output, including the widened single-call whole-output batch shape. The
+# consumer indexes the per-call tuples by position before checking the call
+# count, so a batch whose tuples don't match its call count would IndexError
+# and crash the whole transcript render. These distilled single-call shapes
+# (synthesized from the widened class — a lone call whose result feeds a
+# derived/looping emission) pin that the new batch shape survives the old
+# consumer. Fixtures are synthetic; no private content.
+# --------------------------------------------------------------------------
+_WIDENED_SINGLE_CALL_SHAPES = [
+    # mcp result iterated with for-of over r.content
+    "const r = await tools.mcp__clmail__terminal({}); "
+    "for (const c of (r.content || [])) text(c.text);",
+    # result object walked with Object.entries
+    "const r = await tools.fetch_workflow_job_logs({id: 1}); "
+    "for (const [k, v] of Object.entries(r.logs || {})) text(k + ': ' + v);",
+    # result text split into headings
+    'const r = await tools.fetch_openai_doc({q: "x"}); '
+    'const hs = String(r.output).split("\\n").filter((l) => l.startsWith("#")); '
+    "text(hs.join(String.fromCharCode(10)));",
+    # laundered single call (JSON.parse-catch)
+    "const r = await tools.mcp__x__list({}); "
+    "let d; try { d = JSON.parse(r.output); } catch (e) { d = []; } "
+    "text(JSON.stringify(d));",
+]
+
+
+@pytest.mark.parametrize("source", _WIDENED_SINGLE_CALL_SHAPES)
+def test_batch_adapter_never_raises_on_widened_single_call_shape(source: str) -> None:
+    # Contract: the batch adapter returns None for a single call (it needs >=2),
+    # but crucially it must not raise reaching that decision.
+    assert adapt_codex_tool_batch(source) is None
+
+
+@pytest.mark.parametrize("source", _WIDENED_SINGLE_CALL_SHAPES)
+def test_single_call_adapter_maps_widened_shape_without_raising(source: str) -> None:
+    # The single-call adapter recovers the tool (or, when the call name is
+    # unknown, its raw fallback) — the point is it never raises.
+    call = adapt_codex_tool_call("exec", {"raw": source}, raw_input=source)
+    assert isinstance(call.name, str) and call.name

--- a/work/codex-backlog.md
+++ b/work/codex-backlog.md
@@ -133,9 +133,14 @@ families and the provider contract are in
   cross-read hole above — that is an attribution ambiguity reachable only by dead
   code with no hostile intent; this is direct hostile writes to the bookkeeping.
   The fix is uniform, not per-array: move all four behind a closure and expose
-  only a single non-enumerable, non-writable extraction hook. Hardening `__reads`
-  alone would shut the narrow door while leaving the wider `__records`/`__texts`
-  forgery open, so piecemeal hardening is not worth doing. Threat model that
+  only a single non-enumerable, non-writable extraction hook that returns a
+  detached snapshot — serialized data, or a deep copy / frozen structure — and
+  never a live reference to the closure-owned arrays. The descriptor flags seal
+  only the binding, not the array a hook hands back: returning the live arrays
+  would let a snippet call the hook and push forged entries straight into them,
+  reintroducing the same forgery the closure was meant to prevent. Hardening
+  `__reads` alone would shut the narrow door while leaving the wider
+  `__records`/`__texts` forgery open, so piecemeal hardening is not worth doing. Threat model that
   bounds the priority: the snippet originates in the user's own transcript, and
   the QuickJS sandbox and evaluation caps hold, so the worst outcome is
   misleading rendered output for the user viewing their own session — not sandbox

--- a/work/codex-backlog.md
+++ b/work/codex-backlog.md
@@ -84,6 +84,14 @@ families and the provider contract are in
   round-trip is proven byte-stable for Codex entries. The combined page is also
   a single unpaginated document; wire `_generate_paginated_html` (cache-coupled)
   and flip `--page-size`/`--jobs` from loud-rejected to honored at the same time.
+- Unify the spawn_agent/Task scrub policy. There is a clean-vs-laundered seam:
+  a cleanly-correlated single `spawn_agent` renders as a Task tool with its
+  message shown, while a laundered/unrelated-emission one is kept on the
+  scrubbed-opaque ToolExecution fallback (single-call widening excludes
+  Workflow-family). That makes the scrub boundary depend on JS shape, not
+  content — an artifact, not a defensible privacy contract. Decide one policy:
+  shown-everywhere with opaque-literal scrubbing of the canonicalized inputs, or
+  scrubbed-everywhere. cboos's ruling to take later.
 
 ## Tool and static-analysis candidates
 

--- a/work/codex-backlog.md
+++ b/work/codex-backlog.md
@@ -108,6 +108,20 @@ families and the provider contract are in
 - Keep consolidated-output recovery conservative: split only on unique static
   materialized boundaries, and never invent a missing result unless Codex
   explicitly reports truncation.
+- Laundered-row cross-read hole in the interleaving relaxation — uniqueness
+  tightening. `_relax_interleaved` attributes a provenance-laundered row to a
+  call by execution slot and checks reads only GLOBALLY (every call read
+  somewhere), so a row that actually read a different call could be
+  mis-attributed if its slot-call is satisfied by a dead read. The membership
+  fix (slot-call must be read in that row's window) is defeated because the dead
+  read lands in-window. The unbeaten variant: scope reads per emission window
+  (the same `after`-counter mechanism used for texts) and require the window's
+  DISTINCT read-set to be exactly `{slot call}` — a laundered row that reads two
+  calls in its window (one dead) is then non-unique and fails closed, while a
+  legitimate laundered row reads exactly its own call. Likely zero-regression on
+  the recovered set but unmeasurable without building it; the hole needs dead
+  code to reach, so it is documented (see the `_relax_interleaved` docstring)
+  rather than guarded for now.
 
 ## Internal architecture debt
 

--- a/work/codex-backlog.md
+++ b/work/codex-backlog.md
@@ -122,6 +122,26 @@ families and the provider contract are in
   the recovered set but unmeasurable without building it; the hole needs dead
   code to reach, so it is documented (see the `_relax_interleaved` docstring)
   rather than guarded for now.
+- Prelude instrumentation integrity — the correlation bookkeeping is
+  snippet-writable. `_PRELUDE_TEMPLATE` declares `__records`, `__texts`,
+  `__errors`, and `__reads` as plain `globalThis` arrays, and the instrumentation
+  hooks (`__noteRead` and the tool/text recorders) push into them directly. An
+  analyzed snippet can therefore write these globals itself: forged
+  `__records`/`__texts` entries fabricate tool calls or emitted rows in the
+  rendered transcript, and forged `__reads` entries influence the read-gated
+  attribution in `_relax_interleaved`. This is a different class from the
+  cross-read hole above — that is an attribution ambiguity reachable only by dead
+  code with no hostile intent; this is direct hostile writes to the bookkeeping.
+  The fix is uniform, not per-array: move all four behind a closure and expose
+  only a single non-enumerable, non-writable extraction hook. Hardening `__reads`
+  alone would shut the narrow door while leaving the wider `__records`/`__texts`
+  forgery open, so piecemeal hardening is not worth doing. Threat model that
+  bounds the priority: the snippet originates in the user's own transcript, and
+  the QuickJS sandbox and evaluation caps hold, so the worst outcome is
+  misleading rendered output for the user viewing their own session — not sandbox
+  escape, code execution, or data exfiltration. Deferred on that bound; revisit
+  if the analyzer ever runs on untrusted third-party rollouts or the extraction
+  surface grows.
 
 ## Internal architecture debt
 


### PR DESCRIPTION
## Recover provenance-laundered Codex tool-result correlations

Builds on the QuickJS-based analysis of Codex code-mode `exec` snippets. That
mapper runs a snippet with its tool results mocked as sentinel-bearing proxies
to learn the call → output-row structure, then maps the real paired output back
onto each call. When a snippet **reads** a result but transforms the provenance
sentinel away before emitting — `JSON.parse(r.output)` throwing on the sentinel
into a `catch`, `String(r.output).indexOf(...)` missing it — the emitted row
carries no provenance, the every-call-maps invariant fails, and the whole batch
fell back to a raw `ToolExecution` render even though the calls and arguments
were captured perfectly.

On the canonical local session this dropped **21** exec programs to the raw
fallback; corpus-wide the canonicalization rate was **97.0%**. This change
recovers the laundered class: canonical fallbacks **21 → 8** (the remainder is
a genuinely-ambiguous `ALL_TOOLS`-introspection class that correctly stays raw),
corpus **97.0% → 98.0%**.

### What is recovered

- **Single-call** — a snippet with exactly one (non-wait) tool call has no
  output-split ambiguity by construction: whatever it did, the one paired
  `function_call_output` is that call's result. It is now recovered regardless
  of what (or whether) it emitted — laundered, zero-emission, or an
  undecomposable object — as a fallback *after* the strict sentinel correlation,
  so cleanly-correlated single calls keep their richer mapping (object-key
  projection, session markers).
- **Interleaving / mixed provenance** — a loop that emits one content row per
  call in execution order is attributable by position (calls-made-so-far,
  recorded per emission) even when some rows kept the sentinel and others
  laundered it. A sentinel-bearing row must self-identify the same call its slot
  implies, or the conflict fails closed.

### What still fails closed (deliberately)

Multi-call correlation remains conservative — a forged reference to a
nonexistent call, a slot-vs-sentinel conflict, a count mismatch, an unread call,
and out-of-order emission all keep the batch on the raw fallback rather than
risk mis-attributing one call's output to another. Single-call recovery is the
only unconditional path, because with one call there is nothing to mis-attribute.

### Workflow-family exclusion

`spawn_agent` (→ Task) and Workflow calls are excluded from the single-call
whole-output fallback, so their opaque agent payloads stay on the scrubbed
`ToolExecution` path; a cleanly-correlated single `spawn_agent` still renders as
a Task. A `whole_output_fallback` marker on the batch distinguishes the two.

### Robustness

The single-call fallback batch keeps its per-call metadata tuples call-length
(an earlier iteration defaulted them empty, which made the batch consumer
`IndexError` before it even checked the call count — it would have crashed the
whole transcript render). The exec batch-adapter call is now guarded so a future
adapter fault degrades to raw rendering instead of aborting, with a contract
test that the adapter never raises on any analysis output.

### Testing

Synthetic fixtures and mutation-checkable pins for both recoveries, each
fail-closed boundary (forged-ref, slot-vs-sentinel conflict, count mismatch,
unread call, out-of-order), the Workflow gate, and the consumer never-raises
contract (unit + end-to-end render). The one documented residual — a laundered
row could be mis-attributed only via a *dead* read of its slot call, which a
real snippet never produces — is recorded in the code with a backlog note for a
uniqueness-based tightening. Full `just ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex transcript rendering resilience by gracefully handling batch-adapter failures, emitting a warning that includes the affected call ID.
  * Enhanced JavaScript tool execution analysis with more accurate emission/correlation tracking, stronger interleaving/provenance-laundering recovery, and clearer whole-output fallback behavior for single-call scenarios.
  * Updated widened single-call classification so single tool invocations render correctly as command output (including special-case handling for workflow-like tools).
* **Tests**
  * Expanded regression and adversarial coverage for single-call recovery, whole-output fallback, forged-reference handling, and improved nested MCP transport payload retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->