### PR TITLE
Resolve [Image #N] placeholders from the recorded paste ids

### DIFF
--- a/claude_code_log/factories/attachment_factory.py
+++ b/claude_code_log/factories/attachment_factory.py
@@ -217,7 +217,20 @@ def _create_queued_command_message(
 
     meta = create_meta(transcript)
     result = create_user_message(
-        meta, prompt.items, extract_text_content(prompt.items), is_slash_command=False
+        meta,
+        prompt.items,
+        extract_text_content(prompt.items),
+        is_slash_command=False,
+        # A steering delivery carrying images records its own paste ids, in
+        # the attachment payload rather than at entry top level — the
+        # ``queued_command`` is the carrier here, not the user entry. Nothing
+        # declares the field on the model because ``attachment`` is already a
+        # ``dict[str, Any]`` passthrough, so forgetting *this argument* is the
+        # only way the ids get lost. Without them the ``[Image #N]``
+        # placeholders fall back to the positional reading, which is wrong
+        # wherever the paste counter is not 1..k (see
+        # ``user_factory._image_reference_mapping``).
+        image_paste_ids=payload.get("imagePasteIds"),
     )
     # Defensive only: create_user_message never returns None for a non-empty
     # chunk (it returns None solely on an empty content_list / the empty

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -716,9 +716,16 @@ def _image_reference_mapping(
     """
     if paste_ids is None:
         # Old transcripts recorded no association, so the positional reading
-        # is the only one available. It is trustworthy exactly when the
-        # numbering is 1..k with no gaps and no more numbers than blocks —
-        # the shape a paste counter that has reset or skipped cannot produce.
+        # is the only one available. Use it only for 1..k with no gaps and no
+        # more numbers than blocks — not because a paste counter cannot
+        # produce that shape (one that has just reset produces exactly it),
+        # but because on that shape the two readings COINCIDE and we do not
+        # have to know which regime we are in: paste ids are distinct, >= 1
+        # and recorded in ascending block order, so a list containing 1..k
+        # must carry them in its first k slots, making index(N) == N-1. The
+        # ascending premise is measured, not guaranteed — see
+        # dev-docs/messages.md. A gap or a number above the block count
+        # breaks the coincidence, and those fail closed.
         if not numbers:
             return {}, []
         if numbers == list(range(1, len(numbers) + 1)) and len(numbers) <= len(images):

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -19,6 +19,7 @@ Also provides:
 """
 
 import json
+import logging
 import re
 from typing import Any, Optional, Union, cast
 
@@ -49,6 +50,8 @@ from .task_notification_factory import (
     has_task_notification,
 )
 from .teammate_factory import create_teammate_message, has_teammate_message
+
+logger = logging.getLogger(__name__)
 
 _IMAGE_PLACEHOLDER_RE = re.compile(r"\[Image\s+#(?P<number>[1-9][0-9]*)\]")
 
@@ -478,6 +481,7 @@ def create_user_message(
     content_list: list[ContentItem],
     text_content: str,
     is_slash_command: bool = False,
+    image_paste_ids: Any = None,
 ) -> Optional[UserMessageContent]:
     """Wrapper: build the candidate, then run plugin transformers.
 
@@ -487,9 +491,14 @@ def create_user_message(
     rewriteable by a plugin, not just the generic-text fallback.
     Transformers whose ``applies_to`` doesn't subclass-match the
     candidate's type pass through with no-op cost.
+
+    ``image_paste_ids`` is the carrier's ``imagePasteIds`` field, passed
+    through unvalidated (see :func:`_image_reference_mapping`). It is a
+    parameter rather than a :class:`MessageMeta` field because it describes
+    the content being rendered, not the message.
     """
     candidate = _classify_user_message(
-        meta, content_list, text_content, is_slash_command
+        meta, content_list, text_content, is_slash_command, image_paste_ids
     )
     if candidate is None:
         return None
@@ -502,6 +511,7 @@ def _classify_user_message(
     content_list: list[ContentItem],
     text_content: str,
     is_slash_command: bool = False,
+    image_paste_ids: Any = None,
 ) -> Optional[UserMessageContent]:
     """Create a user message content model from content items.
 
@@ -521,6 +531,7 @@ def _classify_user_message(
         text_content: Pre-extracted text content for pattern detection
         is_slash_command: True for slash command expanded prompts (isMeta=True)
         meta: Message metadata
+        image_paste_ids: The carrier's ``imagePasteIds``, unvalidated
 
     Returns:
         A content model, or None if content_list is empty.
@@ -580,19 +591,20 @@ def _classify_user_message(
     images = [
         image for item in content_list if (image := _as_image_content(item)) is not None
     ]
-    referenced_images = {
-        int(match.group("number"))
-        for item in content_list
-        if hasattr(item, "text")
-        for match in _IMAGE_PLACEHOLDER_RE.finditer(getattr(item, "text"))
-        if int(match.group("number")) <= len(images)
-    }
+    refs = _build_image_refs(images, image_paste_ids, content_list, meta)
 
     # Build items list preserving order, extracting IDE notifications from text
     items: list[
         TextContent | ImageContent | IdeNotificationContent | SystemReminderContent
     ] = []
-    image_number = 0
+    # Where each image block sits in ``items``, so the ones a placeholder
+    # inlined can be removed afterwards. Recording the position rather than
+    # deciding up-front is what keeps the two halves in agreement: a block is
+    # dropped here only because the inliner actually took it, never because a
+    # separate scan predicted it would (a placeholder inside a
+    # ``<system-reminder>`` or an IDE-notification prefix is scanned but never
+    # inlined, and used to cost the block).
+    image_positions: list[tuple[int, int]] = []
 
     for item in content_list:
         # Check for text content
@@ -609,17 +621,137 @@ def _classify_user_message(
             cursor = 0
             for match in SYSTEM_REMINDER_PATTERN.finditer(item_text):
                 _append_user_text_segment(
-                    items, item_text[cursor : match.start()], images
+                    items, item_text[cursor : match.start()], refs
                 )
                 items.append(SystemReminderContent(reminders=[match.group(1).strip()]))
                 cursor = match.end()
-            _append_user_text_segment(items, item_text[cursor:], images)
+            _append_user_text_segment(items, item_text[cursor:], refs)
         elif (image := _as_image_content(item)) is not None:
-            image_number += 1
-            if image_number not in referenced_images:
-                items.append(image)
+            image_positions.append((len(items), len(image_positions)))
+            items.append(image)
+
+    if refs.consumed:
+        inlined = {pos for pos, index in image_positions if index in refs.consumed}
+        items = [item for pos, item in enumerate(items) if pos not in inlined]
 
     return UserTextMessage(items=items, meta=meta)
+
+
+class _ImageRefs:
+    """Resolves ``[Image #N]`` placeholders to image blocks for one message.
+
+    Claude Code records the association explicitly: ``imagePasteIds`` runs
+    parallel to the image content blocks, so ``[Image #N]`` is the block at
+    ``imagePasteIds.index(N)``. N is a paste counter, not a position — it
+    resets when the CLI restarts inside a session that outlives it, and it
+    increments on delete-and-repaste — which is why reading it as a position
+    shows the wrong image without looking wrong.
+
+    Both halves of the rendering share one instance: the inliner takes blocks
+    by number, and the caller appends whichever blocks were not taken. A block
+    therefore cannot be both inlined and appended, nor dropped by one half on
+    a promise the other half never kept.
+    """
+
+    def __init__(self, images: list[ImageContent], mapping: dict[int, int]) -> None:
+        self._images = images
+        self._mapping = mapping
+        self.consumed: set[int] = set()
+
+    def take(self, number: int) -> Optional[ImageContent]:
+        """The block ``[Image #<number>]`` refers to, or None when we cannot
+        show which block that is — the caller then leaves the placeholder as
+        literal text and the block stays detached. A visible gap beats a
+        confident substitution."""
+        index = self._mapping.get(number)
+        if index is None:
+            return None
+        self.consumed.add(index)
+        return self._images[index]
+
+
+def _build_image_refs(
+    images: list[ImageContent],
+    paste_ids: Any,
+    content_list: list[ContentItem],
+    meta: MessageMeta,
+) -> _ImageRefs:
+    """Build the placeholder→block mapping, warning about anything it refuses
+    to map. Every refusal is named separately so a reader can tell an old
+    transcript apart from a malformed one."""
+    if not images:
+        return _ImageRefs(images, {})
+
+    numbers = sorted(
+        {
+            int(match.group("number"))
+            for item in content_list
+            if hasattr(item, "text")
+            for match in _IMAGE_PLACEHOLDER_RE.finditer(getattr(item, "text"))
+        }
+    )
+    mapping, problems = _image_reference_mapping(images, paste_ids, numbers)
+    for problem in problems:
+        logger.warning(
+            "Cannot resolve image reference in message %s of session %s: %s "
+            "- rendering the placeholder literally and leaving the image "
+            "block detached",
+            meta.uuid or "(no uuid)",
+            meta.session_id or "(no session)",
+            problem,
+        )
+    return _ImageRefs(images, mapping)
+
+
+def _image_reference_mapping(
+    images: list[ImageContent],
+    paste_ids: Any,
+    numbers: list[int],
+) -> tuple[dict[int, int], list[str]]:
+    """Map each ``[Image #N]`` number to an index into ``images``.
+
+    Returns the mapping and the reasons for whatever it left out. A number
+    missing from the mapping is one we refuse to resolve, not one that
+    resolves to nothing.
+    """
+    if paste_ids is None:
+        # Old transcripts recorded no association, so the positional reading
+        # is the only one available. It is trustworthy exactly when the
+        # numbering is 1..k with no gaps and no more numbers than blocks —
+        # the shape a paste counter that has reset or skipped cannot produce.
+        if not numbers:
+            return {}, []
+        if numbers == list(range(1, len(numbers) + 1)) and len(numbers) <= len(images):
+            return {number: number - 1 for number in numbers}, []
+        return {}, [
+            f"imagePasteIds is absent and the placeholder numbers {numbers} are "
+            f"not 1..{len(numbers)} over {len(images)} image block(s), so their "
+            f"order carries no information"
+        ]
+
+    if not isinstance(paste_ids, list) or not all(
+        isinstance(entry, int) and not isinstance(entry, bool)
+        for entry in cast(list[Any], paste_ids)
+    ):
+        return {}, [f"imagePasteIds is not a list of integers ({paste_ids!r})"]
+
+    ids = cast(list[int], paste_ids)
+    if len(ids) != len(images):
+        return {}, [
+            f"imagePasteIds has {len(ids)} entries but the message carries "
+            f"{len(images)} image block(s)"
+        ]
+    if len(set(ids)) != len(ids):
+        return {}, [f"imagePasteIds repeats a paste id ({ids})"]
+
+    mapping: dict[int, int] = {}
+    problems: list[str] = []
+    for number in numbers:
+        if number in ids:
+            mapping[number] = ids.index(number)
+        else:
+            problems.append(f"[Image #{number}] is not among the paste ids {ids}")
+    return mapping, problems
 
 
 def _append_user_text_segment(
@@ -627,7 +759,7 @@ def _append_user_text_segment(
         TextContent | ImageContent | IdeNotificationContent | SystemReminderContent
     ],
     text: str,
-    images: list[ImageContent],
+    refs: _ImageRefs,
 ) -> None:
     """Process one plain-text segment (between system reminders) into ``items``:
     peel an IDE notification if present, then append the remaining text with
@@ -641,7 +773,7 @@ def _append_user_text_segment(
     else:
         remaining_text = text
     if remaining_text.strip():
-        _append_text_with_images(items, remaining_text, images)
+        _append_text_with_images(items, remaining_text, refs)
 
 
 def _as_image_content(item: ContentItem) -> Optional[ImageContent]:
@@ -657,17 +789,18 @@ def _append_text_with_images(
         TextContent | ImageContent | IdeNotificationContent | SystemReminderContent
     ],
     text: str,
-    images: list[ImageContent],
+    refs: _ImageRefs,
 ) -> None:
-    """Replace valid numbered image references while preserving surrounding text."""
+    """Replace resolvable numbered image references while preserving surrounding
+    text. An unresolvable reference stays in the text as written."""
     cursor = 0
     for match in _IMAGE_PLACEHOLDER_RE.finditer(text):
-        number = int(match.group("number"))
-        if number > len(images):
+        image = refs.take(int(match.group("number")))
+        if image is None:
             continue
         if match.start() > cursor:
             items.append(TextContent(type="text", text=text[cursor : match.start()]))
-        items.append(images[number - 1])
+        items.append(image)
         cursor = match.end()
     if cursor < len(text):
         items.append(TextContent(type="text", text=text[cursor:]))

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -679,6 +679,25 @@ def _build_image_refs(
     """Build the placeholder→block mapping, warning about anything it refuses
     to map. Every refusal is named separately so a reader can tell an old
     transcript apart from a malformed one."""
+    # A chunk carrying no image blocks. This happens when
+    # ``chunk_message_content`` splits a record between a block and the text
+    # that references it — a tool_result or thinking block lands between them,
+    # so the text segment sees an empty list rather than the record's blocks.
+    #
+    # This early return is a WARNING suppressor, not the thing that prevents a
+    # substitution. Deleting it changes no rendering (measured): the block-count
+    # bounds below — ``len(numbers) <= len(images)`` on the legacy path,
+    # ``len(ids) != len(images)`` on the recorded one — already refuse
+    # everything when there are no blocks. What deleting it costs is a warning
+    # on every split segment, blaming the transcript for our own chunking.
+    #
+    # That redundancy is load-bearing for a different reason: it is why a
+    # partial block list cannot make this resolver substitute where the older
+    # positional code would not have. Both refuse, for the same underlying
+    # reason — you cannot reference a block that is not in the list you were
+    # handed. No mutation of either mechanism can be pinned by a test here,
+    # because each shields the other; that is a property to keep, not a gap
+    # to fill.
     if not images:
         return _ImageRefs(images, {})
 

--- a/claude_code_log/factories/user_factory.py
+++ b/claude_code_log/factories/user_factory.py
@@ -733,6 +733,16 @@ def _image_reference_mapping(
     missing from the mapping is one we refuse to resolve, not one that
     resolves to nothing.
     """
+    # Nothing references a block, so there is nothing to resolve and nothing
+    # to report — whatever shape the ids are in. Raised in review: only the
+    # legacy branch below short-circuited on this, so a message with image
+    # blocks, a malformed or non-parallel ``imagePasteIds`` and no
+    # ``[Image #N]`` anywhere warned about a resolution nobody asked for. The
+    # warnings exist to explain a placeholder that stayed literal; with no
+    # placeholder there is nothing to explain.
+    if not numbers:
+        return {}, []
+
     if paste_ids is None:
         # Old transcripts recorded no association, so the positional reading
         # is the only one available. Use it only for 1..k with no gaps and no
@@ -745,8 +755,6 @@ def _image_reference_mapping(
         # ascending premise is measured, not guaranteed — see
         # dev-docs/messages.md. A gap or a number above the block count
         # breaks the coincidence, and those fail closed.
-        if not numbers:
-            return {}, []
         if numbers == list(range(1, len(numbers) + 1)) and len(numbers) <= len(images):
             return {number: number - 1 for number in numbers}, []
         return {}, [

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -258,6 +258,19 @@ class UserTranscriptEntry(BaseTranscriptEntry):
     message: UserMessageModel
     toolUseResult: Optional[ToolUseResult] = None
     agentId: Optional[str] = None  # From toolUseResult when present
+    # Paste ids for the image blocks in ``message.content``, in block order:
+    # the ``[Image #N]`` placeholder in the text refers to the block at
+    # ``imagePasteIds.index(N)``. N is a paste counter, NOT a position — it
+    # resets when the CLI restarts inside a session that outlives it, and it
+    # increments on delete-and-repaste, so the same N can name different
+    # images within one session and nothing may be keyed at session scope.
+    # Old transcripts do not carry it (see _image_reference_mapping for what
+    # is then left to go on, and dev-docs/messages.md for the sampling).
+    #
+    # Deliberately untyped: a malformed value has to reach the resolver to be
+    # reported, because a ValidationError here would drop the whole entry
+    # (the loader skips any line whose model validation raises).
+    imagePasteIds: Optional[Any] = None
     # Present on isMeta=True entries produced by a Skill tool invocation —
     # carries the id of the originating tool_use so the renderer can fold
     # the skill body into that tool_use block. See issue #93.

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4932,6 +4932,10 @@ def _render_messages(
                         chunk,  # Pass the chunk items
                         chunk_text,  # Pre-extracted text for pattern detection
                         is_slash_command=chunk_meta.is_meta,
+                        # Sibling of ``message``, not inside it — the entry
+                        # carries the [Image #N] ↔ block association that the
+                        # content alone does not.
+                        image_paste_ids=getattr(message, "imagePasteIds", None),
                     )
                 elif effective_type == "assistant":
                     # Pass usage only on first chunk

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -624,6 +624,69 @@ class ImageContent(BaseModel, MessageContent):
     source: ImageSource
 ```
 
+### `[Image #N]` placeholders and `imagePasteIds`
+
+A pasted image leaves an `[Image #N]` placeholder in the surrounding text and
+its bytes in a separate content block. The association between the two is
+recorded on the entry, as a sibling of `message`:
+
+```json
+{
+  "type": "user",
+  "imagePasteIds": [4, 6],
+  "message": {"content": [
+    {"type": "image", "source": {"...": "the block for [Image #4]"}},
+    {"type": "image", "source": {"...": "the block for [Image #6]"}},
+    {"type": "text", "text": "compare [Image #6] with [Image #4]"}
+  ]}
+}
+```
+
+The list runs parallel to the image blocks, so **`[Image #N]` is the block at
+`imagePasteIds.index(N)`**.
+
+**N is a paste counter, not a position.** It resets when the CLI restarts
+inside a session that outlives it, and it increments on delete-and-repaste —
+hence non-contiguous runs like `[4, 6, 8]`, numbers far above the block count,
+and the same N naming different images at different points in one session.
+Nothing may therefore be keyed at session scope: the per-message list is both
+necessary and sufficient.
+
+Reading N as a 1-based index into the blocks — what the renderer did before
+this was modelled — fails three ways, in rising order of how hard it is to
+spot: the placeholder stays literal and the image appends detached (N above
+the block count); a block is dropped; or a *different* image renders where the
+placeholder sat, with nothing in the output to mark it wrong.
+
+Resolution lives in `factories/user_factory.py`
+(`_image_reference_mapping`), and both halves of the rendering share one
+mapping: the inliner takes blocks by number, and whatever it did not take is
+appended in place. A block can therefore never be inlined *and* appended, nor
+dropped by a pass that never rendered it — which is what a placeholder buried
+in a `<system-reminder>` or an IDE-notification prefix used to cause.
+
+When the association cannot be established the placeholder renders literally,
+the block stays detached, and a warning names the condition — an unknown paste
+id, lists that are not parallel, a repeated id, a malformed field. A visible
+gap beats a confident substitution. The model field is deliberately untyped so
+a malformed value reaches that report rather than failing validation and
+costing the whole entry.
+
+Old transcripts carry no `imagePasteIds`, so position is the only evidence
+available there. It is used only when the numbering is `1..k` with no gaps and
+no more numbers than blocks — a shape a counter that has reset or skipped
+cannot produce.
+
+**How old is "old" — measured, with its limits.** In one real archive scanned
+on 2026-07-28 (5,606 transcript files), every image-bearing message that
+contained an `[Image #N]` placeholder carried the field, across versions
+2.1.84–2.1.220; the oldest records lacking it are twenty at 2.0.73–2.0.74,
+none of which contains a placeholder. That does not pin an introduction
+version: both shapes occur *within* 2.0.74, and the archive's sampling floor
+for image-bearing records is 2.0.73. The repo's own `test/test_data` fixtures
+at 1.0.31, 1.0.43 and 1.0.128 do carry placeholders with no field, which is
+what keeps the positional path live rather than historical.
+
 ---
 
 # Part 2: Assistant Messages (AssistantTranscriptEntry)

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -665,6 +665,15 @@ appended in place. A block can therefore never be inlined *and* appended, nor
 dropped by a pass that never rendered it — which is what a placeholder buried
 in a `<system-reminder>` or an IDE-notification prefix used to cause.
 
+An up-front scan of the **raw** item text does survive, but only to decide
+whether an absent-field message's numbering is contiguous, and the asymmetry
+is deliberate: a raw scan can only *widen* the set of numbers, a wider set can
+only make contiguity harder to satisfy, so it can over-fail-close and never
+over-substitute. Using post-split text there would be the unsafe choice — a
+hidden placeholder would be invisible to the contiguity check while still
+being a real reference. Consumption deliberately does **not** use that scan,
+and that asymmetry is the fix.
+
 When the association cannot be established the placeholder renders literally,
 the block stays detached, and a warning names the condition — an unknown paste
 id, lists that are not parallel, a repeated id, a malformed field. A visible

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -694,6 +694,19 @@ other 86, and is correct on all 24. That is evidence from the era that *has*
 the field; the era where the fallback actually applies has no ground truth by
 construction, which is the limit of the argument.
 
+**What this does NOT cover: a chunk-split record.**
+`chunk_message_content` gives `tool_use` / `tool_result` / `thinking` blocks
+their own chunks, so a record whose image block and referencing text are
+separated by one of those yields a text segment that sees **no** image blocks.
+The placeholder then stays literal and the block is appended from its own
+chunk — on this renderer and on every renderer before it, because both refuse
+for the same underlying reason: you cannot reference a block that is not in
+the list you were handed. Two independent mechanisms produce that refusal (an
+early return on the empty list, and the block-count bounds), which is why no
+test pins it — each shields the other from mutation. Zero records in a
+5,606-file archive have image blocks *and* a special block, so this is a
+property to preserve rather than a behaviour anyone relies on.
+
 **How old is "old" — measured, with its limits.** In one real archive scanned
 on 2026-07-28 (5,606 transcript files), every image-bearing message that
 contained an `[Image #N]` placeholder carried the field, across versions

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -674,8 +674,25 @@ costing the whole entry.
 
 Old transcripts carry no `imagePasteIds`, so position is the only evidence
 available there. It is used only when the numbering is `1..k` with no gaps and
-no more numbers than blocks — a shape a counter that has reset or skipped
-cannot produce.
+no more numbers than blocks.
+
+**Why that condition, stated correctly.** Not "a reset counter cannot produce
+`1..k`" — one that has just reset produces exactly that. The condition is
+chosen because on that shape **the two readings coincide**, so the renderer
+does not have to know which regime produced the numbering. Paste ids are
+distinct, `>= 1`, and recorded in ascending block order; a list containing
+`1..k` must therefore hold them in its first `k` slots, which makes
+`ids.index(N)` and `N-1` the same answer. A gap, or a number above the block
+count, breaks the coincidence — and those fail closed.
+
+The ascending premise is **measured, not guaranteed by the format**: 180/180
+distinct messages carrying the field have strictly ascending ids, no
+duplicates, none below 1 (2026-07-28 archive). Scored the other way — pretend
+the field were absent and run the fallback against the recorded ids as ground
+truth — it fires on 24 of the 110 placeholder-bearing messages, refuses the
+other 86, and is correct on all 24. That is evidence from the era that *has*
+the field; the era where the fallback actually applies has no ground truth by
+construction, which is the limit of the argument.
 
 **How old is "old" — measured, with its limits.** In one real archive scanned
 on 2026-07-28 (5,606 transcript files), every image-bearing message that

--- a/test/README.md
+++ b/test/README.md
@@ -60,6 +60,46 @@ These files test:
 - **Edge cases**: Empty files, naming ambiguity, path conversion
 - **CLI operations** with custom projects directory
 
+## Asserting against a full rendered page
+
+`generate_html()` returns a **whole document** — the inlined stylesheets, the
+scripts and the page chrome, all of it ahead of any message content. So a
+substring assertion over that output is **ambiguous by default**, and
+`str.index` / `str.find` return the *earliest* hit, which is very often in the
+CSS.
+
+This is not hypothetical. A test asserting that one image rendered before
+another used the bare words `first` and `second` as its image payloads:
+
+```python
+assert html.index("second") < html.index("first")   # ← cannot fail
+```
+
+`--text-secondary` sits at `claude_code_log/html/templates/components/global_styles.css:87`
+and `.header > span:first-child` at `:180`, both in the `<head>`. The assertion
+compared those two CSS offsets, held for every input, and would have passed
+with the feature it was pinning entirely removed.
+
+**So for any ordering, position or presence claim over a rendered page:**
+
+1. Use tokens that cannot occur in a template, stylesheet, script or prose —
+   not English words, and not anything resembling a CSS identifier.
+2. **Assert the token is unique**, in the test:
+
+   ```python
+   assert html.count("ZZBLOCKALPHAZZ") == 1
+   ```
+
+   Keep this even when the tokens obviously look unique. It is what stops a
+   future stylesheet or template edit silently re-ambiguating the assertion —
+   `first` and `second` were unique-looking too. The one-time check becomes a
+   standing guard so nobody has to remember.
+3. When an assertion is the *only* thing pinning a claim, check that it can
+   fail on its own: neutralise the feature **and** relax the test's other
+   assertions, so that assertion is the only one that could fail — then confirm
+   it does. A green mutation only tells you *some* assertion fired; read which
+   one.
+
 ## Template Tests (`test_template_rendering.py`)
 
 Comprehensive unit tests that verify:

--- a/test/README.md
+++ b/test/README.md
@@ -94,6 +94,14 @@ with the feature it was pinning entirely removed.
    future stylesheet or template edit silently re-ambiguating the assertion —
    `first` and `second` were unique-looking too. The one-time check becomes a
    standing guard so nobody has to remember.
+
+   **Assert the count you actually expect, not always `1`.** Some counts are
+   legitimately higher and the guard is still worth having: **user message text
+   appears twice**, because the renderer emits a markdown view *and* a raw
+   view of the same message, so `count(...) == 2` is correct there and
+   `index()` anchors on the rendered copy. A count guard that asserts the real
+   number still fails when a template change alters it — which is the point.
+   Anchoring on text at all is worth avoiding where an image payload will do.
 3. When an assertion is the *only* thing pinning a claim, check that it can
    fail on its own: neutralise the feature **and** relax the test's other
    assertions, so that assertion is the only one that could fail — then confirm

--- a/test/test_image_paste_ids.py
+++ b/test/test_image_paste_ids.py
@@ -430,8 +430,8 @@ class TestFieldSurvivesParsing:
     ) -> dict[str, object]:
         if content is None:
             content = [
-                self._block(f"first:{_PNG_1X1}"),
-                self._block(f"second:{_PNG_1X1}"),
+                self._block(f"ZZFIRSTZZ{_PNG_1X1}"),
+                self._block(f"ZZSECONDZZ{_PNG_1X1}"),
                 {"type": "text", "text": "look at [Image #2]"},
             ]
         return {
@@ -457,10 +457,26 @@ class TestFieldSurvivesParsing:
 
         assert getattr(messages[0], "imagePasteIds", None) == [2, 3]
 
-        # [Image #2] is the FIRST block, so "first" renders where the text
-        # says it does and "second" appends unreferenced ahead of the text.
+        # Guard the ordering anchors before using them (see test/README.md).
+        # Raised in review — and the counts are not all 1, which is why the
+        # guard is worth asserting rather than eyeballing:
+        #   the payloads are unique, but a bare `second:` also occurs twice in
+        #   the page's date-formatting script (`second: '2-digit'`), which is
+        #   why these use ZZ-delimited tokens;
+        #   the user text occurs TWICE by design — the renderer emits a
+        #   markdown view and a raw view of the same message — so 2 is the
+        #   correct expectation and `index` therefore anchors on the rendered
+        #   copy.
+        assert html.count("ZZFIRSTZZ") == 1
+        assert html.count("ZZSECONDZZ") == 1
+        assert html.count("look at") == 2
+
+        # [Image #2] is the FIRST block, so it renders where the text says it
+        # does, and the second block appends unreferenced ahead of the text.
         assert "[Image #2]" not in html
-        assert html.index("second:") < html.index("look at") < html.index("first:")
+        assert (
+            html.index("ZZSECONDZZ") < html.index("look at") < html.index("ZZFIRSTZZ")
+        )
 
     def test_the_inlined_image_is_renderable(self):
         """The resolved block reaches the page as a usable ``data:`` URL — the

--- a/test/test_image_paste_ids.py
+++ b/test/test_image_paste_ids.py
@@ -274,7 +274,10 @@ class TestLegacyTranscripts:
             )
 
         assert _tags(model) == ["<b>", " then ", "<a>"]
-        assert caplog.text == ""
+        # Scoped to this resolver's own message rather than `caplog.text == ""`:
+        # an unrelated warning from any other logger would otherwise fail this
+        # for a reason that has nothing to do with paste-id resolution.
+        assert "Cannot resolve image reference" not in caplog.text
 
     def test_a_subset_starting_at_one_is_still_positional(self):
         """Two blocks, only the first referenced — the numbering is consistent

--- a/test/test_image_paste_ids.py
+++ b/test/test_image_paste_ids.py
@@ -289,6 +289,23 @@ class TestLegacyTranscripts:
 
         assert _tags(model) == ["<b>", "just ", "<a>"]
 
+    def test_the_two_readings_coincide_wherever_the_fallback_fires(self):
+        """The fallback's justification, pinned.
+
+        It is *not* that a paste counter cannot produce ``1..k`` — one that
+        has just reset produces exactly that. It is that on ``1..k`` the
+        recorded reading and the positional reading give the same answer, so
+        the renderer need not know which regime it is in. That holds because
+        paste ids are distinct, ``>= 1`` and ascending in block order, which
+        forces ``1..k`` into the first ``k`` slots.
+        """
+        for ids in ([1, 2], [1, 2, 3], [1, 2, 9], [1, 2, 3, 40]):
+            blocks = [_image(f"b{i}") for i in range(len(ids))]
+            text = TextContent(type="text", text="[Image #2] then [Image #1]")
+            with_ids = _tags(_render([*blocks, text], paste_ids=ids))
+            without = _tags(_render([*blocks, text]))
+            assert with_ids == without, ids
+
     def test_a_gap_means_the_numbering_is_not_positional(
         self, caplog: pytest.LogCaptureFixture
     ):

--- a/test/test_image_paste_ids.py
+++ b/test/test_image_paste_ids.py
@@ -1,0 +1,444 @@
+"""Tests for ``[Image #N]`` placeholder resolution via ``imagePasteIds``.
+
+Claude Code records the association explicitly: ``imagePasteIds`` runs parallel
+to the image content blocks, so ``[Image #N]`` is the block at
+``imagePasteIds.index(N)``. N is a paste counter — it resets when the CLI
+restarts inside a session that outlives it, and it increments on
+delete-and-repaste — so reading it as a position (block ``N-1``) is wrong in
+ways that do not look wrong.
+
+All fixtures here are synthetic. The image payloads are a 1x1 PNG so the
+rendered output is real image data, distinguishable per block by its alt/data.
+"""
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.factories import create_user_message
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.models import (
+    ContentItem,
+    ImageContent,
+    ImageSource,
+    MessageMeta,
+    SystemReminderContent,
+    TextContent,
+    UserTextMessage,
+)
+from claude_code_log.parser import extract_text_content
+
+# A real 1x1 transparent PNG, base64-encoded.
+_PNG_1X1 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _image(tag: str) -> ImageContent:
+    """An image block tagged so a test can say *which* block was rendered.
+
+    The tag prefixes the payload, which makes it no longer decodable — these
+    fixtures test *which* block lands where, not that it displays.
+    :meth:`TestFieldSurvivesParsing.test_the_inlined_image_is_renderable`
+    covers the payload with an untagged, genuinely valid PNG.
+    """
+    return ImageContent(
+        type="image",
+        source=ImageSource(
+            type="base64", media_type="image/png", data=f"{tag}:{_PNG_1X1}"
+        ),
+    )
+
+
+def _render(
+    content_list: list[ContentItem], paste_ids: object = None
+) -> UserTextMessage:
+    model = create_user_message(
+        MessageMeta.empty(uuid="u-1"),
+        content_list,
+        extract_text_content(content_list),
+        image_paste_ids=paste_ids,
+    )
+    assert isinstance(model, UserTextMessage)
+    return model
+
+
+def _tags(model: UserTextMessage) -> list[str]:
+    """The rendered items as a comparable sequence: text verbatim, image blocks
+    as ``<tag>``."""
+    out: list[str] = []
+    for item in model.items:
+        if isinstance(item, ImageContent):
+            out.append(f"<{item.source.data.split(':', 1)[0]}>")
+        elif isinstance(item, TextContent):
+            out.append(item.text)
+        elif isinstance(item, SystemReminderContent):
+            out.append(f"[reminder]{item.reminders[0]}")
+        else:  # pragma: no cover - no other item type occurs in these fixtures
+            out.append(type(item).__name__)
+    return out
+
+
+class TestPasteIdResolution:
+    """The recorded association decides which block a placeholder names."""
+
+    def test_in_range_but_not_positional_is_the_silent_wrong_image(self):
+        """Two blocks, paste ids ``[2, 3]``: ``[Image #2]`` is the FIRST block.
+
+        The positional reading picks block 2-1 = the second, which is a
+        different image with nothing to mark it as wrong — this is the case
+        the fix exists for, and the only one no reader could catch.
+        """
+        first, second = _image("first"), _image("second")
+        model = _render(
+            [
+                first,
+                second,
+                TextContent(type="text", text="see [Image #2] and [Image #3]"),
+            ],
+            paste_ids=[2, 3],
+        )
+
+        assert _tags(model) == ["see ", "<first>", " and ", "<second>"]
+
+    def test_paste_ids_may_have_gaps(self):
+        """Delete-and-repaste advances the counter, leaving holes: ``[4, 6, 8]``."""
+        blocks = [_image("a"), _image("b"), _image("c")]
+        model = _render(
+            [
+                *blocks,
+                TextContent(
+                    type="text", text="[Image #8] then [Image #4] then [Image #6]"
+                ),
+            ],
+            paste_ids=[4, 6, 8],
+        )
+
+        assert _tags(model) == ["<c>", " then ", "<a>", " then ", "<b>"]
+
+    def test_text_order_need_not_be_ascending(self):
+        """Where the user clicked when pasting has nothing to do with block order."""
+        blocks = [_image("a"), _image("b"), _image("c"), _image("d")]
+        model = _render(
+            [
+                *blocks,
+                TextContent(
+                    type="text", text="[Image #3][Image #1][Image #2][Image #4]"
+                ),
+            ],
+            paste_ids=[1, 2, 3, 4],
+        )
+
+        assert _tags(model) == ["<c>", "<a>", "<b>", "<d>"]
+
+    def test_number_above_the_block_count_still_resolves(self):
+        """A counter that has run ahead of this message: ``[Image #29]``, 1 block.
+
+        The positional rule rejected these as out of range, leaving the
+        placeholder as text and the image detached — 126 of the 168 real
+        placeholders measured on 2026-07-28 took that path.
+        """
+        model = _render(
+            [
+                _image("only"),
+                TextContent(type="text", text="look at [Image #29] please"),
+            ],
+            paste_ids=[29],
+        )
+
+        assert _tags(model) == ["look at ", "<only>", " please"]
+
+    def test_unreferenced_blocks_keep_their_position(self):
+        """A block no placeholder names stays where it sat in the content."""
+        model = _render(
+            [
+                _image("kept"),
+                _image("named"),
+                TextContent(type="text", text="only [Image #7]"),
+            ],
+            paste_ids=[5, 7],
+        )
+
+        assert _tags(model) == ["<kept>", "only ", "<named>"]
+
+    def test_a_block_is_never_both_inlined_and_appended(self):
+        model = _render(
+            [_image("a"), TextContent(type="text", text="x [Image #2] y")],
+            paste_ids=[2],
+        )
+
+        assert _tags(model).count("<a>") == 1
+
+
+class TestFailClosed:
+    """When the association cannot be established, show a gap — never a guess.
+
+    Each condition is separate: they are indistinguishable in the output (a
+    literal placeholder plus a detached block) and only the warning tells a
+    reader whether they are looking at an old transcript or a broken one.
+    """
+
+    def test_paste_id_not_among_the_recorded_ids(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [_image("a"), TextContent(type="text", text="see [Image #9]")],
+                paste_ids=[3],
+            )
+
+        assert _tags(model) == ["<a>", "see [Image #9]"]
+        assert "[Image #9] is not among the paste ids [3]" in caplog.text
+
+    def test_length_mismatch_refuses_every_placeholder(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Parallel lists that are not parallel: nothing in them can be trusted,
+        including the entries that happen to line up."""
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [
+                    _image("a"),
+                    _image("b"),
+                    TextContent(type="text", text="[Image #1] and [Image #2]"),
+                ],
+                paste_ids=[1],
+            )
+
+        assert _tags(model) == ["<a>", "<b>", "[Image #1] and [Image #2]"]
+        assert "has 1 entries but the message carries 2 image block(s)" in caplog.text
+
+    def test_malformed_field_is_reported_not_coerced(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [_image("a"), TextContent(type="text", text="[Image #1]")],
+                paste_ids={"1": 0},
+            )
+
+        assert _tags(model) == ["<a>", "[Image #1]"]
+        assert "is not a list of integers" in caplog.text
+
+    def test_booleans_are_not_paste_ids(self, caplog: pytest.LogCaptureFixture):
+        """``bool`` is an ``int`` in Python; a ``[True]`` field is malformed, and
+        letting it through would map ``[Image #1]`` onto the first block by
+        accident rather than by evidence."""
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [_image("a"), TextContent(type="text", text="[Image #1]")],
+                paste_ids=[True],
+            )
+
+        assert _tags(model) == ["<a>", "[Image #1]"]
+        assert "is not a list of integers" in caplog.text
+
+    def test_repeated_paste_id_is_refused(self, caplog: pytest.LogCaptureFixture):
+        """``index()`` would silently pick the first of two blocks claiming the
+        same id, and the second would look merely unreferenced."""
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [
+                    _image("a"),
+                    _image("b"),
+                    TextContent(type="text", text="[Image #4]"),
+                ],
+                paste_ids=[4, 4],
+            )
+
+        assert _tags(model) == ["<a>", "<b>", "[Image #4]"]
+        assert "repeats a paste id" in caplog.text
+
+
+class TestLegacyTranscripts:
+    """Old transcripts recorded nothing, so position is the only evidence —
+    and it is evidence only when the numbering could have been positional.
+    ``test_data`` still carries 1.0.x sessions of that shape."""
+
+    def test_contiguous_numbering_is_read_positionally(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [
+                    _image("a"),
+                    _image("b"),
+                    TextContent(type="text", text="[Image #2] then [Image #1]"),
+                ]
+            )
+
+        assert _tags(model) == ["<b>", " then ", "<a>"]
+        assert caplog.text == ""
+
+    def test_a_subset_starting_at_one_is_still_positional(self):
+        """Two blocks, only the first referenced — the numbering is consistent
+        with position, and the unreferenced block appends as before."""
+        model = _render(
+            [
+                _image("a"),
+                _image("b"),
+                TextContent(type="text", text="just [Image #1]"),
+            ]
+        )
+
+        assert _tags(model) == ["<b>", "just ", "<a>"]
+
+    def test_a_gap_means_the_numbering_is_not_positional(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """``[Image #2]`` alone over two blocks: under a paste counter that is
+        the FIRST block, under position it is the second. With nothing
+        recorded, both readings are guesses."""
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [
+                    _image("a"),
+                    _image("b"),
+                    TextContent(type="text", text="see [Image #2]"),
+                ]
+            )
+
+        assert _tags(model) == ["<a>", "<b>", "see [Image #2]"]
+        assert "imagePasteIds is absent" in caplog.text
+
+    def test_more_numbers_than_blocks_is_not_positional(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [
+                    _image("a"),
+                    TextContent(type="text", text="[Image #1] and [Image #2]"),
+                ]
+            )
+
+        assert _tags(model) == ["<a>", "[Image #1] and [Image #2]"]
+        assert "imagePasteIds is absent" in caplog.text
+
+
+class TestPlaceholdersOutsideRenderedText:
+    """A placeholder the inliner never reaches must not cost its block.
+
+    ``referenced_images`` used to be scanned over the raw item text while
+    inlining happened over the reminder-split, IDE-peeled segments, so a
+    placeholder inside a ``<system-reminder>`` marked its block as spoken for
+    and the block was then dropped by a pass that never rendered it. No real
+    message measured on 2026-07-28 had that shape; the seam is closed here
+    structurally rather than left to the corpus.
+    """
+
+    def test_placeholder_inside_a_system_reminder_does_not_drop_the_block(self):
+        model = _render(
+            [
+                _image("a"),
+                TextContent(
+                    type="text",
+                    text="hello <system-reminder>ignore [Image #4]</system-reminder>",
+                ),
+            ],
+            paste_ids=[4],
+        )
+
+        assert _tags(model) == ["<a>", "hello ", "[reminder]ignore [Image #4]"]
+
+    def test_placeholder_in_an_ide_notification_prefix_does_not_drop_the_block(self):
+        model = _render(
+            [
+                _image("a"),
+                TextContent(
+                    type="text",
+                    text=(
+                        "<ide_selection>The user selected [Image #4] in the "
+                        "IDE</ide_selection>after"
+                    ),
+                ),
+            ],
+            paste_ids=[4],
+        )
+
+        tags = _tags(model)
+        assert "<a>" in tags, tags
+
+
+class TestFieldSurvivesParsing:
+    """The field is a sibling of ``message``, so it only reaches the factory if
+    the entry model declares it — Pydantic drops unknown fields by default."""
+
+    def _block(self, data: str) -> dict[str, object]:
+        return {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": data},
+        }
+
+    def _entry(
+        self, paste_ids: object, content: Optional[list[dict[str, object]]] = None
+    ) -> dict[str, object]:
+        if content is None:
+            content = [
+                self._block(f"first:{_PNG_1X1}"),
+                self._block(f"second:{_PNG_1X1}"),
+                {"type": "text", "text": "look at [Image #2]"},
+            ]
+        return {
+            "type": "user",
+            "uuid": "u-1",
+            "parentUuid": None,
+            "sessionId": "s-1",
+            "timestamp": "2026-07-28T10:00:00.000Z",
+            "isSidechain": False,
+            "userType": "external",
+            "cwd": "/tmp",
+            "version": "2.1.218",
+            "imagePasteIds": paste_ids,
+            "message": {"role": "user", "content": content},
+        }
+
+    def test_paste_ids_reach_the_renderer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session.jsonl"
+            path.write_text(json.dumps(self._entry([2, 3])) + "\n", encoding="utf-8")
+            messages = load_transcript(path)
+            html = generate_html(messages, "Paste ids")
+
+        assert getattr(messages[0], "imagePasteIds", None) == [2, 3]
+
+        # [Image #2] is the FIRST block, so "first" renders where the text
+        # says it does and "second" appends unreferenced ahead of the text.
+        assert "[Image #2]" not in html
+        assert html.index("second:") < html.index("look at") < html.index("first:")
+
+    def test_the_inlined_image_is_renderable(self):
+        """The resolved block reaches the page as a usable ``data:`` URL — the
+        point of the fix is a visible image, not a correct index."""
+        entry = self._entry(
+            [29],
+            content=[
+                self._block(_PNG_1X1),
+                {"type": "text", "text": "look at [Image #29]"},
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session.jsonl"
+            path.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+            html = generate_html(load_transcript(path), "Renderable")
+
+        assert f"data:image/png;base64,{_PNG_1X1}" in html
+        assert "[Image #29]" not in html
+
+    def test_a_malformed_field_does_not_cost_the_whole_entry(self):
+        """A ValidationError here would drop the message, not just its images."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session.jsonl"
+            path.write_text(
+                json.dumps(self._entry("not-a-list")) + "\n", encoding="utf-8"
+            )
+            messages = load_transcript(path)
+
+        assert len(messages) == 1

--- a/test/test_image_paste_ids.py
+++ b/test/test_image_paste_ids.py
@@ -214,6 +214,35 @@ class TestFailClosed:
         assert _tags(model) == ["<a>", "<b>", "[Image #1] and [Image #2]"]
         assert "has 1 entries but the message carries 2 image block(s)" in caplog.text
 
+    def test_no_placeholder_means_nothing_to_report_or_resolve(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """Bad ids with no `[Image #N]` anywhere: silent, and the blocks render.
+
+        The warnings exist to explain a placeholder that stayed literal, so with
+        no placeholder there is nothing to explain — reporting anyway trains a
+        reader to ignore the warning that does matter. Raised in review.
+
+        One test rather than two because there is one mechanism: the guard sits
+        *above* the recorded/legacy branch split, so ids-present and ids-absent
+        reach the same early return. It covers both halves of what could go
+        wrong — the spurious warning, and the images still reaching the page,
+        since an early return in a resolver is exactly the shape that dropped
+        them before.
+        """
+        with caplog.at_level(logging.WARNING):
+            model = _render(
+                [
+                    _image("a"),
+                    _image("b"),
+                    TextContent(type="text", text="no placeholder in this text"),
+                ],
+                paste_ids=[1],  # non-parallel, and irrelevant: nothing refers
+            )
+
+        assert "Cannot resolve image reference" not in caplog.text
+        assert _tags(model) == ["<a>", "<b>", "no placeholder in this text"]
+
     def test_malformed_field_is_reported_not_coerced(
         self, caplog: pytest.LogCaptureFixture
     ):

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -113,11 +113,13 @@ def _remove(text, *, sid=_SID):
     }
 
 
-def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID):
+def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID, paste_ids=None):
     """Modern in-DAG queued_command attachment paired with a 'remove'.
 
     ``prompt=None`` omits the prompt key entirely (a promptless, non-
-    renderable attachment).
+    renderable attachment). ``paste_ids`` sets ``imagePasteIds`` *inside the
+    attachment payload* — this record is its own carrier, unlike a user entry
+    where the field sits at top level beside ``message``.
     """
     attachment = {
         "type": "queued_command",
@@ -127,6 +129,8 @@ def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID):
     }
     if prompt is not None:
         attachment["prompt"] = prompt
+    if paste_ids is not None:
+        attachment["imagePasteIds"] = paste_ids
     return {
         "type": "attachment",
         "uuid": uuid,
@@ -613,3 +617,54 @@ class TestNonStringPromptShapes:
         assert as_list.count(marker) == as_string.count(marker)
         assert as_list.count("User (steering)") == as_string.count("User (steering)")
         assert TestMixedVersion._imbalance_warnings(caplog) == []
+
+
+class TestSteeringPasteIds:
+    """A steering delivery is its own paste-id carrier.
+
+    ``imagePasteIds`` sits *inside the attachment payload* here, not at entry
+    top level as it does beside a user entry's ``message``. Nothing declares
+    it on the model — ``AttachmentTranscriptEntry.attachment`` is a
+    ``dict[str, Any]`` passthrough — so the only thing that can go wrong is
+    the factory forgetting to hand it to ``create_user_message``, which is
+    exactly what this pins.
+    """
+
+    def test_non_contiguous_paste_ids_resolve_by_id_not_position(self):
+        """Two blocks, ids ``[4, 6]``: ``[Image #6]`` is the SECOND block and
+        ``[Image #4]`` the first.
+
+        The numbering is deliberately non-contiguous so the recorded reading
+        and the positional fallback *disagree*. Under the fallback, `4` and `6`
+        are not 1..k, so neither placeholder resolves at all and both stay as
+        literal text — a contiguous fixture would pass either way and pin
+        nothing.
+        """
+        first, second = _image_block("first"), _image_block("second")
+        html = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _user("u2", "a1", "next real prompt"),
+                _queued_command(
+                    "qc1",
+                    "u2",
+                    [
+                        {"type": "text", "text": "compare [Image #6] with [Image #4]"},
+                        first,
+                        second,
+                    ],
+                    paste_ids=[4, 6],
+                ),
+                _assistant("a2", "qc1", "ok"),
+            ]
+        )
+
+        # Both placeholders resolved — neither survives as literal text.
+        assert "[Image #6]" not in html
+        assert "[Image #4]" not in html
+        # And they resolved BY ID: #6 is the second block, #4 the first, so
+        # "second" precedes "first" in the rendered card.
+        assert html.index("second") < html.index("first"), (
+            "placeholders resolved positionally, not from the recorded ids"
+        )

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -640,7 +640,13 @@ class TestSteeringPasteIds:
         literal text — a contiguous fixture would pass either way and pin
         nothing.
         """
-        first, second = _image_block("first"), _image_block("second")
+        # Payloads must be tokens that cannot occur anywhere else in a rendered
+        # page. Raised in review: the first version of this test used the bare
+        # words "first"/"second", which appear in the inlined stylesheet
+        # (`:first-child`, `--text-secondary`) *before* any message content — so
+        # the ordering assertion below compared two CSS offsets and was true
+        # whatever the resolver did.
+        alpha, beta = _image_block("ZZBLOCKALPHAZZ"), _image_block("ZZBLOCKBETAZZ")
         html = _render(
             [
                 _user("u1", None, "start"),
@@ -651,8 +657,8 @@ class TestSteeringPasteIds:
                     "u2",
                     [
                         {"type": "text", "text": "compare [Image #6] with [Image #4]"},
-                        first,
-                        second,
+                        alpha,
+                        beta,
                     ],
                     paste_ids=[4, 6],
                 ),
@@ -660,11 +666,18 @@ class TestSteeringPasteIds:
             ]
         )
 
+        # Guard the guard: each token must occur exactly once, so a future
+        # template or stylesheet change cannot silently re-ambiguate the
+        # ordering assertion the way the original payloads did.
+        assert html.count("ZZBLOCKALPHAZZ") == 1, "alpha payload is not unique"
+        assert html.count("ZZBLOCKBETAZZ") == 1, "beta payload is not unique"
+
         # Both placeholders resolved — neither survives as literal text.
         assert "[Image #6]" not in html
         assert "[Image #4]" not in html
-        # And they resolved BY ID: #6 is the second block, #4 the first, so
-        # "second" precedes "first" in the rendered card.
-        assert html.index("second") < html.index("first"), (
+        # And they resolved BY ID: id 6 is the SECOND block and id 4 the first,
+        # so beta precedes alpha in the rendered card. Positional resolution
+        # would put alpha first (or, for 4/6 specifically, refuse entirely).
+        assert html.index("ZZBLOCKBETAZZ") < html.index("ZZBLOCKALPHAZZ"), (
             "placeholders resolved positionally, not from the recorded ids"
         )

--- a/test/test_user_renderer.py
+++ b/test/test_user_renderer.py
@@ -235,7 +235,13 @@ class TestParseUserMessageContentRegular:
         assert content_model is None
 
     def test_numbered_image_references_control_image_placement(self):
-        """Claude image blocks render where their text references occur."""
+        """Claude image blocks render where their text references occur.
+
+        The reference numbers are paste ids, so the association comes from
+        ``imagePasteIds`` — here it happens to coincide with block order, which
+        is what lets this case exercise placement on its own. ``[Image #3]``
+        names no recorded paste id and stays literal.
+        """
         first = ImageContent(
             type="image",
             source=ImageSource(type="base64", media_type="image/png", data="first"),
@@ -254,7 +260,10 @@ class TestParseUserMessageContentRegular:
         ]
 
         content_model = create_user_message(
-            MessageMeta.empty(), content_list, extract_text_content(content_list)
+            MessageMeta.empty(),
+            content_list,
+            extract_text_content(content_list),
+            image_paste_ids=[1, 2],
         )
 
         assert isinstance(content_model, UserTextMessage)


### PR DESCRIPTION
A pasted image leaves an `[Image #N]` placeholder in the message text and its
bytes in a separate content block. The renderer inferred which block a
placeholder meant from **position** — `[Image #3]` was the third block — but
the transcript records the association explicitly, in a field we never read.

`imagePasteIds` runs parallel to the image blocks, so `[Image #N]` is the block
at `imagePasteIds.index(N)`.

**N is a paste counter, not a position.** It resets when the CLI restarts
inside a session that outlives it, and it increments on delete-and-repaste —
hence runs like `[4, 6, 8]`, numbers far above the block count, and the same N
meaning different images at different points in one session.

## What it was costing

Across the 168 placeholders in the 110 image-bearing messages of one real
archive (measured 2026-07-28):

| | |
|---|---|
| left as literal text, image detached | 126 |
| resolved to the correct block | 34 |
| **resolved to the WRONG block** | **8**, across 5 messages |

The last row is the one with nothing in the output to mark it: a different
screenshot renders where the placeholder sat. After the change all 168 resolve,
85 messages render differently, and none disagrees with the recorded ids.

## The fix

One mapping serves both halves of the rendering: the inliner takes blocks by
number, and the caller appends whichever were not taken. A block can therefore
never be inlined *and* appended, nor dropped by a pass that never rendered it —
which is what a placeholder buried in a `<system-reminder>` or an
IDE-notification prefix used to cause.

Where the association cannot be established, the placeholder renders literally,
the block stays detached, and a warning names the condition: a paste id we do
not have, lists that are not parallel, a repeated id, a malformed field. A
visible gap beats a confident substitution. The model field is deliberately
untyped so a malformed value reaches that report rather than failing validation
and costing the whole entry.

## Old transcripts, where nothing was recorded

Position is the only evidence there, and it is used only when the numbering is
`1..k` with no gaps and no more numbers than blocks.

**Why that condition** — stated carefully, because the obvious reason is wrong.
It is *not* that a reset counter cannot produce `1..k`; one that has just reset
produces exactly that. It is that on `1..k` **the recorded and positional
readings coincide**, so the renderer never has to know which regime produced the
numbering: paste ids are distinct, `>= 1` and recorded in ascending block order,
so a list containing `1..k` holds those values in its first `k` slots, making
`index(N)` and `N-1` the same answer.

That rests on the ascending premise, which is **measured, not guaranteed by the
format**: 180/180 messages carrying the field have strictly ascending ids, no
duplicates, none below 1. Scored the other way — pretend the field is absent and
run the fallback against the recorded ids as ground truth — it fires on 24 of the
110 placeholder-bearing messages, refuses the other 86, and is correct on all 24.
The era where the fallback actually applies has no ground truth by construction,
which is the limit of the argument.

**How old is "old" — and what the sampling does *not* establish.** In the same
archive, every image-bearing message containing an `[Image #N]` placeholder
carried the field, across versions 2.1.84–2.1.220. The oldest records lacking it
are twenty at 2.0.73–2.0.74, none of which contains a placeholder. That does
**not** pin an introduction version: both shapes occur *within* 2.0.74, and the
archive's oldest image-bearing record is 2.0.73, so the floor is a sampling
floor rather than a fact about the harness. The repo's own fixtures at 1.0.31,
1.0.43 and 1.0.128 do carry placeholders with no field, which is what keeps the
positional path live rather than historical.

The fallback is also strictly narrower than what the renderer did before: it
substituted positionally whenever `N <= len(images)`, unconditionally. So this
can only render *fewer* unverifiable substitutions than its predecessor, never
more.

## Steering cards carry their own paste ids

A steering delivery that carries an image records `imagePasteIds` in its
`queued_command` attachment rather than at entry top level — the attachment is
its own carrier. Image-bearing steering cards only began rendering at all once
the list-shaped prompt was accepted, so this completes that: 19 such cards in
the same archive, whose placeholders now resolve from the recorded ids instead
of from position.

Nothing needed adding to the model for that path: the attachment payload is
already a passthrough dict, so the field arrives intact and the only way to lose
it is to forget the argument at the call site. That is what the new test pins,
with deliberately non-contiguous ids (`[4, 6]`) — contiguous ids make the two
readings agree, so such a test would pass with the argument dropped.

## Tests

Every guard is mutation-checked: neutralise it and confirm the intended test
reddens and no other. That covers the id lookup, the parallel-length and
duplicate-id checks, the bool-is-not-an-int clause, the unknown-id refusal, both
legacy-fallback clauses, the consume-on-inline rule, the model field, and the
call sites. Fixtures are synthetic; one uses a real 1×1 PNG so the resolved
block is checked to reach the page as a usable `data:` URL rather than as a
correct index.

Zero snapshot churn, and structurally so: no fixture data file carries
`imagePasteIds`, so no existing snapshot can reach the recorded-id path, and the
three legacy fixtures that do reach the resolver all satisfy the positional
condition and render identically.

Corpus figures measured 2026-07-28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of `"[Image `#N`]"` placeholders by honoring per-message image paste IDs, including non-sequential and out-of-order references.
  * Fail-closed handling for missing, malformed, duplicate, or mismatched paste-id data to prevent incorrect substitutions or dropped images.
  * Preserved unresolved placeholders and unreferenced image blocks without unintended reordering.
  * Kept legacy positional fallback only when it’s safe/compatible.

* **Documentation**
  * Added guidance on placeholder-to-image mapping, fallback rules, and relevant edge cases.

* **Tests**
  * Added extensive tests covering resolution, failure scenarios, steering queued commands, and JSONL/transcript parsing integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->