### PR TITLE
Regenerate paginated pages when their session membership changes

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -1675,6 +1675,7 @@ class CacheManager:
         page_size_config: int,
         variant_suffix: str = "",
         output_dir: Optional[Path] = None,
+        expected_session_ids: Optional[List[str]] = None,
     ) -> tuple[bool, str]:
         """Check if a page needs regeneration.
 
@@ -1688,6 +1689,11 @@ class CacheManager:
                 ``--output`` runs must pass their destination or the file
                 check reports ``file_missing`` forever (mirrors
                 ``is_transcript_stale``).
+            expected_session_ids: The sessions this page should hold on
+                *this* run, in render order. Every other check below reads
+                the page's *cached* membership, so without this a page whose
+                membership changed while its previously-held sessions stayed
+                untouched reports ``up_to_date`` (see ``sessions_changed``).
 
         Returns:
             Tuple of (is_stale: bool, reason: str)
@@ -1715,6 +1721,23 @@ class CacheManager:
             return True, "file_missing"
         if is_html_outdated(actual_file):
             return True, "file_version_mismatch"
+
+        # Check if the page's *membership* changed. The caller recomputes the
+        # session→page assignment from scratch every run, so a page can gain,
+        # lose, or reorder sessions while every session it previously held is
+        # byte-for-byte untouched:
+        #   - a brand-new session lands on the partially-filled last page;
+        #   - a session imported with older timestamps sorts into the middle,
+        #     shifting the contents of every page after it.
+        # All the checks below (and above) read only the *cached* membership,
+        # so they see nothing amiss and report `up_to_date` — the new sessions
+        # then never get rendered into any page, and the combined output stays
+        # frozen until the HTML is deleted by hand (issue #308).
+        if (
+            expected_session_ids is not None
+            and list(expected_session_ids) != page_data.session_ids
+        ):
+            return True, "sessions_changed"
 
         # Check if any session on this page has changed
         with self._get_connection() as conn:

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1783,7 +1783,11 @@ def _generate_paginated_html(
         # Check if page is stale (resolve against the real output_dir so an
         # --output run doesn't report file_missing on every page forever).
         is_stale, reason = cache_manager.is_page_stale(
-            page_num, page_size, suffix, output_dir=output_dir
+            page_num,
+            page_size,
+            suffix,
+            output_dir=output_dir,
+            expected_session_ids=page_session_ids,
         )
 
         if not is_stale and page_file.exists():

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -144,6 +144,19 @@ cache row, the session is reparsed. The schema-version row also
 invalidates the entire HTML cache when migrations bump the version,
 since rendered output may have changed even when source data hasn't.
 
+Paginated output carries an extra invalidation axis. `--page-size`
+assigns sessions to pages chronologically, and that assignment is
+recomputed from scratch on every run, so a page's *membership* can
+change while every session it already held is untouched: a new session
+lands on the partly-filled last page, or sessions imported from another
+machine sort into the middle by their original timestamps and shift
+everything after them along. Per-session freshness alone can't see
+this, so `is_page_stale()` also compares the run's computed session
+list against the cached `page_sessions` rows and reports
+`sessions_changed`. Without that comparison the affected pages report
+`up_to_date`, and the new sessions land in the cache and in their own
+`session-*.html` but never in any combined page (issue #308).
+
 Connections run in WAL mode with `synchronous=NORMAL` (durable across
 app crashes; only a power/OS crash can lose the last commit — fine for a
 regenerable cache). By default `_get_connection()` opens and closes a

--- a/test/test_pagination.py
+++ b/test/test_pagination.py
@@ -425,6 +425,94 @@ class TestPageCacheMethods:
         assert is_stale is False
         assert "up_to_date" in reason
 
+    def _cache_single_session_page(self, cache_manager, temp_project_dir):
+        """Cache a 1-session page whose session data matches exactly."""
+        cache_manager.update_page_cache(
+            page_number=1,
+            html_path="combined_transcripts.html",
+            page_size_config=5000,
+            session_ids=["s1"],
+            message_count=1000,
+            first_timestamp="2023-01-01T10:00:00Z",
+            last_timestamp="2023-01-01T11:00:00Z",
+            total_input_tokens=100,
+            total_output_tokens=50,
+            total_cache_creation_tokens=0,
+            total_cache_read_tokens=0,
+        )
+        (temp_project_dir / "combined_transcripts.html").write_text("<html></html>")
+        cache_manager.update_session_cache(
+            {
+                "s1": SessionCacheData(
+                    session_id="s1",
+                    message_count=1000,
+                    first_timestamp="2023-01-01T10:00:00Z",
+                    last_timestamp="2023-01-01T11:00:00Z",
+                    first_user_message="Test",
+                    total_input_tokens=100,
+                    total_output_tokens=50,
+                    total_cache_creation_tokens=0,
+                    total_cache_read_tokens=0,
+                )
+            }
+        )
+
+    def test_is_page_stale_sessions_added_to_page(
+        self, cache_manager, temp_project_dir
+    ):
+        """A page that gains a session is stale even if its own sessions didn't change.
+
+        Every other check reads the page's cached membership, so an added
+        session is invisible without ``expected_session_ids`` (issue #308).
+        """
+        self._cache_single_session_page(cache_manager, temp_project_dir)
+
+        with patch("claude_code_log.renderer.is_html_outdated", return_value=False):
+            is_stale, reason = cache_manager.is_page_stale(
+                1, 5000, expected_session_ids=["s1", "s2"]
+            )
+        assert is_stale is True
+        assert reason == "sessions_changed"
+
+    def test_is_page_stale_sessions_reordered_on_page(
+        self, cache_manager, temp_project_dir
+    ):
+        """A page whose sessions shift order is stale — order is render order."""
+        cache_manager.update_page_cache(
+            page_number=1,
+            html_path="combined_transcripts.html",
+            page_size_config=5000,
+            session_ids=["s1", "s2"],
+            message_count=1000,
+            first_timestamp="2023-01-01T10:00:00Z",
+            last_timestamp="2023-01-01T11:00:00Z",
+            total_input_tokens=100,
+            total_output_tokens=50,
+            total_cache_creation_tokens=0,
+            total_cache_read_tokens=0,
+        )
+        (temp_project_dir / "combined_transcripts.html").write_text("<html></html>")
+
+        with patch("claude_code_log.renderer.is_html_outdated", return_value=False):
+            is_stale, reason = cache_manager.is_page_stale(
+                1, 5000, expected_session_ids=["s2", "s1"]
+            )
+        assert is_stale is True
+        assert reason == "sessions_changed"
+
+    def test_is_page_stale_up_to_date_with_matching_expected_sessions(
+        self, cache_manager, temp_project_dir
+    ):
+        """Passing the same membership must not defeat the cache."""
+        self._cache_single_session_page(cache_manager, temp_project_dir)
+
+        with patch("claude_code_log.renderer.is_html_outdated", return_value=False):
+            is_stale, reason = cache_manager.is_page_stale(
+                1, 5000, expected_session_ids=["s1"]
+            )
+        assert is_stale is False
+        assert reason == "up_to_date"
+
     def test_invalidate_all_pages(self, cache_manager):
         """invalidate_all_pages should remove all page cache entries."""
         cache_manager.update_page_cache(
@@ -700,6 +788,104 @@ class TestPaginationIntegration:
         )
         assert "messages" in page1_content.lower()
         assert "Page 1" in page1_content or "page-navigation" in page1_content
+
+
+class TestPaginationPicksUpNewSessions:
+    """Regression tests for issue #308.
+
+    A rebuild recomputes the session→page assignment from scratch, but page
+    staleness used to be judged purely on the sessions a page *already* held.
+    A session that appeared without disturbing any of them — a new session
+    landing on the partly-filled last page, or sessions copied in from another
+    machine sorting into the middle by their original timestamps — was written
+    to the cache and to its own ``session-*.html``, yet never rendered into any
+    combined page. The combined output stayed frozen until it was deleted by
+    hand.
+    """
+
+    @staticmethod
+    def _write_session(project_dir: Path, session_id: str, date: str, count: int = 10):
+        messages = _create_session_messages(session_id, count, date)
+        with open(project_dir / f"{session_id}.jsonl", "w", encoding="utf-8") as f:
+            for msg in messages:
+                f.write(json.dumps(msg) + "\n")
+
+    @staticmethod
+    def _paginated_session_ids(project_dir: Path) -> list[str]:
+        """Session ids reachable from the rendered pages, in page order."""
+        from claude_code_log.cache import CacheManager, get_library_version
+
+        cache_manager = CacheManager(project_dir, get_library_version())
+        return [
+            session_id
+            for page in cache_manager.get_all_pages()
+            for session_id in page.session_ids
+        ]
+
+    def test_new_session_appended_lands_on_last_page(self, temp_project_dir):
+        """A newer session added later must reach the (partly filled) last page."""
+        from claude_code_log.converter import convert_jsonl_to_html
+
+        for i, session_id in enumerate(["s1", "s2", "s3", "s4"]):
+            self._write_session(temp_project_dir, session_id, f"2023-01-0{i + 1}")
+
+        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+        assert "s5" not in self._paginated_session_ids(temp_project_dir)
+
+        # A brand-new session, newer than every existing one. None of the
+        # already-paginated sessions change.
+        self._write_session(temp_project_dir, "s5", "2023-01-09")
+        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+
+        assert "s5" in self._paginated_session_ids(temp_project_dir)
+        combined = "".join(
+            p.read_text(encoding="utf-8")
+            for p in sorted(temp_project_dir.glob("combined_transcripts*.html"))
+        )
+        assert "s5-user-0" in combined
+
+    def test_imported_older_sessions_shift_existing_pages(self, temp_project_dir):
+        """Sessions imported with older timestamps must re-flow the pages after them."""
+        from claude_code_log.converter import convert_jsonl_to_html
+
+        for i, session_id in enumerate(["s5", "s6", "s7", "s8"]):
+            self._write_session(temp_project_dir, session_id, f"2023-01-0{i + 5}")
+
+        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+        before = self._paginated_session_ids(temp_project_dir)
+        assert before == ["s5", "s6", "s7", "s8"]
+
+        # Copied in from another machine: original (older) timestamps, so they
+        # sort to the front and push every later session along.
+        for i, session_id in enumerate(["s1", "s2"]):
+            self._write_session(temp_project_dir, session_id, f"2023-01-0{i + 1}")
+        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+
+        after = self._paginated_session_ids(temp_project_dir)
+        assert after == ["s1", "s2", "s5", "s6", "s7", "s8"]
+        combined = "".join(
+            p.read_text(encoding="utf-8")
+            for p in sorted(temp_project_dir.glob("combined_transcripts*.html"))
+        )
+        for session_id in after:
+            assert f"{session_id}-user-0" in combined
+
+    def test_unchanged_project_still_skips_every_page(self, temp_project_dir):
+        """The membership check must not cost incrementality on a no-op rebuild."""
+        from claude_code_log.converter import convert_jsonl_to_html
+
+        for i, session_id in enumerate(["s1", "s2", "s3", "s4"]):
+            self._write_session(temp_project_dir, session_id, f"2023-01-0{i + 1}")
+
+        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+        pages = sorted(temp_project_dir.glob("combined_transcripts*.html"))
+        assert len(pages) > 1
+        before = {p: p.read_bytes() for p in pages}
+
+        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+
+        for page, content in before.items():
+            assert page.read_bytes() == content
 
 
 class TestNextLinkInPlaceUpdate:

--- a/test/test_pagination.py
+++ b/test/test_pagination.py
@@ -873,6 +873,7 @@ class TestPaginationPicksUpNewSessions:
     def test_unchanged_project_still_skips_every_page(self, temp_project_dir):
         """The membership check must not cost incrementality on a no-op rebuild."""
         from claude_code_log.converter import convert_jsonl_to_html
+        from claude_code_log.html.renderer import HtmlRenderer
 
         for i, session_id in enumerate(["s1", "s2", "s3", "s4"]):
             self._write_session(temp_project_dir, session_id, f"2023-01-0{i + 1}")
@@ -882,8 +883,17 @@ class TestPaginationPicksUpNewSessions:
         assert len(pages) > 1
         before = {p: p.read_bytes() for p in pages}
 
-        convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
+        # Byte-equality alone can't prove the pages were skipped: rendering is
+        # deterministic, so a page re-rendered from scratch is byte-identical
+        # to the one it replaces. Spy on the renderer to assert no page was
+        # rendered at all. `side_effect` keeps the real implementation, so the
+        # output assertions below stay meaningful if this ever regresses.
+        with patch.object(
+            HtmlRenderer, "generate", autospec=True, side_effect=HtmlRenderer.generate
+        ) as generate_spy:
+            convert_jsonl_to_html(temp_project_dir, page_size=25, silent=True)
 
+        assert generate_spy.call_count == 0
         for page, content in before.items():
             assert page.read_bytes() == content
 


### PR DESCRIPTION
`_generate_paginated_html` recomputes the session -> page assignment on every run, but `is_page_stale()` only ever asked "did any session this page *already* held change?". It never compared the recomputed membership against the cached `page_sessions` rows.

So a session could appear without disturbing the ones already paginated, and every page would report `up_to_date`:

  - a new session lands on the partly-filled last page, whose existing sessions are byte-identical;
  - sessions copied in from another machine keep their original timestamps, sort into the middle, and shift every later page along.

The sessions were parsed, cached, and written to their own `session-*.html`, but never rendered into any combined page — the combined output stayed frozen until it was deleted by hand (which forces `file_missing` on every page).

Reproduced on real transcripts via the `--all-projects` path: after copying six sessions into two already-built projects, both reported "3 files updated" while four sessions ended up in the cache and on no page at all; the combined pages were byte-identical before and after.

`is_page_stale()` now takes `expected_session_ids` and reports `sessions_changed` when the run's computed membership differs from the cached one. The comparison is order-sensitive, since that ordering is render order.

This costs nothing on the no-op path: `get_page_data()` was already loading `session_ids` for the existing `session_missing` / `message_count_changed` checks, so this reuses an in-memory list — no extra query, and it short-circuits before the SQL aggregate. Verified against the tie-heaviest project in a real archive (45 identical `first_timestamp` values, 35 pages): a forced rebuild still reported all 35 pages cached, so tied sessions don't destabilise the order. Were they ever to, the cost is one redundant page render rather than a missed session.

Tests cover both real-world shapes (append and mid-timeline import), the unit-level membership checks, and a guard that an unchanged project still skips every page. All six fail on the pre-fix code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paginated page freshness checks to detect when sessions are added, removed, or reordered.
  * Updated generated pages so newly added or imported sessions appear on the correct combined pages.
  * Preserved existing page files when session membership remains unchanged.

* **Documentation**
  * Documented pagination cache invalidation and session membership validation.

* **Tests**
  * Added coverage for session additions, reordering, unchanged pages, and cache staleness detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->