### PR TITLE
Render image-bearing steering prompts instead of dropping them (#294)

### DIFF
--- a/claude_code_log/factories/attachment_factory.py
+++ b/claude_code_log/factories/attachment_factory.py
@@ -16,18 +16,26 @@ in DAG, hidden from rendering" behaviour. New attachment flavours can
 grow their own factory branch here as needed.
 """
 
-from typing import Any, Optional, cast
+import logging
+from typing import Any, NamedTuple, Optional, cast
 
 from ..models import (
     AttachmentTranscriptEntry,
+    ContentItem,
     HookAttachmentMessage,
+    ImageContent,
     MessageContent,
     TextContent,
     UserSteeringMessage,
     UserTextMessage,
 )
+from ..parser import extract_text_content
 from .meta_factory import create_meta
+from .transcript_factory import USER_CONTENT_TYPES, create_message_content
 from .user_factory import create_user_message
+
+
+logger = logging.getLogger(__name__)
 
 
 # Attachment ``type`` values produced when a Claude Code hook fires.
@@ -70,6 +78,99 @@ def _coerce_int(value: Any) -> Optional[int]:
     return None
 
 
+class QueuedCommandPrompt(NamedTuple):
+    """A ``queued_command`` prompt normalized for rendering and pairing.
+
+    Attributes:
+        items: Content items to render. Never empty.
+        pairable: Whether ``items`` yields text the steering-suppression
+            budget can pair a legacy ``remove`` against. False means the
+            paired ``remove`` must stay visible — see
+            :func:`queued_command_prompt_items`.
+        shape: The prompt shape actually seen, for diagnostics
+            (``"str"``, ``"list[image,text]"``, ``"dict"``, ...).
+    """
+
+    items: list[ContentItem]
+    pairable: bool
+    shape: str
+
+
+def _describe_prompt_shape(prompt: Any) -> str:
+    """Name the shape of a ``prompt`` payload for a diagnostic message.
+
+    A bare ``type()`` name is not enough for the list case — the useful
+    detail is *which block types* it held, since that is what a future
+    novel shape will differ in.
+    """
+    if isinstance(prompt, list):
+        blocks = cast(list[Any], prompt)
+        kinds: set[str] = set()
+        for block in blocks:
+            if isinstance(block, dict):
+                block_map = cast(dict[str, Any], block)
+                kinds.add(str(block_map.get("type", "?")))
+            else:
+                kinds.add(type(block).__name__)
+        return f"list[{','.join(sorted(kinds))}]" if kinds else "list[]"
+    return type(prompt).__name__
+
+
+def queued_command_prompt_items(
+    payload: dict[str, Any],
+) -> Optional[QueuedCommandPrompt]:
+    """Normalize a ``queued_command`` payload's ``prompt`` to content items.
+
+    ``prompt`` is a plain string for a text-only steering delivery, but a
+    *list* of content blocks when the steering message carries an image
+    (``[{"type": "text", ...}, {"type": "image", ...}]``) — the shape a
+    pasted screenshot produces. A string yields the single ``TextContent``
+    the pre-list code built by hand, so text-only steering is unaffected.
+
+    Any *other* shape is still rendered, from its ``str()``, rather than
+    dropped: silently discarding a steering delivery is indistinguishable
+    from there having been none. Such a prompt comes back with
+    ``pairable=False`` and the caller is expected to say so out loud —
+    see :func:`_create_queued_command_message`.
+
+    ``pairable`` is exactly "has non-empty text", because text is the only
+    thing the suppression budget can key on. An image-only delivery is
+    renderable but not pairable; its paired ``remove``, which carries no
+    matching text either, simply stays visible.
+
+    Returns ``None`` only when there is nothing at all to render (no
+    ``prompt`` key, or an empty/whitespace one) — the one case where
+    dropping the card loses nothing.
+
+    Shared by :func:`_create_queued_command_message` and the renderer's
+    steering-suppression pre-pass so the two cannot disagree: the
+    pre-pass seeds the budget from the ``pairable`` cards only, and every
+    card the factory emits that it did *not* count leaves the paired
+    legacy ``remove`` visible.
+    """
+    prompt = payload.get("prompt")
+    if prompt is None:
+        return None
+    shape = _describe_prompt_shape(prompt)
+
+    items: list[ContentItem]
+    if isinstance(prompt, (str, list)):
+        items = create_message_content(prompt, USER_CONTENT_TYPES)
+    else:
+        # Fail closed, visibly: keep the payload as text so the delivery
+        # shows up in the page instead of vanishing.
+        items = [TextContent(type="text", text=str(prompt))]
+
+    text = extract_text_content(items).strip()
+    if not text and not any(isinstance(item, ImageContent) for item in items):
+        return None
+    return QueuedCommandPrompt(
+        items=items,
+        pairable=bool(text) and isinstance(prompt, (str, list)),
+        shape=shape,
+    )
+
+
 def _create_queued_command_message(
     transcript: AttachmentTranscriptEntry,
     payload: dict[str, Any],
@@ -92,18 +193,35 @@ def _create_queued_command_message(
     keep the ``user steering`` CSS treatment; a transformed/other
     classification is returned unchanged.
     """
-    prompt = payload.get("prompt")
-    if not isinstance(prompt, str) or not prompt.strip():
+    prompt = queued_command_prompt_items(payload)
+    if prompt is None:
         return None
 
+    if not prompt.pairable:
+        # Rendered, but the suppression pre-pass could not count it, so the
+        # paired legacy ``remove`` stays visible. Name the shape we actually
+        # saw: the next novel prompt shape should be diagnosable from this
+        # line alone, without re-deriving it from an archive.
+        logger.warning(
+            "queued_command prompt shape %s is not pairable (session %s, "
+            "version %s): rendering the steering card, but its legacy "
+            "'remove' cannot be matched and will render too. Only a str or "
+            "a list of blocks with text can be paired.",
+            prompt.shape,
+            transcript.sessionId,
+            transcript.version,
+        )
+
     meta = create_meta(transcript)
-    chunk: list[Any] = [TextContent(type="text", text=prompt)]
-    result = create_user_message(meta, chunk, prompt, is_slash_command=False)
+    result = create_user_message(
+        meta, prompt.items, extract_text_content(prompt.items), is_slash_command=False
+    )
     # Defensive only: create_user_message never returns None for a non-empty
-    # text chunk (it returns None solely on an empty content_list / the empty
+    # chunk (it returns None solely on an empty content_list / the empty
     # is_slash_command path, neither reachable here). Kept to guard against a
     # future change to its contract — the effective render condition upstream
-    # is exactly this ``prompt.strip()``, so pre-pass and factory can't drift.
+    # is exactly ``queued_command_prompt_items``, so pre-pass and factory
+    # can't drift.
     if result is None:
         return None
 

--- a/claude_code_log/factories/attachment_factory.py
+++ b/claude_code_log/factories/attachment_factory.py
@@ -133,10 +133,13 @@ def queued_command_prompt_items(
     ``pairable=False`` and the caller is expected to say so out loud —
     see :func:`_create_queued_command_message`.
 
-    ``pairable`` is exactly "has non-empty text", because text is the only
-    thing the suppression budget can key on. An image-only delivery is
-    renderable but not pairable; its paired ``remove``, which carries no
-    matching text either, simply stays visible.
+    ``pairable`` requires **both** a supported shape (``str`` or a list of
+    blocks) and non-empty text — text because it is the only thing the
+    suppression budget can key on, and shape because a ``str()``-rendered
+    fallback is not something we can claim to have matched. Both conditions
+    bite independently: an image-only list is renderable but not pairable,
+    and a text-bearing ``dict`` is not pairable either. Either way the paired
+    ``remove`` simply stays visible.
 
     Returns ``None`` only when there is nothing at all to render (no
     ``prompt`` key, or an empty/whitespace one) — the one case where

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -76,7 +76,10 @@ from .factories import (
     create_user_message,
     ToolItemResult,
 )
-from .factories.attachment_factory import create_attachment_message
+from .factories.attachment_factory import (
+    create_attachment_message,
+    queued_command_prompt_items,
+)
 from .utils import (
     format_timestamp,
     best_working_dir,
@@ -4598,19 +4601,17 @@ def _render_messages(
             isinstance(entry, AttachmentTranscriptEntry)
             and (entry.attachment or {}).get("type") == "queued_command"
         ):
-            # Only count a ``queued_command`` that will actually render — i.e.
-            # it carries a usable prompt (mirrors the guard in
-            # ``attachment_factory._create_queued_command_message``). Otherwise
-            # a promptless attachment would seed the budget and drop the paired
-            # ``remove`` that still holds the steering text.
-            # NB: with the text-keyed budget below this guard is no longer
-            # load-bearing (a promptless qc would key under ``""`` and can't
-            # match a content-bearing ``remove``) — kept as belt-and-suspenders
-            # and to avoid a spurious ``""`` count feeding the imbalance
-            # warning.
-            qc_prompt = (entry.attachment or {}).get("prompt")
-            if isinstance(qc_prompt, str) and qc_prompt.strip():
-                text = _steering_match_text(qc_prompt)
+            # Only count a ``queued_command`` that will actually render.
+            # ``queued_command_prompt_items`` is the SAME predicate the factory
+            # applies, shared rather than mirrored so the budget can't drift
+            # from what gets emitted: a promptless attachment must not seed the
+            # budget and drop the paired ``remove`` that still holds the
+            # steering text. It also accepts a *list* prompt — an image-bearing
+            # steering delivery — whose text is what the paired ``remove``
+            # carries, so such a pair now matches instead of orphaning.
+            qc_prompt = queued_command_prompt_items(entry.attachment or {})
+            if qc_prompt is not None and qc_prompt.pairable:
+                text = _steering_match_text(qc_prompt.items)
                 key = (entry.sessionId, entry.version, text)
                 renderable_qc_count[key] = renderable_qc_count.get(key, 0) + 1
                 qc_versions.add((entry.sessionId, entry.version))
@@ -4629,8 +4630,19 @@ def _render_messages(
     # exhausted (or absent), further removes with that text are *rendered* as
     # legacy steering rather than dropped. This makes suppression LOSSLESS and
     # order-independent: we hide exactly the removes that have a matching card
-    # (no duplicate), and any orphan removes — the 1:1 pairing does break in
-    # real archives, e.g. a 2.1.160 file with 34 removes / 29 qc — still render.
+    # (no duplicate), and any orphan remove still renders.
+    #
+    # This comment used to cite "a 2.1.160 file with 34 removes / 29 qc" as
+    # proof the 1:1 pairing breaks in real archives. That was a raw record
+    # count: at 2.1.160 EVERY remove carries ``content: null`` (34/34 across
+    # the local corpus on 2026-07-28), and null removes are dropped by
+    # ``_filter_messages`` before this loop, so they can neither pair nor
+    # orphan. Such a count does not measure the pairing performed here. In the
+    # one case investigated end to end (#294) the pairing was exactly 1:1 —
+    # 232/232 — and the orphans came from cards this pass failed to count.
+    # Whether it can break for real is still open, so the lossless design
+    # stays; what changed is that we no longer assert a violation we have not
+    # observed.
     qc_budget: dict[tuple[str, str, str], int] = dict(renderable_qc_count)
     # (session, version) keys already warned about, so the imbalance is logged
     # at most once per key rather than per orphan remove.
@@ -4672,8 +4684,14 @@ def _render_messages(
                 continue
             # No matching queued_command (or its budget is spent) → this is an
             # orphan remove. Fall through to render it (lossless). If the session
-            # DID have cards under this version, the 1:1 pairing broke — flag it
-            # once per (session, version).
+            # DID have cards under this version, say so — but only as what we
+            # actually observed. The earlier wording asserted the
+            # remove↔queued_command pairing was "violated"; that is a claim
+            # about the data we cannot make from here, and it was wrong in the
+            # case that prompted it (#294): the pairing was intact and it was
+            # our own pre-pass that failed to count an image-bearing card.
+            # A card we render but cannot pair warns for itself, naming the
+            # shape, in ``attachment_factory.queued_command_prompt_items``.
             version_key = (message.sessionId, inferred_version)
             if (
                 inferred_version
@@ -4682,11 +4700,12 @@ def _render_messages(
             ):
                 warned_qc_imbalance.add(version_key)
                 logger.warning(
-                    "steering suppression imbalance in session %s under version "
-                    "%s: a 'remove' op has no matching queued_command card — "
-                    "rendering it as legacy steering (content preserved). The "
-                    "remove↔queued_command 1:1 pairing appears violated (seen in "
-                    "real archives).",
+                    "steering 'remove' op in session %s under version %s has no "
+                    "counted queued_command card — rendering it as legacy "
+                    "steering (content preserved). Either the archive holds an "
+                    "unpaired 'remove', or a card was rendered that the "
+                    "suppression pre-pass could not pair; a preceding "
+                    "'not pairable' warning, if any, names the shape.",
                     message.sessionId,
                     inferred_version,
                 )

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -293,26 +293,73 @@ The keying matters on two axes:
   resumed session can span a harness upgrade, so the version is learned
   from the file rather than assumed.
 - **Per prompt-text** — a `remove` is paired to a `queued_command` by
-  *content*, not arrival order. The 1:1 pairing is **not** airtight in
-  real archives (observed: a 2.1.160 file with 34 removes / 29
-  `queued_command`s). Content-keying makes suppression **lossless and
-  order-independent**: exactly the removes with a matching card are hidden,
-  and any orphan `remove` (no matching card, or one arriving before its
-  paired sibling) still renders as legacy steering rather than being
-  dropped. Rendering an orphan under a version that *did* have cards logs a
-  one-shot WARNING (content preserved, invariant-break made visible). Old
-  transcripts (no `queued_command`, empty budget) render `remove` exactly
-  as before.
+  *content*, not arrival order. Content-keying makes suppression
+  **lossless and order-independent**: exactly the removes with a matching
+  card are hidden, and any orphan `remove` (no matching card, or one
+  arriving before its paired sibling) still renders as legacy steering
+  rather than being dropped. Rendering an orphan under a version that
+  *did* have cards logs a one-shot WARNING.
 
-**Null-content era (≥~2.1.187).** In recent harnesses the paired `remove`
-op carries `content: null` — the steering text lives **only** in the
-`queued_command` attachment. Rendering steering from the attachment is
-therefore not just a de-duplication nicety but the *only* path that
+  That warning states only what the renderer observed — an orphan
+  `remove` with no *counted* card. It deliberately does **not** claim the
+  archive's pairing is broken: an uncounted card is at least as likely to
+  be our own doing. In #294 the pairing was intact (232 removes / 232
+  `queued_command`s in the reported session) and the pre-pass was simply
+  not counting image-bearing cards. A card that renders but cannot be
+  paired warns for itself, naming the shape — see *Prompt shapes* below.
+
+**Null-content era (≤2.1.202).** Older harnesses wrote the paired
+`remove` op with `content: null` — the steering text lived **only** in
+the `queued_command` attachment. Rendering steering from the attachment
+is therefore not just a de-duplication nicety but the *only* path that
 surfaces steering text at all on such transcripts (a null `remove`
 renders nothing, and pre-#284 the attachment was ghosted, so the text was
 silently lost). Null-content removes are dropped by the empty-content
 skip in `_filter_messages` *before* the suppression loop, so they neither
 consume budget nor trip the imbalance warning.
+
+Measured over one machine's full local corpus on 2026-07-28 (5606 files,
+4658 removes): every version **≤ 2.1.202** wrote null content (3836
+removes) and every version **≥ 2.1.205** wrote text (822 removes), with
+no version producing both.
+
+Two limits on that, because this is still a sample:
+
+- **The changeover is located to an interval, not a point.** It lies in
+  **(2.1.202, 2.1.205]**, and the versions in between cannot narrow it
+  here: 2.1.203 does not appear in this corpus at all, and 2.1.204
+  appears (268 entries) but produced *no* `remove` ops. "Sharp" describes
+  the observed versions, not a verified single release.
+- **The floor is a sampling floor.** 2.0.55 is the oldest version present
+  and 2.0.73 the oldest carrying a `remove` — oldest *available*, not
+  oldest *existing*. Nothing here shows what pre-2.0 harnesses wrote.
+
+Within those limits: on current harnesses the `remove` does carry its
+text and the content-keyed pairing is meaningful, and null-content is the
+legacy shape rather than the modern one. (An earlier revision of this
+page put the null-content era at "≥~2.1.187" — backwards, from a sample
+that happened to start there. Stating the bound as a dated interval is
+the guard against this correction hardening the same way.)
+
+**Prompt shapes.** `attachment.prompt` is normally a plain string, but a
+steering delivery carrying an image is written as a **list of content
+blocks** (`[{"type": "text", …}, {"type": "image", …}]`). Both shapes are
+normalized by `attachment_factory.queued_command_prompt_items`, which is
+shared with the renderer's pre-pass so the budget is seeded from exactly
+the cards the factory emits. Accepting only `str` (the pre-#294
+behaviour) dropped the card *and* its image outright while the paired
+`remove` rendered the text alone — and then the orphan warning blamed the
+archive for it.
+
+The helper returns a `pairable` flag alongside the items. `pairable` is
+exactly "has non-empty text", because text is the only thing the budget
+can key on; an image-only delivery renders but cannot be paired, so its
+`remove` stays visible rather than being suppressed by a card that cannot
+be shown to match it. Any *other* shape (neither `str` nor list) is
+rendered from its `str()` rather than dropped — silently discarding a
+steering delivery is indistinguishable from there having been none — and
+logs a WARNING naming the shape it saw (`dict`, `list[image,text]`, …) so
+the next novel shape is diagnosable from the log line alone.
 
 **Transformer pass.** The `queued_command` prompt is routed through the
 same `create_user_message` classification + plugin-transformer pass as an
@@ -323,6 +370,16 @@ untransformed `UserTextMessage` is (re)wrapped as `UserSteeringMessage`
 legacy steering conversion in `renderer.py`, prevents a transformer's
 `UserTextMessage` *subclass* (which may carry its text in own fields with
 `items=[]`) from being rebuilt into an empty-items steering card.
+
+The list shape goes through the same seam — the normalized content items
+are handed to `create_user_message`, never assembled into a card
+directly — so a transformer sees an image-bearing prompt exactly as it
+sees a string one. The budget key is taken from the *raw* extracted text,
+before any transformer runs, and the legacy `remove` carries that same
+raw text, so a pair still matches even when what renders is a demoted
+marker rather than a steering card. (A transformer that demotes such a
+prompt drops the image with the rest of the original content; that is the
+plugin's rendering decision, the same as for the string path.)
 
 ### User Memory
 
@@ -812,9 +869,10 @@ The `leafUuid` links the summary to the last message of the session.
 - **Rendered**: Only `remove` operations (as `UserSteeringMessage`). On
   modern transcripts (≳2.1.101) a `remove` is suppressed when a paired
   `queued_command` attachment covers its steering text (rendered instead);
-  a `remove` with no matching card — legacy transcripts, or an orphan when
-  the 1:1 pairing breaks — still renders. See "User Steering (Queue Remove
-  / queued_command)" above.
+  a `remove` with no matching card — legacy transcripts, an unpaired
+  `remove`, or one whose card could not be paired (e.g. an image-only
+  prompt) — still renders. See "User Steering (Queue Remove /
+  queued_command)" above.
 - **CSS Class**: `user steering`
 - **Files**: [queue_operation.json](messages/claude-code/system/queue_operation.json)
 

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -351,15 +351,20 @@ behaviour) dropped the card *and* its image outright while the paired
 `remove` rendered the text alone — and then the orphan warning blamed the
 archive for it.
 
-The helper returns a `pairable` flag alongside the items. `pairable` is
-exactly "has non-empty text", because text is the only thing the budget
-can key on; an image-only delivery renders but cannot be paired, so its
-`remove` stays visible rather than being suppressed by a card that cannot
-be shown to match it. Any *other* shape (neither `str` nor list) is
-rendered from its `str()` rather than dropped — silently discarding a
-steering delivery is indistinguishable from there having been none — and
-logs a WARNING naming the shape it saw (`dict`, `list[image,text]`, …) so
-the next novel shape is diagnosable from the log line alone.
+The helper returns a `pairable` flag alongside the items. A prompt is pairable
+when it is a supported shape — `str` or a list of blocks — **and** yields
+non-empty text, because text is the only thing the budget can key on. Both
+conditions bite: an image-only list renders but cannot be paired, and a
+text-bearing `dict` is not pairable either, however much text it carries. An
+unpairable delivery still renders; its `remove` stays visible rather than
+being suppressed by a card that cannot be shown to match it.
+
+Any *other* shape (neither `str` nor list) is rendered from its `str()` rather
+than dropped — silently discarding a steering delivery is indistinguishable
+from there having been none. Every unpairable card logs a WARNING naming the
+shape it saw, so the next novel shape is diagnosable from the log line alone.
+Note which shapes that covers: `dict` warns, and so does an image-only
+`list[image]`; `list[image,text]` is pairable and warns about nothing.
 
 **Transformer pass.** The `queued_command` prompt is routed through the
 same `create_user_message` classification + plugin-transformer pass as an

--- a/test/test_steering_ordering_composition.py
+++ b/test/test_steering_ordering_composition.py
@@ -165,9 +165,12 @@ def test_image_steering_suppression_composes_with_chronological_splice(tmp_path)
     the paired remove is suppressed, not duplicated — proving #294's count and
     #303's ordering compose on the shared seam."""
     d = _write(tmp_path, _entries())
+    # encoding is explicit because the rendered page is UTF-8 and Windows
+    # would otherwise decode it with the locale codec (cp1252), which fails on
+    # the first non-Latin-1 byte. Matches test_session_id_ordering.py.
     html = Path(
         convert_jsonl_to_html(d, tmp_path / "out", use_cache=False, silent=True)
-    ).read_text()
+    ).read_text(encoding="utf-8")
 
     # The image-bearing card renders (the #294 fix), and its paired remove is
     # suppressed — exactly one steering card, not a duplicate legacy one.

--- a/test/test_steering_ordering_composition.py
+++ b/test/test_steering_ordering_composition.py
@@ -20,6 +20,13 @@ the ``remove``'s inferred version at all; that is what lands the orphan under
 ``_VB``. But the imbalance warning is gated on ``version_key in qc_versions``
 — it fires only for a version that actually had a counted card — and ``_VB``
 has none. So the minimal discriminating fixture *cannot* produce a warning.
+
+That gate is deliberate rather than incidental, which is the other half of why
+padding the fixture would be the wrong fix: an orphaned ``remove`` under a
+version with no counted cards at all is far more likely to be an archive
+artifact than a miscount of ours, so warning there would be noise. The warning
+is scoped to the case where we have positive evidence the pass should have
+paired something.
 The suppression count is the cleaner signal anyway: it is the behaviour, where
 the warning is only our report of it. The "warnings 2 -> 0" shape needs an
 orphan landing under a version that also carries text cards, which the real

--- a/test/test_steering_ordering_composition.py
+++ b/test/test_steering_ordering_composition.py
@@ -1,0 +1,171 @@
+"""Composition pin: #294 (count image-bearing steering cards) must hold on top
+of #303 (place UUID-less queue-ops in chronological order).
+
+Both changes touch the same order-sensitive seam. #294 seeds a suppression
+budget from ``queued_command`` cards keyed by ``(session, version, text)``;
+#303 decides where a UUID-less ``remove`` lands, which decides the *version*
+the suppression pass infers for it (``last_version_by_session``, built in
+render order). If the two did not compose, the ``remove`` for an image-bearing
+steering delivery would be attributed to the wrong harness version and render
+as a duplicate legacy card instead of being suppressed.
+
+Fixtures synthetic; no private data. See test_session_id_ordering.py (dir-mode
+loading) and test_steering_queued_command.py (steering suppression).
+
+**Why this asserts on the suppression count and not on the imbalance
+warning.** It looks like an oversight and it is not, so do not "fix" it by
+adding entries until a warning fires — that makes the fixture non-minimal for
+no gain. Version-spanning is *required* for the chronological splice to change
+the ``remove``'s inferred version at all; that is what lands the orphan under
+``_VB``. But the imbalance warning is gated on ``version_key in qc_versions``
+— it fires only for a version that actually had a counted card — and ``_VB``
+has none. So the minimal discriminating fixture *cannot* produce a warning.
+The suppression count is the cleaner signal anyway: it is the behaviour, where
+the warning is only our report of it. The "warnings 2 -> 0" shape needs an
+orphan landing under a version that also carries text cards, which the real
+archive has and a minimal synthetic would have to manufacture.
+"""
+
+import json
+from pathlib import Path
+
+from claude_code_log.converter import convert_jsonl_to_html
+
+_SID = "sess-compose-1"
+# Both in the text-content ``remove`` era (>= 2.1.205 — see the era boundary in
+# dev-docs/messages.md). That matters: this fixture's ``remove`` carries text,
+# and a null-content one is filtered out before the suppression pass ever sees
+# it, so a version from the legacy era would make the fixture unrepresentable
+# rather than merely unusual.
+_VA = "2.1.205"  # harness version when the steering was issued
+_VB = "2.1.210"  # session resumed after an upgrade
+_T = "please rerun the failing test"  # neutral steering text
+_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _ts(sec: int) -> str:
+    return f"2026-07-11T07:00:0{sec}.000Z"
+
+
+def _user(uuid, parent, text, version, sec):
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": _SID,
+        "version": version,
+        "timestamp": _ts(sec),
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant(uuid, parent, text, version, sec):
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": _SID,
+        "version": version,
+        "timestamp": _ts(sec),
+        "message": {
+            "id": "m" + uuid,
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4",
+            "content": [{"type": "text", "text": text}],
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }
+
+
+def _image_qc(uuid, parent, text, version, sec):
+    """In-DAG queued_command whose prompt is a *list* (image-bearing)."""
+    return {
+        "type": "attachment",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/tmp",
+        "sessionId": _SID,
+        "version": version,
+        "timestamp": _ts(sec),
+        "attachment": {
+            "type": "queued_command",
+            "commandMode": "prompt",
+            "origin": {"kind": "human"},
+            "timestamp": _ts(sec),
+            "prompt": [
+                {"type": "text", "text": text},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": _PNG,
+                    },
+                },
+            ],
+        },
+    }
+
+
+def _remove(text, sec):
+    """UUID-less legacy queue-op — the entry #303 splices chronologically."""
+    return {
+        "type": "queue-operation",
+        "operation": "remove",
+        "timestamp": _ts(sec),
+        "content": text,
+        "sessionId": _SID,
+    }
+
+
+def _write(tmp_path: Path, entries) -> Path:
+    d = tmp_path / "-proj-compose"
+    d.mkdir()
+    (d / f"{_SID}.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8"
+    )
+    return d
+
+
+def _entries():
+    # vA block, then the paired remove chronologically (ts=4) BETWEEN the vA
+    # block and the vB block. #303 splices the remove to ts=4 (under vA, whose
+    # card seeds the budget); appended-at-end it would land under vB and orphan.
+    return [
+        _user("u1", None, "start", _VA, 1),
+        _image_qc("qc1", "u1", _T, _VA, 2),
+        _assistant("a1", "qc1", "ok", _VA, 3),
+        _remove(_T, 4),
+        _user("u2", "a1", "resumed after upgrade", _VB, 5),
+        _assistant("a2", "u2", "ok2", _VB, 6),
+    ]
+
+
+def test_image_steering_suppression_composes_with_chronological_splice(tmp_path):
+    """With both fixes, the image-bearing steering renders once (its card) and
+    the paired remove is suppressed, not duplicated — proving #294's count and
+    #303's ordering compose on the shared seam."""
+    d = _write(tmp_path, _entries())
+    html = Path(
+        convert_jsonl_to_html(d, tmp_path / "out", use_cache=False, silent=True)
+    ).read_text()
+
+    # The image-bearing card renders (the #294 fix), and its paired remove is
+    # suppressed — exactly one steering card, not a duplicate legacy one.
+    assert f"base64,{_PNG}" in html, "image-bearing steering card did not render"
+    assert html.count("User (steering)") == 1, (
+        "expected the remove suppressed (1 steering card); a count of 2 means "
+        "the remove was orphaned — the two fixes did not compose"
+    )

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -304,22 +304,35 @@ class TestMixedVersion:
 
     @staticmethod
     def _imbalance_warnings(caplog):
+        """Orphan-remove warnings emitted by the suppression pass.
+
+        Matches on ``has no counted queued_command card`` — the clause
+        that states what the renderer observed. The message deliberately
+        no longer claims the archive's remove↔queued_command pairing is
+        "violated": in #294 it was intact and the pre-pass was at fault.
+        """
         import logging
 
         return [
             rec
             for rec in caplog.records
-            if "steering suppression imbalance" in rec.message
+            if "has no counted queued_command card" in rec.message
             and rec.levelno == logging.WARNING
         ]
 
     def test_orphan_removes_render_losslessly(self, caplog):
-        """The remove↔queued_command 1:1 pairing is not airtight in real
-        archives (observed: a 2.1.160 file with 34 removes / 29 qc). When a
-        (session, version) has MORE removes than renderable queued_command
-        cards, suppression must be lossless: hide exactly the removes with a
-        matching card (no duplicate), and RENDER the orphan removes rather
-        than drop their steering text. The broken invariant is logged once."""
+        """When a (session, version) has MORE removes than countable
+        queued_command cards, suppression must be lossless: hide exactly
+        the removes with a matching card (no duplicate), and RENDER the
+        orphan removes rather than drop their steering text. The orphan is
+        logged once per (session, version).
+
+        Whether a real archive's remove↔queued_command pairing can break
+        on its own is unsettled — the "2.1.160 file with 34 removes / 29
+        qc" once cited here counted null-content removes that never reach
+        the suppression pass (see the note in renderer.py). Losslessness
+        is required regardless: an uncounted card produces the same shape,
+        and that is what #294 turned out to be."""
         import logging
 
         with caplog.at_level(logging.WARNING, logger="claude_code_log.renderer"):
@@ -382,3 +395,221 @@ class TestMixedVersion:
         # The paired text renders exactly once (via the qc), NOT duplicated.
         assert html.count("paired-STEER") == 2
         assert len(self._imbalance_warnings(caplog)) == 1
+
+
+# --------------------------------------------------------------------------
+# (d) Non-string prompt shapes (#294)
+# --------------------------------------------------------------------------
+# A steering delivery that carries an image is written with ``prompt`` as a
+# LIST of content blocks rather than a string. Both the suppression pre-pass
+# and the attachment factory used to accept only ``str``, so such a card was
+# dropped (losing the image outright) while its paired legacy ``remove``
+# rendered the text alone — and the renderer then blamed the archive for a
+# broken 1:1 pairing that was in fact intact.
+
+# Smallest valid PNG (1x1, transparent) — synthetic, no real capture.
+_PNG_1X1 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAE"
+    "hQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _image_block(data=_PNG_1X1, media_type="image/png"):
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": media_type, "data": data},
+    }
+
+
+class TestNonStringPromptShapes:
+    @staticmethod
+    def _shape_warnings(caplog):
+        import logging
+
+        return [
+            rec
+            for rec in caplog.records
+            if "is not pairable" in rec.message and rec.levelno == logging.WARNING
+        ]
+
+    def test_image_prompt_renders_image_and_suppresses_remove(self, caplog):
+        """A text+image ``prompt`` list pairs with its legacy ``remove``
+        exactly like a string prompt: ONE steering card, carrying the
+        image, and no orphan-remove warning.
+
+        This is the #294 defect. Mutation-check: restore the old guard in
+        ``attachment_factory.queued_command_prompt_items`` (return ``None``
+        unless ``isinstance(prompt, str)``) and this test goes RED three
+        ways — the ``<img`` disappears, the card count stays 1 but comes
+        from the *remove* instead of the attachment (``qc1 &rarr; u2``
+        vanishes), and an orphan warning fires.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            html = _render(
+                [
+                    _user("u1", None, "start"),
+                    _assistant("a1", "u1", "working"),
+                    _remove("look at this screenshot"),
+                    _user("u2", "a1", "next real prompt"),
+                    _queued_command(
+                        "qc1",
+                        "u2",
+                        [
+                            {"type": "text", "text": "look at this screenshot"},
+                            _image_block(),
+                        ],
+                    ),
+                    _assistant("a2", "qc1", "ok"),
+                ]
+            )
+
+        # Exactly one steering card — the remove was suppressed, so the
+        # text is not duplicated.
+        assert html.count("User (steering)") == 1
+        assert html.count("look at this screenshot") == 2  # card + timeline
+        # It is the ATTACHMENT's card (DAG-anchored), not the uuid-less remove.
+        assert "qc1 &rarr; u2" in html
+        # The image survives to the page — the content the old guard dropped.
+        assert f'<img src="data:image/png;base64,{_PNG_1X1}"' in html
+        # The pairing is intact, so nothing is reported.
+        assert self._shape_warnings(caplog) == []
+        assert TestMixedVersion._imbalance_warnings(caplog) == []
+
+    def test_image_only_prompt_is_not_pairable_and_keeps_remove_visible(self, caplog):
+        """An image with no text renders, but cannot seed the budget: the
+        budget keys on text, and there is none. Failing closed means the
+        paired ``remove`` (which does carry text) stays visible rather
+        than being suppressed by a card that cannot be shown to match it.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            html = _render(
+                [
+                    _user("u1", None, "start"),
+                    _assistant("a1", "u1", "working"),
+                    _remove("do not lose this text"),
+                    _user("u2", "a1", "next real prompt"),
+                    _queued_command("qc1", "u2", [_image_block()]),
+                    _assistant("a2", "qc1", "ok"),
+                ]
+            )
+
+        # Both survive: the image card AND the text-bearing remove.
+        assert f'<img src="data:image/png;base64,{_PNG_1X1}"' in html
+        assert "do not lose this text" in html
+        assert html.count("User (steering)") == 2
+        # Said out loud, naming the shape.
+        warnings = self._shape_warnings(caplog)
+        assert len(warnings) == 1
+        assert "list[image]" in warnings[0].message
+
+    def test_unknown_prompt_shape_renders_and_names_the_shape(self, caplog):
+        """A shape we do not understand must fail closed *visibly*: render
+        the payload rather than drop it, name the shape in the log, and
+        leave the paired ``remove`` alone.
+
+        Silently dropping is the failure mode this guards against — it is
+        indistinguishable from there having been no steering delivery.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            html = _render(
+                [
+                    _user("u1", None, "start"),
+                    _assistant("a1", "u1", "working"),
+                    _remove("legacy carrier text"),
+                    _user("u2", "a1", "next real prompt"),
+                    # A dict: not a shape Claude Code writes today.
+                    _queued_command("qc1", "u2", {"unexpected": "payload-42"}),
+                    _assistant("a2", "qc1", "ok"),
+                ]
+            )
+
+        # Nothing vanished: the odd payload is on the page, and so is the
+        # remove's text.
+        assert "payload-42" in html
+        assert "legacy carrier text" in html
+        # Diagnosable from the log line alone — the shape is named.
+        warnings = self._shape_warnings(caplog)
+        assert len(warnings) == 1
+        assert "dict" in warnings[0].message
+
+    def test_promptless_attachment_stays_silent(self, caplog):
+        """A ``queued_command`` with no ``prompt`` key at all renders
+        nothing and warns nothing — there is no content to lose, so it is
+        not a shape problem. Pins the boundary of the new warning so it
+        cannot start firing on the ordinary promptless attachment.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            html = _render(
+                [
+                    _user("u1", None, "start"),
+                    _assistant("a1", "u1", "working"),
+                    _remove("carried by the remove"),
+                    _user("u2", "a1", "next real prompt"),
+                    _queued_command("qc1", "u2", None),
+                    _assistant("a2", "qc1", "ok"),
+                ]
+            )
+
+        assert "carried by the remove" in html
+        assert self._shape_warnings(caplog) == []
+
+    @reference_plugin_required
+    def test_transformed_list_prompt_matches_the_string_path(self, caplog):
+        """A list prompt whose text a transformer rewrites must behave
+        exactly like the same text as a plain string.
+
+        This is the discriminating case for drift between the budget key
+        and the rendered card: the key is built from the RAW extracted
+        text, before any transformer runs, and the legacy ``remove``
+        carries that same raw text — so the pair still matches even though
+        what renders is the demoted ``[testhook]`` marker rather than a
+        steering card. Asserting the two paths produce the SAME counts
+        pins that, where a fixed expected number would only pin today's
+        template.
+
+        If the list path ever hand-built its items past
+        ``create_user_message``, the marker would become a steering card
+        here and the two paths would diverge.
+
+        Note: the demotion drops the image along with the rest of the
+        original content — the transformer returns its own rendering, and
+        the string path has always been returned unchanged in the same
+        way. That is the plugin's call, not the steering path's.
+        """
+        import logging
+
+        prompt_text = "[testhook] monk blocked — permission prompt"
+        marker = "monk blocked — permission prompt"
+
+        def build(prompt):
+            return [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _remove(prompt_text),
+                _user("u2", "a1", "next real prompt"),
+                _queued_command("qc1", "u2", prompt),
+                _assistant("a2", "qc1", "ok"),
+            ]
+
+        with caplog.at_level(logging.WARNING):
+            as_string = _render(build(prompt_text))
+            as_list = _render(
+                build([{"type": "text", "text": prompt_text}, _image_block()])
+            )
+
+        # Demoted to the marker, not promoted to a steering card — and the
+        # remove paired away, so the marker is not rendered twice.
+        assert marker in as_list
+        assert as_list.count("User (steering)") == 0
+        # The list path is indistinguishable from the string path.
+        assert as_list.count(marker) == as_string.count(marker)
+        assert as_list.count("User (steering)") == as_string.count("User (steering)")
+        assert TestMixedVersion._imbalance_warnings(caplog) == []

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -190,10 +190,10 @@ class TestModernQueuedCommand:
             [
                 _user("u1", None, "start"),
                 _assistant("a1", "u1", "working"),
-                _remove("[testhook] monk blocked — permission prompt"),
+                _remove("[testhook] deploy blocked — approval required"),
                 _user("u2", "a1", "next real prompt"),
                 _queued_command(
-                    "qc1", "u2", "[testhook] monk blocked — permission prompt"
+                    "qc1", "u2", "[testhook] deploy blocked — approval required"
                 ),
                 _assistant("a2", "qc1", "ok"),
             ]
@@ -201,7 +201,7 @@ class TestModernQueuedCommand:
 
         # Demoted → rendered as the marker, present exactly once, and NOT
         # promoted to a (would-be empty) steering card.
-        assert "monk blocked — permission prompt" in html
+        assert "deploy blocked — approval required" in html
         assert html.count("User (steering)") == 0
 
     def test_promptless_queued_command_does_not_suppress_remove(self):
@@ -586,8 +586,8 @@ class TestNonStringPromptShapes:
         """
         import logging
 
-        prompt_text = "[testhook] monk blocked — permission prompt"
-        marker = "monk blocked — permission prompt"
+        prompt_text = "[testhook] deploy blocked — approval required"
+        marker = "deploy blocked — approval required"
 
         def build(prompt):
             return [


### PR DESCRIPTION
A steering message that carries an image is written with the `queued_command`
attachment's `prompt` as a **list of content blocks** rather than a string.
Both the suppression pre-pass and the attachment factory accepted only `str`,
so those deliveries were dropped outright — the screenshot never reached the
page — while the paired legacy `remove` rendered its text alone and tripped
the "suppression imbalance" warning.

That warning is what made this hard to see: it asserted the archive's
`remove` ↔ `queued_command` 1:1 pairing was violated. In the reported session
the pairing was exactly 1:1 — 232 removes, 232 attachments, matching per
version by text. The pre-pass simply was not counting 5 image-bearing cards,
which orphaned the 4 that had a text-bearing partner.

## The fix

**One predicate, shared.** `queued_command_prompt_items` normalizes both
shapes and is used by *both* the factory and the pre-pass, so the suppression
budget is seeded from exactly the cards that get emitted. The two cannot drift
apart again, which is the actual defect — the string-only assumption existed
in two places and only one of them mattered for the warning.

A string yields the same single `TextContent` the previous code built by hand,
so text-only steering renders byte-identically. Content items still flow
through `create_user_message`, keeping the classification and
plugin-transformer seam the string path already had; the budget key is still
the raw extracted text.

**Fail closed, visibly.** Any other prompt shape renders via `str()` rather
than vanishing, and every unpairable card warns naming the shape actually seen
— `dict`, or an image-only `list[image]` — so the next novel shape is
diagnosable from the log line alone.

**`pairable` requires both a supported shape and non-empty text.** Text
because it is all the budget can key on; shape because a `str()`-rendered
fallback is not something we can claim to have matched. Both bite
independently: an image-only list renders but leaves its `remove` visible, and
a text-bearing `dict` is unpairable however much text it carries.

**The warning now states only what the renderer observed** — a `remove` with
no *counted* card — instead of asserting a data violation it has no way to
see.

## Measured on a real session, before and after

Rendering one real archive session on both revisions:

| | imbalance warnings | inlined images | steering cards |
|---|---|---|---|
| before | 2 | 46 | 230 |
| after | 0 | 52 | 231 |

**Read the deltas, not the absolutes** — warnings 2 → 0, six images recovered,
one steering card gained. The session is live and has grown since the defect
was first diagnosed, so the absolute counts differ from run to run; the deltas
reproduced unchanged across nine days of growth. Anyone re-running this should
expect different totals and the same differences.

The six recovered images are the point: each is a screenshot that was attached
to a steering message and silently discarded.

## Composition with chronological queue-op placement

Steering suppression keys its budget on `(session, version, text)`, and the
version a UUID-less `remove` is attributed to depends on where it is placed in
render order — which a separate recent change also touches. Neither change's
own tests can pin the interaction, because each passes with the other reverted.

`test_steering_ordering_composition.py` pins it: a fixture spanning two harness
versions, where the paired `remove` falls chronologically between them.
Mutation-verified — reverting either change reddens it.

## Zero snapshot churn, structurally

No fixture carries a list-shaped prompt, so no existing snapshot can reach the
new path. The suite confirms it, but the argument does not rest on that.

## Two documentation corrections

`dev-docs/messages.md` carried two claims measurement did not support.

**The null-content `remove` era is the legacy one, not the recent one.** The
doc said "since ~2.1.187"; it is inverted. Over one machine's corpus every
version up to 2.1.202 wrote `content: null` (3836 removes) and every version
from 2.1.205 wrote text (822), with no version producing both. The boundary is
recorded as the **interval** `(2.1.202, 2.1.205]` rather than a point, because
2.1.203 is absent from that corpus and 2.1.204 produced no removes — neither
can narrow it. The floor is a sampling floor too: 2.0.55 is the oldest version
present, 2.0.73 the oldest carrying a `remove`.

**The long-cited counterexample does not measure the pairing.** A file at
2.1.160 with "34 removes / 29 queued_commands" was taken as proof the pairing
breaks. That is a raw record count: at 2.1.160 every `remove` is
null-content, and `_filter_messages` drops those *before* the suppression
pass, so they can neither pair nor orphan. Whether the pairing can break on
its own is now left explicitly open rather than answered in either direction.

## Tests

Each new test is mutation-checked — reinstating the `str`-only guard, dropping
unknown shapes silently, forcing `pairable` true, silencing the shape warning,
warning on promptless attachments, and bypassing `create_user_message` each
turn the corresponding test red, and only that test.

Fixtures are synthetic, including a 1×1 PNG so the image path carries real
renderable data rather than a placeholder.

Corpus figures measured 2026-07-28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved queued-command prompt normalization (string or content-block lists) with consistent render output and pairable/non-pairable behavior.
  * Enhanced queue-operation steering suppression: pairable queued commands suppress duplicate legacy removes; image-only or unsupported shapes remain visible.
* **Bug Fixes**
  * Refined suppression accounting and one-shot warning behavior when a remove has no counted pairing.
* **Documentation**
  * Updated steering suppression rules, prompt-shape guidance, and transformer pass semantics for pairing.
* **Tests**
  * Added ordering/composition coverage across harness versions and expanded non-string prompt-shape scenarios plus marker/demotion assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->