### PR TITLE
docs: trim the User Steering section to what a reader needs

### DIFF
--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -287,7 +287,10 @@ What the reader sees when pairing does *not* work out is the part worth stating
 here: nothing is ever dropped. A `remove` with no matching card renders as
 legacy steering, and a card that renders but cannot be paired leaves its
 `remove` visible rather than suppressing it on a match that cannot be shown.
-Both paths log a warning naming what was observed.
+A non-pairable card always warns; an unmatched `remove` warns only where that
+session and version did produce a counted card — with no card there is nothing
+for it to be imbalanced against, so a legacy-only transcript stays silent — and
+then only once per `(session, version)`.
 
 **Prompt shapes.** `attachment.prompt` is normally a plain string, but a
 steering delivery carrying an image is written as a **list of content blocks**

--- a/dev-docs/messages.md
+++ b/dev-docs/messages.md
@@ -276,115 +276,60 @@ class UserSteeringMessage(UserTextMessage):
 Steering messages represent user input injected mid-turn to steer an
 ongoing assistant response.
 
-**De-duplication (modern transcripts).** Every steering delivery writes
-*both* a `queued_command` attachment and a legacy `remove` op, normally
-1:1. To avoid a duplicate card, `_render_messages` suppresses the `remove`
-whose steering text is already covered by a rendered `queued_command`. A
-pass-1 pre-pass counts *renderable* `queued_command`s keyed by `(session,
-version, prompt-text)`; pass 2 spends a decrementing budget under the
-matching key. (Queue-op entries carry no `version`, so a `remove`'s
-version is inferred from the last version-bearing entry in file order — a
-turn cannot span a harness restart.)
+**One delivery, two records, one card.** A modern steering delivery writes
+*both* a `queued_command` attachment and a legacy `remove` op, normally 1:1.
+The renderer emits the attachment and suppresses the paired `remove`, so a
+reader sees one card rather than a duplicate. Suppression is content-keyed and
+budgeted per `(session, version, prompt-text)`; the mechanics, and why each
+part of that key is needed, are commented at the pre-pass in `renderer.py`.
 
-The keying matters on two axes:
-
-- **Per `(session, version)`** — session HTML is cached individually, so
-  cross-session state would break incremental-cache correctness; and a
-  resumed session can span a harness upgrade, so the version is learned
-  from the file rather than assumed.
-- **Per prompt-text** — a `remove` is paired to a `queued_command` by
-  *content*, not arrival order. Content-keying makes suppression
-  **lossless and order-independent**: exactly the removes with a matching
-  card are hidden, and any orphan `remove` (no matching card, or one
-  arriving before its paired sibling) still renders as legacy steering
-  rather than being dropped. Rendering an orphan under a version that
-  *did* have cards logs a one-shot WARNING.
-
-  That warning states only what the renderer observed — an orphan
-  `remove` with no *counted* card. It deliberately does **not** claim the
-  archive's pairing is broken: an uncounted card is at least as likely to
-  be our own doing. In #294 the pairing was intact (232 removes / 232
-  `queued_command`s in the reported session) and the pre-pass was simply
-  not counting image-bearing cards. A card that renders but cannot be
-  paired warns for itself, naming the shape — see *Prompt shapes* below.
-
-**Null-content era (≤2.1.202).** Older harnesses wrote the paired
-`remove` op with `content: null` — the steering text lived **only** in
-the `queued_command` attachment. Rendering steering from the attachment
-is therefore not just a de-duplication nicety but the *only* path that
-surfaces steering text at all on such transcripts (a null `remove`
-renders nothing, and pre-#284 the attachment was ghosted, so the text was
-silently lost). Null-content removes are dropped by the empty-content
-skip in `_filter_messages` *before* the suppression loop, so they neither
-consume budget nor trip the imbalance warning.
-
-Measured over one machine's full local corpus on 2026-07-28 (5606 files,
-4658 removes): every version **≤ 2.1.202** wrote null content (3836
-removes) and every version **≥ 2.1.205** wrote text (822 removes), with
-no version producing both.
-
-Two limits on that, because this is still a sample:
-
-- **The changeover is located to an interval, not a point.** It lies in
-  **(2.1.202, 2.1.205]**, and the versions in between cannot narrow it
-  here: 2.1.203 does not appear in this corpus at all, and 2.1.204
-  appears (268 entries) but produced *no* `remove` ops. "Sharp" describes
-  the observed versions, not a verified single release.
-- **The floor is a sampling floor.** 2.0.55 is the oldest version present
-  and 2.0.73 the oldest carrying a `remove` — oldest *available*, not
-  oldest *existing*. Nothing here shows what pre-2.0 harnesses wrote.
-
-Within those limits: on current harnesses the `remove` does carry its
-text and the content-keyed pairing is meaningful, and null-content is the
-legacy shape rather than the modern one. (An earlier revision of this
-page put the null-content era at "≥~2.1.187" — backwards, from a sample
-that happened to start there. Stating the bound as a dated interval is
-the guard against this correction hardening the same way.)
+What the reader sees when pairing does *not* work out is the part worth stating
+here: nothing is ever dropped. A `remove` with no matching card renders as
+legacy steering, and a card that renders but cannot be paired leaves its
+`remove` visible rather than suppressing it on a match that cannot be shown.
+Both paths log a warning naming what was observed.
 
 **Prompt shapes.** `attachment.prompt` is normally a plain string, but a
-steering delivery carrying an image is written as a **list of content
-blocks** (`[{"type": "text", …}, {"type": "image", …}]`). Both shapes are
-normalized by `attachment_factory.queued_command_prompt_items`, which is
-shared with the renderer's pre-pass so the budget is seeded from exactly
-the cards the factory emits. Accepting only `str` (the pre-#294
-behaviour) dropped the card *and* its image outright while the paired
-`remove` rendered the text alone — and then the orphan warning blamed the
-archive for it.
+steering delivery carrying an image is written as a **list of content blocks**
+(`[{"type": "text", …}, {"type": "image", …}]`). Both shapes normalize through
+`attachment_factory.queued_command_prompt_items`, which the renderer's pre-pass
+shares, and any other shape renders from its `str()` rather than vanishing.
+Which shapes can be *paired* — and why an image-only list or a text-bearing
+`dict` cannot — is documented on that function.
 
-The helper returns a `pairable` flag alongside the items. A prompt is pairable
-when it is a supported shape — `str` or a list of blocks — **and** yields
-non-empty text, because text is the only thing the budget can key on. Both
-conditions bite: an image-only list renders but cannot be paired, and a
-text-bearing `dict` is not pairable either, however much text it carries. An
-unpairable delivery still renders; its `remove` stays visible rather than
-being suppressed by a card that cannot be shown to match it.
+**Transformer pass.** A `queued_command` prompt goes through the same
+`create_user_message` classification and plugin-transformer pass as an
+idle-delivered prompt, so a `[monitor] …` steering injection renders as the
+same demoted marker as its non-steering siblings, and only a plain
+`UserTextMessage` is wrapped as `UserSteeringMessage`.
 
-Any *other* shape (neither `str` nor list) is rendered from its `str()` rather
-than dropped — silently discarding a steering delivery is indistinguishable
-from there having been none. Every unpairable card logs a WARNING naming the
-shape it saw, so the next novel shape is diagnosable from the log line alone.
-Note which shapes that covers: `dict` warns, and so does an image-only
-`list[image]`; `list[image,text]` is pairable and warns about nothing.
+**Null-content era (≤2.1.202).** Older harnesses wrote the paired `remove` with
+`content: null` — the steering text lived **only** in the `queued_command`
+attachment. Rendering steering from the attachment is therefore not just a
+de-duplication nicety but the *only* path that surfaces steering text at all on
+such transcripts. Null-content removes are dropped before the suppression pass,
+so they neither consume budget nor trip its warning.
 
-**Transformer pass.** The `queued_command` prompt is routed through the
-same `create_user_message` classification + plugin-transformer pass as an
-idle-delivered prompt, so e.g. a `[monitor] …` steering injection renders
-as the same demoted marker as its non-steering siblings. Only a plain,
-untransformed `UserTextMessage` is (re)wrapped as `UserSteeringMessage`
-— an exact-type (`type(x) is UserTextMessage`) check, mirrored in the
-legacy steering conversion in `renderer.py`, prevents a transformer's
-`UserTextMessage` *subclass* (which may carry its text in own fields with
-`items=[]`) from being rebuilt into an empty-items steering card.
+Measured over one machine's full local corpus on 2026-07-28 (5606 files, 4658
+removes): every version **≤ 2.1.202** wrote null content (3836 removes) and
+every version **≥ 2.1.205** wrote text (822 removes), with no version producing
+both. Two limits on that, because it is still a sample:
 
-The list shape goes through the same seam — the normalized content items
-are handed to `create_user_message`, never assembled into a card
-directly — so a transformer sees an image-bearing prompt exactly as it
-sees a string one. The budget key is taken from the *raw* extracted text,
-before any transformer runs, and the legacy `remove` carries that same
-raw text, so a pair still matches even when what renders is a demoted
-marker rather than a steering card. (A transformer that demotes such a
-prompt drops the image with the rest of the original content; that is the
-plugin's rendering decision, the same as for the string path.)
+- **The changeover is located to an interval, not a point.** It lies in
+  **(2.1.202, 2.1.205]**, and the versions in between cannot narrow it here:
+  2.1.203 does not appear in this corpus at all, and 2.1.204 appears (268
+  entries) but produced *no* `remove` ops. "Sharp" describes the observed
+  versions, not a verified single release.
+- **The floor is a sampling floor.** 2.0.55 is the oldest version present and
+  2.0.73 the oldest carrying a `remove` — oldest *available*, not oldest
+  *existing*. Nothing here shows what pre-2.0 harnesses wrote.
+
+Within those limits: on current harnesses the `remove` does carry its text and
+the content-keyed pairing is meaningful, and null-content is the legacy shape
+rather than the modern one. (An earlier revision of this page put the
+null-content era at "≥~2.1.187" — backwards, from a sample that happened to
+start there. Stating the bound as a dated interval is the guard against this
+correction hardening the same way.)
 
 ### User Memory
 


### PR DESCRIPTION
## What this does

Trims `### User Steering (Queue Remove / queued_command)` in `dev-docs/messages.md`
from **132 lines to 77**, keeping every measured claim byte-identical and cutting
the investigation narrative that accumulated while the behaviour was being worked
out.

At 132 lines it was the largest *behavioural* section in the file — the next is
`### Tool Result Rendering Wrapper` at 87 — and second overall only to
`### Tool Use Message Structure` (294 lines), which is a reference table covering
every tool rather than one message type. `dev-docs/` is as-built reference: the
code is the authority, and prose earns its place by telling a reader something the
code cannot.

## What is preserved, deliberately byte-for-byte

Every *measured* statement, because none of it is re-derivable from the code — it
came from counting real archives:

- the version interval `(2.1.202, 2.1.205]` in which the behaviour changed;
- 2.1.203 absent from the sample, and 2.1.204 present with no removes at all —
  the two observations that narrow the interval to that shape;
- the sampling floor (2.0.55, 2.0.73), so a reader knows what the interval does
  **not** establish;
- the 5606-file measurement;
- the paragraph recording that an earlier `>=~2.1.187` claim was **backwards**.
  That one is kept precisely because it is a correction: without it the next
  reader re-derives the same wrong direction from the same data.

What went is the reasoning that produced those numbers, the alternatives
considered and rejected, and the step-by-step account of how the pairing was
reverse-engineered. Useful while the behaviour was unknown; noise once it is
documented.

## Why this closes #294

#294 reported a warning from a real archive:

```
WARNING: steering suppression imbalance ... a 'remove' op has no matching
queued_command card ... The remove<->queued_command 1:1 pairing appears violated
```

The pairing was **not** violated. Image-bearing steering prompts were being
dropped, so the paired legacy `remove` rendered its text alone and looked
orphaned — and the warning's own diagnosis pointed at the wrong thing, which is
what made it hard to see. Two changes resolved it:

- **#305** rendered image-bearing steering prompts instead of dropping them,
  removing the cause;
- **#306** finished the other half, resolving `[Image #N]` placeholders from the
  recorded `imagePasteIds` rather than by block position — so the images land
  where their references actually point.

The detector itself is deliberately **retained and scoped**, not deleted: it still
fires for a genuine pairing violation, and tests pin both that it fires when the
pairing really breaks and that it stays silent otherwise. What changed is that it
no longer accuses the archive of something our own renderer was doing.

This PR is the documentation tail of that arc — the section had grown while the
behaviour was being established, and it is the last piece still carrying the
investigation. Neither #305 nor #306 used a closing keyword, so the issue stayed
open after the code was fixed; it closes here.

Closes #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded User Steering guidance on dual-record delivery, content-keyed suppression, fallback rendering, and null-content handling.
  * Clarified prompt normalization for strings and content-block lists, including transformer behavior.
  * Documented when unmatched-remove warnings appear and that they are emitted once per session/version.
  * Added corpus-based version observations and sampling limitations.
  * Simplified the guidance by removing implementation-level details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->