### PR TITLE
PR #308 continuation

### DIFF
--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -112,7 +112,13 @@ from ..renderer_timings import (
     report_timing_statistics,
     set_timing_var,
 )
-from ..utils import format_timestamp, split_websearch_queries
+from ..utils import (
+    collect_trunk_session_ids,
+    format_timestamp,
+    get_warmup_session_ids,
+    resume_command_for_session,
+    split_websearch_queries,
+)
 from .system_formatters import (
     format_away_summary_content,
     format_hook_attachment_content,
@@ -1611,6 +1617,7 @@ class HtmlRenderer(Renderer):
                 session_tree=session_tree,
                 page_info=page_info,
                 page_stats=page_stats,
+                repo_cwd=repo_cwd,
             )
 
     def _generate_inner(
@@ -1622,6 +1629,7 @@ class HtmlRenderer(Renderer):
         session_tree: Optional["SessionTree"] = None,
         page_info: Optional[dict[str, Any]] = None,
         page_stats: Optional[dict[str, Any]] = None,
+        repo_cwd: Optional[str] = None,
     ) -> str:
         """Body of ``generate`` running inside the SHA-resolver context."""
         import time
@@ -1664,6 +1672,19 @@ class HtmlRenderer(Renderer):
         with log_timing("Content formatting (pre-order)", t_start):
             render_roots = self._annotate_tree_for_render(root_messages)
 
+        # Resume button: only pages holding a single trunk session get
+        # one — `claude -r <session-id>` is unambiguous there. Combined
+        # pages spanning several sessions don't (which session would
+        # resume?).
+        resume_command = None
+        trunk_sids = collect_trunk_session_ids(
+            messages, get_warmup_session_ids(messages)
+        )
+        if len(trunk_sids) == 1:
+            resume_command = resume_command_for_session(
+                next(iter(trunk_sids)), repo_cwd
+            )
+
         # Render template
         with log_timing("Template environment setup", t_start):
             env = get_template_environment()
@@ -1684,6 +1705,7 @@ class HtmlRenderer(Renderer):
                     is_session_header=is_session_header,
                     page_info=page_info,
                     page_stats=page_stats,
+                    resume_command=resume_command,
                 )
             )
 

--- a/claude_code_log/html/templates/components/global_styles.css
+++ b/claude_code_log/html/templates/components/global_styles.css
@@ -248,12 +248,11 @@ pre {
     bottom: 200px;
 }
 
+/* Text-labelled floating buttons ("uuid", "md") keep the round shape
+ * and size of the emoji ones; only the label typography differs. */
 .debug-toggle.floating-btn {
     bottom: 260px;
-    border-radius: 6px;
-    width: 38px;
-    height: 28px;
-    font-size: 0.65em;
+    font-size: 0.7em;
     font-family: 'SFMono-Regular', Consolas, monospace;
     font-weight: 600;
 }
@@ -348,11 +347,8 @@ body.show-raw-user .user-content:not([data-user-view="md"]) .user-raw {
 }
 
 .user-view-global.floating-btn {
-    bottom: 300px;
-    border-radius: 6px;
-    width: 38px;
-    height: 28px;
-    font-size: 0.65em;
+    bottom: 320px;
+    font-size: 0.7em;
     font-family: 'SFMono-Regular', Consolas, monospace;
     font-weight: 600;
 }
@@ -363,27 +359,21 @@ body.show-raw-user .user-content:not([data-user-view="md"]) .user-raw {
 }
 
 /* Resume-session button (single-session pages only): copies the
- * `cd … && claude -r <session-id>` command to the clipboard. */
+ * `pushd … && claude -r <session-id>` command to the clipboard. */
 .resume-session.floating-btn {
-    bottom: 340px;
-    border-radius: 6px;
-    width: auto;
-    height: 28px;
-    padding: 0 10px;
-    font-size: 0.65em;
-    font-family: 'SFMono-Regular', Consolas, monospace;
-    font-weight: 600;
-    white-space: nowrap;
+    bottom: 380px;
 }
 
-/* Transient confirmation shown after the resume command is copied. */
+/* Transient confirmation shown after the resume command is copied.
+ * Opaque background (not the `…-dimmed` variant the buttons use) so
+ * the transcript text underneath doesn't bleed through the message. */
 .resume-toast {
     position: fixed;
     right: 20px;
-    bottom: 380px;
+    bottom: 440px;
     max-width: 320px;
     padding: 8px 12px;
-    background-color: var(--session-bg-dimmed);
+    background-color: #e8f4fd;
     color: var(--text-muted);
     border-radius: 6px;
     box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);

--- a/claude_code_log/html/templates/components/global_styles.css
+++ b/claude_code_log/html/templates/components/global_styles.css
@@ -362,6 +362,42 @@ body.show-raw-user .user-content:not([data-user-view="md"]) .user-raw {
     color: #333;
 }
 
+/* Resume-session button (single-session pages only): copies the
+ * `cd … && claude -r <session-id>` command to the clipboard. */
+.resume-session.floating-btn {
+    bottom: 340px;
+    border-radius: 6px;
+    width: auto;
+    height: 28px;
+    padding: 0 10px;
+    font-size: 0.65em;
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+/* Transient confirmation shown after the resume command is copied. */
+.resume-toast {
+    position: fixed;
+    right: 20px;
+    bottom: 380px;
+    max-width: 320px;
+    padding: 8px 12px;
+    background-color: var(--session-bg-dimmed);
+    color: var(--text-muted);
+    border-radius: 6px;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+    font-size: 0.8em;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+    z-index: 1000;
+}
+
+.resume-toast.visible {
+    opacity: 1;
+}
+
 @media (max-width: 1280px) {
     .header > span:first-child {
         flex: auto;

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -246,7 +246,8 @@
 
     {% if resume_command %}
     <button class="resume-session floating-btn" id="resumeSession" data-command="{{ resume_command }}"
-        title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+        title="Resume session: copy the command that resumes this session in Claude Code"
+        aria-label="Resume session">▶️</button>
     {% endif %}
     <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
     <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -244,6 +244,10 @@
 
     {% for root in roots %}{{ render_message(root) }}{% endfor %}
 
+    {% if resume_command %}
+    <button class="resume-session floating-btn" id="resumeSession" data-command="{{ resume_command }}"
+        title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+    {% endif %}
     <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
     <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
     <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -271,6 +275,48 @@
                 document.body.classList.toggle('show-debug-info');
                 debugButton.classList.toggle('active');
             });
+
+            // Resume session: copy the resume command to the clipboard
+            // and prompt the user to paste it into a terminal. The
+            // command is built server-side (data-command) from the
+            // session's recorded cwd, so its quoting matches the OS
+            // the transcript was recorded on — which may differ from
+            // the OS viewing this page.
+            const resumeButton = document.getElementById('resumeSession');
+            if (resumeButton) {
+                let resumeToastTimer = null;
+                function showResumeToast(message) {
+                    let toast = document.getElementById('resumeToast');
+                    if (!toast) {
+                        toast = document.createElement('div');
+                        toast.id = 'resumeToast';
+                        toast.className = 'resume-toast';
+                        document.body.appendChild(toast);
+                    }
+                    toast.textContent = message;
+                    toast.classList.add('visible');
+                    if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                    resumeToastTimer = setTimeout(function () {
+                        toast.classList.remove('visible');
+                    }, 5000);
+                }
+                resumeButton.addEventListener('click', function () {
+                    const command = resumeButton.dataset.command;
+                    function copied() {
+                        showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                    }
+                    function fallback() {
+                        // Clipboard API unavailable or refused: let the
+                        // user copy from a prompt instead.
+                        window.prompt('Copy this command, then paste it into your terminal:', command);
+                    }
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(command).then(copied, fallback);
+                    } else {
+                        fallback();
+                    }
+                });
+            }
 
             // User-content view toggle (Markdown / raw).
             //

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -291,6 +291,10 @@
                         toast = document.createElement('div');
                         toast.id = 'resumeToast';
                         toast.className = 'resume-toast';
+                        // Live-region semantics so screen readers
+                        // announce the copy confirmation.
+                        toast.setAttribute('role', 'status');
+                        toast.setAttribute('aria-live', 'polite');
                         document.body.appendChild(toast);
                     }
                     toast.textContent = message;

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -227,7 +227,8 @@ def resume_command_for_session(session_id: str, cwd: Optional[str]) -> Optional[
     """Build a shell one-liner that resumes ``session_id`` in Claude Code.
 
     ``cwd`` is the session's recorded working directory; the command
-    changes there first so ``claude -r`` runs in the right project.
+    changes there first so ``claude -r`` runs in the right project
+    (``cd`` on POSIX, ``pushd`` on Windows — see below).
     Quoting follows the OS the *transcript* was recorded on (detected
     from the path shape, like :func:`path_looks_absolute`), not the
     host rendering the HTML — a Windows-recorded session must be
@@ -251,8 +252,12 @@ def resume_command_for_session(session_id: str, cwd: Optional[str]) -> Optional[
         if _WINDOWS_CWD_UNSAFE_RE.search(cwd):
             return None
         # Windows shells (PowerShell 7+, cmd): double quotes handle
-        # spaces; backslashes are literal inside them.
-        return f'cd "{cwd}" && claude -r {session_id}'
+        # spaces; backslashes are literal inside them. `pushd` rather
+        # than `cd` because cmd's `cd` changes the directory but not
+        # the *drive* — pasted on C:, `cd "D:\proj"` silently leaves
+        # you on C: and `claude -r` runs in the wrong project. `pushd`
+        # switches both, and is a Push-Location alias in PowerShell.
+        return f'pushd "{cwd}" && claude -r {session_id}'
     # POSIX shells: shlex protects spaces and metacharacters.
     import shlex
 

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -212,7 +212,18 @@ def get_project_display_name(
     return best_working_dir(project_dir_name, working_directories)[0]
 
 
-def resume_command_for_session(session_id: str, cwd: Optional[str]) -> str:
+# The resume command is pasted into a shell, and transcript fields are
+# untrusted input (same threat model as the HTML escaping in #245) — so
+# both values are held to conservative charsets and the button is
+# skipped entirely rather than risk smuggling shell syntax.
+_RESUME_SESSION_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+# Inside double quotes, cmd still expands %var% / delayed-expansion
+# !var!, and PowerShell expands $var and `x escapes; a literal " would
+# end the quoting altogether.
+_WINDOWS_CWD_UNSAFE_RE = re.compile(r'["%!$`]')
+
+
+def resume_command_for_session(session_id: str, cwd: Optional[str]) -> Optional[str]:
     """Build a shell one-liner that resumes ``session_id`` in Claude Code.
 
     ``cwd`` is the session's recorded working directory; the command
@@ -222,13 +233,23 @@ def resume_command_for_session(session_id: str, cwd: Optional[str]) -> str:
     host rendering the HTML — a Windows-recorded session must be
     resumed in a Windows shell regardless of where the page is viewed.
 
-    Returns a bare ``claude -r`` command when no cwd was recorded.
+    Returns a bare ``claude -r`` command when no cwd was recorded, and
+    ``None`` (no button) when the session id or a Windows cwd contains
+    characters a shell could interpret. Newlines are rejected in every
+    position: pasting a multi-line clipboard can execute each line
+    immediately, so quoting alone is no defence.
     """
+    if not _RESUME_SESSION_ID_RE.fullmatch(session_id):
+        return None
     if not cwd:
         return f"claude -r {session_id}"
+    if "\n" in cwd or "\r" in cwd:
+        return None
     from pathlib import PureWindowsPath
 
     if PureWindowsPath(cwd).drive:
+        if _WINDOWS_CWD_UNSAFE_RE.search(cwd):
+            return None
         # Windows shells (PowerShell 7+, cmd): double quotes handle
         # spaces; backslashes are literal inside them.
         return f'cd "{cwd}" && claude -r {session_id}'

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -212,6 +212,32 @@ def get_project_display_name(
     return best_working_dir(project_dir_name, working_directories)[0]
 
 
+def resume_command_for_session(session_id: str, cwd: Optional[str]) -> str:
+    """Build a shell one-liner that resumes ``session_id`` in Claude Code.
+
+    ``cwd`` is the session's recorded working directory; the command
+    changes there first so ``claude -r`` runs in the right project.
+    Quoting follows the OS the *transcript* was recorded on (detected
+    from the path shape, like :func:`path_looks_absolute`), not the
+    host rendering the HTML — a Windows-recorded session must be
+    resumed in a Windows shell regardless of where the page is viewed.
+
+    Returns a bare ``claude -r`` command when no cwd was recorded.
+    """
+    if not cwd:
+        return f"claude -r {session_id}"
+    from pathlib import PureWindowsPath
+
+    if PureWindowsPath(cwd).drive:
+        # Windows shells (PowerShell 7+, cmd): double quotes handle
+        # spaces; backslashes are literal inside them.
+        return f'cd "{cwd}" && claude -r {session_id}'
+    # POSIX shells: shlex protects spaces and metacharacters.
+    import shlex
+
+    return f"cd {shlex.quote(cwd)} && claude -r {session_id}"
+
+
 def path_looks_absolute(s: str) -> bool:
     """True if ``s`` looks like an absolute path on either POSIX or
     Windows. Decoupled from the host OS so JSONL-stored cwds don't

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -5217,6 +5217,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -12016,6 +12020,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -21503,6 +21511,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -28805,6 +28817,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -36055,6 +36071,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -43250,6 +43270,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -50272,6 +50296,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -57099,6 +57127,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;
@@ -63875,6 +63907,10 @@
                           toast = document.createElement('div');
                           toast.id = 'resumeToast';
                           toast.className = 'resume-toast';
+                          // Live-region semantics so screen readers
+                          // announce the copy confirmation.
+                          toast.setAttribute('role', 'status');
+                          toast.setAttribute('aria-live', 'polite');
                           document.body.appendChild(toast);
                       }
                       toast.textContent = message;

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -374,6 +374,42 @@
       color: #333;
   }
   
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
+  }
+  
   @media (max-width: 1280px) {
       .header > span:first-child {
           flex: auto;
@@ -5020,6 +5056,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/async-fixture &amp;&amp; claude -r eb000000-0000-4000-8000-000000000001"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -5161,6 +5201,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -7194,6 +7276,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -11737,6 +11855,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/async-fixture &amp;&amp; claude -r eb000000-0000-4000-8000-000000000001"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -11878,6 +12000,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -13911,6 +14075,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -16340,6 +16540,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -21106,6 +21342,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp &amp;&amp; claude -r test_session"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -21247,6 +21487,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -23280,6 +23562,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -28326,6 +28644,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/test-fixture &amp;&amp; claude -r ef000000-0000-4000-8000-000000000001"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -28467,6 +28789,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -30500,6 +30864,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -35497,6 +35897,7 @@
       
       
   
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -35638,6 +36039,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -37671,6 +38114,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -42613,6 +43092,7 @@
       
       
   
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -42754,6 +43234,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -44787,6 +45309,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -49553,6 +50111,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp &amp;&amp; claude -r test_session"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -49694,6 +50256,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -51727,6 +52331,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -56298,6 +56938,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp/project &amp;&amp; claude -r 00000000-0295-4000-8000-000000000001"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -56439,6 +57083,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //
@@ -58472,6 +59158,42 @@
   .user-view-global.floating-btn.active {
       background-color: #d4e8f7;
       color: #333;
+  }
+  
+  /* Resume-session button (single-session pages only): copies the
+   * `cd … && claude -r <session-id>` command to the clipboard. */
+  .resume-session.floating-btn {
+      bottom: 340px;
+      border-radius: 6px;
+      width: auto;
+      height: 28px;
+      padding: 0 10px;
+      font-size: 0.65em;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-weight: 600;
+      white-space: nowrap;
+  }
+  
+  /* Transient confirmation shown after the resume command is copied. */
+  .resume-toast {
+      position: fixed;
+      right: 20px;
+      bottom: 380px;
+      max-width: 320px;
+      padding: 8px 12px;
+      background-color: var(--session-bg-dimmed);
+      color: var(--text-muted);
+      border-radius: 6px;
+      box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+      font-size: 0.8em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 1000;
+  }
+  
+  .resume-toast.visible {
+      opacity: 1;
   }
   
   @media (max-width: 1280px) {
@@ -62992,6 +63714,10 @@
       
       
   
+      
+      <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp/project &amp;&amp; claude -r system_reminder"
+          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+      
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -63133,6 +63859,48 @@
                   document.body.classList.toggle('show-debug-info');
                   debugButton.classList.toggle('active');
               });
+  
+              // Resume session: copy the resume command to the clipboard
+              // and prompt the user to paste it into a terminal. The
+              // command is built server-side (data-command) from the
+              // session's recorded cwd, so its quoting matches the OS
+              // the transcript was recorded on — which may differ from
+              // the OS viewing this page.
+              const resumeButton = document.getElementById('resumeSession');
+              if (resumeButton) {
+                  let resumeToastTimer = null;
+                  function showResumeToast(message) {
+                      let toast = document.getElementById('resumeToast');
+                      if (!toast) {
+                          toast = document.createElement('div');
+                          toast.id = 'resumeToast';
+                          toast.className = 'resume-toast';
+                          document.body.appendChild(toast);
+                      }
+                      toast.textContent = message;
+                      toast.classList.add('visible');
+                      if (resumeToastTimer) clearTimeout(resumeToastTimer);
+                      resumeToastTimer = setTimeout(function () {
+                          toast.classList.remove('visible');
+                      }, 5000);
+                  }
+                  resumeButton.addEventListener('click', function () {
+                      const command = resumeButton.dataset.command;
+                      function copied() {
+                          showResumeToast('📋 Copied! Paste into your terminal to resume this session.');
+                      }
+                      function fallback() {
+                          // Clipboard API unavailable or refused: let the
+                          // user copy from a prompt instead.
+                          window.prompt('Copy this command, then paste it into your terminal:', command);
+                      }
+                      if (navigator.clipboard && navigator.clipboard.writeText) {
+                          navigator.clipboard.writeText(command).then(copied, fallback);
+                      } else {
+                          fallback();
+                      }
+                  });
+              }
   
               // User-content view toggle (Markdown / raw).
               //

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -260,12 +260,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -360,11 +359,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -375,27 +371,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -5058,7 +5048,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/async-fixture &amp;&amp; claude -r eb000000-0000-4000-8000-000000000001"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
@@ -7168,12 +7159,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -7268,11 +7258,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -7283,27 +7270,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -11861,7 +11842,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/async-fixture &amp;&amp; claude -r eb000000-0000-4000-8000-000000000001"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
@@ -13971,12 +13953,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -14071,11 +14052,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -14086,27 +14064,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -16436,12 +16408,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -16536,11 +16507,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -16551,27 +16519,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -21352,7 +21314,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp &amp;&amp; claude -r test_session"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
@@ -23462,12 +23425,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -23562,11 +23524,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -23577,27 +23536,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -28658,7 +28611,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/test-fixture &amp;&amp; claude -r ef000000-0000-4000-8000-000000000001"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
@@ -30768,12 +30722,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -30868,11 +30821,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -30883,27 +30833,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -38022,12 +37966,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -38122,11 +38065,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -38137,27 +38077,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -45221,12 +45155,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -45321,11 +45254,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -45336,27 +45266,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -50137,7 +50061,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp &amp;&amp; claude -r test_session"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
@@ -52247,12 +52172,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -52347,11 +52271,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -52362,27 +52283,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -56968,7 +56883,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp/project &amp;&amp; claude -r 00000000-0295-4000-8000-000000000001"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
@@ -59078,12 +58994,11 @@
       bottom: 200px;
   }
   
+  /* Text-labelled floating buttons ("uuid", "md") keep the round shape
+   * and size of the emoji ones; only the label typography differs. */
   .debug-toggle.floating-btn {
       bottom: 260px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -59178,11 +59093,8 @@
   }
   
   .user-view-global.floating-btn {
-      bottom: 300px;
-      border-radius: 6px;
-      width: 38px;
-      height: 28px;
-      font-size: 0.65em;
+      bottom: 320px;
+      font-size: 0.7em;
       font-family: 'SFMono-Regular', Consolas, monospace;
       font-weight: 600;
   }
@@ -59193,27 +59105,21 @@
   }
   
   /* Resume-session button (single-session pages only): copies the
-   * `cd … && claude -r <session-id>` command to the clipboard. */
+   * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 340px;
-      border-radius: 6px;
-      width: auto;
-      height: 28px;
-      padding: 0 10px;
-      font-size: 0.65em;
-      font-family: 'SFMono-Regular', Consolas, monospace;
-      font-weight: 600;
-      white-space: nowrap;
+      bottom: 380px;
   }
   
-  /* Transient confirmation shown after the resume command is copied. */
+  /* Transient confirmation shown after the resume command is copied.
+   * Opaque background (not the `…-dimmed` variant the buttons use) so
+   * the transcript text underneath doesn't bleed through the message. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 380px;
+      bottom: 440px;
       max-width: 320px;
       padding: 8px 12px;
-      background-color: var(--session-bg-dimmed);
+      background-color: #e8f4fd;
       color: var(--text-muted);
       border-radius: 6px;
       box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
@@ -63748,7 +63654,8 @@
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp/project &amp;&amp; claude -r system_reminder"
-          title="Copy the command that resumes this session in Claude Code">▶ Resume Session</button>
+          title="Resume session: copy the command that resumes this session in Claude Code"
+          aria-label="Resume session">▶️</button>
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>

--- a/test/test_resume_session_browser.py
+++ b/test/test_resume_session_browser.py
@@ -27,6 +27,7 @@ def _user_entry(
     cwd: str = "/tmp/project",
     ts: str = "2026-01-01T10:00:00.000Z",
 ) -> dict:
+    """Build a raw user-entry dict for a JSONL fixture."""
     return {
         "type": "user",
         "timestamp": ts,
@@ -48,9 +49,11 @@ class TestResumeSessionBrowser:
     """Live-browser tests for the Resume Session button."""
 
     def setup_method(self) -> None:
+        """Track temp files created by the test for cleanup."""
         self.temp_files: List[Path] = []
 
     def teardown_method(self) -> None:
+        """Remove the temp files created during the test."""
         for f in self.temp_files:
             try:
                 f.unlink()
@@ -95,10 +98,11 @@ class TestResumeSessionBrowser:
             });
             """
         )
-        page.goto(f"file://{html}")
+        page.goto(html.as_uri())
 
     @pytest.mark.browser
     def test_click_copies_command_and_shows_toast(self, page: Page) -> None:
+        """Clicking the button copies the exact command and shows the toast."""
         html = self._render(
             [_user_entry("u1", "hello", session_id="ab12cd34", cwd="/tmp/project")]
         )
@@ -118,6 +122,7 @@ class TestResumeSessionBrowser:
 
     @pytest.mark.browser
     def test_no_button_on_multi_session_page(self, page: Page) -> None:
+        """Combined pages spanning several sessions render no button."""
         html = self._render(
             [
                 _user_entry("u1", "first", session_id="session_a"),
@@ -129,5 +134,5 @@ class TestResumeSessionBrowser:
                 ),
             ]
         )
-        page.goto(f"file://{html}")
+        page.goto(html.as_uri())
         expect(page.locator("#resumeSession")).to_have_count(0)

--- a/test/test_resume_session_browser.py
+++ b/test/test_resume_session_browser.py
@@ -1,0 +1,133 @@
+"""Playwright tests for the Resume Session floating button.
+
+Covers the live-JS behavior the server-side unit tests can't reach:
+clicking the button writes the resume command to the clipboard and
+shows the paste-into-terminal toast.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from claude_code_log.converter import load_transcript
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.models import TranscriptEntry
+
+
+def _user_entry(
+    uuid: str,
+    text: str,
+    session_id: str = "test_session",
+    cwd: str = "/tmp/project",
+    ts: str = "2026-01-01T10:00:00.000Z",
+) -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": cwd,
+        "sessionId": session_id,
+        "version": "1.0.0",
+        "uuid": uuid,
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+class TestResumeSessionBrowser:
+    """Live-browser tests for the Resume Session button."""
+
+    def setup_method(self) -> None:
+        self.temp_files: List[Path] = []
+
+    def teardown_method(self) -> None:
+        for f in self.temp_files:
+            try:
+                f.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _render(self, entries: List[dict], title: str = "Resume Test") -> Path:
+        """Write entries to a JSONL, render to HTML, return the HTML path."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        ) as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+            jsonl_path = Path(f.name)
+        self.temp_files.append(jsonl_path)
+
+        messages: List[TranscriptEntry] = load_transcript(jsonl_path)
+        html_content = generate_html(messages, title)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".html", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(html_content)
+            html_path = Path(f.name)
+        self.temp_files.append(html_path)
+        return html_path
+
+    def _goto_with_clipboard_stub(self, page: Page, html: Path) -> None:
+        """Navigate to the rendered HTML with ``navigator.clipboard``
+        stubbed to record writes into ``window.__copied``. file:// pages
+        can't reliably get real clipboard permission in the test
+        browser, and a stub also lets the test assert the exact text."""
+        page.add_init_script(
+            """
+            Object.defineProperty(navigator, 'clipboard', {
+                value: {
+                    writeText: function (text) {
+                        window.__copied = text;
+                        return Promise.resolve();
+                    }
+                },
+                configurable: true
+            });
+            """
+        )
+        page.goto(f"file://{html}")
+
+    @pytest.mark.browser
+    def test_click_copies_command_and_shows_toast(self, page: Page) -> None:
+        html = self._render(
+            [_user_entry("u1", "hello", session_id="ab12cd34", cwd="/tmp/project")]
+        )
+        self._goto_with_clipboard_stub(page, html)
+
+        button = page.locator("#resumeSession")
+        expect(button).to_be_visible()
+        expect(button).to_have_text("▶ Resume Session")
+
+        button.click()
+        copied: Optional[str] = page.evaluate("() => window.__copied")
+        assert copied == "cd /tmp/project && claude -r ab12cd34"
+
+        toast = page.locator("#resumeToast")
+        expect(toast).to_be_visible()
+        expect(toast).to_contain_text("Paste into your terminal")
+
+    @pytest.mark.browser
+    def test_no_button_on_multi_session_page(self, page: Page) -> None:
+        html = self._render(
+            [
+                _user_entry("u1", "first", session_id="session_a"),
+                _user_entry(
+                    "u2",
+                    "second",
+                    session_id="session_b",
+                    ts="2026-01-01T10:01:00.000Z",
+                ),
+            ]
+        )
+        page.goto(f"file://{html}")
+        expect(page.locator("#resumeSession")).to_have_count(0)

--- a/test/test_resume_session_browser.py
+++ b/test/test_resume_session_browser.py
@@ -110,7 +110,7 @@ class TestResumeSessionBrowser:
 
         button = page.locator("#resumeSession")
         expect(button).to_be_visible()
-        expect(button).to_have_text("▶ Resume Session")
+        expect(button).to_have_text("▶️")
 
         button.click()
         copied: Optional[str] = page.evaluate("() => window.__copied")

--- a/test/test_resume_session_button.py
+++ b/test/test_resume_session_button.py
@@ -15,6 +15,7 @@ SESSION_B = "37f83ec9-f2ea-42a9-925e-0d5c105cb6e8"
 
 
 def _user_entry(session_id: str, cwd: Optional[str], uuid: str) -> UserTranscriptEntry:
+    """Build a minimal user entry for rendering tests."""
     return UserTranscriptEntry(
         type="user",
         timestamp="2025-06-14T10:00:00.000Z",
@@ -36,37 +37,70 @@ class TestResumeCommandForSession:
     """Command shape follows the OS the transcript was recorded on."""
 
     def test_windows_cwd_uses_double_quotes(self):
+        """A drive-lettered cwd gets Windows double-quote quoting."""
         assert (
             resume_command_for_session(SESSION_A, "C:\\Users\\maxno")
             == f'cd "C:\\Users\\maxno" && claude -r {SESSION_A}'
         )
 
     def test_windows_cwd_with_spaces(self):
+        """Spaces in a Windows cwd stay inside the double quotes."""
         assert (
             resume_command_for_session(SESSION_A, "C:\\My Projects\\app")
             == f'cd "C:\\My Projects\\app" && claude -r {SESSION_A}'
         )
 
     def test_posix_cwd(self):
+        """A plain POSIX cwd needs no quoting at all."""
         assert (
             resume_command_for_session(SESSION_A, "/Users/dain/workspace")
             == f"cd /Users/dain/workspace && claude -r {SESSION_A}"
         )
 
     def test_posix_cwd_with_spaces_is_quoted(self):
+        """Spaces in a POSIX cwd get shlex single-quoting."""
         assert (
             resume_command_for_session(SESSION_A, "/home/u/my project")
             == f"cd '/home/u/my project' && claude -r {SESSION_A}"
         )
 
     def test_no_cwd_falls_back_to_bare_resume(self):
+        """Without a recorded cwd the command is a bare claude -r."""
         assert resume_command_for_session(SESSION_A, None) == f"claude -r {SESSION_A}"
+
+    def test_posix_cwd_with_single_quote_is_escaped(self):
+        """shlex neutralizes an embedded single quote in a POSIX cwd."""
+        command = resume_command_for_session(SESSION_A, "/home/u/it's")
+        assert command == f"""cd '/home/u/it'"'"'s' && claude -r {SESSION_A}"""
+
+    def test_session_id_with_shell_metacharacters_is_rejected(self):
+        """A session id carrying shell syntax yields no command at all."""
+        assert resume_command_for_session("evil; rm -rf ~", "/tmp") is None
+        assert resume_command_for_session("$(whoami)", "/tmp") is None
+        assert resume_command_for_session("", "/tmp") is None
+
+    def test_windows_cwd_with_embedded_quote_is_rejected(self):
+        """A double quote in a Windows cwd would break out of the quoting."""
+        assert resume_command_for_session(SESSION_A, 'C:\\evil" & calc & "') is None
+
+    def test_windows_cwd_with_expansion_characters_is_rejected(self):
+        """cmd %var%/!var! and PowerShell $var/`x expand inside double quotes."""
+        assert resume_command_for_session(SESSION_A, "C:\\x%TEMP%") is None
+        assert resume_command_for_session(SESSION_A, "C:\\x$(calc)") is None
+        assert resume_command_for_session(SESSION_A, "C:\\x`n") is None
+        assert resume_command_for_session(SESSION_A, "C:\\x!var!") is None
+
+    def test_cwd_with_newline_is_rejected(self):
+        """Pasting multi-line text can execute each line — reject outright."""
+        assert resume_command_for_session(SESSION_A, "/tmp/a\nrm -rf ~") is None
+        assert resume_command_for_session(SESSION_A, "C:\\a\r\ncalc") is None
 
 
 class TestResumeButtonInHtml:
     """The button renders only on single-session pages."""
 
     def test_single_session_page_has_button_with_command(self):
+        """A single-session page renders the button with its command."""
         html = generate_html(
             [_user_entry(SESSION_A, "/Users/dain/workspace", "uuid-1")],
             "Test Resume",
@@ -79,6 +113,7 @@ class TestResumeButtonInHtml:
         )
 
     def test_windows_session_command_is_escaped_into_attribute(self):
+        """The Windows command lands HTML-escaped in the data attribute."""
         html = generate_html(
             [_user_entry(SESSION_A, "C:\\Users\\maxno", "uuid-1")],
             "Test Resume Windows",
@@ -86,11 +121,20 @@ class TestResumeButtonInHtml:
         assert f"cd &#34;C:\\Users\\maxno&#34; &amp;&amp; claude -r {SESSION_A}" in html
 
     def test_multi_session_page_has_no_button(self):
+        """Combined pages spanning several sessions render no button."""
         html = generate_html(
             [
                 _user_entry(SESSION_A, "/Users/dain/workspace", "uuid-1"),
                 _user_entry(SESSION_B, "/Users/dain/workspace", "uuid-2"),
             ],
             "Test Combined",
+        )
+        assert 'id="resumeSession"' not in html
+
+    def test_unsafe_session_id_renders_no_button(self):
+        """A transcript with a shell-unsafe session id gets no button."""
+        html = generate_html(
+            [_user_entry("evil; rm -rf ~", "/tmp", "uuid-1")],
+            "Test Unsafe",
         )
         assert 'id="resumeSession"' not in html

--- a/test/test_resume_session_button.py
+++ b/test/test_resume_session_button.py
@@ -40,15 +40,21 @@ class TestResumeCommandForSession:
         """A drive-lettered cwd gets Windows double-quote quoting."""
         assert (
             resume_command_for_session(SESSION_A, "C:\\Users\\maxno")
-            == f'cd "C:\\Users\\maxno" && claude -r {SESSION_A}'
+            == f'pushd "C:\\Users\\maxno" && claude -r {SESSION_A}'
         )
 
     def test_windows_cwd_with_spaces(self):
         """Spaces in a Windows cwd stay inside the double quotes."""
         assert (
             resume_command_for_session(SESSION_A, "C:\\My Projects\\app")
-            == f'cd "C:\\My Projects\\app" && claude -r {SESSION_A}'
+            == f'pushd "C:\\My Projects\\app" && claude -r {SESSION_A}'
         )
+
+    def test_windows_other_drive_uses_pushd(self):
+        """A D: cwd must switch drive too — cmd's `cd` alone wouldn't,
+        so a terminal started on C: would resume in the wrong project."""
+        command = resume_command_for_session(SESSION_A, "D:\\work\\app")
+        assert command == f'pushd "D:\\work\\app" && claude -r {SESSION_A}'
 
     def test_posix_cwd(self):
         """A plain POSIX cwd needs no quoting at all."""
@@ -106,7 +112,7 @@ class TestResumeButtonInHtml:
             "Test Resume",
         )
         assert 'id="resumeSession"' in html
-        assert "▶ Resume Session" in html
+        assert "▶️</button>" in html
         assert (
             f'data-command="cd /Users/dain/workspace &amp;&amp; claude -r {SESSION_A}"'
             in html
@@ -118,7 +124,9 @@ class TestResumeButtonInHtml:
             [_user_entry(SESSION_A, "C:\\Users\\maxno", "uuid-1")],
             "Test Resume Windows",
         )
-        assert f"cd &#34;C:\\Users\\maxno&#34; &amp;&amp; claude -r {SESSION_A}" in html
+        assert (
+            f"pushd &#34;C:\\Users\\maxno&#34; &amp;&amp; claude -r {SESSION_A}" in html
+        )
 
     def test_multi_session_page_has_no_button(self):
         """Combined pages spanning several sessions render no button."""

--- a/test/test_resume_session_button.py
+++ b/test/test_resume_session_button.py
@@ -1,0 +1,96 @@
+"""Tests for the Resume Session floating button and its command builder."""
+
+from typing import Optional
+
+from claude_code_log.html.renderer import generate_html
+from claude_code_log.models import (
+    TextContent,
+    UserMessageModel,
+    UserTranscriptEntry,
+)
+from claude_code_log.utils import resume_command_for_session
+
+SESSION_A = "c2688f20-2ca1-410d-a82b-1a7f11761315"
+SESSION_B = "37f83ec9-f2ea-42a9-925e-0d5c105cb6e8"
+
+
+def _user_entry(session_id: str, cwd: Optional[str], uuid: str) -> UserTranscriptEntry:
+    return UserTranscriptEntry(
+        type="user",
+        timestamp="2025-06-14T10:00:00.000Z",
+        parentUuid=None,
+        isSidechain=False,
+        userType="human",
+        cwd=cwd or "",
+        sessionId=session_id,
+        version="1.0.0",
+        uuid=uuid,
+        message=UserMessageModel(
+            role="user",
+            content=[TextContent(type="text", text=f"Hello from {uuid}")],
+        ),
+    )
+
+
+class TestResumeCommandForSession:
+    """Command shape follows the OS the transcript was recorded on."""
+
+    def test_windows_cwd_uses_double_quotes(self):
+        assert (
+            resume_command_for_session(SESSION_A, "C:\\Users\\maxno")
+            == f'cd "C:\\Users\\maxno" && claude -r {SESSION_A}'
+        )
+
+    def test_windows_cwd_with_spaces(self):
+        assert (
+            resume_command_for_session(SESSION_A, "C:\\My Projects\\app")
+            == f'cd "C:\\My Projects\\app" && claude -r {SESSION_A}'
+        )
+
+    def test_posix_cwd(self):
+        assert (
+            resume_command_for_session(SESSION_A, "/Users/dain/workspace")
+            == f"cd /Users/dain/workspace && claude -r {SESSION_A}"
+        )
+
+    def test_posix_cwd_with_spaces_is_quoted(self):
+        assert (
+            resume_command_for_session(SESSION_A, "/home/u/my project")
+            == f"cd '/home/u/my project' && claude -r {SESSION_A}"
+        )
+
+    def test_no_cwd_falls_back_to_bare_resume(self):
+        assert resume_command_for_session(SESSION_A, None) == f"claude -r {SESSION_A}"
+
+
+class TestResumeButtonInHtml:
+    """The button renders only on single-session pages."""
+
+    def test_single_session_page_has_button_with_command(self):
+        html = generate_html(
+            [_user_entry(SESSION_A, "/Users/dain/workspace", "uuid-1")],
+            "Test Resume",
+        )
+        assert 'id="resumeSession"' in html
+        assert "▶ Resume Session" in html
+        assert (
+            f'data-command="cd /Users/dain/workspace &amp;&amp; claude -r {SESSION_A}"'
+            in html
+        )
+
+    def test_windows_session_command_is_escaped_into_attribute(self):
+        html = generate_html(
+            [_user_entry(SESSION_A, "C:\\Users\\maxno", "uuid-1")],
+            "Test Resume Windows",
+        )
+        assert f"cd &#34;C:\\Users\\maxno&#34; &amp;&amp; claude -r {SESSION_A}" in html
+
+    def test_multi_session_page_has_no_button(self):
+        html = generate_html(
+            [
+                _user_entry(SESSION_A, "/Users/dain/workspace", "uuid-1"),
+                _user_entry(SESSION_B, "/Users/dain/workspace", "uuid-2"),
+            ],
+            "Test Combined",
+        )
+        assert 'id="resumeSession"' not in html


### PR DESCRIPTION
This is a continuation of #308 which I couldn't directly edit.

Addressed Coderabbit's feedback about `cd` on Windows.

I tweaked the UI a bit, including the md/raw and uuid buttons so they are all round now:

<img width="740" height="610" alt="image" src="https://github.com/user-attachments/assets/8d15e40e-d703-40f7-993a-7c2c537330d6" />

<img width="259" height="159" alt="image" src="https://github.com/user-attachments/assets/50692a57-ce10-4905-ac58-8e0f4aa3de41" />

<img width="422" height="212" alt="image" src="https://github.com/user-attachments/assets/82ff40d5-9cf6-4f39-be7c-1ce874107d98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Resume session” button for pages containing a single session.
  * Copies a ready-to-run resume command to the clipboard and shows a confirmation message.
  * Provides a prompt fallback when clipboard access is unavailable.
  * Improved floating-button sizing and positioning.

* **Bug Fixes**
  * Resume controls are hidden when multiple or unsafe sessions are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->