### PR TITLE
Fail fast on --snapshot-update under xdist parallelism

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,17 +125,58 @@ uv run pytest test/test_snapshot_html.py -n0 --snapshot-update
 ```
 
 > **`--snapshot-update` must run serially (`-n0`) — a guard now enforces
-> this.** Syrupy and pytest-xdist race when writing snapshot files in
-> parallel, and it corrupts `.ambr` files in more than one way: once ~6000
-> lines were silently *truncated*, and separately a run *deleted and
-> rewrote* entries in a fixture that wasn't touched — each time leaving a
-> structurally-broken file that still passed on the next read (the second
-> instance also produced a false "the suite has non-isolated rendering
-> state" conclusion). Because `pyproject.toml` defaults to `-n auto`, a
-> `conftest.py` guard (`pytest_configure`) now fails fast if
-> `--snapshot-update` is combined with more than one xdist worker, pointing
-> you at `-n0`. Ordinary parallel test runs (no update) are unaffected, so
-> CI is untouched.
+> this.** Syrupy and pytest-xdist misbehave when writing the shared `.ambr`
+> files in parallel, on two observed occasions. Once, a raced update
+> silently *truncated* ~6000 lines, leaving a structurally-broken file that
+> still passed on the next read — a confirmed corruption. Separately, a
+> parallel `--snapshot-update` with a stale `__pycache__` produced a diff in
+> which an *untouched* fixture appeared to regenerate with structure it had
+> never carried (fold-bar / children markup); re-run serially with a purged
+> cache, the same operation was cleanly additive and that structure did not
+> appear. The mechanism of the second case isn't pinned down (the large
+> deletion count first quoted for it turned out to be alignment noise — see
+> "Recognising the race" below), but an operation that makes an untouched
+> fixture look different is dangerous regardless, and "vanished under `-n0`"
+> is the reproducible part. Because `pyproject.toml` defaults to `-n auto`,
+> this unsafe combination is the *default*, so a `conftest.py` guard
+> (`pytest_configure`) now fails fast when `--snapshot-update` is combined
+> with more than one xdist worker, pointing you at `-n0`. Ordinary parallel
+> runs (no update) are unaffected — CI is untouched.
+
+**Recognising the race in a diff.** The guard prevents the mistake going
+forward, but you may still meet a suspicious `.ambr` diff — reviewing a PR
+that carries snapshot changes, or reading a historical diff from before the
+guard existed. The rule of thumb:
+
+> Any negative in an `.ambr` diff is the race's signature — a purely
+> additive fixture is `+N/-0`; deletions mean either an intentional content
+> change you can name, or the race.
+
+To tell which, check at the **block level**, not the raw git diff: compare
+the set of snapshot names (a race removes or rewrites blocks you didn't
+touch) and diff each block's content. Inserting a snapshot or changing
+embedded CSS realigns shared boilerplate and can show hundreds of
+"deletions" with **zero content lost** — a third case, benign, that is
+neither a content change nor the race. A real `-275` was exactly this:
+block-level inspection found one snapshot added, none removed or renamed,
+and seven blocks each `+3` for a single `white-space: pre-wrap` rule, with
+zero content deleted. Confirm either way with a read-only `-n0` run after
+purging stale bytecode — if every snapshot passes, the committed file
+matches what the code renders and is not a raced artifact:
+
+```bash
+find . -name __pycache__ -type d -prune -exec rm -rf {} +
+uv run pytest test/test_snapshot_html.py -n0
+# all pass → the committed .ambr matches the render (not a raced file)
+```
+
+When you do intend to regenerate, run `--snapshot-update` serially; a purely
+additive result (`+N/-0`, e.g. "8 snapshots passed. 1 snapshot generated.")
+is the healthy signature:
+
+```bash
+uv run pytest test/test_snapshot_html.py -n0 --snapshot-update
+```
 
 When snapshot tests fail:
 1. Review the diff to verify changes are intentional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,11 +124,18 @@ uv run pytest test/test_snapshot_html.py -v
 uv run pytest test/test_snapshot_html.py -n0 --snapshot-update
 ```
 
-> **Warning — don't let `--snapshot-update` run with `-n auto`.** Syrupy
-> and pytest-xdist race when writing snapshot files in parallel: the
-> `.ambr` file ends up truncated (observed: ~6000 lines silently
-> deleted on a single run, leaving the file structurally broken but
-> still passing on next read). Run `--snapshot-update` serially.
+> **`--snapshot-update` must run serially (`-n0`) — a guard now enforces
+> this.** Syrupy and pytest-xdist race when writing snapshot files in
+> parallel, and it corrupts `.ambr` files in more than one way: once ~6000
+> lines were silently *truncated*, and separately a run *deleted and
+> rewrote* entries in a fixture that wasn't touched — each time leaving a
+> structurally-broken file that still passed on the next read (the second
+> instance also produced a false "the suite has non-isolated rendering
+> state" conclusion). Because `pyproject.toml` defaults to `-n auto`, a
+> `conftest.py` guard (`pytest_configure`) now fails fast if
+> `--snapshot-update` is combined with more than one xdist worker, pointing
+> you at `-n0`. Ordinary parallel test runs (no update) are unaffected, so
+> CI is untouched.
 
 When snapshot tests fail:
 1. Review the diff to verify changes are intentional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,16 +148,17 @@ forward, but you may still meet a suspicious `.ambr` diff — reviewing a PR
 that carries snapshot changes, or reading a historical diff from before the
 guard existed. The rule of thumb:
 
-> Any negative in an `.ambr` diff is the race's signature — a purely
-> additive fixture is `+N/-0`; deletions mean either an intentional content
-> change you can name, or the race.
+> A negative in an `.ambr` diff is a signal to **investigate**, not a
+> verdict. A purely additive regeneration is `+N/-0`, so deletions mean one
+> of three things: an intentional content change you can name, a benign
+> realignment of shared boilerplate, or the race.
 
 To tell which, check at the **block level**, not the raw git diff: compare
 the set of snapshot names (a race removes or rewrites blocks you didn't
 touch) and diff each block's content. Inserting a snapshot or changing
 embedded CSS realigns shared boilerplate and can show hundreds of
-"deletions" with **zero content lost** — a third case, benign, that is
-neither a content change nor the race. A real `-275` was exactly this:
+"deletions" with **zero content lost** — that is the benign case, and it is
+the one a raw `-N` most often turns out to be. A real `-275` was exactly this:
 block-level inspection found one snapshot added, none removed or renamed,
 and seven blocks each `+3` for a single `white-space: pre-wrap` rule, with
 zero content deleted. Confirm either way with a read-only `-n0` run after

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,14 +17,15 @@ from test.snapshot_serializers import (
 
 # ========== Guard: --snapshot-update must not run under xdist parallelism ==========
 # syrupy and pytest-xdist race on the shared ``.ambr`` files when snapshots are
-# updated with more than one worker: concurrent writes have TWICE silently
-# corrupted a snapshot file — once ~6000 lines truncated, once a `-274` delete
-# with unrelated structural rewrites — each leaving a structurally-broken file
-# that still passed on the next read, and the second time producing a *false*
-# "the suite has non-isolated rendering state" conclusion. ``pyproject.toml``
-# defaults to ``-n auto --dist=worksteal``, so the unsafe combination is the
-# DEFAULT unless this guard stops it. The fix is always to regenerate serially
-# with ``-n0``. See CONTRIBUTING.md.
+# updated with more than one worker, on two observed occasions. One raced update
+# silently TRUNCATED ~6000 lines, leaving a structurally-broken file that still
+# passed on the next read — a confirmed corruption. Separately, a parallel update
+# with a stale ``__pycache__`` made an *untouched* fixture appear to regenerate
+# with markup it had never carried; that one's mechanism was never pinned down,
+# but it did not survive a serial re-run with purged bytecode.
+# ``pyproject.toml`` defaults to ``-n auto --dist=worksteal``, so the unsafe
+# combination is the DEFAULT unless this guard stops it. The fix is always to
+# regenerate serially with ``-n0``. See CONTRIBUTING.md.
 
 
 def _snapshot_update_xdist_conflict(
@@ -44,9 +45,9 @@ def _snapshot_update_xdist_conflict(
     return (
         f"Refusing to run --snapshot-update under pytest-xdist with {workers} "
         "workers: parallel writes to the shared .ambr snapshot files race and "
-        "can silently DELETE or truncate snapshot content (observed twice), "
-        "leaving a broken file that still passes on the next read. Regenerate "
-        "serially instead:\n\n"
+        "can silently truncate snapshot content (one observed run dropped "
+        "~6000 lines), leaving a broken file that still passes on the next "
+        "read. Regenerate serially instead:\n\n"
         "    uv run pytest <targets> -n0 --snapshot-update\n"
     )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,57 @@ from test.snapshot_serializers import (
 )
 
 
+# ========== Guard: --snapshot-update must not run under xdist parallelism ==========
+# syrupy and pytest-xdist race on the shared ``.ambr`` files when snapshots are
+# updated with more than one worker: concurrent writes have TWICE silently
+# corrupted a snapshot file — once ~6000 lines truncated, once a `-274` delete
+# with unrelated structural rewrites — each leaving a structurally-broken file
+# that still passed on the next read, and the second time producing a *false*
+# "the suite has non-isolated rendering state" conclusion. ``pyproject.toml``
+# defaults to ``-n auto --dist=worksteal``, so the unsafe combination is the
+# DEFAULT unless this guard stops it. The fix is always to regenerate serially
+# with ``-n0``. See CONTRIBUTING.md.
+
+
+def _snapshot_update_xdist_conflict(
+    *, is_worker: bool, update_snapshots: bool, workers: int
+) -> Optional[str]:
+    """Return an error message if this is an unsafe ``--snapshot-update`` ×
+    xdist-parallel combination, else ``None``.
+
+    Pure and side-effect-free so the decision is unit-testable in isolation;
+    :func:`pytest_configure` wraps it. Only the xdist *controller* gates
+    (``is_worker`` False): a single worker (``workers <= 1``) or ``-n0``
+    (``workers == 0``) writes serially and is safe, and a parallel run that
+    is *not* updating snapshots (``update_snapshots`` False) never writes.
+    """
+    if is_worker or not update_snapshots or workers <= 1:
+        return None
+    return (
+        f"Refusing to run --snapshot-update under pytest-xdist with {workers} "
+        "workers: parallel writes to the shared .ambr snapshot files race and "
+        "can silently DELETE or truncate snapshot content (observed twice), "
+        "leaving a broken file that still passes on the next read. Regenerate "
+        "serially instead:\n\n"
+        "    uv run pytest <targets> -n0 --snapshot-update\n"
+    )
+
+
+def pytest_configure(config: "Config") -> None:
+    """Fail fast on an unsafe ``--snapshot-update`` × parallel-xdist run.
+
+    Runs in the controller before workers spawn, so a bad invocation aborts
+    with a clear message rather than corrupting ``.ambr`` files.
+    """
+    message = _snapshot_update_xdist_conflict(
+        is_worker=hasattr(config, "workerinput"),
+        update_snapshots=bool(getattr(config.option, "update_snapshots", False)),
+        workers=getattr(config.option, "numprocesses", None) or 0,
+    )
+    if message:
+        raise pytest.UsageError(message)
+
+
 # ========== Collection cost control ==========
 # Browser test modules import `playwright` and TUI modules import `textual`
 # at module top level. pytest imports every test module during collection and

--- a/test/test_snapshot_update_guard.py
+++ b/test/test_snapshot_update_guard.py
@@ -13,9 +13,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from test.conftest import _snapshot_update_xdist_conflict as _conflict
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Bound the child pytest run. One of these cases spawns real xdist workers, so
+# an indefinite wait is a plausible failure rather than a theoretical one — and
+# a hang here would burn a CI runner until the job-level timeout killed it, with
+# no message saying which test was stuck. Generous enough that a slow machine
+# never trips it; the point is to fail by name rather than to enforce a budget.
+_CHILD_TIMEOUT_S = 300
 
 
 # ---------------------------------------------------------------------------
@@ -61,21 +70,31 @@ def _run_pytest(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     (tmp_path / "conftest.py").write_text(_CONFTEST, encoding="utf-8")
     (tmp_path / "test_trivial.py").write_text(_TEST, encoding="utf-8")
     env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
-    return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            str(tmp_path),
-            *args,
-            "-p",
-            "no:cacheprovider",
-        ],
-        capture_output=True,
-        text=True,
-        env=env,
-        cwd=str(tmp_path),  # rootdir = tmp_path, so repo pyproject addopts don't apply
-    )
+    argv = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(tmp_path),
+        *args,
+        "-p",
+        "no:cacheprovider",
+    ]
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=_CHILD_TIMEOUT_S,
+            cwd=str(tmp_path),  # rootdir = tmp_path, so repo addopts don't apply
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Turn an indefinite hang into a named failure that says what was run.
+        pytest.fail(
+            f"child pytest did not finish within {_CHILD_TIMEOUT_S}s: "
+            f"{' '.join(argv[1:])}"
+        )
+        raise AssertionError from exc  # unreachable; pytest.fail raises
 
 
 def test_execution_snapshot_update_parallel_errors(tmp_path):

--- a/test/test_snapshot_update_guard.py
+++ b/test/test_snapshot_update_guard.py
@@ -1,11 +1,11 @@
 """The ``--snapshot-update`` × xdist-parallel guard (see test/conftest.py).
 
 syrupy and pytest-xdist race on the shared ``.ambr`` files when snapshots are
-updated with more than one worker; it has twice silently corrupted a snapshot
-file. ``pyproject.toml`` defaults to ``-n auto``, so the unsafe combination is
-the default unless the guard rejects it. These tests pin the decision (pure
-function) and prove the end-to-end behaviour by executing real pytest
-subprocesses.
+updated with more than one worker; one raced update silently truncated ~6000
+lines of a snapshot file. ``pyproject.toml`` defaults to ``-n auto``, so the
+unsafe combination is the default unless the guard rejects it. These tests pin
+the decision (pure function) and prove the end-to-end behaviour by executing
+real pytest subprocesses.
 """
 
 import os

--- a/test/test_snapshot_update_guard.py
+++ b/test/test_snapshot_update_guard.py
@@ -1,0 +1,100 @@
+"""The ``--snapshot-update`` × xdist-parallel guard (see test/conftest.py).
+
+syrupy and pytest-xdist race on the shared ``.ambr`` files when snapshots are
+updated with more than one worker; it has twice silently corrupted a snapshot
+file. ``pyproject.toml`` defaults to ``-n auto``, so the unsafe combination is
+the default unless the guard rejects it. These tests pin the decision (pure
+function) and prove the end-to-end behaviour by executing real pytest
+subprocesses.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from test.conftest import _snapshot_update_xdist_conflict as _conflict
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Pure-function pins (fast; the mutation-check target)
+# ---------------------------------------------------------------------------
+
+
+def test_blocks_snapshot_update_under_parallel():
+    msg = _conflict(is_worker=False, update_snapshots=True, workers=8)
+    assert msg is not None
+    assert "-n0" in msg  # points the user at the serial fix
+
+
+def test_allows_snapshot_update_when_serial():
+    # -n0 (0 workers, inline) and a single worker both write serially.
+    assert _conflict(is_worker=False, update_snapshots=True, workers=0) is None
+    assert _conflict(is_worker=False, update_snapshots=True, workers=1) is None
+
+
+def test_allows_parallel_when_not_updating():
+    # The CI path: many workers, no snapshot writes -> must be unaffected.
+    assert _conflict(is_worker=False, update_snapshots=False, workers=8) is None
+
+
+def test_skips_worker_process():
+    # Only the controller gates; a worker must not independently error.
+    assert _conflict(is_worker=True, update_snapshots=True, workers=8) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end execution pins (real pytest subprocesses through the actual hook)
+# ---------------------------------------------------------------------------
+
+# The tmp project re-exports the real ``pytest_configure`` guard from
+# test/conftest.py, so these exercise the wired hook, not a copy. The trivial
+# test carries no snapshot assertions, so ``--snapshot-update`` writes nothing —
+# no real ``.ambr`` is touched.
+_CONFTEST = "from test.conftest import pytest_configure  # noqa: F401 (real hook)\n"
+_TEST = "def test_ok():\n    assert True\n"
+
+
+def _run_pytest(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    (tmp_path / "conftest.py").write_text(_CONFTEST, encoding="utf-8")
+    (tmp_path / "test_trivial.py").write_text(_TEST, encoding="utf-8")
+    env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(tmp_path),
+            *args,
+            "-p",
+            "no:cacheprovider",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),  # rootdir = tmp_path, so repo pyproject addopts don't apply
+    )
+
+
+def test_execution_snapshot_update_parallel_errors(tmp_path):
+    result = _run_pytest(tmp_path, "--snapshot-update", "-n", "auto")
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "Refusing to run --snapshot-update" in output
+    assert "-n0" in output
+
+
+def test_execution_snapshot_update_serial_proceeds(tmp_path):
+    result = _run_pytest(tmp_path, "--snapshot-update", "-n0")
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "1 passed" in output
+
+
+def test_execution_parallel_without_update_proceeds(tmp_path):
+    result = _run_pytest(tmp_path, "-n", "auto")
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "1 passed" in output


### PR DESCRIPTION
## The footgun

`pyproject.toml` sets `addopts = -n auto --dist=worksteal`, so **every** pytest
invocation is parallel by default. Combine that with `--snapshot-update` and
syrupy's workers race each other writing the shared `.ambr` files.

One observed run silently **truncated ~6000 lines** out of
`test_snapshot_html.ambr`. The file was left structurally broken — and still
passed on the next read, because the assertions whose snapshots had vanished
simply had nothing left to compare against. A second parallel update, with
stale `__pycache__` in play, made an *untouched* fixture appear to regenerate
with fold-bar/children markup it had never carried; that one's mechanism was
never pinned down, but it did not survive a serial re-run with purged
bytecode.

What makes this worth a guard rather than a paragraph in the docs is that
**the unsafe combination is the default**. Nobody has to do anything unusual
to reach it — `uv run pytest --snapshot-update` is already the broken
invocation, and the damage is silent in both directions: nothing fails at
write time, and nothing fails on the next read either.

## The guard

`pytest_configure` in `test/conftest.py` raises `pytest.UsageError` when
`--snapshot-update` is combined with more than one xdist worker, pointing at
the serial form:

```
ERROR: Refusing to run --snapshot-update under pytest-xdist with 8 workers:
parallel writes to the shared .ambr snapshot files race and can silently
truncate snapshot content (one observed run dropped ~6000 lines), leaving a
broken file that still passes on the next read. Regenerate serially instead:

    uv run pytest <targets> -n0 --snapshot-update
```

The decision is a pure function —
`_snapshot_update_xdist_conflict(is_worker, update_snapshots, workers)` — so
it is unit-testable without spawning pytest, and `pytest_configure` is a thin
wrapper around it.

Three things it deliberately does **not** block:

- `-n0` (`workers == 0`) and `-n1` — single-writer updates are serial and safe;
- parallel runs that aren't updating (`update_snapshots` false) — they never
  write, so **CI is untouched**;
- the xdist *workers* themselves (`is_worker` true) — only the controller
  gates, before workers spawn.

Two implementation details worth knowing if you touch this: by
`pytest_configure` time `config.option.numprocesses` is already an `int`
(`-n auto` → 8, `-n0` → 0, no flag → `None`), so there's no `"auto"` string to
parse; and syrupy's write flag is `update_snapshots`, while
`--snapshot-warn-unused` is report-only and never writes.

## Tests

`test/test_snapshot_update_guard.py` covers both layers:

- four pure-function tests pinning each arm of the decision — fires on
  parallel update, silent at `-n0`/`-n1`, silent without `--snapshot-update`,
  silent on a worker;
- three **execution** tests that run real pytest subprocesses against a
  temporary project whose `conftest.py` re-exports the real hook, asserting
  the actual exit status and stderr rather than a mocked config object.

The subprocess tests matter here because the guard's whole job is to abort a
real invocation before it does damage; a test that only calls the predicate
would pass just as happily if the hook were never wired up.

## Verified against current `main`

The guard now shares a repository with snapshot fixtures that landed after it
was written, so all three paths were **executed**, not reasoned about:

| invocation | result |
|---|---|
| `--snapshot-update -n auto` | guard fires, exit 4, message points at `-n0` |
| ordinary parallel run, no update | silent — 10 passed, exit 0 |
| `-n0 --snapshot-update` | 10 snapshots passed, 0 generated, `.ambr` byte-identical |

The third is the one that earns its place: a guard whose escape hatch has
never been run is a guard that redirects people into an untested path. Here
the recommended path regenerates the current fixtures to themselves, leaving
the snapshot file unchanged.

## CONTRIBUTING

The guard prevents the mistake going forward, but you can still meet a
suspicious `.ambr` diff — reviewing a PR that carries snapshot changes, or
reading a historical diff from before the guard existed. So the docs also
cover **recognising** it: check at the block level (compare the set of
snapshot names, diff each block's content) rather than trusting a raw `-N`,
because inserting a snapshot or changing embedded CSS realigns shared
boilerplate and can show hundreds of "deletions" with zero content lost. A
real `-275` in this repo was exactly that benign case. Confirm either way with
a read-only `-n0` run after purging stale bytecode: if every snapshot passes,
the committed file matches what the code renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented snapshot updates from running with multiple parallel workers, helping avoid corrupted or unreliable snapshot files.
  * Added a fail-fast guard with a detailed message directing snapshot updates to run serially with `-n0`.
  * Confirmed that ordinary parallel test runs remain unaffected.

* **Documentation**
  * Expanded snapshot-testing guidance with troubleshooting steps for suspicious snapshot diffs and a safe verification workflow.

* **Tests**
  * Added coverage for controller vs worker behavior and end-to-end runs proving parallel update refusal, serial success, and non-updating parallel acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->