### PR TITLE
Perf/render memo and intra project jobs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,28 @@ Set `CLAUDE_CODE_LOG_RENDER_CACHE_MB=0` to disable memoization when
 bisecting a rendering difference; any other value sets the per-cache byte
 budget in MB (default 192).
 
+A project's own pages and session files can additionally be rendered in
+parallel worker processes. This is opt-in — set
+`CLAUDE_CODE_LOG_RENDER_JOBS=auto` (or a worker count) — because it
+overlaps with the memo above and only pays off on large projects. Note that
+each worker holds the project's whole transcript (~3x its bytes on disk),
+so the worker count is capped against available memory; on a small machine
+or a large archive it degrades to serial rather than swapping. See
+[dev-docs/application_model.md § 2.10](dev-docs/application_model.md) for
+the measurements.
+
+To re-measure both on your own hardware (core count changes the answer for
+the fan-out), point the benchmark at a real project:
+
+```bash
+uv run python scripts/bench_render.py ~/.claude/projects/<project>
+```
+
+It copies the project to scratch space, warms the cache, then times every
+combination of the two knobs plus a worker-count sweep — and hashes the
+output of each, so it doubles as an equivalence check across far more real
+data than the test fixtures cover.
+
 ## Diagnosing Hangs
 
 If `claude-code-log` appears stuck (100% CPU, no output), send `SIGUSR1` to print the live Python stack to stderr without killing the process:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,8 +275,12 @@ parallel worker processes, on by default at the CPU count. Set
 `CLAUDE_CODE_LOG_RENDER_JOBS=1` (or `off`) to disable it, or an integer to
 pin a worker count. It earns its keep on the runs that matter — an
 incremental run over a real archive measured 93.2s → 34.6s on 16 cores —
-at the cost of considerably more total CPU, since each worker starts with
-a cold memo cache. Small projects are excluded outright, and because each
+at the cost of more total CPU, since each worker starts with a cold memo
+cache. The fragment store recovers a share of that: page workers export
+their formatted fragments back to the parent, and session workers are fed
+their session's slice, so they verify-and-reuse instead of re-formatting
+(measured −14% total CPU on a 34k-message archive at 8 workers, with
+96–100% worker hit rates). Small projects are excluded outright, and because each
 worker holds the project's whole transcript (~3x its bytes on disk) the
 worker count is capped against available memory: on a small machine or a
 large archive it degrades to serial rather than swapping. See

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,13 @@ Set `CLAUDE_CODE_LOG_RENDER_CACHE_MB=0` to disable memoization when
 bisecting a rendering difference; any other value sets the per-cache byte
 budget in MB (default 192).
 
+Above the leaf memo, a per-conversion fragment store
+(`claude_code_log/fragment_store.py`) reuses each message's complete
+formatted fragment between the combined-page and per-session passes.
+Set `CLAUDE_CODE_LOG_FRAGMENT_STORE=0` to disable it when bisecting;
+see [dev-docs/application_model.md § 2.9](dev-docs/application_model.md)
+for its correctness guards.
+
 A project's own pages and session files are additionally rendered in
 parallel worker processes, on by default at the CPU count. Set
 `CLAUDE_CODE_LOG_RENDER_JOBS=1` (or `off`) to disable it, or an integer to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,8 +266,13 @@ budget in MB (default 192).
 Above the leaf memo, a per-conversion fragment store
 (`claude_code_log/fragment_store.py`) reuses each message's complete
 formatted fragment between the combined-page and per-session passes.
-Set `CLAUDE_CODE_LOG_FRAGMENT_STORE=0` to disable it when bisecting;
-see [dev-docs/application_model.md § 2.9](dev-docs/application_model.md)
+Set `CLAUDE_CODE_LOG_FRAGMENT_STORE=0` to disable it when bisecting.
+The store is a RAM-for-CPU trade (~+0.35× the project's transcript
+bytes at peak, measured), so a memory valve skips it automatically
+when available memory is under ~2.4× those bytes — the conversion
+then runs store-less at its pre-store footprint; an explicit `=1`
+forces the store past the valve. See
+[dev-docs/application_model.md § 2.9](dev-docs/application_model.md)
 for its correctness guards.
 
 A project's own pages and session files are additionally rendered in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,14 +276,15 @@ parallel worker processes, on by default at the CPU count. Set
 pin a worker count. It earns its keep on the runs that matter — an
 incremental run over a real archive measured 93.2s → 34.6s on 16 cores —
 at the cost of more total CPU, since each worker starts with a cold memo
-cache. The fragment store recovers a share of that: page workers export
-their formatted fragments back to the parent, and session workers are fed
-their session's slice, so they verify-and-reuse instead of re-formatting
-(measured −14% total CPU on a 34k-message archive at 8 workers, with
-96–100% worker hit rates). Small projects are excluded outright, and because each
-worker holds the project's whole transcript (~3x its bytes on disk) the
-worker count is capped against available memory: on a small machine or a
-large archive it degrades to serial rather than swapping. See
+cache. Workers are *fed*, not self-loading: each unit crosses the process
+boundary carrying its own entry slice and (for session files) its slice
+of the fragment store, so workers verify-and-reuse formatted fragments
+instead of re-formatting, and no worker loads the project's transcript.
+Small projects are excluded outright, and the worker count is capped
+against available memory (the cap still charges each worker a full
+transcript copy — deliberately conservative until re-measured): on a
+small machine or a large archive it degrades to serial rather than
+swapping. See
 [dev-docs/application_model.md § 2.10](dev-docs/application_model.md) for
 the measurements.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,17 @@ Enable timing instrumentation to identify bottlenecks:
 CLAUDE_CODE_LOG_DEBUG_TIMING=1 claude-code-log path/to/file.jsonl
 ```
 
-This outputs detailed timing for each rendering phase. The timing module is in `claude_code_log/renderer_timings.py`.
+This outputs detailed timing for each rendering phase, plus hit rates for
+the render memo caches. The timing module is in
+`claude_code_log/renderer_timings.py`.
+
+Pygments highlighting and Markdown rendering are memoized because every
+message is formatted twice per run (once for its combined page, once for
+its session file) — see `claude_code_log/render_cache.py` and
+[dev-docs/application_model.md § 2.9](dev-docs/application_model.md).
+Set `CLAUDE_CODE_LOG_RENDER_CACHE_MB=0` to disable memoization when
+bisecting a rendering difference; any other value sets the per-cache byte
+budget in MB (default 192).
 
 ## Diagnosing Hangs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,8 +281,8 @@ boundary carrying its own entry slice and (for session files) its slice
 of the fragment store, so workers verify-and-reuse formatted fragments
 instead of re-formatting, and no worker loads the project's transcript.
 Small projects are excluded outright, and the worker count is capped
-against available memory (the cap still charges each worker a full
-transcript copy — deliberately conservative until re-measured): on a
+against available memory (the parent is charged its measured master-list
+footprint, each fed worker only its measured slice-holding cost): on a
 small machine or a large archive it degrades to serial rather than
 swapping. See
 [dev-docs/application_model.md § 2.10](dev-docs/application_model.md) for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,13 +263,16 @@ Set `CLAUDE_CODE_LOG_RENDER_CACHE_MB=0` to disable memoization when
 bisecting a rendering difference; any other value sets the per-cache byte
 budget in MB (default 192).
 
-A project's own pages and session files can additionally be rendered in
-parallel worker processes. This is opt-in — set
-`CLAUDE_CODE_LOG_RENDER_JOBS=auto` (or a worker count) — because it
-overlaps with the memo above and only pays off on large projects. Note that
-each worker holds the project's whole transcript (~3x its bytes on disk),
-so the worker count is capped against available memory; on a small machine
-or a large archive it degrades to serial rather than swapping. See
+A project's own pages and session files are additionally rendered in
+parallel worker processes, on by default at the CPU count. Set
+`CLAUDE_CODE_LOG_RENDER_JOBS=1` (or `off`) to disable it, or an integer to
+pin a worker count. It earns its keep on the runs that matter — an
+incremental run over a real archive measured 93.2s → 34.6s on 16 cores —
+at the cost of considerably more total CPU, since each worker starts with
+a cold memo cache. Small projects are excluded outright, and because each
+worker holds the project's whole transcript (~3x its bytes on disk) the
+worker count is capped against available memory: on a small machine or a
+large archive it degrades to serial rather than swapping. See
 [dev-docs/application_model.md § 2.10](dev-docs/application_model.md) for
 the measurements.
 

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -323,6 +323,8 @@ class CacheManager:
         project_path: Path,
         library_version: str,
         db_path: Optional[Path] = None,
+        *,
+        read_only: bool = False,
     ):
         """Initialise cache manager for a project.
 
@@ -331,9 +333,18 @@ class CacheManager:
             library_version: Current version of the library for cache invalidation
             db_path: Optional explicit path to the cache database. If not provided,
                 uses CLAUDE_CODE_LOG_CACHE_PATH env var or default location.
+            read_only: Open the cache strictly for reading. Skips the
+                migration run and the project-row upsert, and opens every
+                connection in SQLite's ``mode=ro``, so this instance can
+                never write the shared database. Built for spawned render
+                workers, which would otherwise all race those writes. The
+                project id is looked up rather than created, so a missing
+                database or row degrades to "no cached data" instead of
+                erroring.
         """
         self.project_path = project_path
         self.library_version = library_version
+        self._read_only = read_only
 
         # Priority: explicit db_path > env var > default location
         if db_path:
@@ -348,15 +359,26 @@ class CacheManager:
         # if migrations are ever routed through it.
         self._shared_conn: Optional[sqlite3.Connection] = None
 
-        # Initialise database and ensure project exists
-        self._init_database()
         self._project_id: Optional[int] = None
-        self._ensure_project_exists()
+        if read_only:
+            # Migrations and the project-row upsert both write; a reader
+            # takes the schema and row exactly as the parent process left
+            # them, and only looks its project up.
+            self._lookup_project_id()
+        else:
+            # Initialise database and ensure project exists
+            self._init_database()
+            self._ensure_project_exists()
 
     def _configure_connection(self, conn: sqlite3.Connection) -> None:
         """Apply the standard pragmas/row factory to a fresh connection."""
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON")
+        if self._read_only:
+            # A mode=ro connection cannot switch journal modes, and a
+            # reader needs neither pragma: the writing parent already
+            # keeps the database in WAL.
+            return
         conn.execute("PRAGMA journal_mode = WAL")
         # synchronous=NORMAL is the recommended pairing for WAL: it keeps
         # durability across application crashes (only a power/OS crash can lose
@@ -373,7 +395,14 @@ class CacheManager:
         .db/.db-wal/.db-shm files — the exact failure mode the connection
         lifecycle elsewhere is careful to avoid (Windows WinError 32).
         """
-        conn = sqlite3.connect(self.db_path, timeout=30.0)
+        if self._read_only:
+            # as_uri() percent-encodes the (absolute) path, so URI mode is
+            # safe for paths with spaces or query-ish characters.
+            conn = sqlite3.connect(
+                self.db_path.resolve().as_uri() + "?mode=ro", uri=True, timeout=30.0
+            )
+        else:
+            conn = sqlite3.connect(self.db_path, timeout=30.0)
         try:
             self._configure_connection(conn)
         except BaseException:
@@ -444,6 +473,29 @@ class CacheManager:
             return
         run_migrations(self.db_path)
         _migrated_db_paths.add(key)
+
+    def _lookup_project_id(self) -> None:
+        """Read-only counterpart of ``_ensure_project_exists``: find, never create.
+
+        No version-compatibility handling either — invalidating on a
+        mismatch is a write, and the (writing) parent that spawned this
+        reader already resolved any mismatch before handing over. Leaves
+        ``_project_id`` as None — reads return "no cached data" — when the
+        database, schema, or row is absent, rather than raising out of a
+        worker's initialiser.
+        """
+        if not self.db_path.exists():
+            return
+        try:
+            with self._get_connection() as conn:
+                row = conn.execute(
+                    "SELECT id FROM projects WHERE project_path = ?",
+                    (str(self.project_path),),
+                ).fetchone()
+        except sqlite3.Error:
+            return
+        if row:
+            self._project_id = row["id"]
 
     def _ensure_project_exists(self) -> None:
         """Ensure project record exists and get its ID."""

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1018,8 +1018,9 @@ def main() -> None:
         "Worker processes for converting projects in --all-projects mode "
         "(default: CPU count; 1 disables parallelism). Peak memory scales "
         "with jobs x the largest stale project. Also caps the per-project "
-        "render fan-out, which is opt-in via "
-        "$CLAUDE_CODE_LOG_RENDER_JOBS (auto, or a worker count)."
+        "render fan-out, which is on by default and controlled by "
+        "$CLAUDE_CODE_LOG_RENDER_JOBS (1 or 'off' to disable, auto, or a "
+        "worker count)."
     ),
 )
 @click.option(

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -33,6 +33,7 @@ from .cache import (
     get_library_version,
 )
 from .models import RenderingDepth
+from .render_pool import resolve_render_jobs
 from .search import (
     ENV_INDEX_FIELDS,
     ENV_SEARCH_FIELDS,
@@ -1014,12 +1015,11 @@ def main() -> None:
     type=click.IntRange(min=1),
     default=None,
     help=(
-        "Total worker processes for conversion (default: CPU count; 1 "
-        "disables parallelism). Under --all-projects the budget is split "
-        "between converting projects in parallel and rendering each "
-        "project's own pages/session files in parallel; a single-project "
-        "conversion spends all of it on the latter. Peak memory scales "
-        "with jobs × the largest stale project."
+        "Worker processes for converting projects in --all-projects mode "
+        "(default: CPU count; 1 disables parallelism). Peak memory scales "
+        "with jobs x the largest stale project. Also caps the per-project "
+        "render fan-out, which is opt-in via "
+        "$CLAUDE_CODE_LOG_RENDER_JOBS (auto, or a worker count)."
     ),
 )
 @click.option(
@@ -1971,9 +1971,14 @@ def convert(
             force_regenerate=output is not None and _output_path_is_file(output),
             report=report,
             # A single-project conversion has the whole machine to itself,
-            # so its pages and session files fan out over `--jobs` workers
-            # (None → CPU count). The library default stays 1.
-            render_jobs=jobs,
+            # so `--jobs` is the cap for its render fan-out. Whether that
+            # fan-out runs at all is decided by
+            # $CLAUDE_CODE_LOG_RENDER_JOBS, which is off by default —
+            # `render_jobs=None` consults it, and the min() keeps an
+            # explicit `--jobs` as the ceiling.
+            render_jobs=(
+                min(jobs, resolve_render_jobs(None)) if jobs is not None else None
+            ),
         )
         # Report only work actually done this run. On a pure skip the converter
         # already printed its "... is current, skipping regeneration" line, so

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -1014,8 +1014,11 @@ def main() -> None:
     type=click.IntRange(min=1),
     default=None,
     help=(
-        "Worker processes for converting projects in --all-projects mode "
-        "(default: CPU count; 1 disables parallelism). Peak memory scales "
+        "Total worker processes for conversion (default: CPU count; 1 "
+        "disables parallelism). Under --all-projects the budget is split "
+        "between converting projects in parallel and rendering each "
+        "project's own pages/session files in parallel; a single-project "
+        "conversion spends all of it on the latter. Peak memory scales "
         "with jobs × the largest stale project."
     ),
 )
@@ -1967,6 +1970,10 @@ def convert(
             # with output=None anyway, so its skip is never forced.
             force_regenerate=output is not None and _output_path_is_file(output),
             report=report,
+            # A single-project conversion has the whole machine to itself,
+            # so its pages and session files fan out over `--jobs` workers
+            # (None → CPU count). The library default stays 1.
+            render_jobs=jobs,
         )
         # Report only work actually done this run. On a pure skip the converter
         # already printed its "... is current, skipping regeneration" line, so

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -40,7 +40,7 @@ from .utils import (
     create_session_preview,
     get_warmup_session_ids,
 )
-from .render_pool import RenderUnit
+from .render_pool import RenderUnit, memory_capped_workers, resolve_render_jobs
 from .cache import (
     CacheManager,
     SessionCacheData,
@@ -2026,7 +2026,7 @@ def convert_jsonl_to(
     force_regenerate: bool = False,
     report: Optional["RegenerationReport"] = None,
     archive_search_link: Optional[str] = None,
-    render_jobs: Optional[int] = 1,
+    render_jobs: Optional[int] = None,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -2068,11 +2068,12 @@ def convert_jsonl_to(
             index root. None leaves the link out of the rendered page.
         render_jobs: Worker processes for rendering this project's own
             output files (combined pages + per-session files), which are
-            independent of one another. ``1`` (the default) renders inline,
-            preserving the historical single-threaded behaviour for library
-            callers; ``None`` means "use the CPU count". The CLI passes the
-            budget it wants — see ``_make_render_pool`` for the conditions
-            under which a pool is actually created.
+            independent of one another. ``None`` (the default) consults
+            ``$CLAUDE_CODE_LOG_RENDER_JOBS``, which is unset for almost
+            everyone and means 1 — inline rendering, the historical
+            single-threaded behaviour. An explicit int overrides the
+            environment. See ``_make_render_pool`` for the further
+            conditions under which a pool is actually created.
     """
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {input_path}")
@@ -2630,10 +2631,18 @@ def build_session_title(
 # finish inline before a pool has even started.
 _MIN_UNITS_FOR_RENDER_POOL = 8
 
-# ...and below this many messages the project is small enough that its
-# whole conversion costs less than the pool's startup, however many files
-# it happens to spread that work across.
-_MIN_MESSAGES_FOR_RENDER_POOL = 2000
+# ...and below this many messages the project's render work is too small
+# to repay what each worker costs before it renders anything: `spawn`,
+# package import, and a full reload of the transcript from cache (~1.7s at
+# 47k messages). Measured on 4 cores, with the § 2.9 memo caches on:
+#
+#   12k messages  serial 8.2s  ->  4 workers 9.7s   (a loss)
+#   47k messages  serial 27.6s ->  4 workers 20.0s  (1.38x)
+#
+# so the crossover sits between the two. Set conservatively near the upper
+# measurement rather than the midpoint: below it the cost is a certain
+# regression, above it the win grows with project size and core count.
+_MIN_MESSAGES_FOR_RENDER_POOL = 25_000
 
 
 def _make_render_pool(
@@ -2657,9 +2666,11 @@ def _make_render_pool(
 
     Returns None whenever fanning out would be wrong or wasteful:
 
-    - ``render_jobs`` resolves to 1 — the caller asked for the inline path,
-      which is also what a project worker in the all-projects pool gets when
-      there is no spare capacity (nesting pools would oversubscribe).
+    - ``render_jobs`` resolves to 1 — which is the default, since the
+      fan-out is opt-in via ``$CLAUDE_CODE_LOG_RENDER_JOBS`` (see
+      ``render_pool.resolve_render_jobs``). It is also what a project
+      worker in the all-projects pool gets when there is no spare capacity,
+      since nesting pools would oversubscribe.
     - Single-file mode, or no cache manager. Workers reload the transcript
       from the cache; without one they would each re-parse every JSONL file.
     - ``image_export_mode="referenced"``, where each render writes
@@ -2668,8 +2679,16 @@ def _make_render_pool(
       running them concurrently would let two processes write one file at
       once, so this mode stays serial.
     - Projects too small for the pool's startup to pay for itself.
+    - Not enough memory for even one worker's copy of the transcript.
+
+    The worker count is also capped by available memory, because each
+    worker holds the whole transcript (~3x its bytes on disk). See
+    ``render_pool.memory_capped_workers``.
     """
-    if render_jobs is not None and render_jobs <= 1:
+    from .render_pool import memory_capped_workers, resolve_render_jobs
+
+    max_workers = resolve_render_jobs(render_jobs)
+    if max_workers <= 1:
         return None
     if cache_manager is None or not input_path.is_dir():
         return None
@@ -2678,7 +2697,16 @@ def _make_render_pool(
     if message_count < _MIN_MESSAGES_FOR_RENDER_POOL:
         return None
 
-    from .render_pool import make_render_pool, resolve_render_jobs
+    transcript_bytes = sum(
+        f.stat().st_size
+        for f in input_path.glob("*.jsonl")
+        if not f.name.startswith("agent-")
+    )
+    max_workers = memory_capped_workers(max_workers, transcript_bytes)
+    if max_workers <= 1:
+        return None
+
+    from .render_pool import make_render_pool
 
     return make_render_pool(
         format=format,
@@ -2693,7 +2721,7 @@ def _make_render_pool(
         image_export_mode=image_export_mode,
         archive_search_link=archive_search_link,
         library_version=get_library_version(),
-        max_workers=resolve_render_jobs(render_jobs),
+        max_workers=max_workers,
     )
 
 
@@ -4147,19 +4175,46 @@ def process_projects_hierarchy(
     job_budget = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
     resolved_jobs = max(1, min(job_budget, len(to_convert)))
 
-    # Spare capacity goes to each project's *own* render fan-out. With
-    # fewer stale projects than workers — the shape of every incremental
-    # run — the project pool alone leaves most cores idle, because a
-    # single project's conversion is single-threaded. Dividing the budget
-    # gives one stale project the whole machine and many stale projects
-    # the historical one-worker-each.
+    # Spare capacity goes to each project's *own* render fan-out — but only
+    # when that fan-out is switched on, which it isn't by default (see
+    # `render_pool.resolve_render_jobs`). `--jobs` never enables it; it only
+    # caps it, so the two pool levels together can't oversubscribe.
+    #
+    # With fewer stale projects than workers — the shape of every
+    # incremental run — the project pool alone leaves most cores idle,
+    # because a single project's conversion is single-threaded. Dividing the
+    # budget gives one stale project the whole machine and many stale
+    # projects the historical one-worker-each.
     #
     # This does not fix the *tail* of a large multi-project run: the split
     # is static, so when the small projects finish early their share isn't
     # handed back to the big project still rendering. Making it dynamic
     # needs a single flat pool over render units rather than two nested
     # levels.
-    per_project_render_jobs = max(1, job_budget // max(1, len(to_convert)))
+    #
+    # Memory is the binding constraint, not cores. Every render worker holds
+    # its project's whole transcript (~3x its bytes on disk), and so does
+    # every project worker, so the footprint is the *product* of the two
+    # levels. Left unchecked that is how an `auto` run on a large archive
+    # takes a machine into swap and wedges it. Size the render share against
+    # the largest stale project, divided across the project workers that will
+    # be resident at the same time; each worker re-checks against its own
+    # project before actually starting a pool.
+    render_budget = resolve_render_jobs(None)
+    per_project_render_jobs = 1
+    if render_budget > 1 and to_convert:
+        per_project_render_jobs = max(
+            1,
+            min(
+                render_budget,
+                job_budget // max(1, len(to_convert)),
+                memory_capped_workers(
+                    render_budget,
+                    max(plan.source_bytes for plan in to_convert),
+                    concurrent_projects=resolved_jobs,
+                ),
+            ),
+        )
 
     def _convert_plan_inline(plan: _ProjectPlan) -> None:
         """Convert one project in this process, reporting progress/failure."""

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1966,6 +1966,7 @@ def _generate_paginated_html(
         _render_page_inline,
         _record_page,
         label=lambda unit: f"page {unit.key}",
+        fragment_store=fragment_store,
     )
 
     # Reveal the "Next" link on every page that is no longer last. This
@@ -2776,12 +2777,18 @@ def _dispatch_render_units(
     render_inline: "Callable[[RenderUnit], None]",
     on_written: "Callable[[RenderUnit], None]",
     label: "Callable[[RenderUnit], str]",
+    fragment_store: "Optional[RenderFragmentStore]" = None,
 ) -> None:
     """Render ``units``, over the pool when there is one, else inline.
 
     ``on_written`` runs in the parent for every unit that made it to disk,
     in completion order — it owns the cache bookkeeping, which is why the
     workers never touch the DB for writes.
+
+    ``fragment_store`` absorbs the fragment deltas page workers return, so
+    the fragments a worker formatted still reach the conversion's store —
+    the session pass then feeds on them exactly as if the pages had
+    rendered inline (see RenderUnit.fed_fragments).
 
     Every path back to inline rendering is a *fallback*, never an error:
     a pool that can't bootstrap (a library caller without the
@@ -2810,7 +2817,7 @@ def _dispatch_render_units(
     for future in as_completed(futures):
         unit = futures[future]
         try:
-            _kind, _key, error = future.result()
+            _kind, _key, error, fragments_delta = future.result()
         except Exception as e:
             # The pool itself broke (BrokenProcessPool, a worker killed by
             # the OOM killer, …). Re-render this unit inline and send the
@@ -2824,6 +2831,8 @@ def _dispatch_render_units(
             continue
         if error is not None:
             raise RuntimeError(f"Failed to render {label(unit)}:\n{error}")
+        if fragments_delta and fragment_store is not None:
+            fragment_store.absorb(fragments_delta)
         on_written(unit)
 
     for unit in unsubmitted:
@@ -3033,12 +3042,41 @@ def _generate_individual_session_files(
                 unit.file_name, unit.key, session_message_count
             )
 
+        # Feed each pooled session unit its slice of the fragment store —
+        # by now the combined-page pass has completed (pages dispatch and
+        # drain before this function runs), so the store holds a fragment
+        # for essentially every message, whether the pages rendered inline
+        # or in workers (whose deltas the page dispatch absorbed). A
+        # worker seeds its own store from the slice and skips re-formatting
+        # everything that verifies; anything stale or mis-keyed digests
+        # into a conflict and is formatted fresh, so this is purely a
+        # CPU-saving feed, never a correctness dependency.
+        if fragment_store is not None and render_pool is not None and stale_units:
+            from .utils import get_parent_session_id as _trunk_of
+
+            ordinal_session: dict[int, str] = {}
+            for ordinal, msg in enumerate(messages):
+                msg_sid = getattr(msg, "sessionId", None)
+                if msg_sid:
+                    ordinal_session[ordinal] = _trunk_of(msg_sid)
+            all_fragments = fragment_store.export_fragments()
+            keys_by_session: dict[str, list[Any]] = {}
+            for store_key in all_fragments:
+                key_session = ordinal_session.get(cast(int, store_key[0]))
+                if key_session is not None:
+                    keys_by_session.setdefault(key_session, []).append(store_key)
+            for unit in stale_units:
+                unit_keys = keys_by_session.get(unit.key)
+                if unit_keys:
+                    unit.fed_fragments = {k: all_fragments[k] for k in unit_keys}
+
         _dispatch_render_units(
             stale_units,
             render_pool,
             _render_session_inline,
             _record_session,
             label=lambda unit: f"session {str(unit.key)[:8]}",
+            fragment_store=fragment_store,
         )
 
     return regenerated_count

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1710,12 +1710,16 @@ def _generate_paginated_html(
     archive_search_link: Optional[str] = None,
     render_pool: "Optional[RenderPool]" = None,
     fragment_store: "Optional[RenderFragmentStore]" = None,
+    image_export_mode: Optional[str] = None,
 ) -> tuple[Path, bool]:
     """Generate paginated HTML files for combined transcript.
 
     Args:
         render_pool: Optional pool to fan the stale pages out over. None
             (the default) renders them inline, one at a time.
+        image_export_mode: The conversion's image mode (None → embedded),
+            honored per page so a referenced-mode run writes
+            ``images/`` files instead of silently embedding.
         fragment_store: Optional per-conversion fragment store shared with
             the per-session pass, so inline page renders reuse (and seed)
             each message's formatted fragment.
@@ -1941,7 +1945,7 @@ def _generate_paginated_html(
 
     def _render_page_inline(unit: RenderUnit) -> None:
         assert unit.entries is not None  # every page unit is planned with them
-        page_renderer = HtmlRenderer()
+        page_renderer = HtmlRenderer(image_export_mode=image_export_mode or "embedded")
         page_renderer.depth = depth
         page_renderer.compact = compact
         page_renderer.no_recaps = no_recaps
@@ -1949,6 +1953,7 @@ def _generate_paginated_html(
         html_content = page_renderer.generate(
             unit.entries,
             unit.title,
+            output_dir=output_dir,
             page_info=unit.page_info,
             page_stats=unit.page_stats,
             session_tree=session_tree,
@@ -2340,6 +2345,7 @@ def convert_jsonl_to(
                 archive_search_link=archive_search_link,
                 render_pool=render_pool,
                 fragment_store=fragment_store,
+                image_export_mode=image_export_mode,
             )
         else:
             # Use single-file generation for small projects or filtered views
@@ -2737,12 +2743,14 @@ def _make_render_pool(
       against the conversion's tree; without one they would rebuild a DAG
       from their slice alone, which can genuinely differ (missing
       cross-session hierarchy) — a correctness cliff, so decline instead.
-    - ``image_export_mode="referenced"``, where each render writes
-      ``images/image_NNNN.png`` from a counter it resets per call. Those
-      names already collide between the combined and per-session passes;
-      running them concurrently would let two processes write one file at
-      once, so this mode stays serial.
     - Projects too small for the pool's startup to pay for itself.
+
+    ``image_export_mode="referenced"`` used to decline too, when each
+    render allocated ``images/image_NNNN.png`` names from a per-call
+    counter. Filenames are content-addressed now (see
+    ``image_export.export_image``), so concurrent workers exporting the
+    same image write the same name atomically with identical bytes — the
+    mode is pool-safe.
     - Not enough memory for the fan-out's footprint.
 
     The worker count is also capped by available memory, with the parent
@@ -2757,8 +2765,6 @@ def _make_render_pool(
     if cache_manager is None or not input_path.is_dir():
         return None
     if session_tree is None:
-        return None
-    if image_export_mode == "referenced":
         return None
     if message_count < _MIN_MESSAGES_FOR_RENDER_POOL:
         return None

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -3893,43 +3893,111 @@ class _ProjectPlan:
     # no cache yet (first run). For a stale project it lags reality by
     # one run — fine for the hold-back comparison, which only needs
     # relative magnitudes. Message count predicts conversion cost far
-    # better than bytes: see _dominant_plan.
+    # better than bytes: see _holdback_plans.
     cached_message_count: Optional[int] = None
     error: Optional[str] = None
 
 
-def _dominant_plan(plans: "List[_ProjectPlan]") -> "Optional[_ProjectPlan]":
-    """The plan whose conversion will dominate the pool's wall clock, or None.
+# Bytes stand-in for _MIN_MESSAGES_FOR_RENDER_POOL when the hold-back
+# comparison has to rank plans by source bytes (a plan without a cache row
+# has no message count). Real projects measure ~3-3.4KB of JSONL per
+# message, so 75MB ≈ the 25k-message pool floor.
+_MIN_SOURCE_BYTES_FOR_HOLDBACK = 75 * 1024 * 1024
+
+
+def _fanned_speedup(workers: int) -> float:
+    """Conservative wall-clock speedup of a lone fanned-out conversion.
+
+    Deliberately under the measured single-project numbers (2.7-3.2x at
+    8+ workers, 1.8-1.9x at 4, 1.4x at 2 — work/render-format-once.md):
+    an over-estimate here makes ``_holdback_plans`` serialize projects
+    that were better off pooled, which is the costly direction, while an
+    under-estimate only forgoes part of a win.
+    """
+    if workers >= 8:
+        return 2.5
+    if workers >= 4:
+        return 1.8
+    if workers >= 2:
+        return 1.3
+    return 1.0
+
+
+def _holdback_plans(
+    plans: "List[_ProjectPlan]", *, job_budget: int, render_budget: int
+) -> "List[_ProjectPlan]":
+    """The stale projects to hold out of the pool and convert alone, in order.
+
+    Greedy makespan comparison, largest project first: holding a project
+    back pays ``fanned(largest)`` *after* the pool instead of hiding
+    ``serial(largest)`` inside it, so hold while
+
+        pool_wall(rest) + fanned(largest)  <  wall(pooling everything)
+
+    with the pool wall approximated as ``max(largest member, total /
+    workers)`` and the fanned time as serial cost over the conservative
+    ``_fanned_speedup`` of the workers a lone conversion would actually
+    get (memory-capped against the project's own bytes, so a machine that
+    can't fan the project never holds it back). The loop stops at the
+    first losing hold, which keeps every known pathology out by
+    construction: level-sized projects pool (serializing them wastes the
+    concurrency they already saturate), sub-pool-threshold projects never
+    hold (they can't fan, so holding gains nothing), and a core-bound
+    pool that already dwarfs the largest project keeps it.
 
     Message count predicts conversion cost far better than bytes — the
-    reference archive's 329MB/97k-message project takes as long as its
+    reference archive's 329MB/97k-message giant takes as long as its
     other seven projects combined while being only 1.08x the runner-up's
-    *bytes* (97k vs 47k *messages*) — so compare cached counts when every
-    plan has one and fall back to bytes otherwise; mixing the two units
-    in one ranking would make the ratio meaningless.
+    *bytes* — so costs compare cached counts when every plan has one and
+    fall back to bytes otherwise; mixing the two units in one ranking
+    would make the comparison meaningless.
 
-    2x over the runner-up is the bar. Holding a project back pays
-    ``fanned(largest)`` *after* the pool instead of hiding
-    ``serial(largest)`` inside it, so with level sizes it is a certain
-    loss; at 2x the held-back project's fanned time (~1/3 of serial at 8+
-    workers) still undercuts the runner-up's serial time that now bounds
-    the pool.
+    This generalizes the earlier single-dominant-project hold-back (2x
+    the runner-up): the 2x giant still holds, and shapes it missed — a
+    large project bounding a pool of small ones without being 2x a level
+    twin — now hold too, one at a time, while the numbers keep working.
     """
-    if len(plans) < 2:
-        return None
+    if len(plans) < 2 or job_budget <= 1 or render_budget <= 1:
+        return []
     if all(plan.cached_message_count for plan in plans):
+        eligible_floor = _MIN_MESSAGES_FOR_RENDER_POOL
 
         def cost(plan: "_ProjectPlan") -> int:
             return plan.cached_message_count or 0
     else:
+        eligible_floor = _MIN_SOURCE_BYTES_FOR_HOLDBACK
 
         def cost(plan: "_ProjectPlan") -> int:
             return plan.source_bytes
 
-    ranked = sorted(plans, key=cost, reverse=True)
-    if cost(ranked[0]) >= 2 * max(1, cost(ranked[1])):
-        return ranked[0]
-    return None
+    remaining = sorted(plans, key=cost, reverse=True)
+    held: "List[_ProjectPlan]" = []
+    while len(remaining) >= 2:
+        largest, rest = remaining[0], remaining[1:]
+        if cost(largest) < eligible_floor:
+            break
+        workers_alone = min(
+            render_budget,
+            job_budget,
+            memory_capped_workers(min(render_budget, job_budget), largest.source_bytes),
+        )
+        speedup = _fanned_speedup(workers_alone)
+        if speedup <= 1.0:
+            break
+        wall_pool_all = max(
+            cost(largest),
+            sum(cost(p) for p in remaining) / min(job_budget, len(remaining)),
+        )
+        wall_pool_rest = max(
+            cost(rest[0]),
+            sum(cost(p) for p in rest) / min(job_budget, len(rest)),
+        )
+        if wall_pool_rest + cost(largest) / speedup < wall_pool_all:
+            held.append(largest)
+            remaining = rest
+        else:
+            break
+    return held
 
 
 def _plan_project(
@@ -4363,21 +4431,24 @@ def process_projects_hierarchy(
     job_budget = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
     render_budget = resolve_render_jobs(None)
 
-    # A dominant project is held out of the pool and converted last with
-    # the whole render budget. Measured on the reference archive, the
-    # full-rebuild wall is within 8% of "how long does the biggest project
-    # take", while the static split below grants that project the same
-    # share as everything else; a fanned single project runs ~3x its
-    # serial time, so the wall becomes pool(rest) + fanned(giant) instead
-    # of serial(giant). Only when a pool will actually run and the
-    # fan-out is on — with either off, ordering changes nothing and the
-    # historical path stays.
-    holdback = (
-        _dominant_plan(to_convert)
+    # Projects that would bound the pool's wall clock are held out of it
+    # and converted afterwards, one at a time, each with the whole render
+    # budget. Measured on the reference archive, the full-rebuild wall is
+    # within 8% of "how long does the biggest project take", while the
+    # static split below grants that project the same share as everything
+    # else; a fanned single project runs ~2.5-3x its serial time, so the
+    # wall becomes pool(rest) + Σ fanned(held) instead of serial(giant).
+    # `_holdback_plans` runs the makespan comparison per candidate and
+    # stops at the first losing hold. Only when a pool will actually run
+    # and the fan-out is on — with either off, ordering changes nothing
+    # and the historical path stays.
+    holdbacks = (
+        _holdback_plans(to_convert, job_budget=job_budget, render_budget=render_budget)
         if job_budget > 1 and render_budget > 1 and len(to_convert) >= 2
-        else None
+        else []
     )
-    pooled = [plan for plan in to_convert if plan is not holdback]
+    held_ids = {id(plan) for plan in holdbacks}
+    pooled = [plan for plan in to_convert if id(plan) not in held_ids]
     resolved_jobs = max(1, min(job_budget, len(pooled)))
 
     # Spare capacity goes to each project's *own* render fan-out (on by
@@ -4391,11 +4462,11 @@ def process_projects_hierarchy(
     # budget gives one stale project the whole machine and many stale
     # projects the historical one-worker-each.
     #
-    # The hold-back above covers the dominant-project tail; for a run
-    # whose tail is several level-sized projects the split is still
-    # static (a finished small project's share isn't handed back), and
-    # making it dynamic needs a single flat pool over render units
-    # rather than two nested levels.
+    # The hold-back above covers the tails a makespan comparison can
+    # see (projects that bound the pool and repay a lone fan-out); the
+    # split among what stays pooled is still static (a finished small
+    # project's share isn't handed back), and making it dynamic needs a
+    # single flat pool over render units rather than two nested levels.
     #
     # Memory can bind before cores do. Every *project* worker holds its
     # project's whole master list (~4.5x its transcript bytes on disk with
@@ -4527,11 +4598,12 @@ def process_projects_hierarchy(
                 if id(plan) not in settled:
                     _convert_plan_inline(plan)
 
-    if holdback is not None:
-        # The rest are done and nothing else is resident, so the dominant
-        # project gets the whole machine (`--jobs` still caps it; the
-        # memory cap re-checks inside `_make_render_pool`).
-        _convert_plan_inline(holdback, render_jobs=min(render_budget, job_budget))
+    # The pool has drained and nothing else is resident, so each held-back
+    # project gets the whole machine (`--jobs` still caps it; the memory
+    # cap re-checks inside `_make_render_pool`). Smallest first, so the
+    # run ends on the project that dominates the wall.
+    for plan in reversed(holdbacks):
+        _convert_plan_inline(plan, render_jobs=min(render_budget, job_budget))
 
     # ---- Phase 3 (collect): aggregate per-project index data from the
     # now-fresh cache. Sequential — cheap cache reads (the no-cache

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2251,8 +2251,18 @@ def convert_jsonl_to(
     # the per-session files, so each entry-derived message is formatted
     # once rather than once per output file that contains it (step 3,
     # work/render-format-once.md). Scoped to this call: it dies with the
-    # conversion, so nothing about it needs invalidating.
-    fragment_store = _make_fragment_store(format)
+    # conversion, so nothing about it needs invalidating. The byte count
+    # feeds the store's memory valve (same source-size measure as
+    # _make_render_pool's cap: top-level JSONL, agent files excluded).
+    if input_path.is_dir():
+        source_bytes = sum(
+            f.stat().st_size
+            for f in input_path.glob("*.jsonl")
+            if not f.name.startswith("agent-")
+        )
+    else:
+        source_bytes = input_path.stat().st_size
+    fragment_store = _make_fragment_store(format, transcript_bytes=source_bytes)
     if fragment_store is not None:
         # Store keys are per-entry ordinals in this master list — stable
         # across the differently-filtered subsets each render tree gets,
@@ -2688,22 +2698,54 @@ _MIN_UNITS_FOR_RENDER_POOL = 8
 # The loss below the line shrank with the feed (workers no longer reload
 # the transcript) but did not flip sign — spawn + import + cold memo
 # caches still outweigh a few seconds of render work.
-def _make_fragment_store(format: str) -> "Optional[RenderFragmentStore]":
+# Memory valve for the fragment store: keep it only when available memory
+# comfortably covers a store-carrying conversion. Measured serial peaks on
+# the largest real project (803MB of transcripts): 1252MB with the store
+# off (~1.56x bytes on disk), 1521MB with it on (~1.9x — the +269MB is the
+# fragment text plus per-entry overhead, work/render-format-once.md § 4.9).
+# 2.4x is that store-on peak plus a ~25% margin, so on a machine inside
+# the margin the conversion quietly runs store-less — the pre-store
+# footprint — instead of trading its last RAM for CPU. Whenever this valve
+# trips, the render pool's own memory cap (a far higher bar, ~10x bytes)
+# has already declined, so a store-less conversion is always a serial one
+# and no worker-side coordination is needed.
+_FRAGMENT_STORE_MIN_AVAILABLE_PER_BYTE = 2.4
+
+
+def _make_fragment_store(
+    format: str, transcript_bytes: int = 0
+) -> "Optional[RenderFragmentStore]":
     """Create the per-conversion fragment store, or None when it can't help.
 
     HTML only — the fragment triple it caches is exactly what
     ``HtmlRenderer._annotate_tree_for_render`` computes, and no other
-    renderer consults it. Referenced-image renders are excluded at the
-    consumer (the annotate walk), not here, because the effective image
-    mode lives on the renderer. ``CLAUDE_CODE_LOG_FRAGMENT_STORE=0``
-    disables it for bisecting rendering differences.
+    renderer consults it. ``CLAUDE_CODE_LOG_FRAGMENT_STORE=0`` disables it
+    for bisecting rendering differences; an explicit ``=1`` forces it past
+    the memory valve below, which otherwise skips the store when available
+    memory is under ``_FRAGMENT_STORE_MIN_AVAILABLE_PER_BYTE`` times the
+    project's transcript bytes (the store is a RAM-for-CPU trade, and on a
+    machine that tight the RAM matters more). ``transcript_bytes`` of 0
+    (unknown) skips the valve, as does an unreadable memory probe.
     """
     if format != "html":
         return None
-    from .fragment_store import RenderFragmentStore, fragment_store_enabled
+    from .fragment_store import (
+        RenderFragmentStore,
+        fragment_store_enabled,
+        fragment_store_forced,
+    )
 
     if not fragment_store_enabled():
         return None
+    if transcript_bytes > 0 and not fragment_store_forced():
+        from .render_pool import available_memory_bytes
+
+        available = available_memory_bytes()
+        if (
+            available is not None
+            and available < transcript_bytes * _FRAGMENT_STORE_MIN_AVAILABLE_PER_BYTE
+        ):
+            return None
     return RenderFragmentStore()
 
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2668,17 +2668,20 @@ _MIN_UNITS_FOR_RENDER_POOL = 8
 
 
 # ...and below this many messages the project's render work is too small to
-# repay the pool's startup. Sized when workers still re-loaded the whole
-# transcript from cache (~1.7s at 47k messages) — they are fed entry slices
-# now, so this is due a re-measure (work/render-format-once.md § 7.5).
-# Measured on 4 cores, with the § 2.9 memo caches on:
+# repay the pool's startup. Re-measured post-feeding (2026-08-26, 8-core
+# VM, workers fed entry slices — the work/render-format-once.md § 7.5
+# revisit), best fanned configuration vs the serial memo-only row:
 #
-#   12k messages  serial 8.2s  ->  4 workers 9.7s   (a loss)
-#   47k messages  serial 27.6s ->  4 workers 20.0s  (1.38x)
+#   12.2k messages  serial  7.7s  ->  8.2s   (a loss)
+#   15.5k messages  serial  7.7s  ->  8.3s   (a loss)
+#   25.2k messages  serial 12.7s  ->  6.0s   (2.13x)
 #
-# so the crossover sits between the two. Set conservatively near the upper
-# measurement rather than the midpoint: below it the cost is a certain
+# so the crossover sits between 15.5k and 25.2k and the threshold sits at
+# its upper edge: below it the cost is a certain (if now small)
 # regression, above it the win grows with project size and core count.
+# The loss below the line shrank with the feed (workers no longer reload
+# the transcript) but did not flip sign — spawn + import + cold memo
+# caches still outweigh a few seconds of render work.
 def _make_fragment_store(format: str) -> "Optional[RenderFragmentStore]":
     """Create the per-conversion fragment store, or None when it can't help.
 
@@ -2742,10 +2745,9 @@ def _make_render_pool(
     - Projects too small for the pool's startup to pay for itself.
     - Not enough memory for the fan-out's footprint.
 
-    The worker count is also capped by available memory. The cap formula
-    still charges each worker a full transcript copy — workers now hold
-    only their in-flight unit's slice, so this over-charges and is due a
-    re-size (work/render-format-once.md § 7.5); until then it errs safe.
+    The worker count is also capped by available memory, with the parent
+    charged its full master-list footprint and each fed worker only its
+    measured slice-holding cost — see ``render_pool.memory_capped_workers``.
     """
     from .render_pool import memory_capped_workers, resolve_render_jobs
 
@@ -3881,7 +3883,47 @@ class _ProjectPlan:
     archived_count: int
     stats: GenerationStats
     source_bytes: int
+    # Total message count from the cache row, None when the project has
+    # no cache yet (first run). For a stale project it lags reality by
+    # one run — fine for the hold-back comparison, which only needs
+    # relative magnitudes. Message count predicts conversion cost far
+    # better than bytes: see _dominant_plan.
+    cached_message_count: Optional[int] = None
     error: Optional[str] = None
+
+
+def _dominant_plan(plans: "List[_ProjectPlan]") -> "Optional[_ProjectPlan]":
+    """The plan whose conversion will dominate the pool's wall clock, or None.
+
+    Message count predicts conversion cost far better than bytes — the
+    reference archive's 329MB/97k-message project takes as long as its
+    other seven projects combined while being only 1.08x the runner-up's
+    *bytes* (97k vs 47k *messages*) — so compare cached counts when every
+    plan has one and fall back to bytes otherwise; mixing the two units
+    in one ranking would make the ratio meaningless.
+
+    2x over the runner-up is the bar. Holding a project back pays
+    ``fanned(largest)`` *after* the pool instead of hiding
+    ``serial(largest)`` inside it, so with level sizes it is a certain
+    loss; at 2x the held-back project's fanned time (~1/3 of serial at 8+
+    workers) still undercuts the runner-up's serial time that now bounds
+    the pool.
+    """
+    if len(plans) < 2:
+        return None
+    if all(plan.cached_message_count for plan in plans):
+
+        def cost(plan: "_ProjectPlan") -> int:
+            return plan.cached_message_count or 0
+    else:
+
+        def cost(plan: "_ProjectPlan") -> int:
+            return plan.source_bytes
+
+    ranked = sorted(plans, key=cost, reverse=True)
+    if cost(ranked[0]) >= 2 * max(1, cost(ranked[1])):
+        return ranked[0]
+    return None
 
 
 def _plan_project(
@@ -4016,6 +4058,15 @@ def _plan_project(
         stats.files_loaded_from_cache = len(jsonl_files)
     stats.total_time = time.time() - plan_start
 
+    cached_message_count: Optional[int] = None
+    if cache_manager is not None:
+        try:
+            cache_stats = cache_manager.get_cache_stats()
+            if cache_stats.get("cache_enabled"):
+                cached_message_count = cache_stats["total_cached_messages"]
+        except Exception:
+            cached_message_count = None
+
     return _ProjectPlan(
         project_dir=project_dir,
         dest_dir=dest_dir,
@@ -4025,6 +4076,7 @@ def _plan_project(
         archived_count=archived_count,
         stats=stats,
         source_bytes=sum(f.stat().st_size for f in jsonl_files),
+        cached_message_count=cached_message_count,
     )
 
 
@@ -4303,7 +4355,24 @@ def process_projects_hierarchy(
     # the (WAL-mode) cache DB — so stale projects fan out over a
     # process pool. `jobs=1` keeps the historical inline path.
     job_budget = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
-    resolved_jobs = max(1, min(job_budget, len(to_convert)))
+    render_budget = resolve_render_jobs(None)
+
+    # A dominant project is held out of the pool and converted last with
+    # the whole render budget. Measured on the reference archive, the
+    # full-rebuild wall is within 8% of "how long does the biggest project
+    # take", while the static split below grants that project the same
+    # share as everything else; a fanned single project runs ~3x its
+    # serial time, so the wall becomes pool(rest) + fanned(giant) instead
+    # of serial(giant). Only when a pool will actually run and the
+    # fan-out is on — with either off, ordering changes nothing and the
+    # historical path stays.
+    holdback = (
+        _dominant_plan(to_convert)
+        if job_budget > 1 and render_budget > 1 and len(to_convert) >= 2
+        else None
+    )
+    pooled = [plan for plan in to_convert if plan is not holdback]
+    resolved_jobs = max(1, min(job_budget, len(pooled)))
 
     # Spare capacity goes to each project's *own* render fan-out (on by
     # default — see `render_pool.resolve_render_jobs`; a project worker
@@ -4316,38 +4385,42 @@ def process_projects_hierarchy(
     # budget gives one stale project the whole machine and many stale
     # projects the historical one-worker-each.
     #
-    # This does not fix the *tail* of a large multi-project run: the split
-    # is static, so when the small projects finish early their share isn't
-    # handed back to the big project still rendering. Making it dynamic
-    # needs a single flat pool over render units rather than two nested
-    # levels.
+    # The hold-back above covers the dominant-project tail; for a run
+    # whose tail is several level-sized projects the split is still
+    # static (a finished small project's share isn't handed back), and
+    # making it dynamic needs a single flat pool over render units
+    # rather than two nested levels.
     #
-    # Memory is the binding constraint, not cores. Every render worker holds
-    # its project's whole transcript (~3x its bytes on disk), and so does
-    # every project worker, so the footprint is the *product* of the two
-    # levels. Left unchecked that is how an `auto` run on a large archive
-    # takes a machine into swap and wedges it. Size the render share against
-    # the largest stale project, divided across the project workers that will
+    # Memory can bind before cores do. Every *project* worker holds its
+    # project's whole master list (~4.5x its transcript bytes on disk with
+    # the fragment store); render workers hold only their in-flight unit's
+    # slice, but the footprint is still the *product* of the two levels.
+    # Left unchecked that is how an `auto` run on a large archive takes a
+    # machine into swap and wedges it. Size the render share against the
+    # largest stale project, divided across the project workers that will
     # be resident at the same time; each worker re-checks against its own
     # project before actually starting a pool.
-    render_budget = resolve_render_jobs(None)
     per_project_render_jobs = 1
-    if render_budget > 1 and to_convert:
+    if render_budget > 1 and pooled:
         per_project_render_jobs = max(
             1,
             min(
                 render_budget,
-                job_budget // max(1, len(to_convert)),
+                job_budget // max(1, len(pooled)),
                 memory_capped_workers(
                     render_budget,
-                    max(plan.source_bytes for plan in to_convert),
+                    max(plan.source_bytes for plan in pooled),
                     concurrent_projects=resolved_jobs,
                 ),
             ),
         )
 
-    def _convert_plan_inline(plan: _ProjectPlan) -> None:
+    def _convert_plan_inline(
+        plan: _ProjectPlan, render_jobs: Optional[int] = None
+    ) -> None:
         """Convert one project in this process, reporting progress/failure."""
+        if render_jobs is None:
+            render_jobs = per_project_render_jobs
         project_start_time = time.time()
         try:
             # Generate output for this project (handles cache updates internally)
@@ -4371,7 +4444,7 @@ def process_projects_hierarchy(
                 no_timestamps=no_timestamps,
                 no_recaps=no_recaps,
                 archive_search_link=_archive_search_link(plan),
-                render_jobs=per_project_render_jobs,
+                render_jobs=render_jobs,
             )
         except Exception:
             _print_project_failed(plan, traceback.format_exc())
@@ -4379,13 +4452,13 @@ def process_projects_hierarchy(
         _print_project_done(plan, time.time() - project_start_time)
 
     if resolved_jobs <= 1:
-        for plan in to_convert:
+        for plan in pooled:
             _convert_plan_inline(plan)
-    elif to_convert:
+    elif pooled:
         # Largest projects first: with N workers the wall clock is
         # bounded by the biggest single project, so don't leave it
         # queued behind small ones at the tail.
-        by_size = sorted(to_convert, key=lambda p: p.source_bytes, reverse=True)
+        by_size = sorted(pooled, key=lambda p: p.source_bytes, reverse=True)
         settled: set[int] = set()
         try:
             # `spawn` on every platform: fork is officially unsafe with
@@ -4444,9 +4517,15 @@ def process_projects_hierarchy(
                 f"this as a library, run it under `if __name__ == '__main__':` "
                 f"or pass jobs=1."
             )
-            for plan in to_convert:
+            for plan in pooled:
                 if id(plan) not in settled:
                     _convert_plan_inline(plan)
+
+    if holdback is not None:
+        # The rest are done and nothing else is resident, so the dominant
+        # project gets the whole machine (`--jobs` still caps it; the
+        # memory cap re-checks inside `_make_render_pool`).
+        _convert_plan_inline(holdback, render_jobs=min(render_budget, job_budget))
 
     # ---- Phase 3 (collect): aggregate per-project index data from the
     # now-fresh cache. Sequential — cheap cache reads (the no-cache

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2083,8 +2083,9 @@ def convert_jsonl_to(
         render_jobs: Worker processes for rendering this project's own
             output files (combined pages + per-session files), which are
             independent of one another. ``None`` (the default) consults
-            ``$CLAUDE_CODE_LOG_RENDER_JOBS``, which is unset for almost
-            everyone and means 1 — inline rendering, the historical
+            ``$CLAUDE_CODE_LOG_RENDER_JOBS``: unset (or ``auto``) resolves
+            to the CPU count — the fan-out is on by default — while ``1``
+            or ``off`` opts out into inline rendering, the historical
             single-threaded behaviour. An explicit int overrides the
             environment. See ``_make_render_pool`` for the further
             conditions under which a pool is actually created.
@@ -2722,10 +2723,11 @@ def _make_render_pool(
 
     Returns None whenever fanning out would be wrong or wasteful:
 
-    - ``render_jobs`` resolves to 1 — which is the default, since the
-      fan-out is opt-in via ``$CLAUDE_CODE_LOG_RENDER_JOBS`` (see
-      ``render_pool.resolve_render_jobs``). It is also what a project
-      worker in the all-projects pool gets when there is no spare capacity,
+    - ``render_jobs`` resolves to 1. The fan-out is on by default (an
+      unset ``$CLAUDE_CODE_LOG_RENDER_JOBS`` means the CPU count), so this
+      takes ``1``/``off`` opting out via the environment (see
+      ``render_pool.resolve_render_jobs``) — or a project worker in the
+      all-projects pool getting 1 because there is no spare capacity,
       since nesting pools would oversubscribe.
     - Single-file mode, or no cache manager (staleness planning needs one).
     - No pre-built ``session_tree``. Workers render fed entry slices
@@ -4303,10 +4305,10 @@ def process_projects_hierarchy(
     job_budget = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
     resolved_jobs = max(1, min(job_budget, len(to_convert)))
 
-    # Spare capacity goes to each project's *own* render fan-out — but only
-    # when that fan-out is switched on, which it isn't by default (see
-    # `render_pool.resolve_render_jobs`). `--jobs` never enables it; it only
-    # caps it, so the two pool levels together can't oversubscribe.
+    # Spare capacity goes to each project's *own* render fan-out (on by
+    # default — see `render_pool.resolve_render_jobs`; a project worker
+    # with no spare capacity renders inline). `--jobs` only caps that
+    # fan-out, so the two pool levels together can't oversubscribe.
     #
     # With fewer stale projects than workers — the shape of every
     # incremental run — the project pool alone leaves most cores idle,

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2240,6 +2240,11 @@ def convert_jsonl_to(
     # conversion, so nothing about it needs invalidating.
     fragment_store = _make_fragment_store(format)
     if fragment_store is not None:
+        # Store keys are per-entry ordinals in this master list — stable
+        # across the differently-filtered subsets each render tree gets,
+        # unlike the id(entry) the stamping code has to work with (the
+        # store translates at its boundary, see stable_key()).
+        fragment_store.set_entry_ordinals(messages)
         from .html.renderer import HtmlRenderer as _HtmlRenderer
 
         if isinstance(renderer, _HtmlRenderer):

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 import traceback
 from urllib.parse import quote
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, cast
 
 import dateparser
 
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
     from .cache import CacheManager
     from .providers.base import ProviderTokenTotals
+    from .render_pool import RenderPool
 
 from .utils import (
     coalesce_trunk_session_id,
@@ -39,6 +40,7 @@ from .utils import (
     create_session_preview,
     get_warmup_session_ids,
 )
+from .render_pool import RenderUnit
 from .cache import (
     CacheManager,
     SessionCacheData,
@@ -1705,10 +1707,13 @@ def _generate_paginated_html(
     compact: bool = False,
     no_recaps: bool = False,
     archive_search_link: Optional[str] = None,
+    render_pool: "Optional[RenderPool]" = None,
 ) -> tuple[Path, bool]:
     """Generate paginated HTML files for combined transcript.
 
     Args:
+        render_pool: Optional pool to fan the stale pages out over. None
+            (the default) renders them inline, one at a time.
         messages: All messages (deduplicated)
         output_dir: Directory to write HTML files
         title: Base title for the pages
@@ -1779,7 +1784,13 @@ def _generate_paginated_html(
     # are current are skipped individually, so a run can write nothing.
     wrote_any = False
 
-    # Generate each page
+    # Stale pages, collected before any rendering starts so they can be
+    # dispatched together, plus the cache-write arguments to replay per page
+    # once its file lands (the parent owns every DB write).
+    stale_units: list[RenderUnit] = []
+    page_cache_args: dict[int, dict[str, Any]] = {}
+
+    # Plan each page
     for page_num, page_session_ids in enumerate(pages, start=1):
         html_path = _get_page_html_path(page_num, suffix)
         page_file = output_dir / html_path
@@ -1855,10 +1866,6 @@ def _generate_paginated_html(
             "is_last_page": is_last_page,
         }
 
-        # Enable previous page's next link when creating a new page
-        if page_num > 1:
-            _enable_next_link_on_previous_page(output_dir, page_num - 1, suffix)
-
         # Build page_stats
         date_range = ""
         if first_timestamp and last_timestamp:
@@ -1888,17 +1895,49 @@ def _generate_paginated_html(
             "token_summary": token_summary,
         }
 
-        # Generate HTML for this page
+        # Queue this page. Rendering is deferred so the whole stale set can
+        # be dispatched together; the cache write below is replayed from
+        # `page_cache_args` in the parent once the file lands.
         page_title = f"{title} - Page {page_num}" if page_num > 1 else title
+        stale_units.append(
+            RenderUnit(
+                kind="page",
+                key=page_num,
+                file_name=html_path,
+                title=page_title,
+                session_ids=page_session_ids,
+                page_info=page_info,
+                page_stats=page_stats,
+            )
+        )
+        page_cache_args[page_num] = {
+            "page_number": page_num,
+            "html_path": html_path,
+            "page_size_config": page_size,
+            "session_ids": page_session_ids,
+            "message_count": page_sessions_message_count,
+            "first_timestamp": first_timestamp,
+            "last_timestamp": last_timestamp,
+            "total_input_tokens": total_input_tokens,
+            "total_output_tokens": total_output_tokens,
+            "total_cache_creation_tokens": total_cache_creation_tokens,
+            "total_cache_read_tokens": total_cache_read_tokens,
+            "variant_suffix": suffix,
+        }
+
+    def _render_page_inline(unit: RenderUnit) -> None:
+        page_messages: List[TranscriptEntry] = []
+        for session_id in unit.session_ids or []:
+            page_messages.extend(messages_by_session.get(session_id, []))
         page_renderer = HtmlRenderer()
         page_renderer.depth = depth
         page_renderer.compact = compact
         page_renderer.no_recaps = no_recaps
         html_content = page_renderer.generate(
             page_messages,
-            page_title,
-            page_info=page_info,
-            page_stats=page_stats,
+            unit.title,
+            page_info=unit.page_info,
+            page_stats=unit.page_stats,
             session_tree=session_tree,
             archive_search_link=archive_search_link,
         )
@@ -1906,24 +1945,31 @@ def _generate_paginated_html(
         # JSONL may carry lone surrogates (issue #139); strict UTF-8
         # encoding crashes here. Replace with U+FFFD so output stays
         # valid UTF-8.
-        page_file.write_text(html_content, encoding="utf-8", errors="replace")
-        wrote_any = True
-
-        # Update cache
-        cache_manager.update_page_cache(
-            page_number=page_num,
-            html_path=html_path,
-            page_size_config=page_size,
-            session_ids=page_session_ids,
-            message_count=page_sessions_message_count,
-            first_timestamp=first_timestamp,
-            last_timestamp=last_timestamp,
-            total_input_tokens=total_input_tokens,
-            total_output_tokens=total_output_tokens,
-            total_cache_creation_tokens=total_cache_creation_tokens,
-            total_cache_read_tokens=total_cache_read_tokens,
-            variant_suffix=suffix,
+        (output_dir / unit.file_name).write_text(
+            html_content, encoding="utf-8", errors="replace"
         )
+
+    def _record_page(unit: RenderUnit) -> None:
+        nonlocal wrote_any
+        wrote_any = True
+        cache_manager.update_page_cache(**page_cache_args[unit.key])
+
+    _dispatch_render_units(
+        stale_units,
+        render_pool,
+        _render_page_inline,
+        _record_page,
+        label=lambda unit: f"page {unit.key}",
+    )
+
+    # Reveal the "Next" link on every page that is no longer last. This
+    # used to run per-page, before rendering page N, which made page N's
+    # generation edit page N-1's file — a write ordering the parallel path
+    # can't honour. Doing it once, after all pages have landed, is both
+    # order-independent and idempotent: the helper is a no-op on a page
+    # that has no `last-page` class left to strip.
+    for page_num in range(1, len(pages)):
+        _enable_next_link_on_previous_page(output_dir, page_num, suffix)
 
     return first_page_path, wrote_any
 
@@ -1980,6 +2026,7 @@ def convert_jsonl_to(
     force_regenerate: bool = False,
     report: Optional["RegenerationReport"] = None,
     archive_search_link: Optional[str] = None,
+    render_jobs: Optional[int] = 1,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -2019,6 +2066,13 @@ def convert_jsonl_to(
             the caller that writes a ``search.html`` for it to point at, and
             the only one that knows how deep the project sits below the
             index root. None leaves the link out of the rendered page.
+        render_jobs: Worker processes for rendering this project's own
+            output files (combined pages + per-session files), which are
+            independent of one another. ``1`` (the default) renders inline,
+            preserving the historical single-threaded behaviour for library
+            callers; ``None`` means "use the CPU count". The CLI passes the
+            budget it wants — see ``_make_render_pool`` for the conditions
+            under which a pool is actually created.
     """
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {input_path}")
@@ -2197,176 +2251,203 @@ def convert_jsonl_to(
     # index linking, but the file at that path is not (re-)written.
     # Tracks whether the combined output was actually (re)written this call,
     # reported via the `report` out-parameter for the CLI's message.
-    did_regenerate = False
-    if not write_combined:
-        pass
-    elif use_pagination:
-        # Use paginated HTML generation
-        assert cache_manager is not None  # Ensured by use_pagination condition
-        # Use cached session data if available, otherwise build from messages
-        if cached_data is not None:
-            current_session_ids = collect_trunk_session_ids(
-                messages, get_warmup_session_ids(messages)
-            )
-            session_data = {
-                session_id: session_cache
-                for session_id, session_cache in cached_data.sessions.items()
-                if session_id in current_session_ids
-            }
-        else:
-            session_data = _build_session_data_from_messages(messages)
-        output_path, did_regenerate = _generate_paginated_html(
-            messages,
-            effective_output_dir,
-            title,
-            page_size,
-            cache_manager,
-            session_data,
-            working_directories,
-            silent=silent,
-            session_tree=session_tree,
-            depth=depth,
-            compact=compact,
-            no_recaps=no_recaps,
-            archive_search_link=archive_search_link,
-        )
-    else:
-        # Use single-file generation for small projects or filtered views
-        # Use incremental regeneration via html_cache when available
-        if cache_manager is not None and input_path.is_dir():
-            is_stale, _reason = cache_manager.is_transcript_stale(
-                output_path.name, None, output_dir=output_path.parent
-            )
-            should_regenerate = (
-                # force_regenerate first so the is_outdated() sniff is
-                # short-circuited for an explicit --output (issue #221, and
-                # avoids touching a /dev/stdout destination for #223).
-                force_regenerate
-                or is_stale
-                or renderer.is_outdated(output_path)
-                or from_date is not None
-                or to_date is not None
-                or not output_path.exists()
-            )
-        else:
-            # Fallback: old logic for single file mode or no cache.
-            #
-            # is_outdated() only compares the embedded tool version, not the
-            # source's freshness, so a source that grows between runs (e.g. an
-            # in-progress session re-exported with the same tool version) would
-            # be wrongly skipped as "current" and serve stale HTML (issues #221,
-            # #254). Mirror the cached directory path's source-tracking intent
-            # with an mtime check: regenerate when a source is newer than the
-            # existing output.
-            #
-            # This branch is taken for a single file (which never has a cache)
-            # and for a directory run WITHOUT a cache (e.g. --no-cache); the
-            # cached directory path handles freshness via `is_transcript_stale`
-            # above and doesn't reach here. There's no DB tracking per-source
-            # mtimes, so the *output* file's own mtime is the natural,
-            # persistence-free basis:
-            #   - single file  → the source file's own mtime;
-            #   - directory     → the NEWEST source .jsonl in the directory
-            #                     (the directory analogue; non-recursive, like
-            #                     how directory mode discovers sessions).
-            # This is sufficient because the output is always written after its
-            # sources are read, so `output.mtime >= source.mtime` holds
-            # post-write; a later append bumps the source past it. It shares the
-            # cache's filesystem-mtime granularity limit (a sub-tick append
-            # racing the prior write resolves on the next run) and, for a
-            # directory, the same non-recursive scope — a subagent transcript
-            # under `<stem>/subagents/` growing without its top-level parent
-            # .jsonl being touched isn't caught (rare: the parent session
-            # records the spawning tool_use and usually grows too).
-            source_is_newer = False
-            if output_path.exists():
-                output_mtime = output_path.stat().st_mtime
-                if input_path.is_file():
-                    source_is_newer = input_path.stat().st_mtime > output_mtime
-                elif input_path.is_dir():
-                    source_mtimes = [
-                        f.stat().st_mtime for f in input_path.glob("*.jsonl")
-                    ]
-                    source_is_newer = bool(source_mtimes) and (
-                        max(source_mtimes) > output_mtime
-                    )
-            should_regenerate = (
-                force_regenerate
-                or renderer.is_outdated(output_path)
-                or source_is_newer
-                or from_date is not None
-                or to_date is not None
-                or not output_path.exists()
-                or (input_path.is_dir() and cache_was_updated)
-            )
-
-        did_regenerate = should_regenerate
-        if should_regenerate:
-            # For referenced images, pass the output directory
-            output_dir = output_path.parent
-            generate_kwargs: dict[str, Any] = {}
-            # Markdown/JSON renderers share the `generate` signature only up
-            # to the common arguments; the archive-search link is HTML-only.
-            if format == "html" and archive_search_link:
-                generate_kwargs["archive_search_link"] = archive_search_link
-            content = renderer.generate(
-                messages,
-                title,
-                output_dir=output_dir,
-                session_tree=session_tree,
-                **generate_kwargs,
-            )
-            assert content is not None
-            # See issue #139: errors="replace" for lone-surrogate safety.
-            output_path.write_text(content, encoding="utf-8", errors="replace")
-
-            # Update html_cache for the combined transcript. Written for the
-            # marker-tracked formats (HTML + Markdown); JSON tracks its own
-            # freshness via its `version` field, so a marker-keyed row would
-            # always read stale (see `_tracks_version_marker`).
-            # Skip when the caller explicitly disabled cache writes — the
-            # CLI does this for `-o custom.html` exports so a user's
-            # one-off destination doesn't occupy a cache slot keyed by
-            # their arbitrary path.
-            if (
-                cache_manager is not None
-                and update_cache
-                and _tracks_version_marker(format)
-            ):
-                cache_manager.update_html_cache(
-                    output_path.name, None, total_message_count
+    # One render pool per conversion, shared by the combined pages and
+    # the per-session files: starting a second pool would pay `spawn` +
+    # import + transcript load all over again. Creation is cheap — no
+    # worker starts until the first unit is submitted.
+    render_pool = _make_render_pool(
+        format=format,
+        input_path=input_path,
+        effective_output_dir=effective_output_dir,
+        cache_manager=cache_manager,
+        message_count=len(messages),
+        from_date=from_date,
+        to_date=to_date,
+        depth=depth,
+        compact=compact,
+        no_timestamps=no_timestamps,
+        no_recaps=no_recaps,
+        image_export_mode=image_export_mode,
+        archive_search_link=archive_search_link,
+        render_jobs=render_jobs,
+    )
+    try:
+        did_regenerate = False
+        if not write_combined:
+            pass
+        elif use_pagination:
+            # Use paginated HTML generation
+            assert cache_manager is not None  # Ensured by use_pagination condition
+            # Use cached session data if available, otherwise build from messages
+            if cached_data is not None:
+                current_session_ids = collect_trunk_session_ids(
+                    messages, get_warmup_session_ids(messages)
                 )
-        elif not silent:
-            print(
-                f"{format.upper()} file {output_path.name} is current, skipping regeneration"
+                session_data = {
+                    session_id: session_cache
+                    for session_id, session_cache in cached_data.sessions.items()
+                    if session_id in current_session_ids
+                }
+            else:
+                session_data = _build_session_data_from_messages(messages)
+            output_path, did_regenerate = _generate_paginated_html(
+                messages,
+                effective_output_dir,
+                title,
+                page_size,
+                cache_manager,
+                session_data,
+                working_directories,
+                silent=silent,
+                session_tree=session_tree,
+                depth=depth,
+                compact=compact,
+                no_recaps=no_recaps,
+                archive_search_link=archive_search_link,
+                render_pool=render_pool,
+            )
+        else:
+            # Use single-file generation for small projects or filtered views
+            # Use incremental regeneration via html_cache when available
+            if cache_manager is not None and input_path.is_dir():
+                is_stale, _reason = cache_manager.is_transcript_stale(
+                    output_path.name, None, output_dir=output_path.parent
+                )
+                should_regenerate = (
+                    # force_regenerate first so the is_outdated() sniff is
+                    # short-circuited for an explicit --output (issue #221, and
+                    # avoids touching a /dev/stdout destination for #223).
+                    force_regenerate
+                    or is_stale
+                    or renderer.is_outdated(output_path)
+                    or from_date is not None
+                    or to_date is not None
+                    or not output_path.exists()
+                )
+            else:
+                # Fallback: old logic for single file mode or no cache.
+                #
+                # is_outdated() only compares the embedded tool version, not the
+                # source's freshness, so a source that grows between runs (e.g. an
+                # in-progress session re-exported with the same tool version) would
+                # be wrongly skipped as "current" and serve stale HTML (issues #221,
+                # #254). Mirror the cached directory path's source-tracking intent
+                # with an mtime check: regenerate when a source is newer than the
+                # existing output.
+                #
+                # This branch is taken for a single file (which never has a cache)
+                # and for a directory run WITHOUT a cache (e.g. --no-cache); the
+                # cached directory path handles freshness via `is_transcript_stale`
+                # above and doesn't reach here. There's no DB tracking per-source
+                # mtimes, so the *output* file's own mtime is the natural,
+                # persistence-free basis:
+                #   - single file  → the source file's own mtime;
+                #   - directory     → the NEWEST source .jsonl in the directory
+                #                     (the directory analogue; non-recursive, like
+                #                     how directory mode discovers sessions).
+                # This is sufficient because the output is always written after its
+                # sources are read, so `output.mtime >= source.mtime` holds
+                # post-write; a later append bumps the source past it. It shares the
+                # cache's filesystem-mtime granularity limit (a sub-tick append
+                # racing the prior write resolves on the next run) and, for a
+                # directory, the same non-recursive scope — a subagent transcript
+                # under `<stem>/subagents/` growing without its top-level parent
+                # .jsonl being touched isn't caught (rare: the parent session
+                # records the spawning tool_use and usually grows too).
+                source_is_newer = False
+                if output_path.exists():
+                    output_mtime = output_path.stat().st_mtime
+                    if input_path.is_file():
+                        source_is_newer = input_path.stat().st_mtime > output_mtime
+                    elif input_path.is_dir():
+                        source_mtimes = [
+                            f.stat().st_mtime for f in input_path.glob("*.jsonl")
+                        ]
+                        source_is_newer = bool(source_mtimes) and (
+                            max(source_mtimes) > output_mtime
+                        )
+                should_regenerate = (
+                    force_regenerate
+                    or renderer.is_outdated(output_path)
+                    or source_is_newer
+                    or from_date is not None
+                    or to_date is not None
+                    or not output_path.exists()
+                    or (input_path.is_dir() and cache_was_updated)
+                )
+
+            did_regenerate = should_regenerate
+            if should_regenerate:
+                # For referenced images, pass the output directory
+                output_dir = output_path.parent
+                generate_kwargs: dict[str, Any] = {}
+                # Markdown/JSON renderers share the `generate` signature only up
+                # to the common arguments; the archive-search link is HTML-only.
+                if format == "html" and archive_search_link:
+                    generate_kwargs["archive_search_link"] = archive_search_link
+                content = renderer.generate(
+                    messages,
+                    title,
+                    output_dir=output_dir,
+                    session_tree=session_tree,
+                    **generate_kwargs,
+                )
+                assert content is not None
+                # See issue #139: errors="replace" for lone-surrogate safety.
+                output_path.write_text(content, encoding="utf-8", errors="replace")
+
+                # Update html_cache for the combined transcript. Written for the
+                # marker-tracked formats (HTML + Markdown); JSON tracks its own
+                # freshness via its `version` field, so a marker-keyed row would
+                # always read stale (see `_tracks_version_marker`).
+                # Skip when the caller explicitly disabled cache writes — the
+                # CLI does this for `-o custom.html` exports so a user's
+                # one-off destination doesn't occupy a cache slot keyed by
+                # their arbitrary path.
+                if (
+                    cache_manager is not None
+                    and update_cache
+                    and _tracks_version_marker(format)
+                ):
+                    cache_manager.update_html_cache(
+                        output_path.name, None, total_message_count
+                    )
+            elif not silent:
+                print(
+                    f"{format.upper()} file {output_path.name} is current, skipping regeneration"
+                )
+
+        # Generate individual session files if requested and in directory mode.
+        # Its return count feeds the `report` below: per-session output is an
+        # independent axis from the combined write, so a run that rewrites session
+        # files while the combined stays current (or `--combined no`, which never
+        # writes a combined) still counts as work done — otherwise the CLI would
+        # fall silent on it. Kept separate from `did_regenerate` so the CLI can
+        # confirm session work without falsely claiming to have "combined".
+        sessions_regenerated = 0
+        if generate_individual_sessions and input_path.is_dir():
+            sessions_regenerated = _generate_individual_session_files(
+                format,
+                messages,
+                effective_output_dir,
+                from_date,
+                to_date,
+                cache_manager,
+                cache_was_updated,
+                image_export_mode,
+                silent=silent,
+                session_tree=session_tree,
+                depth=depth,
+                compact=compact,
+                write_combined=write_combined,
+                no_timestamps=no_timestamps,
+                no_recaps=no_recaps,
+                render_pool=render_pool,
             )
 
-    # Generate individual session files if requested and in directory mode.
-    # Its return count feeds the `report` below: per-session output is an
-    # independent axis from the combined write, so a run that rewrites session
-    # files while the combined stays current (or `--combined no`, which never
-    # writes a combined) still counts as work done — otherwise the CLI would
-    # fall silent on it. Kept separate from `did_regenerate` so the CLI can
-    # confirm session work without falsely claiming to have "combined".
-    sessions_regenerated = 0
-    if generate_individual_sessions and input_path.is_dir():
-        sessions_regenerated = _generate_individual_session_files(
-            format,
-            messages,
-            effective_output_dir,
-            from_date,
-            to_date,
-            cache_manager,
-            cache_was_updated,
-            image_export_mode,
-            silent=silent,
-            session_tree=session_tree,
-            depth=depth,
-            compact=compact,
-            write_combined=write_combined,
-            no_timestamps=no_timestamps,
-            no_recaps=no_recaps,
-        )
+    finally:
+        if render_pool is not None:
+            render_pool.close()
 
     if report is not None:
         report.combined_regenerated = did_regenerate
@@ -2543,6 +2624,140 @@ def build_session_title(
     return f"{project_title}: Session {session_id[:8]}"
 
 
+# Below this many stale output files, the fan-out is not worth the ~1s of
+# `spawn` + package import + transcript load each worker pays before it can
+# render anything. Units average well under 200ms, so a handful of them
+# finish inline before a pool has even started.
+_MIN_UNITS_FOR_RENDER_POOL = 8
+
+# ...and below this many messages the project is small enough that its
+# whole conversion costs less than the pool's startup, however many files
+# it happens to spread that work across.
+_MIN_MESSAGES_FOR_RENDER_POOL = 2000
+
+
+def _make_render_pool(
+    *,
+    format: str,
+    input_path: Path,
+    effective_output_dir: Path,
+    cache_manager: Optional["CacheManager"],
+    message_count: int,
+    from_date: Optional[str],
+    to_date: Optional[str],
+    depth: RenderingDepth,
+    compact: bool,
+    no_timestamps: bool,
+    no_recaps: bool,
+    image_export_mode: Optional[str],
+    archive_search_link: Optional[str],
+    render_jobs: Optional[int],
+) -> "Optional[RenderPool]":
+    """Build a render pool for this conversion, or None to render inline.
+
+    Returns None whenever fanning out would be wrong or wasteful:
+
+    - ``render_jobs`` resolves to 1 — the caller asked for the inline path,
+      which is also what a project worker in the all-projects pool gets when
+      there is no spare capacity (nesting pools would oversubscribe).
+    - Single-file mode, or no cache manager. Workers reload the transcript
+      from the cache; without one they would each re-parse every JSONL file.
+    - ``image_export_mode="referenced"``, where each render writes
+      ``images/image_NNNN.png`` from a counter it resets per call. Those
+      names already collide between the combined and per-session passes;
+      running them concurrently would let two processes write one file at
+      once, so this mode stays serial.
+    - Projects too small for the pool's startup to pay for itself.
+    """
+    if render_jobs is not None and render_jobs <= 1:
+        return None
+    if cache_manager is None or not input_path.is_dir():
+        return None
+    if image_export_mode == "referenced":
+        return None
+    if message_count < _MIN_MESSAGES_FOR_RENDER_POOL:
+        return None
+
+    from .render_pool import make_render_pool, resolve_render_jobs
+
+    return make_render_pool(
+        format=format,
+        project_dir=input_path,
+        output_dir=effective_output_dir,
+        from_date=from_date,
+        to_date=to_date,
+        depth=depth,
+        compact=compact,
+        no_timestamps=no_timestamps,
+        no_recaps=no_recaps,
+        image_export_mode=image_export_mode,
+        archive_search_link=archive_search_link,
+        library_version=get_library_version(),
+        max_workers=resolve_render_jobs(render_jobs),
+    )
+
+
+def _dispatch_render_units(
+    units: "list[RenderUnit]",
+    render_pool: "Optional[RenderPool]",
+    render_inline: "Callable[[RenderUnit], None]",
+    on_written: "Callable[[RenderUnit], None]",
+    label: "Callable[[RenderUnit], str]",
+) -> None:
+    """Render ``units``, over the pool when there is one, else inline.
+
+    ``on_written`` runs in the parent for every unit that made it to disk,
+    in completion order — it owns the cache bookkeeping, which is why the
+    workers never touch the DB for writes.
+
+    Every path back to inline rendering is a *fallback*, never an error:
+    a pool that can't bootstrap (a library caller without the
+    ``if __name__ == "__main__"`` guard ``spawn`` requires) or a worker
+    that dies mid-run must still produce complete output. Only a genuine
+    render failure inside a unit propagates.
+    """
+    if not units:
+        return
+
+    if render_pool is None or len(units) < _MIN_UNITS_FOR_RENDER_POOL:
+        for unit in units:
+            render_inline(unit)
+            on_written(unit)
+        return
+
+    futures: dict[Any, RenderUnit] = {}
+    unsubmitted: list[RenderUnit] = []
+    for unit in units:
+        future = render_pool.submit(unit)
+        if future is None:
+            unsubmitted.append(unit)
+        else:
+            futures[future] = unit
+
+    for future in as_completed(futures):
+        unit = futures[future]
+        try:
+            _kind, _key, error = future.result()
+        except Exception as e:
+            # The pool itself broke (BrokenProcessPool, a worker killed by
+            # the OOM killer, …). Re-render this unit inline and send the
+            # rest of the batch the same way.
+            print(
+                f"Warning: render worker failed on {label(unit)} "
+                f"({e.__class__.__name__}: {e}); rendering inline."
+            )
+            render_pool.mark_broken()
+            unsubmitted.append(unit)
+            continue
+        if error is not None:
+            raise RuntimeError(f"Failed to render {label(unit)}:\n{error}")
+        on_written(unit)
+
+    for unit in unsubmitted:
+        render_inline(unit)
+        on_written(unit)
+
+
 def _generate_individual_session_files(
     format: str,
     messages: list[TranscriptEntry],
@@ -2559,8 +2774,13 @@ def _generate_individual_session_files(
     write_combined: bool = True,
     no_timestamps: bool = False,
     no_recaps: bool = False,
+    render_pool: "Optional[RenderPool]" = None,
 ) -> int:
     """Generate individual files for each session in the specified format.
+
+    Args:
+        render_pool: Optional pool to fan the stale sessions out over. None
+            (the default) renders them inline, one at a time.
 
     Returns:
         Number of sessions regenerated
@@ -2604,6 +2824,9 @@ def _generate_individual_session_files(
         no_recaps=no_recaps,
     )
     regenerated_count = 0
+    # Stale sessions, collected before any rendering starts so they can be
+    # dispatched together (inline or over the render pool).
+    stale_units: list[RenderUnit] = []
 
     # Reuse one connection for every per-session staleness check + html_cache
     # write, plus the per-session cache reads inside renderer.generate_session.
@@ -2669,48 +2892,72 @@ def _generate_individual_session_files(
                 )
 
             if should_regenerate_session:
-                # Generate session content. Under `--combined no` the
-                # combined file is never written, so the per-session
-                # back-link would 404 — suppress it.
-                session_content = renderer.generate_session(
-                    messages,
-                    session_id,
-                    session_title,
-                    cache_manager,
-                    output_dir,
-                    session_tree=session_tree,
-                    suppress_combined_link=not write_combined,
-                )
-                assert session_content is not None
-                # Write session file
-                # See issue #139: errors="replace" for lone-surrogate safety.
-                session_file_path.write_text(
-                    session_content, encoding="utf-8", errors="replace"
-                )
-                regenerated_count += 1
-
-                # Update html_cache to track this generation (marker-tracked
-                # formats only; JSON uses its own version-field freshness).
-                if cache_manager is not None and _tracks_version_marker(format):
-                    # Use message count from cache (pre-deduplication) to match
-                    # the count used in is_transcript_stale()
-                    if session_id in session_data:
-                        session_message_count = session_data[session_id].message_count
-                    else:
-                        # Fallback: count from messages list (less accurate due to dedup)
-                        session_message_count = sum(
-                            1
-                            for m in messages
-                            if hasattr(m, "sessionId")
-                            and getattr(m, "sessionId") == session_id
-                        )
-                    cache_manager.update_html_cache(
-                        session_file_name, session_id, session_message_count
+                # Collect rather than render: the whole stale set is
+                # gathered first so it can be fanned out over the render
+                # pool. Staleness checks and cache writes stay here in the
+                # parent, which keeps the DB single-writer.
+                stale_units.append(
+                    RenderUnit(
+                        kind="session",
+                        key=session_id,
+                        file_name=session_file_name,
+                        title=session_title,
+                        # Under `--combined no` the combined file is never
+                        # written, so the per-session back-link would 404.
+                        suppress_combined_link=not write_combined,
                     )
+                )
             elif not silent:
                 print(
                     f"Session file {session_file_path.name} is current, skipping regeneration"
                 )
+
+        def _render_session_inline(unit: RenderUnit) -> None:
+            session_content = renderer.generate_session(
+                messages,
+                unit.key,
+                unit.title,
+                cache_manager,
+                output_dir,
+                session_tree=session_tree,
+                suppress_combined_link=unit.suppress_combined_link,
+            )
+            assert session_content is not None
+            # See issue #139: errors="replace" for lone-surrogate safety.
+            (output_dir / unit.file_name).write_text(
+                session_content, encoding="utf-8", errors="replace"
+            )
+
+        def _record_session(unit: RenderUnit) -> None:
+            """Cache bookkeeping for one written session file."""
+            nonlocal regenerated_count
+            regenerated_count += 1
+            # Update html_cache to track this generation (marker-tracked
+            # formats only; JSON uses its own version-field freshness).
+            if cache_manager is None or not _tracks_version_marker(format):
+                return
+            # Use message count from cache (pre-deduplication) to match
+            # the count used in is_transcript_stale()
+            if unit.key in session_data:
+                session_message_count = session_data[unit.key].message_count
+            else:
+                # Fallback: count from messages list (less accurate due to dedup)
+                session_message_count = sum(
+                    1
+                    for m in messages
+                    if hasattr(m, "sessionId") and getattr(m, "sessionId") == unit.key
+                )
+            cache_manager.update_html_cache(
+                unit.file_name, unit.key, session_message_count
+            )
+
+        _dispatch_render_units(
+            stale_units,
+            render_pool,
+            _render_session_inline,
+            _record_session,
+            label=lambda unit: f"session {str(unit.key)[:8]}",
+        )
 
     return regenerated_count
 
@@ -3659,6 +3906,10 @@ def _convert_project_worker(
             no_timestamps=worker_args["no_timestamps"],
             no_recaps=worker_args["no_recaps"],
             archive_search_link=worker_args["archive_search_link"],
+            # Nested pools: this project worker gets its own share of the
+            # job budget for the render fan-out, computed by the parent so
+            # the two levels together never exceed `--jobs`.
+            render_jobs=worker_args["render_jobs"],
         )
     except Exception:
         error = traceback.format_exc()
@@ -3893,8 +4144,22 @@ def process_projects_hierarchy(
     # conversion touches only its own project dir and its own rows in
     # the (WAL-mode) cache DB — so stale projects fan out over a
     # process pool. `jobs=1` keeps the historical inline path.
-    resolved_jobs = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
-    resolved_jobs = max(1, min(resolved_jobs, len(to_convert)))
+    job_budget = jobs if jobs is not None and jobs > 0 else (os.cpu_count() or 1)
+    resolved_jobs = max(1, min(job_budget, len(to_convert)))
+
+    # Spare capacity goes to each project's *own* render fan-out. With
+    # fewer stale projects than workers — the shape of every incremental
+    # run — the project pool alone leaves most cores idle, because a
+    # single project's conversion is single-threaded. Dividing the budget
+    # gives one stale project the whole machine and many stale projects
+    # the historical one-worker-each.
+    #
+    # This does not fix the *tail* of a large multi-project run: the split
+    # is static, so when the small projects finish early their share isn't
+    # handed back to the big project still rendering. Making it dynamic
+    # needs a single flat pool over render units rather than two nested
+    # levels.
+    per_project_render_jobs = max(1, job_budget // max(1, len(to_convert)))
 
     def _convert_plan_inline(plan: _ProjectPlan) -> None:
         """Convert one project in this process, reporting progress/failure."""
@@ -3921,6 +4186,7 @@ def process_projects_hierarchy(
                 no_timestamps=no_timestamps,
                 no_recaps=no_recaps,
                 archive_search_link=_archive_search_link(plan),
+                render_jobs=per_project_render_jobs,
             )
         except Exception:
             _print_project_failed(plan, traceback.format_exc())
@@ -3967,6 +4233,7 @@ def process_projects_hierarchy(
                             "no_timestamps": no_timestamps,
                             "no_recaps": no_recaps,
                             "archive_search_link": _archive_search_link(plan),
+                            "render_jobs": per_project_render_jobs,
                         },
                     ): plan
                     for plan in by_size

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from .cache import CacheManager
+    from .fragment_store import RenderFragmentStore
     from .providers.base import ProviderTokenTotals
     from .render_pool import RenderPool
 
@@ -1708,12 +1709,16 @@ def _generate_paginated_html(
     no_recaps: bool = False,
     archive_search_link: Optional[str] = None,
     render_pool: "Optional[RenderPool]" = None,
+    fragment_store: "Optional[RenderFragmentStore]" = None,
 ) -> tuple[Path, bool]:
     """Generate paginated HTML files for combined transcript.
 
     Args:
         render_pool: Optional pool to fan the stale pages out over. None
             (the default) renders them inline, one at a time.
+        fragment_store: Optional per-conversion fragment store shared with
+            the per-session pass, so inline page renders reuse (and seed)
+            each message's formatted fragment.
         messages: All messages (deduplicated)
         output_dir: Directory to write HTML files
         title: Base title for the pages
@@ -1933,6 +1938,7 @@ def _generate_paginated_html(
         page_renderer.depth = depth
         page_renderer.compact = compact
         page_renderer.no_recaps = no_recaps
+        page_renderer.fragment_store = fragment_store
         html_content = page_renderer.generate(
             page_messages,
             unit.title,
@@ -2227,6 +2233,18 @@ def convert_jsonl_to(
         no_recaps=no_recaps,
     )
 
+    # One fragment store per conversion, shared by the combined pages and
+    # the per-session files, so each entry-derived message is formatted
+    # once rather than once per output file that contains it (step 3,
+    # work/render-format-once.md). Scoped to this call: it dies with the
+    # conversion, so nothing about it needs invalidating.
+    fragment_store = _make_fragment_store(format)
+    if fragment_store is not None:
+        from .html.renderer import HtmlRenderer as _HtmlRenderer
+
+        if isinstance(renderer, _HtmlRenderer):
+            renderer.fragment_store = fragment_store
+
     # Decide whether to use pagination (HTML only, directory mode, no date filter)
     use_pagination = False
     cached_data = cache_manager.get_cached_project_data() if cache_manager else None
@@ -2306,6 +2324,7 @@ def convert_jsonl_to(
                 no_recaps=no_recaps,
                 archive_search_link=archive_search_link,
                 render_pool=render_pool,
+                fragment_store=fragment_store,
             )
         else:
             # Use single-file generation for small projects or filtered views
@@ -2444,6 +2463,7 @@ def convert_jsonl_to(
                 no_timestamps=no_timestamps,
                 no_recaps=no_recaps,
                 render_pool=render_pool,
+                fragment_store=fragment_store,
             )
 
     finally:
@@ -2631,6 +2651,7 @@ def build_session_title(
 # finish inline before a pool has even started.
 _MIN_UNITS_FOR_RENDER_POOL = 8
 
+
 # ...and below this many messages the project's render work is too small
 # to repay what each worker costs before it renders anything: `spawn`,
 # package import, and a full reload of the transcript from cache (~1.7s at
@@ -2642,6 +2663,25 @@ _MIN_UNITS_FOR_RENDER_POOL = 8
 # so the crossover sits between the two. Set conservatively near the upper
 # measurement rather than the midpoint: below it the cost is a certain
 # regression, above it the win grows with project size and core count.
+def _make_fragment_store(format: str) -> "Optional[RenderFragmentStore]":
+    """Create the per-conversion fragment store, or None when it can't help.
+
+    HTML only — the fragment triple it caches is exactly what
+    ``HtmlRenderer._annotate_tree_for_render`` computes, and no other
+    renderer consults it. Referenced-image renders are excluded at the
+    consumer (the annotate walk), not here, because the effective image
+    mode lives on the renderer. ``CLAUDE_CODE_LOG_FRAGMENT_STORE=0``
+    disables it for bisecting rendering differences.
+    """
+    if format != "html":
+        return None
+    from .fragment_store import RenderFragmentStore, fragment_store_enabled
+
+    if not fragment_store_enabled():
+        return None
+    return RenderFragmentStore()
+
+
 _MIN_MESSAGES_FOR_RENDER_POOL = 25_000
 
 
@@ -2803,12 +2843,16 @@ def _generate_individual_session_files(
     no_timestamps: bool = False,
     no_recaps: bool = False,
     render_pool: "Optional[RenderPool]" = None,
+    fragment_store: "Optional[RenderFragmentStore]" = None,
 ) -> int:
     """Generate individual files for each session in the specified format.
 
     Args:
         render_pool: Optional pool to fan the stale sessions out over. None
             (the default) renders them inline, one at a time.
+        fragment_store: Optional per-conversion fragment store (HTML only)
+            shared with the combined-page pass, so inline session renders
+            reuse the fragments that pass already formatted.
 
     Returns:
         Number of sessions regenerated
@@ -2851,6 +2895,11 @@ def _generate_individual_session_files(
         no_timestamps=no_timestamps,
         no_recaps=no_recaps,
     )
+    if fragment_store is not None:
+        from .html.renderer import HtmlRenderer as _HtmlRenderer
+
+        if isinstance(renderer, _HtmlRenderer):
+            renderer.fragment_store = fragment_store
     regenerated_count = 0
     # Stale sessions, collected before any rendering starts so they can be
     # dispatched together (inline or over the render pool).

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1773,15 +1773,19 @@ def _generate_paginated_html(
                 orphan_path.unlink()
 
     # Group messages by session for fast lookup (agent messages grouped
-    # under their parent session since they don't have their own pages)
+    # under their parent session since they don't have their own pages).
+    # Each message's master-list ordinal is grouped alongside it: stale
+    # page units carry their slice of entries *and* those ordinals, so a
+    # render worker's fragment-store keys name the same positions the
+    # parent's do (see RenderUnit.entries / entry_ordinals).
     messages_by_session: Dict[str, List[TranscriptEntry]] = {}
-    for msg in messages:
+    ordinals_by_session: Dict[str, List[int]] = {}
+    for ordinal, msg in enumerate(messages):
         session_id = getattr(msg, "sessionId", None)
         if session_id:
             key = get_parent_session_id(session_id)
-            if key not in messages_by_session:
-                messages_by_session[key] = []
-            messages_by_session[key].append(msg)
+            messages_by_session.setdefault(key, []).append(msg)
+            ordinals_by_session.setdefault(key, []).append(ordinal)
 
     first_page_path = output_dir / _get_page_html_path(1, suffix)
 
@@ -1818,11 +1822,14 @@ def _generate_paginated_html(
         if not silent:
             print(f"Generating page {page_num} ({reason})...")
 
-        # Collect messages for this page
+        # Collect messages for this page (and their master-list ordinals,
+        # dispatched with the unit so workers never load the transcript)
         page_messages: List[TranscriptEntry] = []
+        page_ordinals: List[int] = []
         for session_id in page_session_ids:
             if session_id in messages_by_session:
                 page_messages.extend(messages_by_session[session_id])
+                page_ordinals.extend(ordinals_by_session[session_id])
 
         # Calculate page stats
         page_message_count = len(page_messages)
@@ -1910,6 +1917,8 @@ def _generate_paginated_html(
                 key=page_num,
                 file_name=html_path,
                 title=page_title,
+                entries=page_messages,
+                entry_ordinals=page_ordinals,
                 session_ids=page_session_ids,
                 page_info=page_info,
                 page_stats=page_stats,
@@ -1931,16 +1940,14 @@ def _generate_paginated_html(
         }
 
     def _render_page_inline(unit: RenderUnit) -> None:
-        page_messages: List[TranscriptEntry] = []
-        for session_id in unit.session_ids or []:
-            page_messages.extend(messages_by_session.get(session_id, []))
+        assert unit.entries is not None  # every page unit is planned with them
         page_renderer = HtmlRenderer()
         page_renderer.depth = depth
         page_renderer.compact = compact
         page_renderer.no_recaps = no_recaps
         page_renderer.fragment_store = fragment_store
         html_content = page_renderer.generate(
-            page_messages,
+            unit.entries,
             unit.title,
             page_info=unit.page_info,
             page_stats=unit.page_stats,
@@ -2278,8 +2285,8 @@ def convert_jsonl_to(
     # reported via the `report` out-parameter for the CLI's message.
     # One render pool per conversion, shared by the combined pages and
     # the per-session files: starting a second pool would pay `spawn` +
-    # import + transcript load all over again. Creation is cheap — no
-    # worker starts until the first unit is submitted.
+    # import all over again. Creation is cheap — no worker starts until
+    # the first unit is submitted.
     render_pool = _make_render_pool(
         format=format,
         input_path=input_path,
@@ -2295,6 +2302,7 @@ def convert_jsonl_to(
         image_export_mode=image_export_mode,
         archive_search_link=archive_search_link,
         render_jobs=render_jobs,
+        session_tree=session_tree,
     )
     try:
         did_regenerate = False
@@ -2652,16 +2660,17 @@ def build_session_title(
 
 
 # Below this many stale output files, the fan-out is not worth the ~1s of
-# `spawn` + package import + transcript load each worker pays before it can
-# render anything. Units average well under 200ms, so a handful of them
-# finish inline before a pool has even started.
+# `spawn` + package import each worker pays before it can render anything.
+# Units average well under 200ms, so a handful of them finish inline
+# before a pool has even started.
 _MIN_UNITS_FOR_RENDER_POOL = 8
 
 
-# ...and below this many messages the project's render work is too small
-# to repay what each worker costs before it renders anything: `spawn`,
-# package import, and a full reload of the transcript from cache (~1.7s at
-# 47k messages). Measured on 4 cores, with the § 2.9 memo caches on:
+# ...and below this many messages the project's render work is too small to
+# repay the pool's startup. Sized when workers still re-loaded the whole
+# transcript from cache (~1.7s at 47k messages) — they are fed entry slices
+# now, so this is due a re-measure (work/render-format-once.md § 7.5).
+# Measured on 4 cores, with the § 2.9 memo caches on:
 #
 #   12k messages  serial 8.2s  ->  4 workers 9.7s   (a loss)
 #   47k messages  serial 27.6s ->  4 workers 20.0s  (1.38x)
@@ -2707,6 +2716,7 @@ def _make_render_pool(
     image_export_mode: Optional[str],
     archive_search_link: Optional[str],
     render_jobs: Optional[int],
+    session_tree: Optional[SessionTree],
 ) -> "Optional[RenderPool]":
     """Build a render pool for this conversion, or None to render inline.
 
@@ -2717,19 +2727,23 @@ def _make_render_pool(
       ``render_pool.resolve_render_jobs``). It is also what a project
       worker in the all-projects pool gets when there is no spare capacity,
       since nesting pools would oversubscribe.
-    - Single-file mode, or no cache manager. Workers reload the transcript
-      from the cache; without one they would each re-parse every JSONL file.
+    - Single-file mode, or no cache manager (staleness planning needs one).
+    - No pre-built ``session_tree``. Workers render fed entry slices
+      against the conversion's tree; without one they would rebuild a DAG
+      from their slice alone, which can genuinely differ (missing
+      cross-session hierarchy) — a correctness cliff, so decline instead.
     - ``image_export_mode="referenced"``, where each render writes
       ``images/image_NNNN.png`` from a counter it resets per call. Those
       names already collide between the combined and per-session passes;
       running them concurrently would let two processes write one file at
       once, so this mode stays serial.
     - Projects too small for the pool's startup to pay for itself.
-    - Not enough memory for even one worker's copy of the transcript.
+    - Not enough memory for the fan-out's footprint.
 
-    The worker count is also capped by available memory, because each
-    worker holds the whole transcript (~3x its bytes on disk). See
-    ``render_pool.memory_capped_workers``.
+    The worker count is also capped by available memory. The cap formula
+    still charges each worker a full transcript copy — workers now hold
+    only their in-flight unit's slice, so this over-charges and is due a
+    re-size (work/render-format-once.md § 7.5); until then it errs safe.
     """
     from .render_pool import memory_capped_workers, resolve_render_jobs
 
@@ -2737,6 +2751,8 @@ def _make_render_pool(
     if max_workers <= 1:
         return None
     if cache_manager is None or not input_path.is_dir():
+        return None
+    if session_tree is None:
         return None
     if image_export_mode == "referenced":
         return None
@@ -2752,9 +2768,11 @@ def _make_render_pool(
     if max_workers <= 1:
         return None
 
+    from .dag import slim_session_tree
     from .render_pool import make_render_pool
 
     return make_render_pool(
+        session_tree=slim_session_tree(session_tree),
         format=format,
         project_dir=input_path,
         output_dir=effective_output_dir,
@@ -3042,33 +3060,51 @@ def _generate_individual_session_files(
                 unit.file_name, unit.key, session_message_count
             )
 
-        # Feed each pooled session unit its slice of the fragment store —
-        # by now the combined-page pass has completed (pages dispatch and
-        # drain before this function runs), so the store holds a fragment
-        # for essentially every message, whether the pages rendered inline
-        # or in workers (whose deltas the page dispatch absorbed). A
-        # worker seeds its own store from the slice and skips re-formatting
-        # everything that verifies; anything stale or mis-keyed digests
-        # into a conflict and is formatted fresh, so this is purely a
-        # CPU-saving feed, never a correctness dependency.
-        if fragment_store is not None and render_pool is not None and stale_units:
+        # Feed each pooled session unit everything its worker renders from:
+        #
+        # 1. Its *entries* — the session's slice of this conversion's master
+        #    list (trunk + integrated agent messages), with their master-
+        #    list ordinals. Workers never load the transcript; the trunk
+        #    grouping here selects exactly the set generate_session's own
+        #    filter would (sessionId == trunk or a "{trunk}#agent-" child),
+        #    so the worker's re-filter of the slice is idempotent.
+        # 2. Its slice of the fragment store — by now the combined-page
+        #    pass has completed (pages dispatch and drain before this
+        #    function runs), so the store holds a fragment for essentially
+        #    every message, whether the pages rendered inline or in workers
+        #    (whose deltas the page dispatch absorbed). A worker seeds its
+        #    own store from the slice and skips re-formatting everything
+        #    that verifies; anything stale or mis-keyed digests into a
+        #    conflict and is formatted fresh, so the fragment feed is
+        #    purely a CPU saver, never a correctness dependency.
+        if render_pool is not None and stale_units:
             from .utils import get_parent_session_id as _trunk_of
 
-            ordinal_session: dict[int, str] = {}
+            entries_by_trunk: dict[str, list[TranscriptEntry]] = {}
+            ordinals_by_trunk: dict[str, list[int]] = {}
+            trunk_of_ordinal: dict[int, str] = {}
             for ordinal, msg in enumerate(messages):
                 msg_sid = getattr(msg, "sessionId", None)
                 if msg_sid:
-                    ordinal_session[ordinal] = _trunk_of(msg_sid)
-            all_fragments = fragment_store.export_fragments()
-            keys_by_session: dict[str, list[Any]] = {}
-            for store_key in all_fragments:
-                key_session = ordinal_session.get(cast(int, store_key[0]))
-                if key_session is not None:
-                    keys_by_session.setdefault(key_session, []).append(store_key)
+                    trunk = _trunk_of(msg_sid)
+                    entries_by_trunk.setdefault(trunk, []).append(msg)
+                    ordinals_by_trunk.setdefault(trunk, []).append(ordinal)
+                    trunk_of_ordinal[ordinal] = trunk
             for unit in stale_units:
-                unit_keys = keys_by_session.get(unit.key)
-                if unit_keys:
-                    unit.fed_fragments = {k: all_fragments[k] for k in unit_keys}
+                unit.entries = entries_by_trunk.get(unit.key, [])
+                unit.entry_ordinals = ordinals_by_trunk.get(unit.key, [])
+
+            if fragment_store is not None:
+                all_fragments = fragment_store.export_fragments()
+                keys_by_session: dict[str, list[Any]] = {}
+                for store_key in all_fragments:
+                    key_session = trunk_of_ordinal.get(cast(int, store_key[0]))
+                    if key_session is not None:
+                        keys_by_session.setdefault(key_session, []).append(store_key)
+                for unit in stale_units:
+                    unit_keys = keys_by_session.get(unit.key)
+                    if unit_keys:
+                        unit.fed_fragments = {k: all_fragments[k] for k in unit_keys}
 
         _dispatch_render_units(
             stale_units,

--- a/claude_code_log/dag.py
+++ b/claude_code_log/dag.py
@@ -8,7 +8,7 @@ See dev-docs/dag.md for the full architecture spec.
 
 import logging
 from dataclasses import dataclass, field
-from typing import Optional, TYPE_CHECKING
+from typing import NoReturn, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .workflow import WorkflowRun
@@ -1073,6 +1073,59 @@ def build_session_tree(
         sessions=sessions,
         roots=roots,
         junction_points=junction_points,
+    )
+
+
+class _NodesUnavailable(dict["str", "MessageNode"]):
+    """The ``nodes`` mapping of a slimmed SessionTree — loud on lookup.
+
+    A slim tree crosses the process boundary to render workers, which
+    consume only ``sessions`` / ``junction_points`` / ``workflow_*``.
+    ``nodes`` holds a ``MessageNode`` (and therefore a ``TranscriptEntry``)
+    per message, so shipping it would drag the whole transcript along —
+    exactly what feeding the workers exists to avoid. Lookups raise so a
+    future render-path consumer of ``nodes`` fails loudly in the worker
+    instead of silently rendering from an empty mapping; iteration-shaped
+    access stays empty-dict-behaved because pickling a dict subclass
+    iterates it.
+    """
+
+    _MESSAGE = (
+        "SessionTree.nodes is not available on a slimmed tree (render "
+        "workers are fed entries instead of the full transcript — see "
+        "slim_session_tree). If the render path genuinely needs nodes, "
+        "the worker feed must grow to carry them."
+    )
+
+    def __getitem__(self, key: str) -> NoReturn:
+        raise RuntimeError(self._MESSAGE)
+
+    def get(self, key: str, default: object = None) -> NoReturn:
+        raise RuntimeError(self._MESSAGE)
+
+    def __contains__(self, key: object) -> NoReturn:
+        raise RuntimeError(self._MESSAGE)
+
+
+def slim_session_tree(tree: SessionTree) -> SessionTree:
+    """A copy of ``tree`` without the per-message ``nodes`` mapping.
+
+    Everything the *render* path reads is shared by reference —
+    ``sessions``, ``roots``, ``junction_points`` and the workflow dicts.
+    ``nodes`` is only consumed at load time (``traverse_session_tree``
+    flattens it into the master message list), and it is the part whose
+    pickled size is the whole transcript, so the render fan-out sends
+    workers this slim form instead. Note ``workflow_runs`` still carries
+    each workflow agent's entries; those are a small slice of a project
+    and the renderer does read them.
+    """
+    return SessionTree(
+        nodes=_NodesUnavailable(),
+        sessions=tree.sessions,
+        roots=tree.roots,
+        junction_points=tree.junction_points,
+        workflow_runs=tree.workflow_runs,
+        workflow_links=tree.workflow_links,
     )
 
 

--- a/claude_code_log/fragment_store.py
+++ b/claude_code_log/fragment_store.py
@@ -226,6 +226,31 @@ class RenderFragmentStore:
         """Record the master message list this conversion renders subsets of."""
         self._entry_ordinals = {id(entry): i for i, entry in enumerate(entries)}
 
+    def set_entry_ordinal_map(self, mapping: dict[int, int]) -> None:
+        """Share a prebuilt ``id(entry) → ordinal`` map (worker-side reuse)."""
+        self._entry_ordinals = mapping
+
+    def export_fragments(self) -> dict[StoreKey, tuple[bytes, Fragment]]:
+        """The raw fragment mapping — digests and strings only, picklable.
+
+        This is what crosses the process boundary in the render fan-out: a
+        page worker exports its fragments back to the parent, and the
+        parent slices them into the session units it dispatches (see
+        converter._dispatch_render_units / render_pool._render_unit_worker).
+        Returned by reference; callers must not mutate it.
+        """
+        return self._fragments
+
+    def absorb(self, fragments: dict[StoreKey, tuple[bytes, Fragment]]) -> None:
+        """Merge fragments computed elsewhere (a worker's delta or a fed
+        slice). First writer wins, matching ``put`` — for a given key the
+        digest pins the content either way, so order cannot change output.
+        """
+        for key, entry in fragments.items():
+            if key not in self._fragments:
+                self._fragments[key] = entry
+                self._bytes += sum(len(part) for part in entry[1])
+
     def stable_key(self, fragment_key: tuple[int, int]) -> Optional[tuple[int, int]]:
         """Translate a stamped ``(id(entry), part_ordinal)`` to a stable key.
 

--- a/claude_code_log/fragment_store.py
+++ b/claude_code_log/fragment_store.py
@@ -20,14 +20,18 @@ invalidation surface at zero:
   fresh store per conversion just like the CLI does.
 - **Keys are entry identity plus tree context, not content.**
   ``MessageContent.fragment_key`` is ``(id(source_entry), part_ordinal)``,
-  stamped by the pass-2 render loop; the consumer appends a signature of
-  the tree-derived render inputs (pair presence, model badge, agent
-  depth, …) so a message that legitimately renders differently in the
-  combined tree than in its session tree occupies two slots instead of
-  poisoning one. The master message list keeps every entry alive for the
-  whole conversion, so the ``id()`` is stable; transcript uuids are NOT
-  usable here because resumed/forked sessions reuse them across distinct
-  messages (work/render-format-once.md § 4.1).
+  stamped by the pass-2 render loop — the only identity available where
+  differently-filtered subsets are rendered. The store translates the id
+  to the entry's ordinal in the conversion's master message list
+  (``set_entry_ordinals`` / ``stable_key``), which every tree — and any
+  process that loads the same master list — agrees on; an unknown id
+  declines caching. The consumer appends a signature of the tree-derived
+  render inputs (pair presence, model badge, agent depth, …) so a
+  message that legitimately renders differently in the combined tree
+  than in its session tree occupies two slots instead of poisoning one.
+  Transcript uuids are NOT usable here because resumed/forked sessions
+  reuse them across distinct messages (work/render-format-once.md
+  § 4.1).
 - **Hits are verified against the content.** ``get`` compares a digest
   of the requesting tree's content against the digest stored at ``put``
   time (:func:`content_digest` — same field coverage as dataclass
@@ -56,7 +60,7 @@ import os
 from hashlib import blake2b
 from typing import TYPE_CHECKING, Optional, cast
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pydantic import BaseModel
 
@@ -195,6 +199,16 @@ class RenderFragmentStore:
 
     def __init__(self) -> None:
         self._fragments: dict[StoreKey, tuple[bytes, Fragment]] = {}
+        # id(entry) → the entry's ordinal in the conversion's master
+        # message list. Stamped fragment_keys carry the entry's Python
+        # id (the only identity available where subsets are rendered);
+        # stable_key() translates it to the ordinal, which two render
+        # trees — and, later, two *processes* that load the same master
+        # list — agree on. The translation also retires the id-reuse
+        # caveat: an id missing from the map (a stamped entry that is
+        # somehow not in the master list) declines caching instead of
+        # risking a stale-id collision.
+        self._entry_ordinals: dict[int, int] = {}
         self._bytes = 0
         self.hits = 0
         self.misses = 0
@@ -207,6 +221,22 @@ class RenderFragmentStore:
         # their output is tree-specific (per-tree ``#msg-d-{N}`` anchors —
         # see HtmlRenderer._annotate_tree_for_render).
         self.skipped = 0
+
+    def set_entry_ordinals(self, entries: "Iterable[object]") -> None:
+        """Record the master message list this conversion renders subsets of."""
+        self._entry_ordinals = {id(entry): i for i, entry in enumerate(entries)}
+
+    def stable_key(self, fragment_key: tuple[int, int]) -> Optional[tuple[int, int]]:
+        """Translate a stamped ``(id(entry), part_ordinal)`` to a stable key.
+
+        Returns ``(master_list_ordinal, part_ordinal)``, or None when the
+        id is unknown — the caller then skips the store for that message,
+        which is always safe.
+        """
+        ordinal = self._entry_ordinals.get(fragment_key[0])
+        if ordinal is None:
+            return None
+        return (ordinal, fragment_key[1])
 
     def get(self, key: StoreKey, content: "MessageContent") -> Optional[Fragment]:
         entry = self._fragments.get(key)

--- a/claude_code_log/fragment_store.py
+++ b/claude_code_log/fragment_store.py
@@ -28,14 +28,22 @@ invalidation surface at zero:
   whole conversion, so the ``id()`` is stable; transcript uuids are NOT
   usable here because resumed/forked sessions reuse them across distinct
   messages (work/render-format-once.md § 4.1).
-- **Hits are verified against the content.** ``get`` compares the stored
-  content object with the requesting tree's content (dataclass equality,
-  with per-tree fields excluded via ``compare=False``); a mismatch is a
-  conflict, not a hit. This is the backstop for content built from
-  cross-message context that resolves differently per tree — e.g. a tool
-  result whose paired ``tool_use`` lives in another session, so the
-  factory resolves the tool name in the combined tree but not in the
-  session tree (work/render-format-once.md § 4.8).
+- **Hits are verified against the content.** ``get`` compares a digest
+  of the requesting tree's content against the digest stored at ``put``
+  time (:func:`content_digest` — same field coverage as dataclass
+  equality, with the per-tree ``compare=False`` fields excluded); a
+  mismatch is a conflict, not a hit. This is the backstop for content
+  built from cross-message context that resolves differently per tree —
+  e.g. a tool result whose paired ``tool_use`` lives in another session,
+  so the factory resolves the tool name in the combined tree but not in
+  the session tree (work/render-format-once.md § 4.8). A digest is
+  stored rather than the content object itself so the store holds only
+  strings and bytes — picklable, spillable, and unable to pin object
+  graphs — which is what lets phase 2 feed fragments to workers.
+  Measured peak-RSS-neutral on the reference 803MB archive (the stored
+  contents there alias objects the master entry list keeps alive
+  anyway — work/render-format-once.md § 4.9), but the retention it
+  removes is workload-shaped, and the structural property is the point.
 
 The store is a pure performance feature: a renderer with no store (or a
 content with no key) formats exactly as before.
@@ -43,8 +51,14 @@ content with no key) formats exactly as before.
 
 from __future__ import annotations
 
+import dataclasses
 import os
-from typing import TYPE_CHECKING, Optional
+from hashlib import blake2b
+from typing import TYPE_CHECKING, Optional, cast
+
+from collections.abc import Sequence
+
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from .models import MessageContent
@@ -56,6 +70,108 @@ Fragment = tuple[str, str, str]
 # (id(entry), part_ordinal) from MessageContent.fragment_key, extended by
 # the consumer with the tree-context signature tuple.
 StoreKey = tuple[object, ...]
+
+
+def content_digest(content: "MessageContent") -> bytes:
+    """Canonical 16-byte digest of a content's compare-relevant state.
+
+    Stands in for dataclass ``__eq__`` in the store's hit-verification so
+    the store need not retain the content object itself
+    (work/render-format-once.md § 4.9). Field coverage matches dataclass
+    equality exactly: compare-excluded fields (the per-tree
+    ``message_index`` / ``fragment_key``) are skipped, everything else is
+    fed into the hash with type tags and length prefixes so no two
+    distinct structures can collide by concatenation.
+
+    Divergence from ``__eq__`` is tolerated only in the safe direction:
+    where Python equality is looser than this canonical form (``True ==
+    1``, equal dicts with different insertion order, identity-``repr``
+    objects), the digests differ, the lookup counts as a conflict, and
+    the fragment is formatted fresh — never the reverse.
+    """
+    h = blake2b(digest_size=16)
+    _feed(h, content)
+    return h.digest()
+
+
+def _feed(h: "blake2b", obj: object) -> None:  # noqa: C901 - flat type dispatch
+    # Singletons / primitives first. bool before int (bool subclasses
+    # int); str before Enum (value-equality StrEnums digest as their
+    # value, matching ``==``), and likewise int catches IntEnums.
+    if obj is None:
+        h.update(b"N")
+    elif obj is True:
+        h.update(b"T")
+    elif obj is False:
+        h.update(b"F")
+    elif isinstance(obj, str):
+        b = obj.encode("utf-8", "surrogatepass")
+        h.update(b"s%d:" % len(b))
+        h.update(b)
+    elif isinstance(obj, int):
+        b = b"%d" % obj
+        h.update(b"i%d:" % len(b))
+        h.update(b)
+    elif isinstance(obj, float):
+        b = repr(obj).encode()
+        h.update(b"f%d:" % len(b))
+        h.update(b)
+    elif isinstance(obj, bytes):
+        h.update(b"y%d:" % len(obj))
+        h.update(obj)
+    elif isinstance(obj, (list, tuple)):
+        # Distinct tags: [1] == (1,) is False in Python too.
+        items = cast("Sequence[object]", obj)
+        h.update(
+            b"l%d:" % len(items) if isinstance(obj, list) else b"t%d:" % len(items)
+        )
+        for item in items:
+            _feed(h, item)
+    elif isinstance(obj, dict):
+        mapping = cast("dict[object, object]", obj)
+        h.update(b"d%d:" % len(mapping))
+        for k, v in mapping.items():
+            _feed(h, k)
+            _feed(h, v)
+    elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        # Dataclass __eq__ requires identical classes, then compares the
+        # compare=True fields positionally — mirror both.
+        cls = type(obj)
+        _feed_class_tag(h, b"D", cls)
+        for f in dataclasses.fields(obj):
+            if f.compare:
+                _feed(h, getattr(obj, f.name))
+        h.update(b".")
+    elif isinstance(obj, BaseModel):
+        # Pydantic v2 __eq__ compares class, __dict__ and (for
+        # extra="allow" models) __pydantic_extra__. Keys are sorted
+        # because dict *order* does not affect pydantic equality.
+        _feed_class_tag(h, b"P", type(obj))
+        for k in sorted(obj.__dict__):
+            _feed(h, k)
+            _feed(h, obj.__dict__[k])
+        extra = getattr(obj, "__pydantic_extra__", None)
+        if extra:
+            h.update(b"x")
+            for k in sorted(extra):
+                _feed(h, k)
+                _feed(h, extra[k])
+        h.update(b".")
+    else:
+        # Unknown object: fall back to repr. An identity-based repr makes
+        # every lookup for that content a conflict (served fresh — safe),
+        # and the conflict counter makes the cost visible.
+        b = repr(obj).encode("utf-8", "surrogatepass")
+        _feed_class_tag(h, b"r", type(obj))
+        h.update(b"%d:" % len(b))
+        h.update(b)
+
+
+def _feed_class_tag(h: "blake2b", tag: bytes, cls: type) -> None:
+    name = f"{cls.__module__}.{cls.__qualname__}".encode()
+    h.update(tag)
+    h.update(b"%d:" % len(name))
+    h.update(name)
 
 
 def fragment_store_enabled() -> bool:
@@ -78,14 +194,14 @@ class RenderFragmentStore:
     """
 
     def __init__(self) -> None:
-        self._fragments: dict[StoreKey, tuple["MessageContent", Fragment]] = {}
+        self._fragments: dict[StoreKey, tuple[bytes, Fragment]] = {}
         self._bytes = 0
         self.hits = 0
         self.misses = 0
-        # Lookups whose stored content did not compare equal to the
-        # requesting tree's content — served fresh instead. A non-zero
-        # count is expected on real archives (cross-tree factory context);
-        # a LARGE one means a per-tree field is missing compare=False.
+        # Lookups whose stored content digest did not match the
+        # requesting tree's — served fresh instead. A non-zero count is
+        # expected on real archives (cross-tree factory context); a LARGE
+        # one means a per-tree field is missing compare=False.
         self.conflicts = 0
         # Fragments the consumer computed but declined to store because
         # their output is tree-specific (per-tree ``#msg-d-{N}`` anchors —
@@ -97,11 +213,12 @@ class RenderFragmentStore:
         if entry is None:
             self.misses += 1
             return None
-        stored_content, fragment = entry
+        stored_digest, fragment = entry
         # Verify the stored render really was computed from an equal
-        # content. Same-typed dataclasses compare field-wise; a type
-        # mismatch (uuid-collision-style key accidents) compares unequal.
-        if stored_content != content:
+        # content. The digest covers exactly the compare=True fields, so
+        # a type mismatch (uuid-collision-style key accidents) or any
+        # cross-tree content divergence compares unequal here.
+        if stored_digest != content_digest(content):
             self.conflicts += 1
             return None
         self.hits += 1
@@ -110,7 +227,7 @@ class RenderFragmentStore:
     def put(self, key: StoreKey, content: "MessageContent", fragment: Fragment) -> None:
         if key in self._fragments:
             return
-        self._fragments[key] = (content, fragment)
+        self._fragments[key] = (content_digest(content), fragment)
         self._bytes += sum(len(part) for part in fragment)
 
     def stats(self) -> dict[str, int]:

--- a/claude_code_log/fragment_store.py
+++ b/claude_code_log/fragment_store.py
@@ -1,0 +1,126 @@
+"""Per-conversion store of formatted message fragments.
+
+Step 3 of the render optimisation work ("format once, assemble many" —
+see work/render-format-once.md). A project conversion renders every
+message twice: once into its combined-transcript page and once into its
+``session-*.html``. The leaf memo in ``render_cache.py`` recovers the two
+expensive leaves of that duplication (Pygments, Markdown); this store
+removes the duplication itself by caching each message's complete
+formatted fragment — the ``(title, html, timestamp)`` triple that
+``HtmlRenderer._annotate_tree_for_render`` writes onto the tree — and
+serving it to every subsequent tree that contains the same message.
+
+Scope and lifetime are deliberately narrow, which is what keeps the
+invalidation surface at zero:
+
+- **One store per conversion call.** A conversion runs a single renderer
+  configuration (depth / compact / repo cwd / plugins), so none of those
+  need to appear in the key, and a fragment can never outlive the code or
+  config that produced it. Long-lived hosts (``serve``, the TUI) create a
+  fresh store per conversion just like the CLI does.
+- **Keys are entry identity plus tree context, not content.**
+  ``MessageContent.fragment_key`` is ``(id(source_entry), part_ordinal)``,
+  stamped by the pass-2 render loop; the consumer appends a signature of
+  the tree-derived render inputs (pair presence, model badge, agent
+  depth, …) so a message that legitimately renders differently in the
+  combined tree than in its session tree occupies two slots instead of
+  poisoning one. The master message list keeps every entry alive for the
+  whole conversion, so the ``id()`` is stable; transcript uuids are NOT
+  usable here because resumed/forked sessions reuse them across distinct
+  messages (work/render-format-once.md § 4.1).
+- **Hits are verified against the content.** ``get`` compares the stored
+  content object with the requesting tree's content (dataclass equality,
+  with per-tree fields excluded via ``compare=False``); a mismatch is a
+  conflict, not a hit. This is the backstop for content built from
+  cross-message context that resolves differently per tree — e.g. a tool
+  result whose paired ``tool_use`` lives in another session, so the
+  factory resolves the tool name in the combined tree but not in the
+  session tree (work/render-format-once.md § 4.8).
+
+The store is a pure performance feature: a renderer with no store (or a
+content with no key) formats exactly as before.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .models import MessageContent
+
+# A formatted fragment: (rendered_title, rendered_html, rendered_timestamp),
+# exactly the triple _annotate_tree_for_render writes onto a TemplateMessage.
+Fragment = tuple[str, str, str]
+
+# (id(entry), part_ordinal) from MessageContent.fragment_key, extended by
+# the consumer with the tree-context signature tuple.
+StoreKey = tuple[object, ...]
+
+
+def fragment_store_enabled() -> bool:
+    """Whether the fragment store should be used, per the environment.
+
+    ``CLAUDE_CODE_LOG_FRAGMENT_STORE=0`` (or ``off``/``false``) disables it,
+    mirroring ``CLAUDE_CODE_LOG_RENDER_CACHE_MB=0`` for the leaf memo — the
+    switch exists for bisecting rendering differences, not for tuning.
+    """
+    value = os.environ.get("CLAUDE_CODE_LOG_FRAGMENT_STORE", "").strip().lower()
+    return value not in ("0", "off", "false")
+
+
+class RenderFragmentStore:
+    """In-memory fragment store for a single conversion.
+
+    Single-threaded by design: the parent renders pages and session files
+    sequentially within one conversion (the process-level fan-out gives
+    each worker its own store), so no locking is needed.
+    """
+
+    def __init__(self) -> None:
+        self._fragments: dict[StoreKey, tuple["MessageContent", Fragment]] = {}
+        self._bytes = 0
+        self.hits = 0
+        self.misses = 0
+        # Lookups whose stored content did not compare equal to the
+        # requesting tree's content — served fresh instead. A non-zero
+        # count is expected on real archives (cross-tree factory context);
+        # a LARGE one means a per-tree field is missing compare=False.
+        self.conflicts = 0
+        # Fragments the consumer computed but declined to store because
+        # their output is tree-specific (per-tree ``#msg-d-{N}`` anchors —
+        # see HtmlRenderer._annotate_tree_for_render).
+        self.skipped = 0
+
+    def get(self, key: StoreKey, content: "MessageContent") -> Optional[Fragment]:
+        entry = self._fragments.get(key)
+        if entry is None:
+            self.misses += 1
+            return None
+        stored_content, fragment = entry
+        # Verify the stored render really was computed from an equal
+        # content. Same-typed dataclasses compare field-wise; a type
+        # mismatch (uuid-collision-style key accidents) compares unequal.
+        if stored_content != content:
+            self.conflicts += 1
+            return None
+        self.hits += 1
+        return fragment
+
+    def put(self, key: StoreKey, content: "MessageContent", fragment: Fragment) -> None:
+        if key in self._fragments:
+            return
+        self._fragments[key] = (content, fragment)
+        self._bytes += sum(len(part) for part in fragment)
+
+    def stats(self) -> dict[str, int]:
+        # Same shape as render_cache.ByteBoundedCache.stats() so the
+        # DEBUG_TIMING report can print all three caches uniformly.
+        return {
+            "entries": len(self._fragments),
+            "bytes": self._bytes,
+            "hits": self.hits,
+            "misses": self.misses,
+            "conflicts": self.conflicts,
+            "skipped": self.skipped,
+        }

--- a/claude_code_log/fragment_store.py
+++ b/claude_code_log/fragment_store.py
@@ -189,6 +189,19 @@ def fragment_store_enabled() -> bool:
     return value not in ("0", "off", "false")
 
 
+def fragment_store_forced() -> bool:
+    """Whether the environment *explicitly* asks for the store.
+
+    An explicit ``CLAUDE_CODE_LOG_FRAGMENT_STORE=1`` (or ``on``/``true``)
+    overrides the memory valve in ``converter._make_fragment_store`` — the
+    store is a RAM-for-CPU trade the valve declines on tight machines, and
+    this is the knob for someone who wants the trade anyway. Unset means
+    "enabled, but let the valve decide".
+    """
+    value = os.environ.get("CLAUDE_CODE_LOG_FRAGMENT_STORE", "").strip().lower()
+    return value in ("1", "on", "true")
+
+
 class RenderFragmentStore:
     """In-memory fragment store for a single conversion.
 

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -287,6 +287,17 @@ def resolve_sha_for_current_render(sha: str) -> Optional[str]:
     return resolve_sha(_render_repo_cwd.get(), sha)
 
 
+def current_render_repo_cwd() -> Optional[str]:
+    """The repo cwd bound by the innermost ``render_with_repo_context``.
+
+    Public read accessor for the ContextVar. Markdown memoization keys on
+    this: the SHA-linkifier makes rendered output depend on which repo the
+    render is scoped to, so the same text is *not* interchangeable across
+    projects (see ``render_cache``).
+    """
+    return _render_repo_cwd.get()
+
+
 @contextlib.contextmanager
 def render_with_repo_context(cwd: Optional[str]) -> Iterator[None]:
     """Bind a canonical repo cwd for the duration of a render pass.

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -224,6 +224,7 @@ from .utils import (
 
 if TYPE_CHECKING:
     from ..cache import CacheManager
+    from ..fragment_store import RenderFragmentStore
 
 
 def check_html_version(html_file_path: Path) -> Optional[str]:
@@ -359,6 +360,11 @@ class HtmlRenderer(Renderer):
         """
         super().__init__()
         self.image_export_mode = image_export_mode
+        # Per-conversion fragment store (step 3, work/render-format-once.md):
+        # set by the converter so the combined-page pass and the per-session
+        # pass share each message's formatted fragment instead of formatting
+        # it twice. None (the default) formats every message fresh.
+        self.fragment_store: "Optional[RenderFragmentStore]" = None
         self._output_dir: Path | None = None
         self._image_counter = 0
         # session_id -> {teammate_id -> color}, snapshotted from the
@@ -1535,12 +1541,72 @@ class HtmlRenderer(Renderer):
         for root in roots:
             index_tree(root)
 
+        # Fragment store (step 3, work/render-format-once.md): serve each
+        # entry-derived message's fragment from the store when a prior tree
+        # already formatted it. Referenced-image renders are excluded — they
+        # allocate images/image_NNNN.png names from a per-generate counter,
+        # so replaying a fragment would skip the file writes it implies.
+        fragment_store = (
+            self.fragment_store if self.image_export_mode != "referenced" else None
+        )
+
         def visit(msg: TemplateMessage) -> None:
-            # Update current message ID for timing tracking
-            set_timing_var("_current_msg_id", msg.message_id)
-            title = self.title_content(msg)
-            html = self.format_content(msg)
-            formatted_ts = format_timestamp(msg.meta.timestamp if msg.meta else None)
+            # Store key = source-entry identity + a signature of the
+            # tree-derived inputs the formatters read off the
+            # TemplateMessage. The same message can legitimately render
+            # differently in different trees — a Task spawn card shows the
+            # sub-agent's model badge only in a tree containing that
+            # sub-agent's transcript, a tool_use renders its pair duration
+            # only when its result is in the tree, etc. Folding those into
+            # the key gives each variant its own slot instead of letting
+            # one tree's render leak into another's output.
+            fragment_key = None
+            if fragment_store is not None and msg.content.fragment_key is not None:
+                fragment_key = (
+                    *msg.content.fragment_key,
+                    msg.pair_first is None,
+                    msg.pair_middle is None,
+                    msg.pair_last is None,
+                    msg.display_model,
+                    msg.agent_depth,
+                    msg.spawns_collapsed_transcript,
+                    msg.in_workflow_sidechannel,
+                )
+            cached = (
+                fragment_store.get(fragment_key, msg.content)
+                if fragment_store is not None and fragment_key is not None
+                else None
+            )
+            if cached is not None:
+                title, html, formatted_ts = cached
+            else:
+                # Update current message ID for timing tracking
+                set_timing_var("_current_msg_id", msg.message_id)
+                title = self.title_content(msg)
+                html = self.format_content(msg)
+                formatted_ts = format_timestamp(
+                    msg.meta.timestamp if msg.meta else None
+                )
+                if fragment_store is not None and fragment_key is not None:
+                    # A fragment embedding a ``#msg-d-{N}`` anchor is
+                    # tree-specific, not message-specific: the N is the
+                    # *partner* message's index in THIS tree's
+                    # RenderingContext (async task links, background-job
+                    # links, hook parent links…), and the same message gets
+                    # a different partner index in the combined-page tree
+                    # than in its session tree. Caching one would carry the
+                    # wrong anchor into the other, so such fragments are
+                    # formatted per tree. Testing the output catches every
+                    # emitter, present and future; a transcript whose text
+                    # merely mentions "msg-d-" just declines caching, which
+                    # is always safe. Found by hash-diffing a real project —
+                    # see work/render-format-once.md § 4.8.
+                    if "msg-d-" in html or "msg-d-" in title:
+                        fragment_store.skipped += 1
+                    else:
+                        fragment_store.put(
+                            fragment_key, msg.content, (title, html, formatted_ts)
+                        )
             msg.rendered_title = title
             msg.rendered_html = html
             msg.rendered_timestamp = formatted_ts
@@ -1580,12 +1646,13 @@ class HtmlRenderer(Renderer):
                     ("Pygments", pygments_timings),
                 ]
             )
-            report_cache_statistics(
-                [
-                    ("Markdown", markdown_cache.stats()),
-                    ("Pygments", pygments_cache.stats()),
-                ]
-            )
+            cache_stats = [
+                ("Markdown", markdown_cache.stats()),
+                ("Pygments", pygments_cache.stats()),
+            ]
+            if fragment_store is not None:
+                cache_stats.append(("Fragments", fragment_store.stats()))
+            report_cache_statistics(cache_stats)
 
         return roots
 

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -1562,16 +1562,23 @@ class HtmlRenderer(Renderer):
             # one tree's render leak into another's output.
             fragment_key = None
             if fragment_store is not None and msg.content.fragment_key is not None:
-                fragment_key = (
-                    *msg.content.fragment_key,
-                    msg.pair_first is None,
-                    msg.pair_middle is None,
-                    msg.pair_last is None,
-                    msg.display_model,
-                    msg.agent_depth,
-                    msg.spawns_collapsed_transcript,
-                    msg.in_workflow_sidechannel,
-                )
+                # The stamped key carries id(entry); translate it to the
+                # entry's master-list ordinal so the key means the same
+                # thing in every tree (and, eventually, every process
+                # that loads the same master list). An unknown id
+                # declines caching.
+                stable = fragment_store.stable_key(msg.content.fragment_key)
+                if stable is not None:
+                    fragment_key = (
+                        *stable,
+                        msg.pair_first is None,
+                        msg.pair_middle is None,
+                        msg.pair_last is None,
+                        msg.display_model,
+                        msg.agent_depth,
+                        msg.spawns_collapsed_transcript,
+                        msg.in_workflow_sidechannel,
+                    )
             cached = (
                 fragment_store.get(fragment_key, msg.content)
                 if fragment_store is not None and fragment_key is not None

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -106,9 +106,11 @@ from ..renderer import (
     prepare_projects_index,
     title_for_projects_index,
 )
+from ..render_cache import markdown_cache, pygments_cache
 from ..renderer_timings import (
     DEBUG_TIMING,
     log_timing,
+    report_cache_statistics,
     report_timing_statistics,
     set_timing_var,
 )
@@ -1567,12 +1569,21 @@ class HtmlRenderer(Renderer):
         for root in roots:
             visit(root)
 
-        # Report timing statistics for Markdown/Pygments operations
+        # Report timing statistics for Markdown/Pygments operations.
+        # The memo stats sit alongside them because the two are read
+        # together: a low hit rate explains a high recompute total, and
+        # a large `bytes` explains a tight cache budget.
         if DEBUG_TIMING:
             report_timing_statistics(
                 [
                     ("Markdown", markdown_timings),
                     ("Pygments", pygments_timings),
+                ]
+            )
+            report_cache_statistics(
+                [
+                    ("Markdown", markdown_cache.stats()),
+                    ("Pygments", pygments_cache.stats()),
                 ]
             )
 

--- a/claude_code_log/html/renderer.py
+++ b/claude_code_log/html/renderer.py
@@ -366,7 +366,6 @@ class HtmlRenderer(Renderer):
         # it twice. None (the default) formats every message fresh.
         self.fragment_store: "Optional[RenderFragmentStore]" = None
         self._output_dir: Path | None = None
-        self._image_counter = 0
         # session_id -> {teammate_id -> color}, snapshotted from the
         # RenderingContext at the start of each render. Formatters look
         # up the per-session map via self._colors_for(message) so
@@ -487,12 +486,10 @@ class HtmlRenderer(Renderer):
         """Format image based on export mode."""
         from ..image_export import export_image
 
-        self._image_counter += 1
         src = export_image(
             image,
             self.image_export_mode,
             output_dir=self._output_dir,
-            counter=self._image_counter,
         )
         if src is None:
             return "[Image]"
@@ -1543,12 +1540,12 @@ class HtmlRenderer(Renderer):
 
         # Fragment store (step 3, work/render-format-once.md): serve each
         # entry-derived message's fragment from the store when a prior tree
-        # already formatted it. Referenced-image renders are excluded — they
-        # allocate images/image_NNNN.png names from a per-generate counter,
-        # so replaying a fragment would skip the file writes it implies.
-        fragment_store = (
-            self.fragment_store if self.image_export_mode != "referenced" else None
-        )
+        # already formatted it. Referenced-image renders participate too:
+        # filenames are content-addressed (see image_export.export_image),
+        # so a stored fragment's <img src> is the same name any tree would
+        # allocate, and a fragment can only exist because a prior pass this
+        # conversion already wrote (or placeholdered) that file.
+        fragment_store = self.fragment_store
 
         def visit(msg: TemplateMessage) -> None:
             # Store key = source-entry identity + a signature of the
@@ -1732,7 +1729,6 @@ class HtmlRenderer(Renderer):
 
         # Set output directory for image export (used in "referenced" mode)
         self._output_dir = output_dir
-        self._image_counter = 0
 
         if not title:
             title = "Claude Transcript"

--- a/claude_code_log/html/renderer_code.py
+++ b/claude_code_log/html/renderer_code.py
@@ -19,6 +19,7 @@ from pygments.formatter import Formatter
 from pygments.formatters import HtmlFormatter
 from pygments.util import ClassNotFound
 
+from ..render_cache import pygments_cache
 from ..renderer_timings import timing_stat
 
 
@@ -89,6 +90,15 @@ def highlight_code_with_pygments(
     Returns:
         HTML string with syntax-highlighted code
     """
+    # Memoized: highlighting is a pure function of these four arguments,
+    # and the same content is highlighted repeatedly within a run — once
+    # for the combined page and again for the session file, plus whenever
+    # the same file is Read more than once. See ``render_cache``.
+    memo_key = (code, file_path, show_linenos, linenostart)
+    cached = pygments_cache.get(memo_key)
+    if cached is not None:
+        return cached
+
     # Get caches (initialized lazily)
     pattern_cache, extension_cache = _init_lexer_caches()
 
@@ -130,7 +140,9 @@ def highlight_code_with_pygments(
 
     # Highlight the code with timing if enabled
     with timing_stat("_pygments_timings"):
-        return str(highlight(code, lexer, formatter))
+        highlighted = str(highlight(code, lexer, formatter))
+    pygments_cache.put(memo_key, highlighted)
+    return highlighted
 
 
 def truncate_highlighted_preview(highlighted_html: str, max_lines: int) -> str:

--- a/claude_code_log/html/templates/archive_search.html
+++ b/claude_code_log/html/templates/archive_search.html
@@ -597,14 +597,23 @@
             }
 
             async function start() {
+                if (location.protocol === 'file:') {
+                    // A relative api/ping can never reach a server from a
+                    // file:// page, so don't attempt the fetch: the page
+                    // used to rely on Chromium refusing it outright, but
+                    // that rejection is not dependable cross-platform
+                    // (Windows CI observed the probe never settling, so
+                    // the setup panel never appeared).
+                    setup.hidden = false;
+                    return;
+                }
                 let ping;
                 try {
                     const response = await fetch('api/ping');
                     if (!response.ok) throw new Error(response.status);
                     ping = await response.json();
                 } catch (err) {
-                    // Either no server, or the page was opened over file://
-                    // (where the request is refused outright). Same remedy.
+                    // No server behind this origin (or it is not ours).
                     setup.hidden = false;
                     return;
                 }

--- a/claude_code_log/html/utils.py
+++ b/claude_code_log/html/utils.py
@@ -50,6 +50,7 @@ from ..models import (
     WorkflowAgentMessage,
     WorkflowPhaseMessage,
 )
+from ..render_cache import markdown_cache
 from ..renderer_timings import timing_stat
 
 if TYPE_CHECKING:
@@ -469,12 +470,42 @@ def _get_markdown_renderer() -> mistune.Markdown:
     )
 
 
-def render_markdown(text: str) -> str:
-    """Convert markdown text to HTML using mistune with Pygments syntax highlighting."""
+def _render_markdown_memoized(text: str, escaping_user_renderer: bool) -> str:
+    """Render ``text`` through one of the two mistune singletons, memoized.
+
+    Markdown output is a pure function of the text *and* the active render
+    repo cwd: the SHA-linkifier plugin resolves commit hashes against
+    ``git_remote._render_repo_cwd``, so the same ``5baac35`` links to
+    different repositories in different transcripts. The cwd is therefore
+    part of the key — without it a long-lived host (``serve``, the TUI)
+    would serve one project's commit links inside another's page.
+
+    ``escaping_user_renderer`` selects between the two renderer singletons
+    (they differ only in call site convention today, but they are distinct
+    objects and must not share cache entries).
+    """
+    from ..git_remote import current_render_repo_cwd
+
+    memo_key = (escaping_user_renderer, current_render_repo_cwd(), text)
+    cached = markdown_cache.get(memo_key)
+    if cached is not None:
+        return cached
+
     # Track markdown rendering time if enabled
     with timing_stat("_markdown_timings"):
-        renderer = _get_markdown_renderer()
-        return str(renderer(text))
+        renderer = (
+            _get_user_markdown_renderer()
+            if escaping_user_renderer
+            else _get_markdown_renderer()
+        )
+        rendered = str(renderer(text))
+    markdown_cache.put(memo_key, rendered)
+    return rendered
+
+
+def render_markdown(text: str) -> str:
+    """Convert markdown text to HTML using mistune with Pygments syntax highlighting."""
+    return _render_markdown_memoized(text, escaping_user_renderer=False)
 
 
 _INLINE_PARA_BOUNDARY_RE = re.compile(r"</p>\s*<p>")
@@ -494,9 +525,7 @@ def render_markdown_inline(text: str) -> str:
     ``<option>``, …) is escaped to literal characters rather than injected —
     these short fields were previously HTML-escaped, so keep that contract.
     """
-    with timing_stat("_markdown_timings"):
-        renderer = _get_user_markdown_renderer()
-        rendered = str(renderer(text)).strip()
+    rendered = _render_markdown_memoized(text, escaping_user_renderer=True).strip()
     if rendered.startswith("<p>") and rendered.endswith("</p>"):
         inner = rendered[len("<p>") : -len("</p>")]
         return _INLINE_PARA_BOUNDARY_RE.sub("<br>", inner)
@@ -540,9 +569,7 @@ def _get_user_markdown_renderer() -> mistune.Markdown:
 
 def render_user_markdown(text: str) -> str:
     """Render user-authored Markdown with HTML escaping enabled."""
-    with timing_stat("_markdown_timings"):
-        renderer = _get_user_markdown_renderer()
-        return str(renderer(text))
+    return _render_markdown_memoized(text, escaping_user_renderer=True)
 
 
 # HTML tags that are self-closing / void per the HTML spec — these do

--- a/claude_code_log/image_export.py
+++ b/claude_code_log/image_export.py
@@ -6,6 +6,8 @@ by both HTML and Markdown renderers.
 
 import base64
 import binascii
+import hashlib
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,23 +19,35 @@ def export_image(
     image: "ImageContent",
     mode: str,
     output_dir: Path | None = None,
-    counter: int = 0,
 ) -> str | None:
     """Export image content and return the source URL/path.
 
     This is a format-agnostic function that handles image export logic
     and returns just the src. Callers format the result as HTML or Markdown.
 
+    Referenced-mode filenames are content-addressed — a digest of the
+    decoded image bytes — so a given image maps to exactly one file no
+    matter which render pass, run, or worker process exports it. That is
+    a correctness requirement, not a convenience: a project conversion
+    renders every message twice (combined page + its session file), and
+    the per-render counter this replaced assigned the same
+    ``image_NNNN`` names to *different* images across those passes,
+    silently overwriting one pass's files with the other's. Content
+    addressing also makes the write idempotent (an existing file is
+    already the right bytes) and safe under the render fan-out, where
+    concurrent workers may export the same image: writers go through a
+    unique temp file + atomic ``os.replace``, and racing writers replace
+    identical content.
+
     Args:
         image: ImageContent with base64-encoded image data
         mode: Export mode - "placeholder", "embedded", or "referenced"
         output_dir: Output directory for referenced images (required for "referenced" mode)
-        counter: Image counter for generating unique filenames
 
     Returns:
         For "placeholder" mode: None (caller should render placeholder text)
         For "embedded" mode: data URL (e.g., "data:image/png;base64,...")
-        For "referenced" mode: relative path (e.g., "images/image_0001.png")
+        For "referenced" mode: relative path (e.g., "images/image_2f7a91c4d3b8e6a0.png")
         For unsupported mode: None
     """
     if mode == "placeholder":
@@ -46,24 +60,34 @@ def export_image(
         if output_dir is None:
             return None
 
+        tmp_path: Path | None = None
         try:
+            image_data = base64.b64decode(image.source.data)
+
             # Create images subdirectory
             images_dir = output_dir / "images"
             images_dir.mkdir(exist_ok=True)
 
-            # Generate filename based on media type
+            digest = hashlib.blake2b(image_data, digest_size=8).hexdigest()
             ext = _get_extension(image.source.media_type)
-            filename = f"image_{counter:04d}{ext}"
+            filename = f"image_{digest}{ext}"
             filepath = images_dir / filename
 
-            # Decode and write image
-            image_data = base64.b64decode(image.source.data)
-            filepath.write_bytes(image_data)
+            if not filepath.exists():
+                tmp_path = images_dir / f".{filename}.{os.getpid()}.tmp"
+                tmp_path.write_bytes(image_data)
+                os.replace(tmp_path, filepath)
+                tmp_path = None
 
             return f"images/{filename}"
         except (OSError, binascii.Error, ValueError):
             # Graceful degradation: return None to trigger placeholder rendering
             # Covers: PermissionError (mkdir/write), disk full, malformed base64
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
             return None
 
     # Unsupported mode

--- a/claude_code_log/markdown/renderer.py
+++ b/claude_code_log/markdown/renderer.py
@@ -469,7 +469,6 @@ class MarkdownRenderer(Renderer):
         super().__init__()
         self.image_export_mode = image_export_mode
         self._output_dir: Path | None = None
-        self._image_counter = 0
         self._ctx: RenderingContext | None = None
         # session_id -> {teammate_id -> color}, snapshotted at render
         # start. Scoped to avoid cross-session contamination in
@@ -558,12 +557,10 @@ class MarkdownRenderer(Renderer):
         """Format image based on export mode."""
         from ..image_export import export_image
 
-        self._image_counter += 1
         src = export_image(
             image,
             self.image_export_mode,
             output_dir=self._output_dir,
-            counter=self._image_counter,
         )
         if src is None:
             return "[Image]"
@@ -2411,7 +2408,6 @@ class MarkdownRenderer(Renderer):
     ) -> str:
         """Body of ``generate`` running inside the SHA-resolver context."""
         self._output_dir = output_dir
-        self._image_counter = 0
         self._last_heading_category: Optional[str] = None
         # Per-message timestamp date-on-change state (issue #160).
         # Reset each generate() so reusing a renderer across pages /

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -498,7 +498,27 @@ class MessageContent:
 
     # Set by RenderingContext.register() to enable content→TemplateMessage lookup
     # Using init=False to avoid dataclass inheritance issues with required fields
-    message_index: Optional[int] = field(default=None, init=False, repr=False)
+    # compare=False: the index is assigned per render tree, and the fragment
+    # store compares two trees' contents for the same source entry to decide
+    # whether a cached fragment may be reused — a per-tree field must not
+    # defeat that comparison (the contents ARE the same message).
+    message_index: Optional[int] = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    # Identity of the source (TranscriptEntry, part) this content was built
+    # from: ``(id(entry), part_ordinal)``. Stamped by the pass-2 render loop
+    # for entry-derived content only — synthesized content (session/branch
+    # headers, grafted sidechannel nodes, ghost placeholders) stays None and
+    # is always formatted fresh. Valid only while the conversion's master
+    # message list keeps every entry alive (an ``id()`` can be reused after
+    # its object is freed), which is why the fragment store that consumes it
+    # is scoped to a single conversion. NOT a uuid: transcript uuids collide
+    # across resumed/forked sessions (see work/render-format-once.md § 4.1).
+    # compare=False for the same reason as message_index.
+    fragment_key: Optional[tuple[int, int]] = field(
+        default=None, init=False, repr=False, compare=False
+    )
 
     @property
     def message_type(self) -> str:

--- a/claude_code_log/render_cache.py
+++ b/claude_code_log/render_cache.py
@@ -39,12 +39,19 @@ Configure with ``CLAUDE_CODE_LOG_RENDER_CACHE_MB`` (default 192 MB;
 ``0`` disables memoization entirely, restoring the previous behaviour).
 """
 
+import contextlib
 import os
 import threading
 from collections import OrderedDict
-from typing import Hashable, Optional
+from typing import Hashable, Iterator, Optional
 
-__all__ = ["ByteBoundedCache", "markdown_cache", "pygments_cache", "clear_all"]
+__all__ = [
+    "ByteBoundedCache",
+    "markdown_cache",
+    "pygments_cache",
+    "clear_all",
+    "disabled",
+]
 
 
 DEFAULT_CACHE_MB = 192
@@ -75,7 +82,7 @@ def _configured_budget_bytes() -> int:
 class ByteBoundedCache:
     """An LRU cache of ``str`` values bounded by their total size in bytes.
 
-    Thread-safe: the render fan-out (see ``converter._render_jobs``) uses
+    Thread-safe: the render fan-out (``render_pool``) uses
     processes rather than threads, so contention is not expected, but the
     HTML helpers are also reachable from the TUI and from ``serve`` request
     handlers, and a torn ``OrderedDict`` would be a very unpleasant bug to
@@ -134,6 +141,22 @@ class ByteBoundedCache:
             self.hits = 0
             self.misses = 0
 
+    @property
+    def budget_bytes(self) -> int:
+        return self._budget
+
+    def set_budget(self, budget_bytes: int) -> None:
+        """Resize (or, at 0, switch off) this cache, dropping its contents.
+
+        Used by ``disabled()`` to toggle the shared singletons in place —
+        call sites imported the objects by value, so replacing the module
+        attributes would not reach them.
+        """
+        self.clear()
+        with self._lock:
+            self._budget = max(0, budget_bytes)
+            self._max_entry = int(self._budget * _MAX_ENTRY_FRACTION)
+
     def stats(self) -> dict[str, int]:
         with self._lock:
             return {
@@ -148,9 +171,33 @@ class ByteBoundedCache:
 # can't starve the Markdown cache (and vice versa).
 pygments_cache = ByteBoundedCache()
 markdown_cache = ByteBoundedCache()
+_ALL_CACHES = (pygments_cache, markdown_cache)
 
 
 def clear_all() -> None:
     """Drop both caches. Used by tests and by long-lived hosts (``serve``)."""
     pygments_cache.clear()
     markdown_cache.clear()
+
+
+@contextlib.contextmanager
+def disabled() -> Iterator[None]:
+    """Turn memoization off for the duration of the block.
+
+    Flips the budgets on the existing singletons rather than replacing
+    them, because every call site imported the objects by value
+    (``from ..render_cache import pygments_cache``) — rebinding the module
+    attributes would not reach them.
+
+    This is the in-process equivalent of ``CLAUDE_CODE_LOG_RENDER_CACHE_MB=0``,
+    and it exists so a conversion can be run both ways and the outputs
+    compared (see ``test_render_cache_equivalence.py``).
+    """
+    saved = [(cache, cache.budget_bytes) for cache in _ALL_CACHES]
+    for cache in _ALL_CACHES:
+        cache.set_budget(0)
+    try:
+        yield
+    finally:
+        for cache, budget in saved:
+            cache.set_budget(budget)

--- a/claude_code_log/render_cache.py
+++ b/claude_code_log/render_cache.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Byte-bounded memo caches for the expensive pure leaves of rendering.
+
+Why this exists
+---------------
+A full project conversion renders every message **twice**: once into its
+combined-transcript page and once into its individual ``session-*.html``.
+Both go through ``HtmlRenderer.generate``, which rebuilds the tree and
+re-formats every message from the same source entries — so the two passes
+duplicate all of the per-message formatting work. Measured on a 118-file,
+12k-message project: 22,420 ``format_content`` calls covering 11,113
+distinct messages.
+
+The two dominant leaves of that work are Pygments highlighting and mistune
+Markdown rendering, and both are pure functions of their string inputs
+(with one caveat, below). Memoizing just those two removes the duplication
+without touching the render pipeline's structure — and also collapses the
+*intra*-pass repeats, since the same file contents are commonly re-read
+across many messages (measured hit rate for Pygments: ~68%, higher than
+the 50% that page-vs-session duplication alone would give).
+
+The one caveat: Markdown rendering is **not** purely a function of its
+text. The SHA-linkifier plugin resolves commit hashes against the
+per-render repo cwd carried by ``git_remote._render_repo_cwd``
+(a ContextVar), so a cache shared across projects would leak commit links
+between repos. Markdown keys therefore include that cwd; Pygments has no
+such coupling and keys on its arguments alone.
+
+Sizing
+------
+Rendered fragments are large (a highlighted 2000-line file is hundreds of
+KB), so an entry-count bound like ``functools.lru_cache(maxsize=N)`` gives
+no control over footprint. These caches are bounded by the *bytes* of the
+values they hold, evicting least-recently-used, and refuse to admit any
+single entry larger than a fraction of the budget so one huge file can't
+evict everything else.
+
+Configure with ``CLAUDE_CODE_LOG_RENDER_CACHE_MB`` (default 192 MB;
+``0`` disables memoization entirely, restoring the previous behaviour).
+"""
+
+import os
+import threading
+from collections import OrderedDict
+from typing import Hashable, Optional
+
+__all__ = ["ByteBoundedCache", "markdown_cache", "pygments_cache", "clear_all"]
+
+
+DEFAULT_CACHE_MB = 192
+
+# A single entry may occupy at most this fraction of the budget. Without
+# it, one multi-MB highlighted file admitted into a small cache evicts
+# every cheap entry behind it and the cache thrashes to a 0% hit rate.
+_MAX_ENTRY_FRACTION = 0.125
+
+
+def _configured_budget_bytes() -> int:
+    """Resolve the per-cache byte budget from the environment.
+
+    Returns 0 when memoization is disabled (``...CACHE_MB=0``) or the
+    value is unparseable — an unreadable setting should degrade to the
+    old, always-recompute behaviour rather than crash a conversion.
+    """
+    raw = os.getenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB")
+    if raw is None:
+        return DEFAULT_CACHE_MB * 1024 * 1024
+    try:
+        mb = int(raw.strip())
+    except ValueError:
+        return DEFAULT_CACHE_MB * 1024 * 1024
+    return max(0, mb) * 1024 * 1024
+
+
+class ByteBoundedCache:
+    """An LRU cache of ``str`` values bounded by their total size in bytes.
+
+    Thread-safe: the render fan-out (see ``converter._render_jobs``) uses
+    processes rather than threads, so contention is not expected, but the
+    HTML helpers are also reachable from the TUI and from ``serve`` request
+    handlers, and a torn ``OrderedDict`` would be a very unpleasant bug to
+    chase for a pure performance feature.
+    """
+
+    def __init__(self, budget_bytes: Optional[int] = None) -> None:
+        self._budget = (
+            _configured_budget_bytes() if budget_bytes is None else budget_bytes
+        )
+        self._max_entry = int(self._budget * _MAX_ENTRY_FRACTION)
+        self._entries: "OrderedDict[Hashable, str]" = OrderedDict()
+        self._bytes = 0
+        self._lock = threading.Lock()
+        self.hits = 0
+        self.misses = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._budget > 0
+
+    def get(self, key: Hashable) -> Optional[str]:
+        if self._budget <= 0:
+            return None
+        with self._lock:
+            value = self._entries.get(key)
+            if value is None:
+                self.misses += 1
+                return None
+            self._entries.move_to_end(key)
+            self.hits += 1
+            return value
+
+    def put(self, key: Hashable, value: str) -> None:
+        if self._budget <= 0:
+            return
+        # len() on a str is close enough to the retained size for a
+        # budget knob, and avoids encoding every value just to measure it.
+        size = len(value)
+        if size > self._max_entry:
+            return
+        with self._lock:
+            if key in self._entries:
+                self._bytes -= len(self._entries[key])
+                self._entries.pop(key)
+            self._entries[key] = value
+            self._bytes += size
+            while self._bytes > self._budget and self._entries:
+                _, evicted = self._entries.popitem(last=False)
+                self._bytes -= len(evicted)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._bytes = 0
+            self.hits = 0
+            self.misses = 0
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "entries": len(self._entries),
+                "bytes": self._bytes,
+                "hits": self.hits,
+                "misses": self.misses,
+            }
+
+
+# Module-level singletons. Separate budgets so a Pygments-heavy project
+# can't starve the Markdown cache (and vice versa).
+pygments_cache = ByteBoundedCache()
+markdown_cache = ByteBoundedCache()
+
+
+def clear_all() -> None:
+    """Drop both caches. Used by tests and by long-lived hosts (``serve``)."""
+    pygments_cache.clear()
+    markdown_cache.clear()

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -23,12 +23,20 @@ metadata.
 
 Design
 ------
-Workers are **self-sufficient rather than fed**. The alternative — pickling
-the parent's parsed transcript to each worker — moves ~114MB per worker
-for a mid-sized project. Instead each worker re-loads from the (already
-warm) SQLite cache in its own ``initializer``, measured at 0.71s, and the
-parent sends only small per-unit metadata. That also keeps the parent's
-peak memory flat.
+Workers are **self-sufficient for the transcript, fed for the fragments**.
+Pickling the parent's parsed transcript to each worker would move ~114MB
+per worker for a mid-sized project, so each worker re-loads from the
+(already warm) SQLite cache in its own ``initializer``, measured at 0.71s,
+and the parent sends only small per-unit metadata. That also keeps the
+parent's peak memory flat. Formatted *fragments*, however, are plain
+strings and cheap to move, so those flow through the parent instead of
+being recomputed per worker: page units export their fragment store back
+in the result tuple, the parent absorbs the deltas, and the session units
+it dispatches afterwards each carry their session's slice
+(``RenderUnit.fed_fragments``) — collapsing the page-vs-session duplicate
+formatting that previously came back in every cold worker. The feed is
+verified the same way as any store hit (content digest + tree signature),
+so a stale or mis-keyed fragment costs a recompute, never wrong output.
 
 This makes a warm cache a hard prerequisite: without one a worker would
 re-parse every JSONL file (~3.3s each, per worker), so ``RenderPool`` is
@@ -82,6 +90,14 @@ class RenderUnit:
     page_info: Optional[Dict[str, Any]] = None
     page_stats: Optional[Dict[str, Any]] = None
     suppress_combined_link: bool = False
+    # Session units: this session's slice of the parent's fragment store
+    # (digests + strings, picklable), formatted by the combined-page pass
+    # that always completes before sessions dispatch. The worker absorbs
+    # it into its own store so the session render reuses instead of
+    # re-formatting. Purely an optimisation: a stale, missing or
+    # mis-keyed slice degrades to a digest conflict or a miss — formatted
+    # fresh — never to wrong output.
+    fed_fragments: Optional[Dict[Any, Any]] = None
 
 
 @dataclass
@@ -379,6 +395,11 @@ _worker_messages: "Optional[List[TranscriptEntry]]" = None
 _worker_session_tree: Any = None
 _worker_cache_manager: Any = None
 _worker_messages_by_session: "Optional[Dict[str, List[TranscriptEntry]]]" = None
+# id(entry) → master-list ordinal, built once per worker. Fragment-store
+# keys are these ordinals, which the parent and every worker agree on as
+# long as they load the same master list in the same order — and a skew
+# only costs hits (digest conflict → formatted fresh), never correctness.
+_worker_entry_ordinals: Optional[Dict[int, int]] = None
 
 
 def _init_render_worker(setup: _WorkerSetup) -> None:
@@ -391,6 +412,7 @@ def _init_render_worker(setup: _WorkerSetup) -> None:
     """
     global _worker_setup, _worker_messages, _worker_session_tree
     global _worker_cache_manager, _worker_messages_by_session
+    global _worker_entry_ordinals
 
     from .cache import CacheManager
     from .converter import (
@@ -419,6 +441,7 @@ def _init_render_worker(setup: _WorkerSetup) -> None:
     _worker_session_tree = session_tree
     _worker_cache_manager = cache_manager
     _worker_messages_by_session = by_session
+    _worker_entry_ordinals = {id(msg): i for i, msg in enumerate(messages)}
 
 
 def _build_worker_renderer() -> Any:
@@ -441,8 +464,42 @@ def _build_worker_renderer() -> Any:
     )
 
 
-def _render_unit_worker(unit: RenderUnit) -> "tuple[str, Any, Optional[str]]":
-    """Render and write one unit. Returns ``(kind, key, error_or_None)``.
+def _unit_fragment_store(unit: RenderUnit, renderer: Any) -> Any:
+    """Attach a per-unit fragment store to an HTML renderer, or None.
+
+    Page units get an empty store whose contents are exported back to the
+    parent (the delta in the result tuple); session units get a store
+    seeded with the slice the parent fed on the unit. Either way the
+    store's semantics are the per-conversion ones — this worker's master
+    list is the same conversion's, only re-loaded.
+    """
+    from .fragment_store import RenderFragmentStore, fragment_store_enabled
+
+    assert _worker_setup is not None
+    if _worker_setup.format != "html" or not fragment_store_enabled():
+        return None
+    from .html.renderer import HtmlRenderer
+
+    if not isinstance(renderer, HtmlRenderer):
+        return None
+    store = RenderFragmentStore()
+    assert _worker_entry_ordinals is not None
+    store.set_entry_ordinal_map(_worker_entry_ordinals)
+    if unit.fed_fragments:
+        store.absorb(unit.fed_fragments)
+    renderer.fragment_store = store
+    return store
+
+
+def _render_unit_worker(
+    unit: RenderUnit,
+) -> "tuple[str, Any, Optional[str], Optional[Dict[Any, Any]]]":
+    """Render and write one unit.
+
+    Returns ``(kind, key, error_or_None, fragments_delta_or_None)``. The
+    delta is a page unit's exported fragment store — the parent absorbs it
+    and feeds slices of it to the session units it dispatches afterwards.
+    Session units return None there (nothing renders after them).
 
     Failures come back as a formatted traceback rather than propagating,
     matching ``_convert_project_worker``: the parent needs to attribute the
@@ -455,6 +512,7 @@ def _render_unit_worker(unit: RenderUnit) -> "tuple[str, Any, Optional[str]]":
 
         output_dir = Path(_worker_setup.output_dir)
         renderer = _build_worker_renderer()
+        store = _unit_fragment_store(unit, renderer)
 
         if unit.kind == "page":
             page_messages: "List[TranscriptEntry]" = []
@@ -484,8 +542,11 @@ def _render_unit_worker(unit: RenderUnit) -> "tuple[str, Any, Optional[str]]":
             content, encoding="utf-8", errors="replace"
         )
     except Exception:
-        return unit.kind, unit.key, traceback.format_exc()
-    return unit.kind, unit.key, None
+        return unit.kind, unit.key, traceback.format_exc(), None
+    delta = (
+        store.export_fragments() if store is not None and unit.kind == "page" else None
+    )
+    return unit.kind, unit.key, None, delta
 
 
 # --------------------------------------------------------------------------
@@ -536,7 +597,7 @@ class RenderPool:
 
     def submit(
         self, unit: RenderUnit
-    ) -> Optional["Future[tuple[str, Any, str | None]]"]:
+    ) -> Optional["Future[tuple[str, Any, str | None, Dict[Any, Any] | None]]"]:
         """Queue a unit, or return None if the caller should render inline."""
         executor = self._ensure_executor()
         if executor is None:

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -192,19 +192,33 @@ def resolve_render_jobs(requested: Optional[int]) -> int:
         return _default()
 
 
-# A loaded transcript costs far more resident memory than it does on
-# disk — the JSONL becomes Pydantic entries, a TemplateMessage tree and a
-# SessionTree. Measured peak RSS against transcript bytes: 2.0x for a
-# 118MB/12k-message project, 3.0x for a 140MB/47k-message one. Denser
-# transcripts (more, smaller messages) cost more per byte, so take the
-# upper end.
-_RSS_PER_TRANSCRIPT_BYTE = 3.0
+# Post-feeding footprints, measured 2026-08-26 on the 8-core/16GB dev VM
+# (the work/render-format-once.md § 7.5 re-measure) by polling VmHWM
+# across fanned-out conversions of two real projects — 140MB/47k-message
+# and 329MB/97k-message:
+#
+#   conversion parent   598MB / 1458MB  ->  ~4.4x transcript bytes
+#   largest worker      218MB /  329MB  ->  ~136MB + 0.59x transcript
+#
+# The parent is the heavyweight: the JSONL becomes Pydantic entries, a
+# TemplateMessage tree and a SessionTree (~3x on its own), plus the
+# fragment store's text and the in-flight pickled slices. Fed workers
+# hold only base imports, their memo caches and the in-flight unit's
+# entry slice, so their cost scales weakly with project size. The
+# charges below carry a ~1.2-1.35x margin over the measured fit. The
+# pathological case — one session spanning most of the transcript, whose
+# unit slice re-inflates toward the parent's ~3x inside its worker — is
+# deliberately not charged for: it is a single outlier that fits inside
+# the headroom fraction, and such a project yields too few units to fan
+# wide anyway.
+_PARENT_RSS_PER_TRANSCRIPT_BYTE = 4.5
+_WORKER_RSS_PER_TRANSCRIPT_BYTE = 0.8
 
 # Interpreter, imports, Pygments' lexer tables and the render memo caches,
-# before any transcript is loaded. Measured base RSS was ~44MB and the memo
-# caches held 16MB on a 12k-message project; 150MB leaves room for a
-# Pygments-heavy project to fill more of its memo budget without making the
-# estimate so pessimistic that small projects never get a worker.
+# before any unit arrives. Measured worker intercept was ~136MB; 150MB
+# leaves room for a Pygments-heavy project to fill more of its memo budget
+# without making the estimate so pessimistic that small projects never get
+# a worker. Charged to the parent too (same interpreter, same caches).
 _WORKER_BASE_BYTES = 150 * 1024 * 1024
 
 # Never hand the whole of available memory to workers — the parent still
@@ -371,19 +385,21 @@ def memory_capped_workers(
 ) -> int:
     """Reduce ``requested`` to what memory can actually hold.
 
-    The formula still charges each worker a full transcript copy (~3x its
-    bytes on disk) — the footprint the fan-out had when workers re-loaded
-    the project, where an unguarded ``auto`` on a large archive exhausted
-    RAM and drove the machine into swap, pegging every core. Workers are
-    now *fed* per-unit entry slices and hold only their in-flight unit,
-    so this over-charges — deliberately, until the re-size is measured
-    (work/render-format-once.md § 7.5): the parent's master list, the
-    absorbed fragment text and the in-flight pickled slices still cost
-    real memory, and the swap failure mode is far worse than rendering
-    serially, so the cap errs safe rather than trusting the request.
+    Sized from the measured post-feeding footprints above: the parent —
+    master entry list, session tree, fragment store — is charged
+    ``_PARENT_RSS_PER_TRANSCRIPT_BYTE`` times the transcript's bytes on
+    disk, while each fed worker (base imports + memo caches + its
+    in-flight unit's slice) is charged the flat base plus a weak multiple
+    of transcript size. The pre-feeding formula charged every *worker*
+    the parent's ~3x copy — the footprint of the era when workers
+    re-loaded the whole project, where an unguarded ``auto`` on a large
+    archive exhausted RAM, drove the machine into swap and pegged every
+    core. Swap-thrash is far worse than rendering serially, which is why
+    the charges keep a margin over the measured fit and the headroom
+    fraction stays where it is.
 
     ``concurrent_projects`` is how many project conversions run at once
-    (the ``--all-projects`` pool). Each holds a transcript copy of its own
+    (the ``--all-projects`` pool). Each holds a master list of its own
     *and* spawns its own render workers, so the footprint is multiplicative
     across the two levels and the budget has to be split before it is spent.
 
@@ -394,16 +410,22 @@ def memory_capped_workers(
     if requested <= 1:
         return 1
 
-    per_copy = int(transcript_bytes * _RSS_PER_TRANSCRIPT_BYTE) + _WORKER_BASE_BYTES
+    parent_cost = (
+        int(transcript_bytes * _PARENT_RSS_PER_TRANSCRIPT_BYTE) + _WORKER_BASE_BYTES
+    )
+    worker_cost = (
+        int(transcript_bytes * _WORKER_RSS_PER_TRANSCRIPT_BYTE) + _WORKER_BASE_BYTES
+    )
     available = _available_memory_bytes()
     if available is None:
         return min(requested, 2)
 
     budget = int(available * _MEMORY_HEADROOM_FRACTION) // max(1, concurrent_projects)
-    # The conversion holding these workers has a copy of its own, already
-    # charged against `available` when it is the caller but not yet when
-    # the all-projects parent is sizing budgets for workers it will spawn.
-    affordable = (budget - per_copy) // max(1, per_copy)
+    # The parent's share is already resident when the conversion itself is
+    # the caller (its master list loads before the pool is sized) but not
+    # yet when the all-projects parent pre-sizes budgets for project
+    # workers it hasn't spawned; subtracting it in both cases errs safe.
+    affordable = (budget - parent_cost) // max(1, worker_cost)
     return max(1, min(requested, affordable))
 
 

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Intra-project render fan-out.
+
+Why this exists
+---------------
+``process_projects_hierarchy`` already fans whole projects out over a
+process pool, but a project's *own* conversion is single-threaded. That
+leaves two gaps:
+
+1. **The tail.** With N workers the all-projects wall clock is bounded by
+   the largest single project, which runs on one core while the rest of
+   the pool drains. Measured on 5 real projects across 4 cores: 195s of
+   work, 65.0s wall — and 65.0s is exactly the largest project's own time.
+   Average parallelism was 2.18 of 4 cores.
+2. **Incremental runs.** A day-to-day run has one or two stale projects,
+   so only one or two workers ever start.
+
+Both are fixed by the same thing: rendering *within* a project is
+embarrassingly parallel. A conversion writes one file per combined page
+and one per session — 88 independent units for the project measured above
+— and each is a pure function of the loaded transcript plus its own
+metadata.
+
+Design
+------
+Workers are **self-sufficient rather than fed**. The alternative — pickling
+the parent's parsed transcript to each worker — moves ~114MB per worker
+for a mid-sized project. Instead each worker re-loads from the (already
+warm) SQLite cache in its own ``initializer``, measured at 0.71s, and the
+parent sends only small per-unit metadata. That also keeps the parent's
+peak memory flat.
+
+This makes a warm cache a hard prerequisite: without one a worker would
+re-parse every JSONL file (~3.3s each, per worker), so ``RenderPool`` is
+only created when the caller has a ``CacheManager``. Staleness checks and
+all cache writes stay in the parent — workers render and write output
+files, nothing else — so the DB keeps a single writer.
+
+The pool is created lazily on first use: a project with one stale session
+should not pay ~1s of ``spawn`` + import per worker to save 60ms.
+"""
+
+import multiprocessing
+import os
+import traceback
+from concurrent.futures import Future, ProcessPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from .models import RenderingDepth, TranscriptEntry
+
+__all__ = ["RenderPool", "RenderUnit", "resolve_render_jobs"]
+
+
+@dataclass
+class RenderUnit:
+    """One output file to render.
+
+    ``kind`` is ``"page"`` or ``"session"``; ``key`` identifies the unit
+    within its kind (page number / session id) and is echoed back in the
+    result so the parent can attribute cache writes and failures.
+    """
+
+    kind: str
+    key: Any
+    file_name: str
+    title: str
+    # Page units: the session ids whose messages make up the page.
+    # Session units: unused (the worker filters by session id itself).
+    session_ids: Optional[List[str]] = None
+    page_info: Optional[Dict[str, Any]] = None
+    page_stats: Optional[Dict[str, Any]] = None
+    suppress_combined_link: bool = False
+
+
+@dataclass
+class _WorkerSetup:
+    """Everything a worker needs to reconstruct the parent's render state.
+
+    Deliberately all-picklable primitives so it survives ``spawn``.
+    """
+
+    format: str
+    project_dir: str
+    output_dir: str
+    from_date: Optional[str]
+    to_date: Optional[str]
+    depth: "RenderingDepth"
+    compact: bool
+    no_timestamps: bool
+    no_recaps: bool
+    image_export_mode: Optional[str]
+    archive_search_link: Optional[str]
+    library_version: str
+
+
+def resolve_render_jobs(requested: Optional[int]) -> int:
+    """Resolve a render-worker count from an explicit request.
+
+    ``None`` means "decide for me" → CPU count. Values below 1 (and an
+    unavailable CPU count) collapse to 1, i.e. the inline path.
+    """
+    if requested is not None:
+        return max(1, requested)
+    return max(1, os.cpu_count() or 1)
+
+
+# --------------------------------------------------------------------------
+# Worker side
+# --------------------------------------------------------------------------
+
+# Per-worker state, populated once by the initializer and reused for every
+# unit that worker handles. Module-level because that is the only state a
+# `spawn`ed worker can carry between tasks.
+_worker_setup: Optional[_WorkerSetup] = None
+_worker_messages: "Optional[List[TranscriptEntry]]" = None
+_worker_session_tree: Any = None
+_worker_cache_manager: Any = None
+_worker_messages_by_session: "Optional[Dict[str, List[TranscriptEntry]]]" = None
+
+
+def _init_render_worker(setup: _WorkerSetup) -> None:
+    """Load the project's transcript once, at worker start.
+
+    Mirrors what ``convert_jsonl_to`` does in the parent — load from cache,
+    date-filter, deduplicate — so a worker's message list is identical to
+    the parent's. Any divergence here shows up as differing output files,
+    which the test suite pins byte-for-byte against a serial run.
+    """
+    global _worker_setup, _worker_messages, _worker_session_tree
+    global _worker_cache_manager, _worker_messages_by_session
+
+    from .cache import CacheManager
+    from .converter import (
+        deduplicate_messages,
+        filter_messages_by_date,
+        load_directory_transcripts,
+    )
+    from .utils import get_parent_session_id
+
+    project_dir = Path(setup.project_dir)
+    cache_manager = CacheManager(project_dir, setup.library_version)
+    messages, session_tree = load_directory_transcripts(
+        project_dir, cache_manager, setup.from_date, setup.to_date, True
+    )
+    messages = filter_messages_by_date(messages, setup.from_date, setup.to_date)
+    messages = deduplicate_messages(messages)
+
+    by_session: "Dict[str, List[TranscriptEntry]]" = {}
+    for msg in messages:
+        session_id = getattr(msg, "sessionId", None)
+        if session_id:
+            by_session.setdefault(get_parent_session_id(session_id), []).append(msg)
+
+    _worker_setup = setup
+    _worker_messages = messages
+    _worker_session_tree = session_tree
+    _worker_cache_manager = cache_manager
+    _worker_messages_by_session = by_session
+
+
+def _build_worker_renderer() -> Any:
+    """A renderer configured exactly like the parent's.
+
+    Goes through ``get_renderer`` rather than constructing ``HtmlRenderer``
+    directly so page/session units render identically to the inline path,
+    for every format the caller supports.
+    """
+    from .renderer import get_renderer
+
+    assert _worker_setup is not None
+    return get_renderer(
+        _worker_setup.format,
+        _worker_setup.image_export_mode,
+        depth=_worker_setup.depth,
+        compact=_worker_setup.compact,
+        no_timestamps=_worker_setup.no_timestamps,
+        no_recaps=_worker_setup.no_recaps,
+    )
+
+
+def _render_unit_worker(unit: RenderUnit) -> "tuple[str, Any, Optional[str]]":
+    """Render and write one unit. Returns ``(kind, key, error_or_None)``.
+
+    Failures come back as a formatted traceback rather than propagating,
+    matching ``_convert_project_worker``: the parent needs to attribute the
+    failure to a specific page/session and keep going.
+    """
+    try:
+        assert _worker_setup is not None
+        assert _worker_messages is not None
+        assert _worker_messages_by_session is not None
+
+        output_dir = Path(_worker_setup.output_dir)
+        renderer = _build_worker_renderer()
+
+        if unit.kind == "page":
+            page_messages: "List[TranscriptEntry]" = []
+            for session_id in unit.session_ids or []:
+                page_messages.extend(_worker_messages_by_session.get(session_id, []))
+            content = renderer.generate(
+                page_messages,
+                unit.title,
+                page_info=unit.page_info,
+                page_stats=unit.page_stats,
+                session_tree=_worker_session_tree,
+                archive_search_link=_worker_setup.archive_search_link,
+            )
+        else:
+            content = renderer.generate_session(
+                _worker_messages,
+                unit.key,
+                unit.title,
+                _worker_cache_manager,
+                output_dir,
+                session_tree=_worker_session_tree,
+                suppress_combined_link=unit.suppress_combined_link,
+            )
+
+        # errors="replace" for lone-surrogate safety — see issue #139.
+        (output_dir / unit.file_name).write_text(
+            content, encoding="utf-8", errors="replace"
+        )
+    except Exception:
+        return unit.kind, unit.key, traceback.format_exc()
+    return unit.kind, unit.key, None
+
+
+# --------------------------------------------------------------------------
+# Parent side
+# --------------------------------------------------------------------------
+
+
+class RenderPool:
+    """Lazily-started process pool for one project's render units.
+
+    Use as a context manager for the duration of a conversion so pages and
+    session files share the same warmed-up workers — starting a second pool
+    would pay ``spawn`` + import + transcript load all over again.
+
+    ``submit`` falls back to rendering inline (returning None) whenever the
+    pool can't or shouldn't be used, so callers keep a single code path:
+    ``if pool is None or (fut := pool.submit(unit)) is None: render inline``.
+    """
+
+    def __init__(self, setup: _WorkerSetup, max_workers: int) -> None:
+        self._setup = setup
+        self._max_workers = max_workers
+        self._executor: Optional[ProcessPoolExecutor] = None
+        self._broken = False
+
+    def _ensure_executor(self) -> Optional[ProcessPoolExecutor]:
+        if self._executor is not None or self._broken:
+            return self._executor
+        try:
+            # `spawn` everywhere for the same reason the project-level pool
+            # uses it: fork is unsafe with threads and inherits arbitrary
+            # parent state — including, here, the parent's open SQLite
+            # connections.
+            ctx = multiprocessing.get_context("spawn")
+            self._executor = ProcessPoolExecutor(
+                max_workers=self._max_workers,
+                mp_context=ctx,
+                initializer=_init_render_worker,
+                initargs=(self._setup,),
+            )
+        except Exception:
+            # Can't bootstrap (e.g. a library caller without the
+            # `if __name__ == "__main__"` guard `spawn` requires).
+            # Degrade to inline rendering rather than failing the run.
+            self._broken = True
+            self._executor = None
+        return self._executor
+
+    def submit(
+        self, unit: RenderUnit
+    ) -> Optional["Future[tuple[str, Any, str | None]]"]:
+        """Queue a unit, or return None if the caller should render inline."""
+        executor = self._ensure_executor()
+        if executor is None:
+            return None
+        try:
+            return executor.submit(_render_unit_worker, unit)
+        except Exception:
+            self._broken = True
+            return None
+
+    @property
+    def broken(self) -> bool:
+        """True once the pool has failed; callers should render inline."""
+        return self._broken
+
+    def mark_broken(self) -> None:
+        """Called by the parent when a pool-level failure surfaces on a
+        result, so subsequent units go inline instead of re-failing."""
+        self._broken = True
+
+    def close(self) -> None:
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
+    def __enter__(self) -> "RenderPool":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+
+def make_render_pool(
+    *,
+    format: str,
+    project_dir: Path,
+    output_dir: Path,
+    from_date: Optional[str],
+    to_date: Optional[str],
+    depth: "RenderingDepth",
+    compact: bool,
+    no_timestamps: bool,
+    no_recaps: bool,
+    image_export_mode: Optional[str],
+    archive_search_link: Optional[str],
+    library_version: str,
+    max_workers: int,
+) -> RenderPool:
+    """Construct a pool. Cheap — no process starts until the first submit."""
+    return RenderPool(
+        _WorkerSetup(
+            format=format,
+            project_dir=str(project_dir),
+            output_dir=str(output_dir),
+            from_date=from_date,
+            to_date=to_date,
+            depth=depth,
+            compact=compact,
+            no_timestamps=no_timestamps,
+            no_recaps=no_recaps,
+            image_export_mode=image_export_mode,
+            archive_search_link=archive_search_link,
+            library_version=library_version,
+        ),
+        max_workers,
+    )

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -23,26 +23,33 @@ metadata.
 
 Design
 ------
-Workers are **self-sufficient for the transcript, fed for the fragments**.
-Pickling the parent's parsed transcript to each worker would move ~114MB
-per worker for a mid-sized project, so each worker re-loads from the
-(already warm) SQLite cache in its own ``initializer``, measured at 0.71s,
-and the parent sends only small per-unit metadata. That also keeps the
-parent's peak memory flat. Formatted *fragments*, however, are plain
-strings and cheap to move, so those flow through the parent instead of
-being recomputed per worker: page units export their fragment store back
-in the result tuple, the parent absorbs the deltas, and the session units
-it dispatches afterwards each carry their session's slice
-(``RenderUnit.fed_fragments``) — collapsing the page-vs-session duplicate
-formatting that previously came back in every cold worker. The feed is
-verified the same way as any store hit (content digest + tree signature),
-so a stale or mis-keyed fragment costs a recompute, never wrong output.
+Workers are **fed, not self-sufficient**. Each unit crosses the process
+boundary carrying exactly what its render reads: the unit's own entry
+slice (a page's sessions, or one session's messages — the same objects
+the parent's master list holds), those entries' master-list ordinals
+(so fragment-store keys mean the same thing in every process), and — for
+session units — the session's slice of the parent's fragment store
+(``RenderUnit.fed_fragments``), formatted by the combined-page pass that
+always completes first. The one per-*worker* piece of state is a slimmed
+``SessionTree`` (``dag.slim_session_tree``) sent through the pool
+initializer: the render path reads only its DAG lines, junction points
+and workflow dicts, so the per-message ``nodes`` mapping — whose pickled
+size is the whole transcript — stays behind in the parent.
 
-This makes a warm cache a hard prerequisite: without one a worker would
-re-parse every JSONL file (~3.3s each, per worker), so ``RenderPool`` is
-only created when the caller has a ``CacheManager``. Staleness checks and
-all cache writes stay in the parent — workers render and write output
-files, nothing else — so the DB keeps a single writer.
+Workers previously re-loaded the whole transcript from the SQLite cache
+instead (once per worker, ~0.7s at 12k messages, ~12s of CPU at 329MB of
+transcript), which made per-worker cost — CPU *and* the ~3x-bytes-on-disk
+resident copy — scale with project size rather than unit size. Feeding
+moves each entry at most twice per conversion (its page unit, then its
+session unit) rather than once per worker, and what a worker holds is
+bounded by its largest single unit.
+
+Every fed fragment is verified the same way as any store hit (content
+digest + tree signature), so a stale or mis-keyed fragment costs a
+recompute, never wrong output. Staleness checks and all cache writes stay
+in the parent — workers render and write output files, nothing else — so
+the DB keeps a single writer (workers still open the cache read-only for
+the per-session combined-link lookup).
 
 The pool is created lazily on first use: a project with one stale session
 should not pay ~1s of ``spawn`` + import per worker to save 60ms.
@@ -84,8 +91,18 @@ class RenderUnit:
     key: Any
     file_name: str
     title: str
-    # Page units: the session ids whose messages make up the page.
-    # Session units: unused (the worker filters by session id itself).
+    # The unit's slice of the parent's master message list — a page's
+    # sessions' entries, or one session's (trunk + integrated agents).
+    # This is what the worker renders; it never loads the transcript
+    # itself. None only for inline rendering, which reads the parent's
+    # own lists instead.
+    entries: "Optional[List[TranscriptEntry]]" = None
+    # Master-list ordinal of each entry in ``entries`` (parallel list).
+    # Fragment-store keys are these ordinals, so the parent and every
+    # worker agree on what a key names without holding the same list.
+    entry_ordinals: Optional[List[int]] = None
+    # Page units: the session ids whose messages make up the page (kept
+    # for the parent's cache bookkeeping; workers render ``entries``).
     session_ids: Optional[List[str]] = None
     page_info: Optional[Dict[str, Any]] = None
     page_stats: Optional[Dict[str, Any]] = None
@@ -104,7 +121,10 @@ class RenderUnit:
 class _WorkerSetup:
     """Everything a worker needs to reconstruct the parent's render state.
 
-    Deliberately all-picklable primitives so it survives ``spawn``.
+    Everything here must survive a ``spawn`` pickle. ``session_tree`` is
+    the *slim* tree (``dag.slim_session_tree``) — its per-message
+    ``nodes`` mapping raises on lookup, so it must never be the full one:
+    that would ship the whole transcript to every worker.
     """
 
     format: str
@@ -119,6 +139,7 @@ class _WorkerSetup:
     image_export_mode: Optional[str]
     archive_search_link: Optional[str]
     library_version: str
+    session_tree: Any = None
 
 
 RENDER_JOBS_ENV = "CLAUDE_CODE_LOG_RENDER_JOBS"
@@ -350,13 +371,16 @@ def memory_capped_workers(
 ) -> int:
     """Reduce ``requested`` to what memory can actually hold.
 
-    Every worker loads the project's whole transcript — that is what makes
-    workers independent of the parent, and it means peak memory is
-    ``workers x project size``, not a fixed overhead. A 1GB project costs
-    roughly 3GB per worker, so an unguarded ``auto`` on a large archive
-    exhausts RAM and drives the machine into swap, where it pegs every core
-    and stops responding. That failure mode is far worse than rendering
-    serially, so cap rather than trust the request.
+    The formula still charges each worker a full transcript copy (~3x its
+    bytes on disk) — the footprint the fan-out had when workers re-loaded
+    the project, where an unguarded ``auto`` on a large archive exhausted
+    RAM and drove the machine into swap, pegging every core. Workers are
+    now *fed* per-unit entry slices and hold only their in-flight unit,
+    so this over-charges — deliberately, until the re-size is measured
+    (work/render-format-once.md § 7.5): the parent's master list, the
+    absorbed fragment text and the in-flight pickled slices still cost
+    real memory, and the swap failure mode is far worse than rendering
+    serially, so the cap errs safe rather than trusting the request.
 
     ``concurrent_projects`` is how many project conversions run at once
     (the ``--all-projects`` pool). Each holds a transcript copy of its own
@@ -391,57 +415,24 @@ def memory_capped_workers(
 # unit that worker handles. Module-level because that is the only state a
 # `spawn`ed worker can carry between tasks.
 _worker_setup: Optional[_WorkerSetup] = None
-_worker_messages: "Optional[List[TranscriptEntry]]" = None
-_worker_session_tree: Any = None
 _worker_cache_manager: Any = None
-_worker_messages_by_session: "Optional[Dict[str, List[TranscriptEntry]]]" = None
-# id(entry) → master-list ordinal, built once per worker. Fragment-store
-# keys are these ordinals, which the parent and every worker agree on as
-# long as they load the same master list in the same order — and a skew
-# only costs hits (digest conflict → formatted fresh), never correctness.
-_worker_entry_ordinals: Optional[Dict[int, int]] = None
 
 
 def _init_render_worker(setup: _WorkerSetup) -> None:
-    """Load the project's transcript once, at worker start.
+    """Set up the worker's render state. Deliberately cheap.
 
-    Mirrors what ``convert_jsonl_to`` does in the parent — load from cache,
-    date-filter, deduplicate — so a worker's message list is identical to
-    the parent's. Any divergence here shows up as differing output files,
-    which the test suite pins byte-for-byte against a serial run.
+    The transcript itself never loads here: every unit arrives carrying
+    its own entry slice (``RenderUnit.entries``), already date-filtered
+    and deduplicated by the parent — so a worker's messages are the
+    parent's, not a reconstruction that could drift. The cache manager is
+    only constructed (no load) for the per-session combined-link lookup.
     """
-    global _worker_setup, _worker_messages, _worker_session_tree
-    global _worker_cache_manager, _worker_messages_by_session
-    global _worker_entry_ordinals
+    global _worker_setup, _worker_cache_manager
 
     from .cache import CacheManager
-    from .converter import (
-        deduplicate_messages,
-        filter_messages_by_date,
-        load_directory_transcripts,
-    )
-    from .utils import get_parent_session_id
-
-    project_dir = Path(setup.project_dir)
-    cache_manager = CacheManager(project_dir, setup.library_version)
-    messages, session_tree = load_directory_transcripts(
-        project_dir, cache_manager, setup.from_date, setup.to_date, True
-    )
-    messages = filter_messages_by_date(messages, setup.from_date, setup.to_date)
-    messages = deduplicate_messages(messages)
-
-    by_session: "Dict[str, List[TranscriptEntry]]" = {}
-    for msg in messages:
-        session_id = getattr(msg, "sessionId", None)
-        if session_id:
-            by_session.setdefault(get_parent_session_id(session_id), []).append(msg)
 
     _worker_setup = setup
-    _worker_messages = messages
-    _worker_session_tree = session_tree
-    _worker_cache_manager = cache_manager
-    _worker_messages_by_session = by_session
-    _worker_entry_ordinals = {id(msg): i for i, msg in enumerate(messages)}
+    _worker_cache_manager = CacheManager(Path(setup.project_dir), setup.library_version)
 
 
 def _build_worker_renderer() -> Any:
@@ -469,9 +460,10 @@ def _unit_fragment_store(unit: RenderUnit, renderer: Any) -> Any:
 
     Page units get an empty store whose contents are exported back to the
     parent (the delta in the result tuple); session units get a store
-    seeded with the slice the parent fed on the unit. Either way the
-    store's semantics are the per-conversion ones — this worker's master
-    list is the same conversion's, only re-loaded.
+    seeded with the slice the parent fed on the unit. The ordinal map
+    comes from the unit's own ``entry_ordinals``, so keys name the same
+    master-list positions the parent's store uses — without either side
+    holding the other's list.
     """
     from .fragment_store import RenderFragmentStore, fragment_store_enabled
 
@@ -483,8 +475,13 @@ def _unit_fragment_store(unit: RenderUnit, renderer: Any) -> Any:
     if not isinstance(renderer, HtmlRenderer):
         return None
     store = RenderFragmentStore()
-    assert _worker_entry_ordinals is not None
-    store.set_entry_ordinal_map(_worker_entry_ordinals)
+    if unit.entries is not None and unit.entry_ordinals is not None:
+        store.set_entry_ordinal_map(
+            {
+                id(entry): ordinal
+                for entry, ordinal in zip(unit.entries, unit.entry_ordinals)
+            }
+        )
     if unit.fed_fragments:
         store.absorb(unit.fed_fragments)
     renderer.fragment_store = store
@@ -507,33 +504,36 @@ def _render_unit_worker(
     """
     try:
         assert _worker_setup is not None
-        assert _worker_messages is not None
-        assert _worker_messages_by_session is not None
+        # The unit's entries ARE its transcript — the parent slices its
+        # own (date-filtered, deduplicated) master list per unit.
+        # ``submit`` declines entry-less units to the inline path, so
+        # this is a backstop, not a reachable fallback.
+        assert unit.entries is not None, "render unit dispatched without entries"
 
         output_dir = Path(_worker_setup.output_dir)
         renderer = _build_worker_renderer()
         store = _unit_fragment_store(unit, renderer)
 
         if unit.kind == "page":
-            page_messages: "List[TranscriptEntry]" = []
-            for session_id in unit.session_ids or []:
-                page_messages.extend(_worker_messages_by_session.get(session_id, []))
             content = renderer.generate(
-                page_messages,
+                unit.entries,
                 unit.title,
                 page_info=unit.page_info,
                 page_stats=unit.page_stats,
-                session_tree=_worker_session_tree,
+                session_tree=_worker_setup.session_tree,
                 archive_search_link=_worker_setup.archive_search_link,
             )
         else:
+            # generate_session re-applies its own session filter to the
+            # fed slice; the parent sliced with the same predicate, so
+            # this is idempotent and keeps one code path with inline.
             content = renderer.generate_session(
-                _worker_messages,
+                unit.entries,
                 unit.key,
                 unit.title,
                 _worker_cache_manager,
                 output_dir,
-                session_tree=_worker_session_tree,
+                session_tree=_worker_setup.session_tree,
                 suppress_combined_link=unit.suppress_combined_link,
             )
 
@@ -559,7 +559,7 @@ class RenderPool:
 
     Use as a context manager for the duration of a conversion so pages and
     session files share the same warmed-up workers — starting a second pool
-    would pay ``spawn`` + import + transcript load all over again.
+    would pay ``spawn`` + package import all over again.
 
     ``submit`` falls back to rendering inline (returning None) whenever the
     pool can't or shouldn't be used, so callers keep a single code path:
@@ -598,7 +598,14 @@ class RenderPool:
     def submit(
         self, unit: RenderUnit
     ) -> Optional["Future[tuple[str, Any, str | None, Dict[Any, Any] | None]]"]:
-        """Queue a unit, or return None if the caller should render inline."""
+        """Queue a unit, or return None if the caller should render inline.
+
+        A unit with no entry slice is declined rather than queued: workers
+        never load the transcript, so only the parent's inline path (which
+        holds the full master list) can render it.
+        """
+        if unit.entries is None:
+            return None
         executor = self._ensure_executor()
         if executor is None:
             return None
@@ -645,8 +652,13 @@ def make_render_pool(
     archive_search_link: Optional[str],
     library_version: str,
     max_workers: int,
+    session_tree: Any = None,
 ) -> RenderPool:
-    """Construct a pool. Cheap — no process starts until the first submit."""
+    """Construct a pool. Cheap — no process starts until the first submit.
+
+    ``session_tree`` must be the slim form (``dag.slim_session_tree``);
+    it is pickled into every worker via the pool initializer.
+    """
     return RenderPool(
         _WorkerSetup(
             format=format,
@@ -661,6 +673,7 @@ def make_render_pool(
             image_export_mode=image_export_mode,
             archive_search_link=archive_search_link,
             library_version=library_version,
+            session_tree=session_tree,
         ),
         max_workers,
     )

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -425,14 +425,19 @@ def _init_render_worker(setup: _WorkerSetup) -> None:
     its own entry slice (``RenderUnit.entries``), already date-filtered
     and deduplicated by the parent — so a worker's messages are the
     parent's, not a reconstruction that could drift. The cache manager is
-    only constructed (no load) for the per-session combined-link lookup.
+    only constructed (no load) for the per-session combined-link lookup,
+    and read-only: the parent already migrated the shared cache DB and
+    wrote this project's row, so N workers must not race those writes —
+    or any other.
     """
     global _worker_setup, _worker_cache_manager
 
     from .cache import CacheManager
 
     _worker_setup = setup
-    _worker_cache_manager = CacheManager(Path(setup.project_dir), setup.library_version)
+    _worker_cache_manager = CacheManager(
+        Path(setup.project_dir), setup.library_version, read_only=True
+    )
 
 
 def _build_worker_renderer() -> Any:

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -73,6 +73,7 @@ __all__ = [
     "RENDER_JOBS_ENV",
     "RenderPool",
     "RenderUnit",
+    "available_memory_bytes",
     "memory_capped_workers",
     "resolve_render_jobs",
 ]
@@ -324,7 +325,7 @@ def _windows_available_bytes() -> Optional[int]:
         return None
 
 
-def _available_memory_bytes() -> Optional[int]:
+def available_memory_bytes() -> Optional[int]:
     """Best-effort read of memory we may actually use, or None if unknown.
 
     Checks the cgroup limit first: inside a container the host's totals are
@@ -416,7 +417,7 @@ def memory_capped_workers(
     worker_cost = (
         int(transcript_bytes * _WORKER_RSS_PER_TRANSCRIPT_BYTE) + _WORKER_BASE_BYTES
     )
-    available = _available_memory_bytes()
+    available = available_memory_bytes()
     if available is None:
         return min(requested, 2)
 

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -545,6 +545,7 @@ def _render_unit_worker(
             content = renderer.generate(
                 unit.entries,
                 unit.title,
+                output_dir=output_dir,
                 page_info=unit.page_info,
                 page_stats=unit.page_stats,
                 session_tree=_worker_setup.session_tree,

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -216,6 +216,50 @@ def _darwin_available_bytes() -> Optional[int]:
     return _parse_vm_stat(completed.stdout)
 
 
+def _windows_available_bytes() -> Optional[int]:
+    """Available physical memory on Windows, or None elsewhere / on failure.
+
+    Windows has no ``/proc/meminfo`` and no ``os.sysconf`` at all, so
+    without this it lands in the same conservative unknown-memory branch
+    that capped macOS at 2 workers. ``GlobalMemoryStatusEx`` is the
+    documented API and reachable through ``ctypes``, so this needs no
+    dependency; ``ullAvailPhys`` is what the OS considers immediately
+    available, which is the same thing the other probes estimate.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        class _MemoryStatusEx(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        status = _MemoryStatusEx()
+        status.dwLength = ctypes.sizeof(_MemoryStatusEx)
+        # windll exists only on Windows, which the platform check above
+        # has already established.
+        if not ctypes.windll.kernel32.GlobalMemoryStatusEx(  # type: ignore[attr-defined]
+            ctypes.byref(status)
+        ):
+            return None
+        return int(status.ullAvailPhys) or None
+    except Exception:
+        # ctypes is optional in some builds and the call is a foreign
+        # function into the OS; an unknown reading is recoverable (the
+        # caller just stays conservative), a crash mid-conversion is not.
+        return None
+
+
 def _available_memory_bytes() -> Optional[int]:
     """Best-effort read of memory we may actually use, or None if unknown.
 
@@ -248,16 +292,20 @@ def _available_memory_bytes() -> Optional[int]:
         pass
 
     if not limits:
-        darwin = _darwin_available_bytes()
-        if darwin is not None:
-            limits.append(darwin)
+        # Exactly one of these can return a reading on any given machine;
+        # both return None elsewhere.
+        for probe in (_darwin_available_bytes, _windows_available_bytes):
+            reading = probe()
+            if reading is not None:
+                limits.append(reading)
+                break
 
     if not limits:
         # Anything else with a POSIX free-page count. Conservative — it
         # ignores memory the OS could reclaim, which is the right way to
-        # be wrong here. Absent on macOS, which is why the probe above
-        # exists: falling through to "unknown" there capped every Mac at
-        # the 2-worker fallback regardless of how much RAM it had.
+        # be wrong here. Absent on both macOS and Windows, which is why
+        # the probes above exist: falling through to "unknown" capped
+        # those platforms at 2 workers regardless of their RAM.
         try:
             limits.append(
                 os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")  # type: ignore[arg-type]

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -42,6 +42,9 @@ should not pay ~1s of ``spawn`` + import per worker to save 60ms.
 
 import multiprocessing
 import os
+import re
+import subprocess
+import sys
 import traceback
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
@@ -159,6 +162,60 @@ _WORKER_BASE_BYTES = 150 * 1024 * 1024
 _MEMORY_HEADROOM_FRACTION = 0.6
 
 
+# Pages `vm_stat` reports that can be handed to a new process without
+# pushing anything to swap. "inactive" and "speculative" are clean, cheaply
+# reclaimable page cache — excluding them reports a busy Mac as having
+# almost nothing free, which is exactly the under-read that capped a 16-core
+# machine at the 2-worker fallback.
+_DARWIN_RECLAIMABLE_PAGE_KINDS = ("free", "inactive", "speculative", "purgeable")
+
+_VM_STAT_PAGE_SIZE_RE = re.compile(r"page size of (\d+) bytes")
+_VM_STAT_LINE_RE = re.compile(r'^"?Pages ([A-Za-z -]+?)"?:\s+(\d+)\.?\s*$')
+
+
+def _parse_vm_stat(output: str) -> Optional[int]:
+    """Turn ``vm_stat`` output into a reclaimable byte count.
+
+    Split out from the subprocess call so it can be tested off-macOS.
+    """
+    page_size_match = _VM_STAT_PAGE_SIZE_RE.search(output)
+    # vm_stat's own default when the header is missing; every current macOS
+    # states it explicitly (4096 on Intel, 16384 on Apple silicon).
+    page_size = int(page_size_match.group(1)) if page_size_match else 4096
+
+    pages = 0
+    matched = False
+    for line in output.splitlines():
+        match = _VM_STAT_LINE_RE.match(line.strip())
+        if match and match.group(1).strip() in _DARWIN_RECLAIMABLE_PAGE_KINDS:
+            pages += int(match.group(2))
+            matched = True
+    if not matched:
+        return None
+    return pages * page_size
+
+
+def _darwin_available_bytes() -> Optional[int]:
+    """Reclaimable memory on macOS, or None off-macOS / on any failure.
+
+    macOS has no ``MemAvailable`` and no ``SC_AVPHYS_PAGES``, so this shells
+    out to ``vm_stat`` (present on every macOS, no dependency needed). Any
+    failure returns None and the caller falls back to its conservative
+    unknown-memory behaviour.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        completed = subprocess.run(
+            ["/usr/bin/vm_stat"], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return _parse_vm_stat(completed.stdout)
+
+
 def _available_memory_bytes() -> Optional[int]:
     """Best-effort read of memory we may actually use, or None if unknown.
 
@@ -191,9 +248,16 @@ def _available_memory_bytes() -> Optional[int]:
         pass
 
     if not limits:
-        # macOS and the rest: free physical pages. Conservative, since it
+        darwin = _darwin_available_bytes()
+        if darwin is not None:
+            limits.append(darwin)
+
+    if not limits:
+        # Anything else with a POSIX free-page count. Conservative — it
         # ignores memory the OS could reclaim, which is the right way to
-        # be wrong here.
+        # be wrong here. Absent on macOS, which is why the probe above
+        # exists: falling through to "unknown" there capped every Mac at
+        # the 2-worker fallback regardless of how much RAM it had.
         try:
             limits.append(
                 os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")  # type: ignore[arg-type]

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -113,33 +113,46 @@ def resolve_render_jobs(requested: Optional[int]) -> int:
 
     ``1`` means the inline path — no pool, no worker processes.
 
-    The fan-out is **off by default** and enabled by ``$RENDER_JOBS_ENV``
-    (``auto`` for the CPU count, or an explicit worker count). That default
-    is deliberate: it competes with the render memo caches, since each
-    worker starts with a cold cache and re-does the page-vs-session
-    formatting the memo would have collapsed. It wins clearly on large
-    projects and loses on small ones (see ``application_model.md`` § 2.10),
-    which is not a trade to make on everyone's behalf until the two-phase
-    restructuring removes the conflict.
+    **On by default** at the CPU count, since measuring it on a 16-core
+    machine settled the question: an incremental run (one stale project,
+    the everyday shape) went 93.2s → 34.6s, a 2.7x improvement using 10.6
+    of 16 cores instead of 1. ``$RENDER_JOBS_ENV`` overrides — ``1``
+    disables it, ``auto`` is the default, an integer pins a worker count.
+
+    The cost is total CPU: workers start with cold memo caches and redo
+    the page-vs-session formatting the memo would have collapsed, so that
+    run burned 367.9s of CPU against 90.8s serial. Wall clock is what the
+    user waits for, so the trade is worth making by default — but it is
+    why ``_MIN_MESSAGES_FOR_RENDER_POOL`` keeps small projects out (below
+    the crossover the fan-out is a net loss) and why the count is capped
+    against available memory. See ``application_model.md`` § 2.10.
 
     ``requested`` is an explicit caller override (the ``render_jobs``
     argument to ``convert_jsonl_to``) and wins over the environment;
-    ``None`` consults it. An unparseable setting means off, not a crash.
+    ``None`` consults it. A number below 1 means "none of it" (mirroring
+    ``CLAUDE_CODE_LOG_RENDER_CACHE_MB=0``); an unparseable setting falls
+    back to the default rather than crashing a conversion.
     """
     if requested is not None:
         return max(1, requested)
+
+    def _default() -> int:
+        return max(1, os.cpu_count() or 1)
+
     raw = os.getenv(RENDER_JOBS_ENV)
     if raw is None:
-        return 1
+        return _default()
     value = raw.strip().lower()
     if not value:
-        return 1
+        return _default()
     if value in ("auto", "cpu"):
-        return max(1, os.cpu_count() or 1)
+        return _default()
+    if value in ("off", "no", "false", "serial"):
+        return 1
     try:
         return max(1, int(value))
     except ValueError:
-        return 1
+        return _default()
 
 
 # A loaded transcript costs far more resident memory than it does on

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -51,7 +51,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     from .models import RenderingDepth, TranscriptEntry
 
-__all__ = ["RenderPool", "RenderUnit", "resolve_render_jobs"]
+__all__ = [
+    "RENDER_JOBS_ENV",
+    "RenderPool",
+    "RenderUnit",
+    "memory_capped_workers",
+    "resolve_render_jobs",
+]
 
 
 @dataclass
@@ -96,15 +102,144 @@ class _WorkerSetup:
     library_version: str
 
 
-def resolve_render_jobs(requested: Optional[int]) -> int:
-    """Resolve a render-worker count from an explicit request.
+RENDER_JOBS_ENV = "CLAUDE_CODE_LOG_RENDER_JOBS"
 
-    ``None`` means "decide for me" → CPU count. Values below 1 (and an
-    unavailable CPU count) collapse to 1, i.e. the inline path.
+
+def resolve_render_jobs(requested: Optional[int]) -> int:
+    """How many workers to render this project's output files over.
+
+    ``1`` means the inline path — no pool, no worker processes.
+
+    The fan-out is **off by default** and enabled by ``$RENDER_JOBS_ENV``
+    (``auto`` for the CPU count, or an explicit worker count). That default
+    is deliberate: it competes with the render memo caches, since each
+    worker starts with a cold cache and re-does the page-vs-session
+    formatting the memo would have collapsed. It wins clearly on large
+    projects and loses on small ones (see ``application_model.md`` § 2.10),
+    which is not a trade to make on everyone's behalf until the two-phase
+    restructuring removes the conflict.
+
+    ``requested`` is an explicit caller override (the ``render_jobs``
+    argument to ``convert_jsonl_to``) and wins over the environment;
+    ``None`` consults it. An unparseable setting means off, not a crash.
     """
     if requested is not None:
         return max(1, requested)
-    return max(1, os.cpu_count() or 1)
+    raw = os.getenv(RENDER_JOBS_ENV)
+    if raw is None:
+        return 1
+    value = raw.strip().lower()
+    if not value:
+        return 1
+    if value in ("auto", "cpu"):
+        return max(1, os.cpu_count() or 1)
+    try:
+        return max(1, int(value))
+    except ValueError:
+        return 1
+
+
+# A loaded transcript costs far more resident memory than it does on
+# disk — the JSONL becomes Pydantic entries, a TemplateMessage tree and a
+# SessionTree. Measured peak RSS against transcript bytes: 2.0x for a
+# 118MB/12k-message project, 3.0x for a 140MB/47k-message one. Denser
+# transcripts (more, smaller messages) cost more per byte, so take the
+# upper end.
+_RSS_PER_TRANSCRIPT_BYTE = 3.0
+
+# Interpreter, imports, Pygments' lexer tables and the render memo caches,
+# before any transcript is loaded. Measured base RSS was ~44MB and the memo
+# caches held 16MB on a 12k-message project; 150MB leaves room for a
+# Pygments-heavy project to fill more of its memo budget without making the
+# estimate so pessimistic that small projects never get a worker.
+_WORKER_BASE_BYTES = 150 * 1024 * 1024
+
+# Never hand the whole of available memory to workers — the parent still
+# holds its own copy of the transcript and keeps rendering alongside them.
+_MEMORY_HEADROOM_FRACTION = 0.6
+
+
+def _available_memory_bytes() -> Optional[int]:
+    """Best-effort read of memory we may actually use, or None if unknown.
+
+    Checks the cgroup limit first: inside a container the host's totals are
+    a lie, and this is exactly where an over-eager fan-out gets the whole
+    machine OOM-killed or swap-thrashed into unresponsiveness.
+    """
+    limits: list[int] = []
+
+    # cgroup v2 (containers, systemd slices).
+    try:
+        with open("/sys/fs/cgroup/memory.max") as handle:
+            raw = handle.read().strip()
+        if raw != "max":
+            with open("/sys/fs/cgroup/memory.current") as handle:
+                current = int(handle.read().strip())
+            limits.append(max(0, int(raw) - current))
+    except (OSError, ValueError):
+        pass
+
+    # Linux: MemAvailable accounts for reclaimable page cache, which
+    # SC_AVPHYS_PAGES (free pages only) badly under-reports.
+    try:
+        with open("/proc/meminfo") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    limits.append(int(line.split()[1]) * 1024)
+                    break
+    except (OSError, ValueError, IndexError):
+        pass
+
+    if not limits:
+        # macOS and the rest: free physical pages. Conservative, since it
+        # ignores memory the OS could reclaim, which is the right way to
+        # be wrong here.
+        try:
+            limits.append(
+                os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")  # type: ignore[arg-type]
+            )
+        except (ValueError, OSError, AttributeError):
+            return None
+
+    return min(limits) if limits else None
+
+
+def memory_capped_workers(
+    requested: int, transcript_bytes: int, *, concurrent_projects: int = 1
+) -> int:
+    """Reduce ``requested`` to what memory can actually hold.
+
+    Every worker loads the project's whole transcript — that is what makes
+    workers independent of the parent, and it means peak memory is
+    ``workers x project size``, not a fixed overhead. A 1GB project costs
+    roughly 3GB per worker, so an unguarded ``auto`` on a large archive
+    exhausts RAM and drives the machine into swap, where it pegs every core
+    and stops responding. That failure mode is far worse than rendering
+    serially, so cap rather than trust the request.
+
+    ``concurrent_projects`` is how many project conversions run at once
+    (the ``--all-projects`` pool). Each holds a transcript copy of its own
+    *and* spawns its own render workers, so the footprint is multiplicative
+    across the two levels and the budget has to be split before it is spent.
+
+    Returns at least 1 (the inline path). When available memory can't be
+    determined, allows at most 2 workers — enough to be useful, small
+    enough not to be dangerous on an unknown machine.
+    """
+    if requested <= 1:
+        return 1
+
+    per_copy = int(transcript_bytes * _RSS_PER_TRANSCRIPT_BYTE) + _WORKER_BASE_BYTES
+    available = _available_memory_bytes()
+    if available is None:
+        return min(requested, 2)
+
+    budget = int(available * _MEMORY_HEADROOM_FRACTION) // max(1, concurrent_projects)
+    # The conversion holding these workers has a copy of its own, already
+    # charged against `available` when it is the caller but not yet when
+    # the all-projects parent is sizing budgets for workers it will spawn.
+    affordable = (budget - per_copy) // max(1, per_copy)
+    return max(1, min(requested, affordable))
 
 
 # --------------------------------------------------------------------------

--- a/claude_code_log/renderer.py
+++ b/claude_code_log/renderer.py
@@ -4792,6 +4792,14 @@ def _render_messages(
         # Handle system messages (already filtered in pass 1)
         if isinstance(message, SystemTranscriptEntry):
             system_content = create_system_message(message)
+            if system_content is not None:
+                # Fragment identity for the render fragment store (step 3,
+                # work/render-format-once.md): the entry's Python id is
+                # stable for the whole conversion because the master
+                # message list keeps it alive. Only real factory output is
+                # stamped — the fork placeholder below depends on ctx
+                # state, so it stays unstamped and renders fresh per tree.
+                system_content.fragment_key = (id(message), 0)
             # A content-less system entry (e.g. ``turn_duration``,
             # ``stop_hook_summary`` with no body) is normally dropped — but if
             # it is a *within-session fork point* (issue #233), dropping it
@@ -4817,6 +4825,7 @@ def _render_messages(
         if isinstance(message, AttachmentTranscriptEntry):
             attachment_content = create_attachment_message(message)
             if attachment_content:
+                attachment_content.fragment_key = (id(message), 0)
                 attachment_msg = TemplateMessage(attachment_content)
                 if effective_session:
                     attachment_msg.render_session_id = effective_session
@@ -4913,8 +4922,13 @@ def _render_messages(
         usage_used = False
 
         # Process each chunk - regular chunks (list) become text/image messages,
-        # special chunks (single item) become tool/thinking messages
-        for chunk in chunks:
+        # special chunks (single item) become tool/thinking messages.
+        # The enumerate ordinal doubles as the fragment-key part index:
+        # chunking is a pure function of the entry, so the same entry
+        # yields the same ordinals in every render pass, and keying by
+        # chunk position (rather than by surviving-content position) stays
+        # aligned even when an empty chunk is skipped.
+        for part_ordinal, chunk in enumerate(chunks):
             # Each chunk needs its own meta copy to preserve original values
             chunk_meta = replace(meta)
 
@@ -4967,6 +4981,7 @@ def _render_messages(
                 if not chunk or content_model is None:
                     continue
 
+                content_model.fragment_key = (id(message), part_ordinal)
                 chunk_msg = TemplateMessage(content_model)
                 if effective_session:
                     chunk_msg.render_session_id = effective_session
@@ -5017,6 +5032,7 @@ def _render_messages(
                 if tool_result.content is None:
                     continue
 
+                tool_result.content.fragment_key = (id(message), part_ordinal)
                 tool_msg = TemplateMessage(tool_result.content)
                 if effective_session:
                     tool_msg.render_session_id = effective_session

--- a/claude_code_log/renderer_timings.py
+++ b/claude_code_log/renderer_timings.py
@@ -110,6 +110,27 @@ def timing_stat(list_name: str) -> Iterator[None]:
             _timing_data[list_name].append((duration, msg_id))
 
 
+def report_cache_statistics(
+    cache_stats: list[Tuple[str, dict[str, int]]],
+) -> None:
+    """Report memo-cache effectiveness for the pure render leaves.
+
+    Args:
+        cache_stats: List of (name, stats) pairs, where stats is the dict
+                     returned by ``render_cache.ByteBoundedCache.stats()``.
+    """
+    for name, stats in cache_stats:
+        lookups = stats["hits"] + stats["misses"]
+        if not lookups:
+            continue
+        rate = 100.0 * stats["hits"] / lookups
+        print(
+            f"[TIMING] {name} memo: {stats['hits']}/{lookups} hits ({rate:.0f}%), "
+            f"{stats['entries']} entries, {stats['bytes'] / 1e6:.1f}MB",
+            flush=True,
+        )
+
+
 def report_timing_statistics(
     operation_timings: list[Tuple[str, list[Tuple[float, str]]]],
 ) -> None:

--- a/claude_code_log/renderer_timings.py
+++ b/claude_code_log/renderer_timings.py
@@ -124,9 +124,15 @@ def report_cache_statistics(
         if not lookups:
             continue
         rate = 100.0 * stats["hits"] / lookups
+        extras = [
+            f"{stats[extra_key]} {extra_key}"
+            for extra_key in ("conflicts", "skipped")
+            if stats.get(extra_key)
+        ]
+        skipped_note = f", {', '.join(extras)}" if extras else ""
         print(
             f"[TIMING] {name} memo: {stats['hits']}/{lookups} hits ({rate:.0f}%), "
-            f"{stats['entries']} entries, {stats['bytes'] / 1e6:.1f}MB",
+            f"{stats['entries']} entries, {stats['bytes'] / 1e6:.1f}MB{skipped_note}",
             flush=True,
         )
 

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -80,9 +80,10 @@ single transcript or directory. Major flags:
   output, packing whole sessions into pages of up to N messages each
   (sessions are never split across pages, so individual pages may
   overflow). Per-session HTML files are not paginated.
-- `--jobs N` / `-j N` — total worker processes for conversion (default:
-  CPU count; `1` disables parallelism). Split between converting projects
-  in parallel and each project's own render fan-out (§ 2.10).
+- `--jobs N` / `-j N` — worker processes for the all-projects conversion
+  phase (default: CPU count; `1` disables parallelism). Also caps the
+  per-project render fan-out, which is opt-in via
+  `$CLAUDE_CODE_LOG_RENDER_JOBS` (§ 2.10).
 
 CLI orchestration delegates to `converter.py` (which owns the
 high-level "load + render + write" flow) and never touches `renderer.py`
@@ -96,11 +97,11 @@ three phases: **plan** (sequential, cheap — per-project staleness via
 cache mtimes, also ensures DB schema/migrations exist), **execute**
 (stale projects fan out over a `ProcessPoolExecutor` with the `spawn`
 start method, largest-first; rendering is CPU-bound pure Python and
-projects are independent, so this scales near-linearly with cores; any
-budget left over after one worker per stale project is handed to each
-project's own render fan-out, § 2.10), and **collect** (sequential —
-per-project index data is read back from the cache and the cross-project
-`index.html` is written last). Workers
+projects are independent, so this scales near-linearly with cores; when
+the per-project render fan-out is enabled, any budget left over after one
+worker per stale project is handed to it, § 2.10), and **collect**
+(sequential — per-project index data is read back from the cache and the
+cross-project `index.html` is written last). Workers
 run silent; the parent prints one progress line per project as results
 arrive. All workers share the WAL-mode SQLite cache DB — each writes
 only its own project's rows, and WAL serialises the short write
@@ -401,33 +402,71 @@ which would move ~114MB per worker. The parent sends only small per-unit
 metadata, keeps every staleness check and cache write to itself (so the DB
 stays single-writer), and the pool starts lazily on first submit.
 
-`convert_jsonl_to(render_jobs=...)` controls it. The library default is
-`1` — inline, exactly as before — so no existing caller changes behaviour.
-The CLI passes its `--jobs` budget: a single-project conversion spends all
-of it here, while `--all-projects` divides it (`jobs // stale projects`)
-so the two pool levels together never oversubscribe. `_make_render_pool`
-declines entirely for single-file mode, a missing cache manager,
-`image_export_mode="referenced"` (renders write `images/image_NNNN.png`
-from a per-call counter, so concurrent renders would collide on those
-names), and projects below the size where the pool pays for itself.
+**Memory is the binding constraint, not cores.** That self-sufficiency
+means every worker holds a full copy of the transcript, and a loaded
+transcript costs far more than its bytes on disk: measured peak RSS was
+2.0× for a 118MB/12k-message project and 3.0× for a 140MB/47k-message one
+(denser transcripts cost more per byte). So peak memory is
+`workers × project size`, and under `--all-projects` it multiplies again
+with the project pool — `project workers × render workers × project size`.
+A 1GB project is ~3GB *per process*; four render workers under two project
+workers is ~24GB. Unguarded, that exhausts RAM and drives the machine into
+swap, where it pegs every core and stops responding — a far worse outcome
+than rendering serially. `render_pool.memory_capped_workers` therefore caps
+the worker count against available memory (cgroup limit first, since inside
+a container the host's totals are a lie; then `MemAvailable`, then free
+physical pages), taking 60% of it as budget and charging one transcript
+copy per worker plus one for the conversion itself. The all-projects parent
+applies the same cap with `concurrent_projects=resolved_jobs` before
+handing out any budget, and each worker re-checks against its own project
+before starting a pool. Unknown memory allows at most 2 workers.
 
-One ordering change made this possible: the paginated writer used to
-reveal page N-1's "Next" link while generating page N, so page N's
+**Opt-in.** The fan-out is off unless `$CLAUDE_CODE_LOG_RENDER_JOBS` is
+set (`auto` for the CPU count, or an explicit worker count) — see
+`render_pool.resolve_render_jobs`. `--jobs` never enables it; it only caps
+it, so the two pool levels together can't oversubscribe. An explicit
+`convert_jsonl_to(render_jobs=N)` overrides the environment; the default
+`None` consults it. `_make_render_pool` declines regardless for
+single-file mode, a missing cache manager, `image_export_mode="referenced"`
+(renders write `images/image_NNNN.png` from a per-call counter, so
+concurrent renders would collide on those names), projects below
+`_MIN_MESSAGES_FOR_RENDER_POOL`, and machines without the memory for a
+second copy of the transcript.
+
+One ordering change made the pages parallelisable: the paginated writer
+used to reveal page N-1's "Next" link while generating page N, so page N's
 render edited page N-1's file. That fixup now runs once after all pages
 land — order-independent and idempotent.
 
-**Measured limits.** The fan-out and the memo caches in § 2.9 work against
-each other: splitting units across processes gives each worker a cold
-cache, so the page-vs-session duplication the memo removes comes back.
-On a 4-core box, a 47k-message project went 27.8s → 20.2s (1.38×) while
-total CPU rose 26.7s → 44.8s. Below roughly 12k messages the fan-out is a
-net *loss* — worker startup plus the lost memo hits exceed the parallelism
-— which is what `_MIN_MESSAGES_FOR_RENDER_POOL` guards. Machines with more
-cores absorb the inflated CPU better, so the win grows with core count,
-but the inflation itself is the ceiling. Removing it needs the two-phase
-"format once, assemble many" restructuring: format each distinct message
-once (in parallel), then assemble pages and session files from the
-fragments — template rendering itself is only ~0.08s for a 20MB page.
+**Measured** on 4 cores, 47k-message project (240 session files, 218
+output units); the serial floor — cache check, transcript load, planning,
+all in the parent and none of it parallelised — is 4.7s:
+
+| | wall | total CPU |
+|---|---|---|
+| neither optimisation | 44.8s | 43.5s |
+| memo only (§ 2.9) | 27.6s | 26.2s |
+| fan-out only (4 workers) | 22.5s | 57.0s |
+| both | **20.0s** | 48.8s |
+
+Read those together, because the pair is easy to misread. The fan-out
+parallelises perfectly well on its own — 44.8s → 22.5s is 2.0× on 4 cores
+against a 4.7s serial floor. It looks weak *on top of the memo* (27.6s →
+20.0s, 1.38×) only because the two optimisations attack the same work: the
+memo removes the page-vs-session duplication, and splitting units across
+processes gives each worker a cold cache and brings some of it back. Both
+together is still the fastest configuration, so they compose — just
+sub-additively.
+
+Two consequences. First, core count matters a lot: 48.8s of CPU over 4
+cores is 12.2s plus the 4.7s floor, so a 10-core machine should land near
+9.5s rather than 20s. Second, the per-worker cost (a full transcript
+reload plus a cold memo) grows with worker count — CPU went 26.2s → 38.2s
+→ 48.8s at 1, 2 and 4 workers — so the speedup saturates rather than
+scaling indefinitely. Removing that ceiling needs the two-phase "format
+once, assemble many" restructuring: format each distinct message once (in
+parallel), then assemble pages and session files from the fragments —
+template rendering itself is only ~0.08s for a 20MB page.
 
 ### 2.11 Diagnosing hangs (SIGUSR1 stack dump)
 

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -35,7 +35,7 @@ for user-facing operations docs see [`docs/`](../docs/).
 | Depth filter | renderer.py § Depth filtering, `models.RenderingDepth` | inlined below (§ 2.6) |
 | Image export | [`image_export.py`](../claude_code_log/image_export.py) | inlined below (§ 2.7) |
 | Performance profiling | [`renderer_timings.py`](../claude_code_log/renderer_timings.py) | inlined below (§ 2.8) |
-| Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.10) |
+| Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.11) |
 | Adding a new tool renderer | [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), `html/tool_formatters.py` | [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md) (how-to) |
 | Which tools have a specialized renderer or provider adapter | `TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` in [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), plus provider adapters | [tools-coverage.md](tools-coverage.md) (Claude and Codex status vs. upstream references) |
 | Plugin system (third-party message transformers) | [`plugins.py`](../claude_code_log/plugins.py), [`factories/priorities.py`](../claude_code_log/factories/priorities.py), `Renderer._dispatch_format` | [plugins.md](plugins.md) |
@@ -80,8 +80,9 @@ single transcript or directory. Major flags:
   output, packing whole sessions into pages of up to N messages each
   (sessions are never split across pages, so individual pages may
   overflow). Per-session HTML files are not paginated.
-- `--jobs N` / `-j N` — worker processes for the all-projects
-  conversion phase (default: CPU count; `1` disables parallelism).
+- `--jobs N` / `-j N` — total worker processes for conversion (default:
+  CPU count; `1` disables parallelism). Split between converting projects
+  in parallel and each project's own render fan-out (§ 2.10).
 
 CLI orchestration delegates to `converter.py` (which owns the
 high-level "load + render + write" flow) and never touches `renderer.py`
@@ -95,9 +96,11 @@ three phases: **plan** (sequential, cheap — per-project staleness via
 cache mtimes, also ensures DB schema/migrations exist), **execute**
 (stale projects fan out over a `ProcessPoolExecutor` with the `spawn`
 start method, largest-first; rendering is CPU-bound pure Python and
-projects are independent, so this scales near-linearly with cores),
-and **collect** (sequential — per-project index data is read back from
-the cache and the cross-project `index.html` is written last). Workers
+projects are independent, so this scales near-linearly with cores; any
+budget left over after one worker per stale project is handed to each
+project's own render fan-out, § 2.10), and **collect** (sequential —
+per-project index data is read back from the cache and the cross-project
+`index.html` is written last). Workers
 run silent; the parent prints one progress line per project as results
 arrive. All workers share the WAL-mode SQLite cache DB — each writes
 only its own project's rows, and WAL serialises the short write
@@ -380,7 +383,53 @@ Two properties matter for correctness:
 `CLAUDE_CODE_LOG_DEBUG_TIMING=1` prints hit rate, entry count and bytes
 per cache alongside the render timings.
 
-### 2.10 Diagnosing hangs (SIGUSR1 stack dump)
+### 2.10 Intra-project render fan-out
+
+[`render_pool.py`](../claude_code_log/render_pool.py) fans a single
+project's output files — its combined pages and its per-session files —
+out over worker processes. This sits *below* the project-level pool in
+§ 2.1 and exists because that one leaves cores idle in two shapes:
+the all-projects wall clock is bounded by the largest single project
+(measured: 5 real projects, 4 cores, 195s of work, 65.0s wall — exactly
+the largest project's own time, at 2.18 cores average), and an
+incremental run has only one or two stale projects to fan out at all.
+
+Workers are **self-sufficient rather than fed**: each re-loads the
+transcript from the warm cache in its `initializer` (~0.7s for a 12k-message
+project, ~1.7s for 47k) instead of receiving the parent's parsed messages,
+which would move ~114MB per worker. The parent sends only small per-unit
+metadata, keeps every staleness check and cache write to itself (so the DB
+stays single-writer), and the pool starts lazily on first submit.
+
+`convert_jsonl_to(render_jobs=...)` controls it. The library default is
+`1` — inline, exactly as before — so no existing caller changes behaviour.
+The CLI passes its `--jobs` budget: a single-project conversion spends all
+of it here, while `--all-projects` divides it (`jobs // stale projects`)
+so the two pool levels together never oversubscribe. `_make_render_pool`
+declines entirely for single-file mode, a missing cache manager,
+`image_export_mode="referenced"` (renders write `images/image_NNNN.png`
+from a per-call counter, so concurrent renders would collide on those
+names), and projects below the size where the pool pays for itself.
+
+One ordering change made this possible: the paginated writer used to
+reveal page N-1's "Next" link while generating page N, so page N's
+render edited page N-1's file. That fixup now runs once after all pages
+land — order-independent and idempotent.
+
+**Measured limits.** The fan-out and the memo caches in § 2.9 work against
+each other: splitting units across processes gives each worker a cold
+cache, so the page-vs-session duplication the memo removes comes back.
+On a 4-core box, a 47k-message project went 27.8s → 20.2s (1.38×) while
+total CPU rose 26.7s → 44.8s. Below roughly 12k messages the fan-out is a
+net *loss* — worker startup plus the lost memo hits exceed the parallelism
+— which is what `_MIN_MESSAGES_FOR_RENDER_POOL` guards. Machines with more
+cores absorb the inflated CPU better, so the win grows with core count,
+but the inflation itself is the ceiling. Removing it needs the two-phase
+"format once, assemble many" restructuring: format each distinct message
+once (in parallel), then assemble pages and session files from the
+fragments — template rendering itself is only ~0.08s for a 20MB page.
+
+### 2.11 Diagnosing hangs (SIGUSR1 stack dump)
 
 When `claude-code-log` appears stuck (100% CPU, no output), a
 single `SIGUSR1` to the running process dumps the live Python
@@ -587,6 +636,6 @@ Common entry questions and their best first stop:
 - "How do I export to JSON for downstream tooling?"
   → § 2.5 here (and `--format json` from § 2.1).
 - "claude-code-log is hung — how do I see what it's doing?"
-  → § 2.10 (`SIGUSR1` stack dump).
+  → § 2.11 (`SIGUSR1` stack dump).
 - "What's planned but not implemented?"
   → [`work/`](../work/) — each `.md` is an in-flight or proposed plan.

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -384,6 +384,35 @@ Two properties matter for correctness:
 `CLAUDE_CODE_LOG_DEBUG_TIMING=1` prints hit rate, entry count and bytes
 per cache alongside the render timings.
 
+**The fragment store sits above the leaf memo** and removes the
+page-vs-session duplication itself rather than its expensive leaves:
+[`fragment_store.py`](../claude_code_log/fragment_store.py) caches each
+message's complete formatted fragment — the `(title, html, timestamp)`
+triple `_annotate_tree_for_render` writes onto the tree — for the length
+of one conversion, so the per-session pass reuses what the combined-page
+pass formatted (measured: 64,968 lookups → 32,441 formats, a 50% hit
+rate, on a 803MB/187-file archive). One store per `convert_jsonl_to`
+call, created by `_make_fragment_store` (HTML only) and handed to the
+combined-page and session-file loops; it dies with the conversion, so
+nothing about it ever needs invalidating.
+`CLAUDE_CODE_LOG_FRAGMENT_STORE=0` disables it for bisecting.
+
+A fragment is *not* a pure function of its source entry, and the store
+carries three guards for the three ways the same message legitimately
+renders differently in different trees (each found by hash-diffing real
+projects — see `work/render-format-once.md` § 4.8): fragments embedding
+per-tree `#msg-d-{N}` anchors are never stored (output scan); a
+signature of the tree-derived render inputs (pair presence,
+`display_model`, `agent_depth`, sidechannel/collapse flags) is part of
+the store key; and `get()` verifies the stored `MessageContent` compares
+equal to the requesting tree's before serving (dataclass equality, with
+the per-tree `message_index`/`fragment_key` fields excluded via
+`compare=False`). Keys are `(id(source_entry), part_ordinal)` — entry
+identity, stamped in the pass-2 render loop — because transcript uuids
+collide across resumed/forked sessions. Renders with
+`image_export_mode="referenced"` bypass the store entirely (fragments
+imply image-file writes that replaying would skip).
+
 ### 2.10 Intra-project render fan-out
 
 [`render_pool.py`](../claude_code_log/render_pool.py) fans a single

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -421,6 +421,14 @@ applies the same cap with `concurrent_projects=resolved_jobs` before
 handing out any budget, and each worker re-checks against its own project
 before starting a pool. Unknown memory allows at most 2 workers.
 
+macOS needs its own probe: it has neither `MemAvailable` nor
+`SC_AVPHYS_PAGES`, so it fell through to that unknown-memory branch and
+every Mac was capped at 2 workers regardless of its cores or RAM — a
+16-core machine measured the whole fan-out on 2. `_darwin_available_bytes`
+shells out to `vm_stat` (present on every macOS, no dependency) and counts
+free + inactive + speculative + purgeable pages; excluding the cheaply
+reclaimable ones reports a busy Mac as having almost nothing free.
+
 **Opt-in.** The fan-out is off unless `$CLAUDE_CODE_LOG_RENDER_JOBS` is
 set (`auto` for the CPU count, or an explicit worker count) — see
 `render_pool.resolve_render_jobs`. `--jobs` never enables it; it only caps
@@ -457,6 +465,15 @@ memo removes the page-vs-session duplication, and splitting units across
 processes gives each worker a cold cache and brings some of it back. Both
 together is still the fastest configuration, so they compose — just
 sub-additively.
+
+A 16-core Mac over 8 real projects (1543MB of transcripts) confirms the
+shape at larger scale, though that run predates the macOS memory probe and
+so used only 2 render workers:
+
+| scenario | neither | memo only | both |
+|---|---|---|---|
+| full rebuild, 8 projects | 124.7s | 101.7s | 82.1s (1.24x) |
+| incremental, 1 stale project | 118.9s | 92.1s | 73.5s (1.25x) |
 
 Two consequences. First, core count matters a lot: 48.8s of CPU over 4
 cores is 12.2s plus the 4.7s floor, so a 10-core machine should land near

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -451,7 +451,10 @@ and workflow dicts, so the per-message `nodes` mapping — whose pickled
 size is the whole transcript — stays behind (its lookups raise on a slim
 tree, so a future render-path consumer of `nodes` fails loudly in a
 worker instead of silently diverging). The parent keeps every staleness
-check and cache write to itself (so the DB stays single-writer), slices
+check and cache write to itself (so the DB stays single-writer — a
+worker's own `CacheManager`, kept only for the per-session combined-link
+lookup, is constructed `read_only=True`: no migrations, no project-row
+upsert, `mode=ro` connections), slices
 session units with the same trunk predicate `generate_session` filters
 by (so the worker's re-filter of the fed slice is idempotent), and the
 pool starts lazily on first submit. `RenderPool.submit` declines a unit

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -437,35 +437,57 @@ the all-projects wall clock is bounded by the largest single project
 the largest project's own time, at 2.18 cores average), and an
 incremental run has only one or two stale projects to fan out at all.
 
-Workers are **self-sufficient for the transcript, fed for the
-fragments**: each re-loads the transcript from the warm cache in its
-`initializer` (~0.7s for a 12k-message project, ~1.7s for 47k) instead of
-receiving the parent's parsed messages, which would move ~114MB per
-worker. The parent sends only small per-unit metadata, keeps every
-staleness check and cache write to itself (so the DB stays
-single-writer), and the pool starts lazily on first submit. Formatted
-fragments do cross the boundary, though (they are plain strings + digests
-— § 2.9's store made them portable): a page worker returns its fragment
-store as a delta in its result, the parent absorbs it, and each session
-unit dispatched afterwards carries its session's slice
-(`RenderUnit.fed_fragments`), which the worker seeds its own store from.
-Pages always drain before sessions dispatch, so the feed covers
-essentially every message; every fed fragment is digest-verified on use,
-so the worst a stale slice can do is cost the recompute it would have
-cost anyway. This removes the fan-out's main CPU tax — cold workers
-re-formatting in the session pass what the page pass already formatted.
+Workers are **fed, never self-sufficient**: they do not load the
+transcript at all. Each dispatched unit carries its own slice of the
+parent's master message list (`RenderUnit.entries` — a page's sessions'
+entries, or one session's trunk + integrated agent entries), the
+master-list ordinal of each entry (`entry_ordinals`, so fragment-store
+keys name the same positions in every process), and — for session units —
+the session's slice of the parent's fragment store
+(`RenderUnit.fed_fragments`). The one per-worker piece of state is a
+*slim* `SessionTree` (`dag.slim_session_tree`, sent via the pool
+initializer): the render path reads only the DAG lines, junction points
+and workflow dicts, so the per-message `nodes` mapping — whose pickled
+size is the whole transcript — stays behind (its lookups raise on a slim
+tree, so a future render-path consumer of `nodes` fails loudly in a
+worker instead of silently diverging). The parent keeps every staleness
+check and cache write to itself (so the DB stays single-writer), slices
+session units with the same trunk predicate `generate_session` filters
+by (so the worker's re-filter of the fed slice is idempotent), and the
+pool starts lazily on first submit. `RenderPool.submit` declines a unit
+with no entry slice to the inline path, and a pool is only created when
+the conversion has a pre-built session tree — a worker-side DAG rebuild
+from a slice alone could genuinely differ.
 
-**Memory is the binding constraint, not cores.** That self-sufficiency
-means every worker holds a full copy of the transcript, and a loaded
-transcript costs far more than its bytes on disk: measured peak RSS was
-2.0× for a 118MB/12k-message project and 3.0× for a 140MB/47k-message one
-(denser transcripts cost more per byte). So peak memory is
-`workers × project size`, and under `--all-projects` it multiplies again
-with the project pool — `project workers × render workers × project size`.
-A 1GB project is ~3GB *per process*; four render workers under two project
-workers is ~24GB. Unguarded, that exhausts RAM and drives the machine into
-swap, where it pegs every core and stops responding — a far worse outcome
-than rendering serially. `render_pool.memory_capped_workers` therefore caps
+Before the feed, each worker re-loaded the whole transcript from the
+warm cache in its initializer (~0.7s at 12k messages; ~12s of CPU per
+worker at 329MB of transcript), so per-worker cost scaled with project
+size rather than unit size — measured post-fragment-feed on a 16-core
+Mac, 16 workers still burned 286.1s of CPU to do 91.1s of serial work,
+almost all of it transcript reloads, and 16 workers came out *slower*
+than 8. Feeding moves each entry at most twice per conversion (its page
+unit, then its session unit) instead of once per worker. Fragments cross
+the boundary as before (plain strings + digests — § 2.9's store made
+them portable): a page worker returns its fragment store as a delta in
+its result, the parent absorbs it, and session units dispatch afterwards
+carrying their slices. Pages always drain before sessions dispatch, so
+the feed covers essentially every message; every fed fragment is
+digest-verified on use, so the worst a stale slice can do is cost the
+recompute it would have cost anyway.
+
+**Memory: the cap still charges the old footprint.** A loaded transcript
+costs far more than its bytes on disk (measured peak RSS 2.0× for a
+118MB/12k-message project, 3.0× for 140MB/47k; denser transcripts cost
+more per byte). When workers held a full copy each, peak memory was
+`workers × project size` — multiplied again by the project pool under
+`--all-projects` — and an unguarded `auto` on a large archive exhausted
+RAM and drove the machine into swap, pegging every core: a far worse
+outcome than rendering serially. Workers now hold only their in-flight
+unit's slice, but `render_pool.memory_capped_workers` deliberately still
+charges each worker a full copy until the re-size is measured
+(`work/render-format-once.md` § 7.5) — the parent's master list, the
+absorbed fragment text and in-flight pickled slices still cost real
+memory, and the cap errs safe. It caps
 the worker count against available memory (cgroup limit first, since inside
 a container the host's totals are a lie; then `MemAvailable`, then free
 physical pages), taking 60% of it as budget and charging one transcript
@@ -494,11 +516,12 @@ below. `$CLAUDE_CODE_LOG_RENDER_JOBS` overrides: `1` or `off` disables it,
 it only caps it, so the two pool levels together can't oversubscribe. An
 explicit `convert_jsonl_to(render_jobs=N)` overrides the environment; the
 default `None` consults it. `_make_render_pool` declines regardless for
-single-file mode, a missing cache manager, `image_export_mode="referenced"`
-(renders write `images/image_NNNN.png` from a per-call counter, so
-concurrent renders would collide on those names), projects below
-`_MIN_MESSAGES_FOR_RENDER_POOL`, and machines without the memory for a
-second copy of the transcript.
+single-file mode, a missing cache manager, a missing pre-built session
+tree (workers render fed slices against the conversion's tree),
+`image_export_mode="referenced"` (renders write `images/image_NNNN.png`
+from a per-call counter, so concurrent renders would collide on those
+names), projects below `_MIN_MESSAGES_FOR_RENDER_POOL`, and machines
+without the memory the cap formula demands.
 
 One ordering change made the pages parallelisable: the paginated writer
 used to reveal page N-1's "Next" link while generating page N, so page N's
@@ -553,15 +576,24 @@ would change.
 
 Two consequences. First, core count matters a lot: 48.8s of CPU over 4
 cores is 12.2s plus the 4.7s floor, so a 10-core machine should land near
-9.5s rather than 20s. Second, the per-worker cost (a full transcript
-reload plus a cold memo) grows with worker count — CPU went 26.2s → 38.2s
-→ 48.8s at 1, 2 and 4 workers — so the speedup saturates rather than
-scaling indefinitely. Removing that ceiling needs the two-phase "format
-once, assemble many" restructuring: format each distinct message once (in
-parallel), then assemble pages and session files from the fragments —
-template rendering itself is only ~0.08s for a 20MB page. That would also
-remove the per-worker transcript copy, and with it the reason the memory
-cap has to be so conservative. Planned in
+9.5s rather than 20s. Second, the per-worker cost (then: a full
+transcript reload plus a cold memo) grows with worker count, so the
+speedup saturates rather than scaling indefinitely.
+
+Those tables predate the fragment feed and the entry feed, which removed
+most of that per-worker cost in two steps. Re-measured on an 8-core VM
+over the same 8-project archive (1539MB): with fragments fed, the
+incremental scenario reached 2.08x at +76% CPU over serial (the
+pre-feed baseline burned +305%); with entries fed as well — no worker
+transcript loads at all — it reached **2.87x at +3% CPU** (62.6s →
+21.8s wall, 62.5s CPU vs 60.5s serial), and the single-project sweep's
+per-worker CPU overhead fell from ~4.4s to ~0.7s at 8 workers. What
+remains unsolved is the full-rebuild scenario (the project pool grants
+each conversion too few render workers — the still-unrevised memory cap
+alone caps a 16GB machine at 1 worker/project) and the serial parent
+floor (load + parse + plan). Both land with the remaining
+"format once, assemble many" steps — the flat pool over render units
+and the § 7.5 threshold/cap re-size. Planned in
 [`work/render-format-once.md`](../work/render-format-once.md).
 
 ### 2.11 Diagnosing hangs (SIGUSR1 stack dump)

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -478,26 +478,29 @@ the feed covers essentially every message; every fed fragment is
 digest-verified on use, so the worst a stale slice can do is cost the
 recompute it would have cost anyway.
 
-**Memory: the cap still charges the old footprint.** A loaded transcript
-costs far more than its bytes on disk (measured peak RSS 2.0× for a
-118MB/12k-message project, 3.0× for 140MB/47k; denser transcripts cost
-more per byte). When workers held a full copy each, peak memory was
-`workers × project size` — multiplied again by the project pool under
-`--all-projects` — and an unguarded `auto` on a large archive exhausted
-RAM and drove the machine into swap, pegging every core: a far worse
-outcome than rendering serially. Workers now hold only their in-flight
-unit's slice, but `render_pool.memory_capped_workers` deliberately still
-charges each worker a full copy until the re-size is measured
-(`work/render-format-once.md` § 7.5) — the parent's master list, the
-absorbed fragment text and in-flight pickled slices still cost real
-memory, and the cap errs safe. It caps
-the worker count against available memory (cgroup limit first, since inside
-a container the host's totals are a lie; then `MemAvailable`, then free
-physical pages), taking 60% of it as budget and charging one transcript
-copy per worker plus one for the conversion itself. The all-projects parent
-applies the same cap with `concurrent_projects=resolved_jobs` before
-handing out any budget, and each worker re-checks against its own project
-before starting a pool. Unknown memory allows at most 2 workers.
+**Memory: the cap charges measured post-feeding footprints.** The
+conversion *parent* is the heavyweight — its master entry list (Pydantic
+entries, TemplateMessage tree, SessionTree) plus the fragment store's
+text and in-flight pickled slices measured ~4.4× the transcript's bytes
+on disk (598MB on a 140MB/47k-message project, 1458MB on 329MB/97k; VmHWM
+polling, 2026-08-26). Fed workers hold only base imports, their memo
+caches and the in-flight unit's slice: the largest worker measured
+~136MB + 0.59× transcript across the same runs.
+`render_pool.memory_capped_workers` charges the parent 4.5× + base and
+each worker 0.8× + base — a ~1.2–1.35× margin over the fit, because the
+alternative failure mode is real: when workers each held a full copy, an
+unguarded `auto` on a large archive exhausted RAM and drove the machine
+into swap, pegging every core — far worse than rendering serially. (The
+one under-charged pathology is a single session spanning most of the
+transcript, whose unit slice re-inflates toward the parent's ~3× in its
+worker; it is one outlier inside the headroom, and such projects yield
+too few units to fan wide.) The cap reads available memory as cgroup
+limit first (inside a container the host's totals are a lie), then
+`MemAvailable`, then free physical pages, taking 60% of it as budget.
+The all-projects parent applies the same cap with
+`concurrent_projects=resolved_jobs` before handing out any budget, and
+each worker re-checks against its own project before starting a pool.
+Unknown memory allows at most 2 workers.
 
 Both non-Linux platforms need their own probe, since each would otherwise
 fall through to that unknown-memory branch and be capped at 2 workers
@@ -572,10 +575,14 @@ the run is, to within 8%, "how long does the biggest project take". The
 static budget split then gives that project `jobs // stale projects` = 2
 render workers while the seven small ones finish and 13 cores go idle. So
 the fan-out helps it barely (1.27x) even though the same project alone
-reaches 2.70x. Fixing it needs the split to be dynamic — budget handed
-back as projects complete — or a single flat pool over render units rather
-than two nested levels. § 2.1's `per_project_render_jobs` is where that
-would change.
+reaches 2.70x. The *dominant-project* form of this is now handled by
+hold-back: `_dominant_plan` (2x the runner-up, compared on cached
+message counts when available — bytes alone would miss a dense giant)
+keeps that project out of the pool and converts it last with the full
+render budget, measured 65.4s → 58.5s (1.12x) on the 8-core VM, where
+the 47k-message runner-up then bounds the pool. Fixing the general case
+— several level-sized projects — still needs the split to be dynamic, or
+a single flat pool over render units rather than two nested levels.
 
 Two consequences. First, core count matters a lot: 48.8s of CPU over 4
 cores is 12.2s plus the 4.7s floor, so a 10-core machine should land near
@@ -590,13 +597,17 @@ incremental scenario reached 2.08x at +76% CPU over serial (the
 pre-feed baseline burned +305%); with entries fed as well — no worker
 transcript loads at all — it reached **2.87x at +3% CPU** (62.6s →
 21.8s wall, 62.5s CPU vs 60.5s serial), and the single-project sweep's
-per-worker CPU overhead fell from ~4.4s to ~0.7s at 8 workers. What
-remains unsolved is the full-rebuild scenario (the project pool grants
-each conversion too few render workers — the still-unrevised memory cap
-alone caps a 16GB machine at 1 worker/project) and the serial parent
-floor (load + parse + plan). Both land with the remaining
-"format once, assemble many" steps — the flat pool over render units
-and the § 7.5 threshold/cap re-size. Planned in
+per-worker CPU overhead fell from ~4.4s to ~0.7s at 8 workers. With the
+memory cap re-sized to the measured post-feeding footprints (above),
+the same VM's incremental cap went 5 → 8 of 8 workers and the scenario
+reached **3.24x at +6% CPU** (61.8s → 19.1s wall, 63.3s CPU vs 59.5s
+serial), byte-identical in every configuration. The full-rebuild
+scenario improved to 1.12x via the dominant-project hold-back (above);
+what remains is its general case — several level-sized projects, where
+the *core* split `jobs // stale` still grants 1 render worker/project —
+and the serial parent floor (load + parse + plan). Both land with the
+remaining "format once, assemble many" step: the flat pool over render
+units. Planned in
 [`work/render-format-once.md`](../work/render-format-once.md).
 
 ### 2.11 Diagnosing hangs (SIGUSR1 stack dump)

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -596,14 +596,26 @@ the run is, to within 8%, "how long does the biggest project take". The
 static budget split then gives that project `jobs // stale projects` = 2
 render workers while the seven small ones finish and 13 cores go idle. So
 the fan-out helps it barely (1.27x) even though the same project alone
-reaches 2.70x. The *dominant-project* form of this is now handled by
-hold-back: `_dominant_plan` (2x the runner-up, compared on cached
-message counts when available — bytes alone would miss a dense giant)
-keeps that project out of the pool and converts it last with the full
-render budget, measured 65.4s → 58.5s (1.12x) on the 8-core VM, where
-the 47k-message runner-up then bounds the pool. Fixing the general case
-— several level-sized projects — still needs the split to be dynamic, or
-a single flat pool over render units rather than two nested levels.
+reaches 2.70x. Pool-bounding projects are now handled by hold-back:
+`_holdback_plans` runs a greedy makespan comparison, largest first
+(hold while `pool(rest) + fanned(largest)` beats pooling everything,
+with fanned time from the conservative `_fanned_speedup` of the
+workers a lone memory-capped conversion would get), keeps what it
+holds out of the pool and converts each alone with the full render
+budget afterwards. Costs compare cached message counts when every
+plan has one (bytes alone would miss a dense giant), bytes otherwise.
+On the reference archive it holds exactly the 97k giant — measured
+65.4s → 58.5s (1.12x) on the 8-core VM under the original
+single-dominant rule, whose decision the general rule reproduces
+there, since the twin 47k projects keep each other's pool bounded —
+and it additionally covers shapes the 2x-dominance bar missed, such
+as a runner-up that bounds a pool of small projects without being 2x
+any of them. What it deliberately never does is serialize level-sized
+projects (a certain loss — they already saturate the pool) or hold
+anything a machine can't actually fan. Fixing the truly general case —
+several level-sized projects sharing one static split — still needs
+the split to be dynamic, or a single flat pool over render units
+rather than two nested levels.
 
 Two consequences. First, core count matters a lot: 48.8s of CPU over 4
 cores is 12.2s plus the 4.7s floor, so a 10-core machine should land near
@@ -623,12 +635,13 @@ memory cap re-sized to the measured post-feeding footprints (above),
 the same VM's incremental cap went 5 → 8 of 8 workers and the scenario
 reached **3.24x at +6% CPU** (61.8s → 19.1s wall, 63.3s CPU vs 59.5s
 serial), byte-identical in every configuration. The full-rebuild
-scenario improved to 1.12x via the dominant-project hold-back (above);
-what remains is its general case — several level-sized projects, where
-the *core* split `jobs // stale` still grants 1 render worker/project —
-and the serial parent floor (load + parse + plan). Both land with the
-remaining "format once, assemble many" step: the flat pool over render
-units. Planned in
+scenario improved to 1.12x via the hold-back (above, since
+generalized from the single-dominant rule to the greedy makespan
+comparison); what remains is its general case — several level-sized
+projects, where the *core* split `jobs // stale` still grants 1
+render worker/project — and the serial parent floor (load + parse +
+plan). Both land with the remaining "format once, assemble many"
+step: the flat pool over render units. Planned in
 [`work/render-format-once.md`](../work/render-format-once.md).
 
 ### 2.11 Diagnosing hangs (SIGUSR1 stack dump)

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -434,12 +434,13 @@ ones reports a busy Mac as having almost nothing free. Windows has no
 returns None rather than raising, so an unreadable platform stays
 conservative instead of failing a conversion.
 
-**Opt-in.** The fan-out is off unless `$CLAUDE_CODE_LOG_RENDER_JOBS` is
-set (`auto` for the CPU count, or an explicit worker count) — see
-`render_pool.resolve_render_jobs`. `--jobs` never enables it; it only caps
-it, so the two pool levels together can't oversubscribe. An explicit
-`convert_jsonl_to(render_jobs=N)` overrides the environment; the default
-`None` consults it. `_make_render_pool` declines regardless for
+**On by default** at the CPU count, settled by the 16-core measurement
+below. `$CLAUDE_CODE_LOG_RENDER_JOBS` overrides: `1` or `off` disables it,
+`auto` is the default, an integer pins a count — see
+`render_pool.resolve_render_jobs`. `--jobs` never enables or disables it;
+it only caps it, so the two pool levels together can't oversubscribe. An
+explicit `convert_jsonl_to(render_jobs=N)` overrides the environment; the
+default `None` consults it. `_make_render_pool` declines regardless for
 single-file mode, a missing cache manager, `image_export_mode="referenced"`
 (renders write `images/image_NNNN.png` from a per-call counter, so
 concurrent renders would collide on those names), projects below
@@ -471,14 +472,31 @@ processes gives each worker a cold cache and brings some of it back. Both
 together is still the fastest configuration, so they compose — just
 sub-additively.
 
-A 16-core Mac over 8 real projects (1543MB of transcripts) confirms the
-shape at larger scale, though that run predates the macOS memory probe and
-so used only 2 render workers:
+A 16-core Mac over 8 real projects (1543MB of transcripts, largest 329MB)
+shows what happens with cores to spare — and why the two `--all-projects`
+scenarios diverge so sharply:
 
-| scenario | neither | memo only | both |
-|---|---|---|---|
-| full rebuild, 8 projects | 124.7s | 101.7s | 82.1s (1.24x) |
-| incremental, 1 stale project | 118.9s | 92.1s | 73.5s (1.25x) |
+| scenario | config | wall | CPU | cores used |
+|---|---|---|---|---|
+| full rebuild, 8 projects | memo only | 100.8s | 226.0s | 2.2 of 16 |
+| full rebuild, 8 projects | both | 79.3s (1.27x) | 324.8s | 4.1 of 16 |
+| incremental, 1 stale | memo only | 93.2s | 90.8s | 1.0 of 16 |
+| incremental, 1 stale | both | **34.6s (2.70x)** | 367.9s | 10.6 of 16 |
+
+The incremental row is what flipped the default: 2.70x on the everyday
+shape of a run, using 10.6 cores instead of 1.
+
+The full-rebuild row is the *unsolved* case, and the numbers say exactly
+why. Converting the largest project alone takes 93.2s; converting all
+eight takes 100.8s. The other seven cost 7.6s of wall clock between them —
+the run is, to within 8%, "how long does the biggest project take". The
+static budget split then gives that project `jobs // stale projects` = 2
+render workers while the seven small ones finish and 13 cores go idle. So
+the fan-out helps it barely (1.27x) even though the same project alone
+reaches 2.70x. Fixing it needs the split to be dynamic — budget handed
+back as projects complete — or a single flat pool over render units rather
+than two nested levels. § 2.1's `per_project_render_jobs` is where that
+would change.
 
 Two consequences. First, core count matters a lot: 48.8s of CPU over 4
 cores is 12.2s plus the 4.7s floor, so a 10-core machine should land near

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -404,10 +404,23 @@ projects — see `work/render-format-once.md` § 4.8): fragments embedding
 per-tree `#msg-d-{N}` anchors are never stored (output scan); a
 signature of the tree-derived render inputs (pair presence,
 `display_model`, `agent_depth`, sidechannel/collapse flags) is part of
-the store key; and `get()` verifies the stored `MessageContent` compares
-equal to the requesting tree's before serving (dataclass equality, with
-the per-tree `message_index`/`fragment_key` fields excluded via
-`compare=False`). Keys are `(id(source_entry), part_ordinal)` — entry
+the store key; and `get()` verifies the requesting tree's content
+digest matches the one stored at `put` time before serving.
+`fragment_store.content_digest` is a canonical BLAKE2b walk over
+exactly the compare-relevant state — same field coverage as dataclass
+equality, with the per-tree `message_index`/`fragment_key` fields
+excluded via `compare=False`, and any looseness of Python `==` that
+the canonical form can't express (bool/int, dict order,
+identity-`repr` objects) resolving to a conflict served fresh, never
+a false hit. A digest is stored rather than the content object so the
+store holds only strings and bytes — picklable, spillable, and unable
+to pin object graphs — the property the planned fed-worker format
+phase depends on. On the reference 803MB archive this is peak-RSS-
+neutral (measured 1521MB either way: the stored contents alias
+objects the master entry list keeps alive, and the store-on peak of
++269MB over store-off is the 186MB of fragment text plus per-entry
+overhead), so the fragment text itself is what any future memory
+bounding must address. Keys are `(id(source_entry), part_ordinal)` — entry
 identity, stamped in the pass-2 render loop — because transcript uuids
 collide across resumed/forked sessions. Renders with
 `image_export_mode="referenced"` bypass the store entirely (fragments

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -334,6 +334,19 @@ Default is `embedded` for HTML (single self-contained file) and
 `referenced` for Markdown (keeps the `.md` text small and lets
 images live as separate PNGs alongside).
 
+Referenced filenames are **content-addressed** — `images/image_<digest>.<ext>`
+from a BLAKE2b digest of the decoded bytes — so a given image maps to
+exactly one file no matter which render pass, run, or worker process
+exports it, and re-exporting is idempotent (an existing file is already
+the right bytes; writers go through a unique temp file + atomic
+`os.replace`, so concurrent exporters of the same image replace
+identical content). This replaced a per-render counter whose names
+collided between the combined-page and per-session passes — each pass
+restarted at `image_0001` and assigned the same names to different
+images, so the last pass to run overwrote the other's files. Content
+addressing is also what lets referenced-mode renders use the fragment
+store (§ 2.9) and the render fan-out (§ 2.10).
+
 ### 2.8 Performance profiling
 
 [`renderer_timings.py`](../claude_code_log/renderer_timings.py)
@@ -423,8 +436,11 @@ overhead), so the fragment text itself is what any future memory
 bounding must address. Keys are `(id(source_entry), part_ordinal)` — entry
 identity, stamped in the pass-2 render loop — because transcript uuids
 collide across resumed/forked sessions. Renders with
-`image_export_mode="referenced"` bypass the store entirely (fragments
-imply image-file writes that replaying would skip).
+`image_export_mode="referenced"` participate like any other: image
+filenames are content-addressed (§ 2.7), so a stored fragment's
+`src=` names the file the first formatting of that message already
+wrote, and replaying the fragment skips only a write that has
+happened.
 
 ### 2.10 Intra-project render fan-out
 
@@ -524,10 +540,15 @@ explicit `convert_jsonl_to(render_jobs=N)` overrides the environment; the
 default `None` consults it. `_make_render_pool` declines regardless for
 single-file mode, a missing cache manager, a missing pre-built session
 tree (workers render fed slices against the conversion's tree),
-`image_export_mode="referenced"` (renders write `images/image_NNNN.png`
-from a per-call counter, so concurrent renders would collide on those
-names), projects below `_MIN_MESSAGES_FOR_RENDER_POOL`, and machines
-without the memory the cap formula demands.
+projects below `_MIN_MESSAGES_FOR_RENDER_POOL`, and machines without
+the memory the cap formula demands.
+`image_export_mode="referenced"` used to decline too, when renders
+allocated `images/image_NNNN.png` names from a per-call counter that
+collided across passes and processes; referenced filenames are now
+content-addressed (`image_export.export_image` digests the decoded
+bytes and writes via temp-file + atomic replace), so any pass, run, or
+worker exporting the same image converges on the same file and the
+mode fans out like any other.
 
 One ordering change made the pages parallelisable: the paginated writer
 used to reveal page N-1's "Next" link while generating page N, so page N's

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -437,12 +437,23 @@ the all-projects wall clock is bounded by the largest single project
 the largest project's own time, at 2.18 cores average), and an
 incremental run has only one or two stale projects to fan out at all.
 
-Workers are **self-sufficient rather than fed**: each re-loads the
-transcript from the warm cache in its `initializer` (~0.7s for a 12k-message
-project, ~1.7s for 47k) instead of receiving the parent's parsed messages,
-which would move ~114MB per worker. The parent sends only small per-unit
-metadata, keeps every staleness check and cache write to itself (so the DB
-stays single-writer), and the pool starts lazily on first submit.
+Workers are **self-sufficient for the transcript, fed for the
+fragments**: each re-loads the transcript from the warm cache in its
+`initializer` (~0.7s for a 12k-message project, ~1.7s for 47k) instead of
+receiving the parent's parsed messages, which would move ~114MB per
+worker. The parent sends only small per-unit metadata, keeps every
+staleness check and cache write to itself (so the DB stays
+single-writer), and the pool starts lazily on first submit. Formatted
+fragments do cross the boundary, though (they are plain strings + digests
+— § 2.9's store made them portable): a page worker returns its fragment
+store as a delta in its result, the parent absorbs it, and each session
+unit dispatched afterwards carries its session's slice
+(`RenderUnit.fed_fragments`), which the worker seeds its own store from.
+Pages always drain before sessions dispatch, so the feed covers
+essentially every message; every fed fragment is digest-verified on use,
+so the worst a stale slice can do is cost the recompute it would have
+cost anyway. This removes the fan-out's main CPU tax — cold workers
+re-formatting in the session pass what the page pass already formatted.
 
 **Memory is the binding constraint, not cores.** That self-sufficiency
 means every worker holds a full copy of the transcript, and a loaded

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -421,13 +421,18 @@ applies the same cap with `concurrent_projects=resolved_jobs` before
 handing out any budget, and each worker re-checks against its own project
 before starting a pool. Unknown memory allows at most 2 workers.
 
-macOS needs its own probe: it has neither `MemAvailable` nor
-`SC_AVPHYS_PAGES`, so it fell through to that unknown-memory branch and
-every Mac was capped at 2 workers regardless of its cores or RAM — a
-16-core machine measured the whole fan-out on 2. `_darwin_available_bytes`
-shells out to `vm_stat` (present on every macOS, no dependency) and counts
-free + inactive + speculative + purgeable pages; excluding the cheaply
-reclaimable ones reports a busy Mac as having almost nothing free.
+Both non-Linux platforms need their own probe, since each would otherwise
+fall through to that unknown-memory branch and be capped at 2 workers
+regardless of cores or RAM — a 16-core Mac measured the whole fan-out on
+2 before this was fixed. macOS has neither `MemAvailable` nor
+`SC_AVPHYS_PAGES`: `_darwin_available_bytes` shells out to `vm_stat`
+(present on every macOS, no dependency) and counts free + inactive +
+speculative + purgeable pages, since excluding the cheaply reclaimable
+ones reports a busy Mac as having almost nothing free. Windows has no
+`/proc` and no `os.sysconf` at all: `_windows_available_bytes` reads
+`ullAvailPhys` from `GlobalMemoryStatusEx` via `ctypes`. Every probe
+returns None rather than raising, so an unreadable platform stays
+conservative instead of failing a conversion.
 
 **Opt-in.** The fan-out is off unless `$CLAUDE_CODE_LOG_RENDER_JOBS` is
 set (`auto` for the CPU count, or an explicit worker count) — see

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -35,7 +35,7 @@ for user-facing operations docs see [`docs/`](../docs/).
 | Depth filter | renderer.py § Depth filtering, `models.RenderingDepth` | inlined below (§ 2.6) |
 | Image export | [`image_export.py`](../claude_code_log/image_export.py) | inlined below (§ 2.7) |
 | Performance profiling | [`renderer_timings.py`](../claude_code_log/renderer_timings.py) | inlined below (§ 2.8) |
-| Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.9) |
+| Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.10) |
 | Adding a new tool renderer | [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), `html/tool_formatters.py` | [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md) (how-to) |
 | Which tools have a specialized renderer or provider adapter | `TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` in [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), plus provider adapters | [tools-coverage.md](tools-coverage.md) (Claude and Codex status vs. upstream references) |
 | Plugin system (third-party message transformers) | [`plugins.py`](../claude_code_log/plugins.py), [`factories/priorities.py`](../claude_code_log/factories/priorities.py), `Renderer._dispatch_format` | [plugins.md](plugins.md) |
@@ -338,7 +338,49 @@ provides `log_timing(label, t_start)` context managers used throughout
 times to stderr — useful for spotting which phase regressed when a
 large transcript suddenly takes seconds longer than before.
 
-### 2.9 Diagnosing hangs (SIGUSR1 stack dump)
+### 2.9 Render memo caches
+
+A project conversion renders every message **twice**: once into its
+combined-transcript page and once into its individual `session-*.html`.
+Both go through `HtmlRenderer.generate`, which rebuilds the tree from the
+same source entries, so the per-message formatting work is duplicated
+wholesale. On a 118-file, 12k-message project that is 22,420
+`format_content` calls covering 11,113 distinct messages.
+
+[`render_cache.py`](../claude_code_log/render_cache.py) memoizes the two
+dominant leaves of that work — Pygments highlighting
+(`html/renderer_code.py::highlight_code_with_pygments`) and mistune
+Markdown (`html/utils.py::_render_markdown_memoized`, behind
+`render_markdown` / `render_user_markdown` / `render_markdown_inline`).
+Measured effect on that project: 12.4s → 8.7s wall, with all 88 output
+files byte-identical. Hit rates run ~69% (Pygments) and ~59% (Markdown);
+Pygments exceeds the 50% that page-vs-session duplication alone implies
+because the same file contents are commonly re-read across messages.
+
+Two properties matter for correctness:
+
+- **Markdown is not a pure function of its text.** The SHA-linkifier
+  plugin resolves commit hashes against the per-render repo cwd carried
+  by `git_remote._render_repo_cwd` (read via `current_render_repo_cwd()`),
+  so identical text legitimately renders different links in different
+  projects. That cwd is part of the Markdown key — without it a
+  long-lived host (`serve`, the TUI) would serve one project's commit
+  links inside another's page. Pygments has no such coupling and keys on
+  its arguments alone.
+- **Bounded by bytes, not entries.** Rendered fragments are large, so
+  `functools.lru_cache(maxsize=N)` gives no control over footprint. The
+  caches evict LRU against a byte budget and refuse any single entry
+  above 1/8 of it, so one huge highlighted file cannot evict everything
+  behind it. `CLAUDE_CODE_LOG_RENDER_CACHE_MB` sets the budget (default
+  192 MB per cache; `0` disables memoization and restores the previous
+  always-recompute behaviour). Typical projects stay far under it — the
+  measured project held 13.3 MB of Pygments and 2.7 MB of Markdown with
+  zero evictions.
+
+`CLAUDE_CODE_LOG_DEBUG_TIMING=1` prints hit rate, entry count and bytes
+per cache alongside the render timings.
+
+### 2.10 Diagnosing hangs (SIGUSR1 stack dump)
 
 When `claude-code-log` appears stuck (100% CPU, no output), a
 single `SIGUSR1` to the running process dumps the live Python
@@ -545,6 +587,6 @@ Common entry questions and their best first stop:
 - "How do I export to JSON for downstream tooling?"
   → § 2.5 here (and `--format json` from § 2.1).
 - "claude-code-log is hung — how do I see what it's doing?"
-  → § 2.9 (`SIGUSR1` stack dump).
+  → § 2.10 (`SIGUSR1` stack dump).
 - "What's planned but not implemented?"
   → [`work/`](../work/) — each `.md` is an in-flight or proposed plan.

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -409,6 +409,16 @@ call, created by `_make_fragment_store` (HTML only) and handed to the
 combined-page and session-file loops; it dies with the conversion, so
 nothing about it ever needs invalidating.
 `CLAUDE_CODE_LOG_FRAGMENT_STORE=0` disables it for bisecting.
+Because the store is a RAM-for-CPU trade — measured serial peaks on the
+803MB reference project: 1252MB store-off vs 1521MB store-on, the
++269MB being the fragment text plus per-entry overhead —
+`_make_fragment_store` carries a memory valve: when available memory is
+under `_FRAGMENT_STORE_MIN_AVAILABLE_PER_BYTE` (2.4×, the store-on peak
+plus margin) times the project's transcript bytes, the conversion runs
+store-less at its pre-store footprint instead of trading its last RAM
+for CPU. An explicit `CLAUDE_CODE_LOG_FRAGMENT_STORE=1` overrides the
+valve; whenever the valve trips, the render pool's far higher memory
+bar has already declined, so a store-less conversion is always serial.
 
 A fragment is *not* a pure function of its source entry, and the store
 carries three guards for the three ways the same message legitimately

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -506,7 +506,10 @@ reload plus a cold memo) grows with worker count — CPU went 26.2s → 38.2s
 scaling indefinitely. Removing that ceiling needs the two-phase "format
 once, assemble many" restructuring: format each distinct message once (in
 parallel), then assemble pages and session files from the fragments —
-template rendering itself is only ~0.08s for a 20MB page.
+template rendering itself is only ~0.08s for a 20MB page. That would also
+remove the per-worker transcript copy, and with it the reason the memory
+cap has to be so conservative. Planned in
+[`work/render-format-once.md`](../work/render-format-once.md).
 
 ### 2.11 Diagnosing hangs (SIGUSR1 stack dump)
 

--- a/foldyard.toml
+++ b/foldyard.toml
@@ -140,6 +140,20 @@ name = "just"
 check = "command -v just"
 install = "apt-get install -y --no-install-recommends just"
 
+# `uv run pyright` (the `just ci` typecheck leg) needs a Node runtime: the pyright PyPI
+# package is a thin wrapper that BUNDLES the pyright JS inside its wheel and prefers a
+# global `node` from PATH (PYRIGHT_PYTHON_GLOBAL_NODE defaults on). Without one it falls
+# back to nodeenv, which fetches a node tarball from nodejs.org — denied by the wall.
+# Debian's nodejs (v20) satisfies it outright, so this is the whole fix: no npm, no
+# registry.npmjs.org grant (only the PYRIGHT_PYTHON_FORCE_VERSION escape hatch would npm-
+# install a non-bundled version), and the wrapper's update check uses the already-granted
+# pypi.org JSON API with a 1s timeout that fails silent. Verified in-box: apt nodejs alone
+# takes `uv run pyright` from the nodeenv RuntimeError to a clean run.
+[[box.tools]]
+name = "nodejs-for-pyright"
+check = "command -v node"
+install = "apt-get install -y --no-install-recommends nodejs"
+
 # Browser tests (`just test-browser`, `uv run pytest -m browser`) need Chromium's shared
 # libraries in the box. On Debian, `playwright install-deps` is the supported path: playwright
 # itself owns the apt list for the browser build the lockfile pins, so a Chromium bump can't

--- a/foldyard.toml
+++ b/foldyard.toml
@@ -37,34 +37,33 @@ memory_mib = 16384   # MiB — any whole number
 disk_gib = 60
 
 # Egress proxy. Declaring [proxy] routes the box's egress through the Mac proxy — REQUIRED
-# by the wall (which otherwise leaves the box with no way out). Locked down: only the
-# bootstrap hosts below are allowed; anything else is denied and shows live in `fy tui`,
-# where you can grant it. Any keyless host (below) is ALWAYS allowed implicitly — never
-# list it.
+# by the wall (which otherwise leaves the box with no way out). Locked down: anything not
+# granted is denied and shows live in `fy tui`, where you can grant it. Any keyless host
+# (below) is ALWAYS allowed implicitly — never list it.
+#
+# Per-host GRANTS do not live in this file (the box can write it — `fy config widenings`
+# explains); `default_deny` below only SEEDS the first answer, `fy allow wall on|off` is the
+# switch from then on. `recommend` is the committed, team-shared half: each entry is OFFERED
+# per host at `fy up`/`fy allow sync`/the TUI's wall pane, and becomes a grant only on that
+# machine's operator's yes.
 [proxy]
 default_deny = true
-# git fetch/clone; uv/pip (box bootstrap + deps); dnf for [[box.tools]], pinned to the
-# master mirror dl.fedoraproject.org by the dnf-direct-mirror step below (the default
-# mirror system redirects to arbitrary hosts no allowlist can name); the playwright
-# browser bundles; and unpkg.com, which the generated transcript pages load vis-timeline
-# from (the browser test suite renders them).
-#
-# downloads.claude.ai is `claude --upgrade` (and `claude plugin`): the version manifest,
-# the release binaries, and the official plugin marketplace all sit under
-# /claude-code-releases on that one host. It is NOT the keyless host — api.anthropic.com
-# is, and it's allowed implicitly — so this needs listing, and it carries no credential:
-# a public CDN serving signed release artefacts. Without it the updater fails with
-# "proxy refused the connection" and the box stays pinned at whatever version it was
-# built with.
-allow = [
-  "github.com",
-  "pypi.org",
-  "*.pypi.org",
-  "files.pythonhosted.org",
-  "*.fedoraproject.org",
-  "cdn.playwright.dev",
-  "unpkg.com",
-  "downloads.claude.ai",
+recommend = [
+  { host = "github.com", why = "git fetch/clone + release-asset redirects" },
+  { host = "objects.githubusercontent.com", why = "GitHub release assets CDN — uv-managed Python (python-build-standalone)" },
+  { host = "release-assets.githubusercontent.com", why = "GitHub release assets CDN (newer host, same role)" },
+  { host = "pypi.org", why = "uv/pip — box bootstrap + deps" },
+  { host = "*.pypi.org", why = "uv/pip mirrors" },
+  { host = "files.pythonhosted.org", why = "uv/pip package downloads" },
+  { host = "deb.debian.org", why = "apt — [[box.tools]] system packages + playwright install-deps" },
+  { host = "registry-1.docker.io", why = "box image build — debian base image manifest/blobs" },
+  { host = "auth.docker.io", why = "box image build — Docker Hub auth token for the base pull" },
+  { host = "production.cloudfront.docker.com", why = "box image build — Docker Hub blob CDN" },
+  { host = "ghcr.io", why = "box image build — the uv binary image layer" },
+  { host = "pkg-containers.githubusercontent.com", why = "box image build — ghcr.io blob storage" },
+  { host = "cdn.playwright.dev", why = "playwright browser bundles" },
+  { host = "unpkg.com", why = "vis-timeline, loaded by generated transcript pages (the browser test suite renders them)" },
+  { host = "downloads.claude.ai", why = "claude --upgrade / claude plugin — public CDN of signed release artefacts (NOT the keyless host; api.anthropic.com is implicit)" },
 ]
 # passthrough = ["@all"]   # hosts tunnelled UN-decrypted under default_deny (the toolchain)
 
@@ -100,77 +99,63 @@ foldyard.toml.
 [box]
 # Shared named volumes mounted into the box at a $HOME-relative path, so they survive box
 # recreation. Playwright's browser bundle is ~900 MB — without this, every fresh box
-# re-downloads it through the proxy. The dnf volume pairs with the dnf-keepcache step
-# below: metadata and kept RPMs land in ~/.cache/dnf, so a rebuilt box installs its
-# tools from cache instead of re-downloading from the master mirror. The uv volume spares
-# the wheel downloads on every rebuild.
+# re-downloads it through the proxy. The apt volume pairs with the apt-keepcache step
+# below: downloaded .debs land in ~/.cache/apt, so a rebuilt box installs its tools from
+# cache instead of re-downloading from deb.debian.org. The uv volumes spare the wheel
+# downloads AND the uv-managed Python (the Debian slim base ships none — uv provisions its
+# own from python-build-standalone) on every rebuild.
 caches = [
   { volume = "devbox_playwright", path = ".cache/ms-playwright" },
-  { volume = "devbox_dnf", path = ".cache/dnf" },
+  { volume = "devbox_apt", path = ".cache/apt" },
   { volume = "devbox_uv", path = ".cache/uv" },
+  { volume = "devbox_uv_python", path = ".local/share/uv" },
 ]
 shadow_volumes = [".venv"]                      # masks the host bind mount at that subpath
 warmup = [{ dir = ".", run = "uv sync" }]       # populate it — it starts empty
 env = { UV_LINK_MODE = "copy" }                 # venv volume ≠ cache volume ⇒ no hardlinks
 
 # Consumer tools installed once per fresh box, as MONITORED steps (reported ✓/✗). They run
-# as root, in the checkout, before the deps warm-up.
-#
-# The Fedora repos ship pointing at the mirror system: dnf resolves a metalink at
-# mirrors.fedoraproject.org, which hands every fetch to an arbitrary volunteer mirror —
-# unpredictable hostnames that can never sit in a proxy allowlist. Pin the two enabled
-# repos to the project's master mirror instead (direct downloads, no redirect, covered by
-# "*.fedoraproject.org" in [proxy] allow), and switch off the openh264 repo, whose payload
-# lives on Cisco's CDN and which nothing here installs from. Must stay ABOVE the dnf steps
-# below — [[box.tools]] run in order.
-[[box.tools]]
-name = "dnf-direct-mirror"
-check = "grep -q '^baseurl=https://dl.fedoraproject.org' /etc/yum.repos.d/fedora.repo"
-install = "sed -i -e 's|^metalink=|#metalink=|' -e 's|^#baseurl=http://download.example/pub/fedora/linux|baseurl=https://dl.fedoraproject.org/pub/fedora/linux|' /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora-updates.repo && sed -i '0,/^enabled=1/s//enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo"
+# as root, in the checkout, before the deps warm-up. The box is Debian (foldyard's generic
+# base, debian:trixie-slim), so apt pulls everything from the one allowlisted
+# deb.debian.org.
 
-# Keep downloaded RPMs (dnf discards them after install by default) and move the whole
-# dnf cache — metadata + packages — under ~/.cache/dnf, where the devbox_dnf volume in
-# [box] caches above persists it across box recreations. A rebuilt box then installs its
-# tools from cache: zero mirror traffic when the metadata is still fresh, ~600 KB of
-# metadata revalidation from the (allowlisted) master mirror when it isn't. The lines are
-# appended to dnf.conf's [main] section, which the stock file ends in. Verified in-box:
-# with egress fully denied, `dnf install` of a cached package succeeds. Must also stay
-# ABOVE the dnf install steps below.
+# Keep downloaded .debs (apt normally discards them, and the slim image ships a docker-clean
+# hook that deletes them on sight) in ~/.cache/apt, where the devbox_apt volume in [box]
+# caches above persists them across box recreations. A rebuilt box then installs its tools
+# from cache, with only index revalidation touching the (allowlisted) mirror. Ends with the
+# `apt-get update` the install steps below rely on — the slim image ships no package index.
+# Must stay ABOVE the apt install steps — [[box.tools]] run in order.
 [[box.tools]]
-name = "dnf-keepcache"
-check = "grep -q '^system_cachedir=/root/.cache/dnf' /etc/dnf/dnf.conf"
-install = "mkdir -p /root/.cache/dnf && printf '\\nkeepcache=True\\nsystem_cachedir=/root/.cache/dnf\\ncachedir=/root/.cache/dnf\\n' >> /etc/dnf/dnf.conf"
+name = "apt-keepcache"
+check = "grep -qs 'fy-keepcache' /etc/apt/apt.conf.d/90fy-keepcache"
+install = "mkdir -p /root/.cache/apt/archives/partial && rm -f /etc/apt/apt.conf.d/docker-clean && printf '// fy-keepcache\\nDir::Cache::Archives \"/root/.cache/apt/archives\";\\nAPT::Keep-Downloaded-Packages \"true\";\\n' > /etc/apt/apt.conf.d/90fy-keepcache && apt-get update"
 
 # `just` is this project's documented entry point: CLAUDE.md and CONTRIBUTING.md route every
 # workflow through it (`just ci` before pushing, `just test`, `just docs-build`), so without
-# it the box can't follow its own instructions — and the recipes below name it too. Fedora
-# packages it in `updates` (1.57.0 on F44), so this is a plain dnf install: no COPR, no cargo
-# build, no prebuilt binary fetched past the proxy. It pulls fzf in as a dependency (just's
-# `--choose`); the check names only what we asked for.
+# it the box can't follow its own instructions — and the recipes below name it too. Debian
+# trixie packages it, so this is a plain apt install: no cargo build, no prebuilt binary
+# fetched past the proxy.
 [[box.tools]]
 name = "just"
-check = "rpm -q just"
-install = "dnf install -y just"
+check = "command -v just"
+install = "apt-get install -y --no-install-recommends just"
 
 # Browser tests (`just test-browser`, `uv run pytest -m browser`) need Chromium's shared
-# libraries in the box. `playwright install --with-deps` CANNOT do this here: it only knows
-# apt (Ubuntu/Debian) and the box image is Fedora, so the system libs are an explicit dnf
-# step. The list below is the empirically-verified minimum for headless Chromium on
-# fedora-toolbox aarch64 — libatomic is a separate line because the headless_shell binary
-# needs it and it isn't pulled in by any of the others.
+# libraries in the box. On Debian, `playwright install-deps` is the supported path: playwright
+# itself owns the apt list for the browser build the lockfile pins, so a Chromium bump can't
+# silently outgrow a hand-maintained library list. The check names a few marker
+# libraries so a warm box skips the apt round-trip.
 [[box.tools]]
 name = "chromium-system-libs"
-check = "rpm -q nss atk at-spi2-atk libXcomposite libXrandr mesa-libgbm libatomic"
-install = "dnf install -y libX11 libXcomposite libXdamage libXext libXfixes libXrandr alsa-lib atk at-spi2-atk at-spi2-core dbus-libs mesa-libgbm nspr nss nss-util libxcb cups-libs pango cairo libdrm libatomic"
+check = "dpkg -s libnspr4 libnss3 libgbm1 libatomic1 > /dev/null 2>&1"
+install = "uv run --frozen playwright install-deps chromium"
 
 # Browser binaries, from the version of playwright uv.lock pins (NOT a floating `uvx
 # playwright` — the browser build number is tied to the library version). `--frozen` keeps
 # uv from rewriting the lockfile on the host bind mount, and the sync it does here doubles
 # as the venv warm-up. `check = "false"` means always run: `playwright install` is idempotent
 # and cheap once the cache volume above is warm, and re-running is what picks up a new
-# browser build when the playwright pin moves. It prints "your OS is not officially
-# supported … downloading fallback build for ubuntu20.04" on Fedora — expected, and that
-# fallback build is the one the suite passes on.
+# browser build when the playwright pin moves.
 [[box.tools]]
 name = "playwright-chromium"
 check = "false"

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -213,14 +213,27 @@ def _bench_single(target: Path, sweep: list[int]) -> set[str]:
     print(f"  cache built in {time.monotonic() - warm_start:.1f}s")
 
     print("\nRunning configurations...", flush=True)
+    # Fan-out-less rows pin RENDER_JOBS=off explicitly: the fan-out is on
+    # by default now, so an unset variable means "auto", and the serial
+    # baselines would silently run the pool (which is exactly what
+    # happened when the default flipped — every row measured the same
+    # configuration and the table's labels lied).
     results = [
         _run(
             target,
             "neither",
-            {"CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0"},
+            {
+                "CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0",
+                "CLAUDE_CODE_LOG_RENDER_JOBS": "off",
+            },
             all_projects=False,
         ),
-        _run(target, "memo only", {}, all_projects=False),
+        _run(
+            target,
+            "memo only",
+            {"CLAUDE_CODE_LOG_RENDER_JOBS": "off"},
+            all_projects=False,
+        ),
         _run(
             target,
             "fan-out only",
@@ -267,10 +280,18 @@ def _bench_hierarchy(target: Path) -> set[str]:
         _run(
             target,
             "neither",
-            {"CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0"},
+            {
+                "CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0",
+                "CLAUDE_CODE_LOG_RENDER_JOBS": "off",
+            },
             all_projects=True,
         ),
-        _run(target, "memo only", {}, all_projects=True),
+        _run(
+            target,
+            "memo only",
+            {"CLAUDE_CODE_LOG_RENDER_JOBS": "off"},
+            all_projects=True,
+        ),
         _run(
             target,
             "both (auto)",
@@ -295,11 +316,20 @@ def _bench_hierarchy(target: Path) -> set[str]:
         _run(
             target,
             "neither",
-            {"CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0"},
+            {
+                "CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0",
+                "CLAUDE_CODE_LOG_RENDER_JOBS": "off",
+            },
             all_projects=True,
             stale=[largest],
         ),
-        _run(target, "memo only", {}, all_projects=True, stale=[largest]),
+        _run(
+            target,
+            "memo only",
+            {"CLAUDE_CODE_LOG_RENDER_JOBS": "off"},
+            all_projects=True,
+            stale=[largest],
+        ),
         _run(
             target,
             "both (auto)",

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -67,11 +67,16 @@ from claude_code_log.render_pool import (  # noqa: E402
 )
 
 
+# os.times() reports children_user / children_system as 0.0 on Windows —
+# there is no child-process CPU accounting there.
+CHILD_CPU_UNAVAILABLE = os.name == "nt"
+
+
 @dataclass
 class Result:
     label: str
     wall: float
-    cpu: float
+    cpu: Optional[float]
     digest: str
     files: int
 
@@ -164,7 +169,9 @@ def _run(
 
     # CPU is measured across the whole process tree, which is the number
     # that exposes the fan-out's overhead: wall time can improve while
-    # total CPU nearly doubles.
+    # total CPU nearly doubles. Windows has no child-process accounting in
+    # os.times() (the children_* fields are always zero there), so the
+    # column is reported as unavailable rather than as a misleading 0.0.
     before = os.times()
     start = time.monotonic()
     proc = subprocess.run(command, env=env, capture_output=True, text=True)
@@ -172,9 +179,11 @@ def _run(
     after = os.times()
     if proc.returncode != 0:
         sys.exit(f"{label}: conversion failed\n{proc.stderr[-2000:]}")
-    cpu = (after.children_user - before.children_user) + (
+    cpu: Optional[float] = (after.children_user - before.children_user) + (
         after.children_system - before.children_system
     )
+    if CHILD_CPU_UNAVAILABLE:
+        cpu = None
 
     digest, files = _digest_outputs(target, all_projects)
     return Result(label, wall, cpu, digest, files)
@@ -187,10 +196,8 @@ def _report(title: str, results: list[Result], baseline_label: str) -> set[str]:
     print("-" * 60)
     for result in results:
         speedup = baseline.wall / result.wall if result.wall else 0.0
-        print(
-            f"{result.label:<24} {result.wall:7.1f}s {result.cpu:7.1f}s "
-            f"{speedup:15.2f}x"
-        )
+        cpu = f"{result.cpu:7.1f}s" if result.cpu is not None else "    n/a"
+        print(f"{result.label:<24} {result.wall:7.1f}s {cpu} {speedup:15.2f}x")
     fastest = min(results, key=lambda r: r.wall)
     print(
         f"fastest: {fastest.label} ({baseline.wall / fastest.wall:.2f}x over "

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -77,10 +77,16 @@ class Result:
 
 
 def _cli_command() -> list[str]:
-    """Prefer the installed console script; fall back to the module."""
-    if shutil.which("claude-code-log"):
-        return ["claude-code-log"]
-    return [sys.executable, "-m", "claude_code_log"]
+    """Prefer the installed console script; fall back to the entry point.
+
+    The fallback invokes ``cli.main`` directly rather than ``-m
+    claude_code_log`` — the package has no ``__main__``, so the module form
+    fails outright when the console script isn't on PATH.
+    """
+    console_script = shutil.which("claude-code-log")
+    if console_script:
+        return [console_script]
+    return [sys.executable, "-c", "from claude_code_log.cli import main; main()"]
 
 
 def _project_dirs(root: Path) -> list[Path]:
@@ -388,23 +394,45 @@ def main() -> None:
 
         # Show what the memory cap will actually allow, so a run that
         # reports "no speedup" isn't quietly a run that never fanned out.
+        # Each worker holds a whole transcript, so this is often the real
+        # limit rather than core count.
         largest = max(_transcript_bytes(p) for p in sources)
         available = _available_memory_bytes()
-        concurrent = min(cpu_count, len(sources)) if args.all_projects else 1
-        allowed = memory_capped_workers(
-            cpu_count, largest, concurrent_projects=concurrent
-        )
         available_note = (
-            f"{available / 1e9:.1f}GB available" if available else "unknown"
+            f"{available / 1e9:.1f}GB reclaimable"
+            if available
+            else "UNKNOWN (capped at 2 workers)"
         )
-        print(
-            f"Memory:  {available_note}; largest project {largest / 1e6:.0f}MB "
-            f"-> at most {allowed} render worker(s) of the {cpu_count} requested"
-        )
+        print(f"Memory:  {available_note}; largest project {largest / 1e6:.0f}MB")
+
+        if args.all_projects:
+            # The two scenarios differ in how many conversions are resident
+            # at once, and therefore in how much is left for render workers.
+            concurrent = min(cpu_count, len(sources))
+            full = memory_capped_workers(
+                cpu_count, largest, concurrent_projects=concurrent
+            )
+            incremental = memory_capped_workers(cpu_count, largest)
+            print(
+                f"         full rebuild: {concurrent} concurrent projects "
+                f"-> at most {full} render worker(s) each"
+            )
+            print(
+                f"         incremental:  1 project -> at most {incremental} "
+                f"render worker(s) of the {cpu_count} requested"
+            )
+            allowed = max(full, incremental)
+        else:
+            allowed = memory_capped_workers(cpu_count, largest)
+            print(
+                f"         at most {allowed} render worker(s) of the "
+                f"{cpu_count} requested"
+            )
         if allowed <= 1:
             print(
-                "         (memory-capped to serial — the fan-out rows below will\n"
-                "          match 'memo only'. Use a smaller project or more RAM.)"
+                "         (memory-capped to serial — the fan-out rows below "
+                "will match\n          'memo only'. Use a smaller project or "
+                "free up RAM.)"
             )
 
         for project in sources:

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -338,15 +338,22 @@ def _bench_hierarchy(target: Path) -> set[str]:
             stale=[largest],
         ),
     ]
-    # Not folded into the digest comparison: this scenario regenerates a
-    # subset, so its file set legitimately differs from a full rebuild's.
-    _report(
+    # Not folded into the full-rebuild digest comparison: this scenario
+    # regenerates a subset, so its file set legitimately differs from a
+    # full rebuild's. The configurations *within* it rebuilt the same
+    # subset though, so they must agree with each other.
+    incremental_digests = _report(
         "Incremental — one project stale, the shape of a daily run. The\n"
         "project pool has nothing to spread, so the fan-out is the only\n"
         "thing that can use the other cores.",
         incremental,
         "memo only",
     )
+    if len(incremental_digests) > 1:
+        print(
+            "\nMISMATCH — incremental configurations disagreed on the rendered bytes."
+        )
+        sys.exit(1)
     return digests
 
 
@@ -420,6 +427,24 @@ def main() -> None:
     if holder is None:
         temp_holder = tempfile.mkdtemp(prefix="ccl-bench-")
         holder = Path(temp_holder)
+
+    # Refuse a work dir that overlaps the source tree before touching the
+    # filesystem: the copy loop rmtree's <holder>/<project name> and
+    # _clear_outputs sweeps the holder, so an overlapping --work-dir would
+    # delete real transcripts rather than scratch copies.
+    holder_resolved = holder.resolve()
+    for project in sources:
+        project_resolved = project.resolve()
+        if (
+            holder_resolved == project_resolved
+            or holder_resolved in project_resolved.parents
+            or project_resolved in holder_resolved.parents
+        ):
+            sys.exit(
+                f"--work-dir {holder} overlaps source project {project}; "
+                "pick a directory outside the source tree"
+            )
+
     holder.mkdir(parents=True, exist_ok=True)
 
     try:

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -62,7 +62,7 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from claude_code_log.render_pool import (  # noqa: E402
-    _available_memory_bytes,
+    available_memory_bytes,
     memory_capped_workers,
 )
 
@@ -471,7 +471,7 @@ def main() -> None:
         # Each worker holds a whole transcript, so this is often the real
         # limit rather than core count.
         largest = max(_transcript_bytes(p) for p in sources)
-        available = _available_memory_bytes()
+        available = available_memory_bytes()
         available_note = (
             f"{available / 1e9:.1f}GB reclaimable"
             if available

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Benchmark the two render optimisations against real transcripts.
+
+Measures the render memo caches (``CLAUDE_CODE_LOG_RENDER_CACHE_MB``) and
+the intra-project render fan-out (``CLAUDE_CODE_LOG_RENDER_JOBS``), both
+documented in ``dev-docs/application_model.md`` §§ 2.9-2.10.
+
+Run it on your own machine because **core count changes the answer**: the
+committed numbers come from a 4-core VM, the fan-out's payoff scales with
+cores, and its overhead scales with worker count. This is the measurement
+that decides whether the fan-out's default should stay off.
+
+Two modes, and they answer different questions:
+
+    # One project — the clearest read on the fan-out itself.
+    uv run python scripts/bench_render.py ~/.claude/projects/<project>
+
+    # The whole hierarchy — what a `claude-code-log` run actually costs.
+    uv run python scripts/bench_render.py ~/.claude/projects --all-projects
+
+The hierarchy mode matters because the two levels of parallelism trade
+off: `process_projects_hierarchy` already runs stale projects
+concurrently, and only hands leftover budget to the per-project fan-out.
+So it reports two scenarios separately —
+
+    full rebuild   every project stale. The project pool saturates the
+                   machine on its own and the fan-out gets nothing; this
+                   is a pure read on the memo caches.
+    incremental    one project stale, which is what a daily run looks
+                   like. Here the project pool has nothing to spread and
+                   the fan-out is the only thing that can use the cores.
+
+Everything is done on a **copy** — each run needs its own cache DB, and
+the benchmark deletes generated HTML between configurations, which must
+never happen to a real projects tree. Check you have the disk space; the
+copy is as large as what you point it at.
+
+A note on memory: every render worker holds the project's whole transcript
+(~3x its bytes on disk), and under --all-projects that multiplies with the
+project pool. The library caps workers against available memory
+(``render_pool.memory_capped_workers``), and this script prints what that
+cap allows before running, so a big archive degrades to serial rendering
+rather than taking the machine into swap.
+
+Every configuration's output is hashed, so a run doubles as an
+equivalence check across far more real data than the test fixtures
+cover: all configurations must produce byte-identical HTML.
+"""
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from claude_code_log.render_pool import (  # noqa: E402
+    _available_memory_bytes,
+    memory_capped_workers,
+)
+
+
+@dataclass
+class Result:
+    label: str
+    wall: float
+    cpu: float
+    digest: str
+    files: int
+
+
+def _cli_command() -> list[str]:
+    """Prefer the installed console script; fall back to the module."""
+    if shutil.which("claude-code-log"):
+        return ["claude-code-log"]
+    return [sys.executable, "-m", "claude_code_log"]
+
+
+def _project_dirs(root: Path) -> list[Path]:
+    return sorted(d for d in root.iterdir() if d.is_dir() and any(d.glob("*.jsonl")))
+
+
+def _transcript_bytes(project: Path) -> int:
+    return sum(f.stat().st_size for f in project.glob("*.jsonl"))
+
+
+def _clear_outputs(target: Path, all_projects: bool) -> None:
+    """Delete generated HTML so the next run has work to do.
+
+    Deleting a project's HTML is how staleness is simulated: the cache
+    reports a missing output as stale, which is exactly the state a real
+    incremental run finds for a project whose transcripts have grown.
+    """
+    for path in target.glob("*.html"):
+        path.unlink()
+    if all_projects:
+        for project in _project_dirs(target):
+            for path in project.glob("*.html"):
+                path.unlink()
+
+
+def _digest_outputs(target: Path, all_projects: bool) -> tuple[str, int]:
+    """Hash every generated file so configurations can be compared."""
+    hasher = hashlib.sha256()
+    count = 0
+    roots = [target, *(_project_dirs(target) if all_projects else [])]
+    for root in roots:
+        for path in sorted(root.glob("*.html")):
+            hasher.update(str(path.relative_to(target)).encode())
+            hasher.update(path.read_bytes())
+            count += 1
+    return hasher.hexdigest(), count
+
+
+def _run(
+    target: Path,
+    label: str,
+    env_overrides: dict[str, str],
+    *,
+    all_projects: bool,
+    stale: Optional[list[Path]] = None,
+    jobs: Optional[int] = None,
+) -> Result:
+    """Time one conversion.
+
+    ``stale`` restricts what gets invalidated beforehand — None means
+    "everything", a list means only those projects (plus the index, which
+    is always rewritten).
+    """
+    if stale is None:
+        _clear_outputs(target, all_projects)
+    else:
+        for path in target.glob("*.html"):
+            path.unlink()
+        for project in stale:
+            for path in project.glob("*.html"):
+                path.unlink()
+
+    env = dict(os.environ)
+    # Start from a known state: an inherited value for either knob would
+    # silently contaminate every row.
+    env.pop("CLAUDE_CODE_LOG_RENDER_CACHE_MB", None)
+    env.pop("CLAUDE_CODE_LOG_RENDER_JOBS", None)
+    env.update(env_overrides)
+
+    command = [*_cli_command(), str(target)]
+    if all_projects:
+        command.append("--all-projects")
+    if jobs is not None:
+        command += ["-j", str(jobs)]
+
+    # CPU is measured across the whole process tree, which is the number
+    # that exposes the fan-out's overhead: wall time can improve while
+    # total CPU nearly doubles.
+    before = os.times()
+    start = time.monotonic()
+    proc = subprocess.run(command, env=env, capture_output=True, text=True)
+    wall = time.monotonic() - start
+    after = os.times()
+    if proc.returncode != 0:
+        sys.exit(f"{label}: conversion failed\n{proc.stderr[-2000:]}")
+    cpu = (after.children_user - before.children_user) + (
+        after.children_system - before.children_system
+    )
+
+    digest, files = _digest_outputs(target, all_projects)
+    return Result(label, wall, cpu, digest, files)
+
+
+def _report(title: str, results: list[Result], baseline_label: str) -> set[str]:
+    baseline = next(r for r in results if r.label == baseline_label)
+    print(f"\n{title}")
+    print(f"{'configuration':<24} {'wall':>8} {'CPU':>8} {'vs ' + baseline_label:>16}")
+    print("-" * 60)
+    for result in results:
+        speedup = baseline.wall / result.wall if result.wall else 0.0
+        print(
+            f"{result.label:<24} {result.wall:7.1f}s {result.cpu:7.1f}s "
+            f"{speedup:15.2f}x"
+        )
+    fastest = min(results, key=lambda r: r.wall)
+    print(
+        f"fastest: {fastest.label} ({baseline.wall / fastest.wall:.2f}x over "
+        f"{baseline_label})"
+    )
+    return {r.digest for r in results}
+
+
+def _bench_single(target: Path, sweep: list[int]) -> set[str]:
+    print("\nWarming the cache (parse + index, not measured)...", flush=True)
+    warm_start = time.monotonic()
+    _run(target, "warm", {}, all_projects=False)
+    print(f"  cache built in {time.monotonic() - warm_start:.1f}s")
+
+    print("\nRunning configurations...", flush=True)
+    results = [
+        _run(
+            target,
+            "neither",
+            {"CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0"},
+            all_projects=False,
+        ),
+        _run(target, "memo only", {}, all_projects=False),
+        _run(
+            target,
+            "fan-out only",
+            {
+                "CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0",
+                "CLAUDE_CODE_LOG_RENDER_JOBS": "auto",
+            },
+            all_projects=False,
+        ),
+        _run(
+            target,
+            "both (auto)",
+            {"CLAUDE_CODE_LOG_RENDER_JOBS": "auto"},
+            all_projects=False,
+        ),
+    ]
+    for workers in sweep:
+        results.append(
+            _run(
+                target,
+                f"both ({workers} workers)",
+                {"CLAUDE_CODE_LOG_RENDER_JOBS": str(workers)},
+                all_projects=False,
+            )
+        )
+    return _report(
+        f"Single project ({results[0].files} output files)", results, "memo only"
+    )
+
+
+def _bench_hierarchy(target: Path) -> set[str]:
+    projects = _project_dirs(target)
+    largest = max(projects, key=_transcript_bytes)
+
+    print("\nWarming the cache (parse + index, not measured)...", flush=True)
+    warm_start = time.monotonic()
+    _run(target, "warm", {}, all_projects=True)
+    print(f"  cache built in {time.monotonic() - warm_start:.1f}s")
+
+    digests: set[str] = set()
+
+    print(f"\nScenario 1/2: full rebuild, all {len(projects)} projects", flush=True)
+    full = [
+        _run(
+            target,
+            "neither",
+            {"CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0"},
+            all_projects=True,
+        ),
+        _run(target, "memo only", {}, all_projects=True),
+        _run(
+            target,
+            "both (auto)",
+            {"CLAUDE_CODE_LOG_RENDER_JOBS": "auto"},
+            all_projects=True,
+        ),
+    ]
+    digests |= _report(
+        "Full rebuild — every project stale. The project pool already "
+        "saturates\nthe machine, so the fan-out gets no leftover budget "
+        "and this is a\nread on the memo caches alone.",
+        full,
+        "memo only",
+    )
+
+    size_mb = _transcript_bytes(largest) / 1e6
+    print(
+        f"\nScenario 2/2: incremental — only {largest.name} stale ({size_mb:.0f}MB)",
+        flush=True,
+    )
+    incremental = [
+        _run(
+            target,
+            "neither",
+            {"CLAUDE_CODE_LOG_RENDER_CACHE_MB": "0"},
+            all_projects=True,
+            stale=[largest],
+        ),
+        _run(target, "memo only", {}, all_projects=True, stale=[largest]),
+        _run(
+            target,
+            "both (auto)",
+            {"CLAUDE_CODE_LOG_RENDER_JOBS": "auto"},
+            all_projects=True,
+            stale=[largest],
+        ),
+    ]
+    # Not folded into the digest comparison: this scenario regenerates a
+    # subset, so its file set legitimately differs from a full rebuild's.
+    _report(
+        "Incremental — one project stale, the shape of a daily run. The\n"
+        "project pool has nothing to spread, so the fan-out is the only\n"
+        "thing that can use the other cores.",
+        incremental,
+        "memo only",
+    )
+    return digests
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="A project directory, or the projects root with --all-projects",
+    )
+    parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Benchmark the whole hierarchy (full-rebuild + incremental scenarios)",
+    )
+    parser.add_argument(
+        "--projects",
+        type=int,
+        default=8,
+        help=(
+            "With --all-projects, copy only the N largest projects "
+            "(default: 8; 0 copies everything — check your disk space)"
+        ),
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help="Where to copy (default: a temp dir, removed afterwards)",
+    )
+    parser.add_argument(
+        "--keep", action="store_true", help="Keep the working copy afterwards"
+    )
+    parser.add_argument(
+        "--workers",
+        default="",
+        help="Single-project mode: worker counts to sweep (default: 2,4,CPU count)",
+    )
+    args = parser.parse_args()
+
+    source: Path = args.path.expanduser().resolve()
+    if not source.is_dir():
+        sys.exit(f"Not a directory: {source}")
+
+    cpu_count = os.cpu_count() or 1
+    if args.workers:
+        sweep = [int(v) for v in args.workers.split(",") if v.strip()]
+    else:
+        sweep = sorted({2, 4, cpu_count})
+
+    if args.all_projects:
+        sources = _project_dirs(source)
+        if not sources:
+            sys.exit(f"No project directories with .jsonl files under {source}")
+        if args.projects > 0:
+            sources = sorted(sources, key=_transcript_bytes, reverse=True)[
+                : args.projects
+            ]
+    else:
+        if not list(source.glob("*.jsonl")):
+            sys.exit(
+                f"No .jsonl transcripts in {source} "
+                f"(for a projects root, pass --all-projects)"
+            )
+        sources = [source]
+
+    holder = Path(args.work_dir).expanduser() if args.work_dir else None
+    temp_holder = None
+    if holder is None:
+        temp_holder = tempfile.mkdtemp(prefix="ccl-bench-")
+        holder = Path(temp_holder)
+    holder.mkdir(parents=True, exist_ok=True)
+
+    try:
+        total_mb = sum(_transcript_bytes(p) for p in sources) / 1e6
+        print(f"Source:  {source}")
+        print(f"Copy to: {holder}")
+        print(f"Data:    {len(sources)} project(s), {total_mb:.0f}MB of transcripts")
+        print(f"Cores:   {cpu_count}")
+
+        # Show what the memory cap will actually allow, so a run that
+        # reports "no speedup" isn't quietly a run that never fanned out.
+        largest = max(_transcript_bytes(p) for p in sources)
+        available = _available_memory_bytes()
+        concurrent = min(cpu_count, len(sources)) if args.all_projects else 1
+        allowed = memory_capped_workers(
+            cpu_count, largest, concurrent_projects=concurrent
+        )
+        available_note = (
+            f"{available / 1e9:.1f}GB available" if available else "unknown"
+        )
+        print(
+            f"Memory:  {available_note}; largest project {largest / 1e6:.0f}MB "
+            f"-> at most {allowed} render worker(s) of the {cpu_count} requested"
+        )
+        if allowed <= 1:
+            print(
+                "         (memory-capped to serial — the fan-out rows below will\n"
+                "          match 'memo only'. Use a smaller project or more RAM.)"
+            )
+
+        for project in sources:
+            # Keep each project's own directory name: the rendered title is
+            # derived from it, so renaming would change output for no reason.
+            destination = holder / project.name
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(project, destination)
+        # Don't inherit generated output or a cache from the source tree.
+        _clear_outputs(holder, all_projects=True)
+        for stale_db in holder.glob("claude-code-log-cache.db*"):
+            stale_db.unlink()
+
+        if args.all_projects:
+            digests = _bench_hierarchy(holder)
+        else:
+            digests = _bench_single(holder / sources[0].name, sweep)
+
+        print()
+        if len(digests) == 1:
+            print("Every configuration produced byte-identical output.")
+        else:
+            print("MISMATCH — configurations disagreed on the rendered bytes.")
+            sys.exit(1)
+        print(
+            "\nIf a fan-out row beats 'memo only' comfortably — especially in the\n"
+            "incremental scenario — that is the argument for flipping the default\n"
+            "in render_pool.resolve_render_jobs."
+        )
+    finally:
+        if temp_holder and not args.keep:
+            shutil.rmtree(temp_holder, ignore_errors=True)
+        elif args.keep:
+            print(f"\nWorking copy kept at {holder}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -445,6 +445,18 @@ def main() -> None:
                 "pick a directory outside the source tree"
             )
 
+    # And it must be new or empty: the copy loop creates <holder>/<project
+    # name> and the output sweep clears the holder, so a directory with
+    # existing contents — even an unrelated one that merely shares a
+    # project's name — would have files this script never created deleted
+    # or overwritten. That includes a previous --keep run's copy: delete
+    # it yourself to reuse the path.
+    if holder.exists():
+        if not holder.is_dir():
+            sys.exit(f"--work-dir {holder} is not a directory")
+        if any(holder.iterdir()):
+            sys.exit(f"--work-dir {holder} is not empty; pass a new or empty directory")
+
     holder.mkdir(parents=True, exist_ok=True)
 
     try:
@@ -500,10 +512,10 @@ def main() -> None:
         for project in sources:
             # Keep each project's own directory name: the rendered title is
             # derived from it, so renaming would change output for no reason.
-            destination = holder / project.name
-            if destination.exists():
-                shutil.rmtree(destination)
-            shutil.copytree(project, destination)
+            # The holder was verified new-or-empty above, so the destination
+            # cannot pre-exist — copytree fails loudly rather than this loop
+            # deleting anything it didn't create.
+            shutil.copytree(project, holder / project.name)
         # Don't inherit generated output or a cache from the source tree.
         _clear_outputs(holder, all_projects=True)
         for stale_db in holder.glob("claude-code-log-cache.db*"):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for caching functionality."""
 
+import sqlite3
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -577,6 +578,45 @@ class TestCacheManager:
 
         stats = cache_manager.get_cache_stats()
         assert stats["total_cached_messages"] == 50
+
+
+class TestReadOnlyCacheManager:
+    """read_only=True is what spawned render workers construct: it must
+    see the parent's data but be physically unable to write the shared DB."""
+
+    def test_reads_existing_project_without_writing(
+        self, temp_project_dir, mock_version
+    ):
+        writer = CacheManager(temp_project_dir, mock_version)
+        writer.update_project_aggregates(
+            total_message_count=5,
+            total_input_tokens=50,
+            total_output_tokens=100,
+            total_cache_creation_tokens=0,
+            total_cache_read_tokens=0,
+            earliest_timestamp="2023-01-01T10:00:00Z",
+            latest_timestamp="2023-01-01T20:00:00Z",
+        )
+
+        reader = CacheManager(temp_project_dir, mock_version, read_only=True)
+        assert reader._project_id == writer._project_id
+        cached = reader.get_cached_project_data()
+        assert cached is not None
+        assert cached.total_message_count == 5
+
+    def test_connections_reject_writes(self, temp_project_dir, mock_version):
+        CacheManager(temp_project_dir, mock_version)  # create the DB
+        reader = CacheManager(temp_project_dir, mock_version, read_only=True)
+        with pytest.raises(sqlite3.OperationalError):
+            with reader._get_connection() as conn:
+                conn.execute("DELETE FROM projects")
+
+    def test_missing_database_degrades_to_no_data(self, temp_project_dir, mock_version):
+        reader = CacheManager(temp_project_dir, mock_version, read_only=True)
+        assert reader._project_id is None
+        assert reader.get_cached_project_data() is None
+        # Construction must not have created the database as a side effect.
+        assert not reader.db_path.exists()
 
 
 class TestLibraryVersion:

--- a/test/test_fragment_store.py
+++ b/test/test_fragment_store.py
@@ -1,0 +1,116 @@
+"""Unit tests for the fragment store's content digest.
+
+The digest replaces the retained ``MessageContent`` reference in the
+store's hit-verification (work/render-format-once.md § 4.9 — retaining
+one content per fragment pinned +270MB of object graphs on a large
+archive). Its contract is: **same field coverage as dataclass equality**,
+so a stored fragment is served iff the requesting tree's content would
+have compared equal to the one that produced it. These tests pin the
+directions that matter:
+
+- equality-relevant state (including nested pydantic models and their
+  ``extra="allow"`` fields) must change the digest;
+- the per-tree ``compare=False`` fields must NOT change it (they differ
+  between the combined-page and per-session trees for the *same*
+  message — a digest sensitive to them would kill every hit);
+- distinct content classes must never collide, even with identical
+  field values (dataclass ``__eq__`` requires identical classes).
+
+The end-to-end byte-equivalence proof lives in
+``test_render_cache_equivalence.py::test_fragment_store_render_is_byte_identical``.
+"""
+
+from claude_code_log.fragment_store import RenderFragmentStore, content_digest
+from claude_code_log.models import (
+    GrepInput,
+    MessageMeta,
+    SystemMessage,
+    ToolUseMessage,
+)
+
+
+def _system(text: str = "hello", level: str = "info") -> SystemMessage:
+    return SystemMessage(meta=MessageMeta.empty("u1"), level=level, text=text)
+
+
+def test_equal_contents_have_equal_digests():
+    assert content_digest(_system()) == content_digest(_system())
+
+
+def test_per_tree_fields_do_not_affect_digest():
+    # The same message gets different message_index / fragment_key values
+    # in the combined tree vs its session tree; both are compare=False
+    # and must be invisible to the digest, exactly as they are to __eq__.
+    a, b = _system(), _system()
+    a.message_index = 7
+    a.fragment_key = (123, 0)
+    b.message_index = 991
+    b.fragment_key = (456, 2)
+    assert a == b
+    assert content_digest(a) == content_digest(b)
+
+
+def test_compare_field_change_changes_digest():
+    assert content_digest(_system("one")) != content_digest(_system("two"))
+    assert content_digest(_system(level="info")) != content_digest(
+        _system(level="error")
+    )
+
+
+def test_nested_meta_change_changes_digest():
+    a = _system()
+    b = _system()
+    b.meta.cwd = "/somewhere/else"
+    assert a != b
+    assert content_digest(a) != content_digest(b)
+
+
+def test_distinct_classes_never_collide():
+    # Dataclass __eq__ requires identical classes; the digest tags the
+    # class, so structurally similar contents of different types differ.
+    meta = MessageMeta.empty("u1")
+    tool = ToolUseMessage(
+        meta=meta,
+        input=GrepInput(pattern="hello"),
+        tool_use_id="t1",
+        tool_name="Grep",
+    )
+    assert content_digest(tool) != content_digest(_system())
+
+
+def test_pydantic_extra_fields_affect_digest():
+    # extra="allow" models carry unknown transcript fields in
+    # __pydantic_extra__, and pydantic equality includes them.
+    plain = GrepInput.model_validate({"pattern": "x"})
+    with_extra = GrepInput.model_validate({"pattern": "x", "-i": True})
+    with_same_extra = GrepInput.model_validate({"pattern": "x", "-i": True})
+
+    def tool_with(inp: GrepInput) -> ToolUseMessage:
+        return ToolUseMessage(
+            meta=MessageMeta.empty("u1"),
+            input=inp,
+            tool_use_id="t1",
+            tool_name="Grep",
+        )
+
+    assert content_digest(tool_with(plain)) != content_digest(tool_with(with_extra))
+    assert content_digest(tool_with(with_extra)) == content_digest(
+        tool_with(with_same_extra)
+    )
+
+
+def test_store_hit_requires_matching_digest():
+    store = RenderFragmentStore()
+    key = (1, 0, "sig")
+    fragment = ("title", "<p>html</p>", "12:00")
+    store.put(key, _system(), fragment)
+
+    # Equal content (fresh object, different per-tree fields) → hit.
+    requester = _system()
+    requester.message_index = 42
+    assert store.get(key, requester) == fragment
+    assert store.hits == 1
+
+    # Diverged content under the same key → conflict, served fresh.
+    assert store.get(key, _system("changed")) is None
+    assert store.conflicts == 1

--- a/test/test_fragment_store.py
+++ b/test/test_fragment_store.py
@@ -99,6 +99,22 @@ def test_pydantic_extra_fields_affect_digest():
     )
 
 
+def test_stable_key_translates_ids_to_master_list_ordinals():
+    store = RenderFragmentStore()
+    entries = [object(), object(), object()]
+    store.set_entry_ordinals(entries)
+
+    # A stamped (id(entry), part) maps to the entry's position in the
+    # master list — the identity two trees (or two processes loading the
+    # same list) agree on.
+    assert store.stable_key((id(entries[2]), 0)) == (2, 0)
+    assert store.stable_key((id(entries[0]), 5)) == (0, 5)
+
+    # An id the master list doesn't contain declines caching.
+    stranger = object()
+    assert store.stable_key((id(stranger), 0)) is None
+
+
 def test_store_hit_requires_matching_digest():
     store = RenderFragmentStore()
     key = (1, 0, "sig")

--- a/test/test_image_export.py
+++ b/test/test_image_export.py
@@ -41,7 +41,15 @@ class TestExportImageEmbedded:
 
 
 class TestExportImageReferenced:
-    """Tests for referenced mode."""
+    """Tests for referenced mode.
+
+    Filenames are content-addressed (a digest of the decoded bytes), so a
+    given image maps to exactly one file regardless of which render pass,
+    run, or worker exports it. That property is what fixes the historical
+    combined-vs-session name collision (a per-render counter assigned the
+    same ``image_NNNN`` names to different images across the two passes)
+    and what makes the mode safe under the render fan-out.
+    """
 
     def test_referenced_without_output_dir_returns_none(
         self, sample_image: ImageContent
@@ -50,33 +58,72 @@ class TestExportImageReferenced:
         result = export_image(sample_image, mode="referenced", output_dir=None)
         assert result is None
 
-    def test_referenced_creates_image_file(
+    def test_referenced_creates_content_addressed_file(
         self, sample_image: ImageContent, tmp_path: Path
     ):
-        """Referenced mode creates image file and returns relative path."""
-        result = export_image(
-            sample_image,
-            mode="referenced",
-            output_dir=tmp_path,
-            counter=1,
-        )
+        """Referenced mode writes the decoded bytes under a digest name."""
+        import base64
+        import re
 
-        assert result == "images/image_0001.png"
-        assert (tmp_path / "images" / "image_0001.png").exists()
+        result = export_image(sample_image, mode="referenced", output_dir=tmp_path)
 
-    def test_referenced_with_different_counter(
+        assert result is not None
+        assert re.fullmatch(r"images/image_[0-9a-f]{16}\.png", result)
+        exported = tmp_path / result
+        assert exported.read_bytes() == base64.b64decode(sample_image.source.data)
+
+    def test_same_image_maps_to_same_file_across_calls(
         self, sample_image: ImageContent, tmp_path: Path
     ):
-        """Referenced mode uses counter for filename."""
-        result = export_image(
-            sample_image,
-            mode="referenced",
-            output_dir=tmp_path,
-            counter=42,
+        """Re-exporting an image is idempotent: same name, one file.
+
+        This is the collision fix: the combined-page pass and the session
+        pass both export the image, and both must land on the same file
+        instead of the second pass overwriting the first's names.
+        """
+        first = export_image(sample_image, mode="referenced", output_dir=tmp_path)
+        second = export_image(sample_image, mode="referenced", output_dir=tmp_path)
+
+        assert first == second
+        assert len(list((tmp_path / "images").iterdir())) == 1
+
+    def test_distinct_images_get_distinct_names(
+        self, sample_image: ImageContent, tmp_path: Path
+    ):
+        """Different bytes never share a filename (the overwrite bug)."""
+        import base64
+
+        other_bytes = base64.b64decode(sample_image.source.data) + b"\x00"
+        other = ImageContent(
+            type="image",
+            source=ImageSource(
+                type="base64",
+                media_type="image/png",
+                data=base64.b64encode(other_bytes).decode("ascii"),
+            ),
         )
 
-        assert result == "images/image_0042.png"
-        assert (tmp_path / "images" / "image_0042.png").exists()
+        first = export_image(sample_image, mode="referenced", output_dir=tmp_path)
+        second = export_image(other, mode="referenced", output_dir=tmp_path)
+
+        assert first is not None and second is not None
+        assert first != second
+        assert len(list((tmp_path / "images").iterdir())) == 2
+
+    def test_malformed_base64_degrades_to_none(self, tmp_path: Path):
+        """Bad data returns None (placeholder) and leaves no temp litter."""
+        bad = ImageContent(
+            type="image",
+            source=ImageSource(
+                type="base64", media_type="image/png", data="%%%not-base64%%%"
+            ),
+        )
+
+        result = export_image(bad, mode="referenced", output_dir=tmp_path)
+
+        assert result is None
+        images_dir = tmp_path / "images"
+        assert not images_dir.exists() or not list(images_dir.iterdir())
 
 
 class TestExportImageUnsupportedMode:
@@ -86,3 +133,117 @@ class TestExportImageUnsupportedMode:
         """Unsupported mode returns None."""
         result = export_image(sample_image, mode="unknown_mode")
         assert result is None
+
+
+class TestReferencedModeAcrossRenderPasses:
+    """Regression: the combined and per-session passes share one images/ dir.
+
+    Under the old per-render counter, the combined pass named its images
+    ``image_0001…N`` and each session pass restarted at ``image_0001`` —
+    assigning the same names to *different* images, so whichever pass ran
+    last overwrote the other's files and the survivor pages showed the
+    wrong images. Content-addressed names make both passes converge on
+    the same file per image.
+    """
+
+    @staticmethod
+    def _image_entry(session_id: str, uuid: str, ts: str, png_b64: str) -> str:
+        import json
+
+        return json.dumps(
+            {
+                "type": "user",
+                "timestamp": ts,
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": "/tmp",
+                "sessionId": session_id,
+                "version": "1.0.0",
+                "uuid": uuid,
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": f"screenshot in {session_id}"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": png_b64,
+                            },
+                        },
+                    ],
+                },
+            }
+        )
+
+    # page_size=1 forces the paginated combined path, which used to drop
+    # the image mode entirely (pages always embedded); 2000 keeps the
+    # single-file combined path.
+    @pytest.mark.parametrize("page_size", [2000, 1])
+    def test_combined_and_session_files_reference_intact_images(
+        self, sample_image: ImageContent, tmp_path: Path, page_size: int
+    ):
+        import base64
+        import hashlib
+        import re
+
+        from claude_code_log.converter import convert_jsonl_to
+
+        png_a = sample_image.source.data
+        png_b = base64.b64encode(base64.b64decode(png_a) + b"\x00").decode("ascii")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "aaaaaaaa-0000-0000-0000-000000000001.jsonl").write_text(
+            self._image_entry(
+                "aaaaaaaa-0000-0000-0000-000000000001",
+                "aaaaaaaa-0000-0000-0000-00000000000a",
+                "2025-07-01T10:00:00Z",
+                png_a,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (project / "bbbbbbbb-0000-0000-0000-000000000002.jsonl").write_text(
+            self._image_entry(
+                "bbbbbbbb-0000-0000-0000-000000000002",
+                "bbbbbbbb-0000-0000-0000-00000000000b",
+                "2025-07-01T11:00:00Z",
+                png_b,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        convert_jsonl_to(
+            "html",
+            project,
+            image_export_mode="referenced",
+            generate_individual_sessions=True,
+            silent=True,
+            page_size=page_size,
+        )
+
+        html_files = sorted(project.glob("*.html"))
+        session_files = [f for f in html_files if f.name.startswith("session-")]
+        combined_files = [f for f in html_files if f.name.startswith("combined")]
+        assert combined_files and len(session_files) == 2
+
+        src_re = re.compile(r"images/image_[0-9a-f]{16}\.png")
+        referenced: set[str] = set()
+        for html_file in html_files:
+            srcs = set(src_re.findall(html_file.read_text(encoding="utf-8")))
+            assert srcs, f"{html_file.name} references no exported images"
+            referenced |= srcs
+
+        # Two distinct images → two files, every reference resolvable, and
+        # every file's bytes still match the digest in its own name (the
+        # old bug left files whose content belonged to a different name).
+        assert len(referenced) == 2
+        for rel in referenced:
+            exported = project / rel
+            assert exported.exists(), f"{rel} referenced but missing"
+            digest = hashlib.blake2b(exported.read_bytes(), digest_size=8).hexdigest()
+            assert exported.name == f"image_{digest}.png"

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -384,3 +384,31 @@ Pages purgeable:                           1000.
     def test_probe_returns_none_off_darwin(self, monkeypatch):
         monkeypatch.setattr(render_pool_module.sys, "platform", "linux")
         assert render_pool_module._darwin_available_bytes() is None
+
+
+class TestWindowsMemoryProbe:
+    """Windows has no /proc/meminfo and no os.sysconf at all.
+
+    Without a probe of its own it lands in the same 2-worker
+    unknown-memory branch that macOS was stuck in.
+    """
+
+    def test_probe_returns_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(render_pool_module.sys, "platform", "linux")
+        assert render_pool_module._windows_available_bytes() is None
+
+    def test_probe_never_raises(self, monkeypatch):
+        """A failed foreign-function call must degrade, not crash a run."""
+        monkeypatch.setattr(render_pool_module.sys, "platform", "win32")
+        # No ctypes.windll off Windows, so this exercises the failure path.
+        assert render_pool_module._windows_available_bytes() is None
+
+    def test_available_memory_still_resolves_when_probes_fail(self, monkeypatch):
+        """The dispatcher tolerates every probe returning None."""
+        monkeypatch.setattr(render_pool_module, "_darwin_available_bytes", lambda: None)
+        monkeypatch.setattr(
+            render_pool_module, "_windows_available_bytes", lambda: None
+        )
+        # Whatever this machine reports, it must be a size or an honest None.
+        result = render_pool_module._available_memory_bytes()
+        assert result is None or result > 0

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -17,6 +17,7 @@ from claude_code_log.models import DEFAULT_DEPTH
 from claude_code_log import render_pool as render_pool_module
 from claude_code_log.render_pool import (
     RENDER_JOBS_ENV,
+    _parse_vm_stat,
     memory_capped_workers,
     resolve_render_jobs,
 )
@@ -331,3 +332,55 @@ class TestMemoryCap:
     def test_a_request_of_one_stays_one(self, monkeypatch):
         self._with_memory(monkeypatch, 64 * 1024**3)
         assert memory_capped_workers(1, 1) == 1
+
+
+class TestDarwinMemoryProbe:
+    """macOS has neither MemAvailable nor SC_AVPHYS_PAGES.
+
+    Without a working probe every Mac fell through to the conservative
+    "unknown memory" branch, which caps the fan-out at 2 workers however
+    many cores and however much RAM the machine actually has.
+    """
+
+    # Apple silicon: 16KB pages, and the counts carry a trailing period.
+    APPLE_SILICON = """Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              123456.
+Pages active:                            987654.
+Pages inactive:                          200000.
+Pages speculative:                        50000.
+Pages throttled:                              0.
+Pages wired down:                        300000.
+Pages purgeable:                          10000.
+"Translation faults":                 123456789.
+Pages copy-on-write:                    1234567.
+"""
+
+    # Intel: 4KB pages.
+    INTEL = """Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                               10000.
+Pages active:                            500000.
+Pages inactive:                           20000.
+Pages speculative:                         5000.
+Pages purgeable:                           1000.
+"""
+
+    def test_apple_silicon_page_size_and_reclaimable_set(self):
+        expected = (123456 + 200000 + 50000 + 10000) * 16384
+        assert _parse_vm_stat(self.APPLE_SILICON) == expected
+
+    def test_intel_page_size(self):
+        expected = (10000 + 20000 + 5000 + 1000) * 4096
+        assert _parse_vm_stat(self.INTEL) == expected
+
+    def test_active_and_wired_pages_are_not_counted(self):
+        """Those are in use; counting them would over-promise and swap."""
+        parsed = _parse_vm_stat(self.APPLE_SILICON)
+        assert parsed is not None
+        assert parsed < (987654 + 300000) * 16384
+
+    def test_unrecognisable_output_is_reported_as_unknown(self):
+        assert _parse_vm_stat("not vm_stat output at all") is None
+
+    def test_probe_returns_none_off_darwin(self, monkeypatch):
+        monkeypatch.setattr(render_pool_module.sys, "platform", "linux")
+        assert render_pool_module._darwin_available_bytes() is None

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -238,7 +238,7 @@ class TestRenderPoolCreation:
         # tested, not about how much RAM the machine running them has.
         if monkeypatch is not None:
             monkeypatch.setattr(
-                render_pool_module, "_available_memory_bytes", lambda: 64 * 1024**3
+                render_pool_module, "available_memory_bytes", lambda: 64 * 1024**3
             )
         project = tmp_path / "project"
         project.mkdir(exist_ok=True)
@@ -285,7 +285,7 @@ class TestRenderPoolCreation:
         """
         monkeypatch.setenv(RENDER_JOBS_ENV, "4")
         monkeypatch.setattr(
-            render_pool_module, "_available_memory_bytes", lambda: 256 * 1024**2
+            render_pool_module, "available_memory_bytes", lambda: 256 * 1024**2
         )
         assert self._make(tmp_path) is None
 
@@ -410,7 +410,7 @@ class TestMemoryCap:
     @staticmethod
     def _with_memory(monkeypatch, available_bytes):
         monkeypatch.setattr(
-            render_pool_module, "_available_memory_bytes", lambda: available_bytes
+            render_pool_module, "available_memory_bytes", lambda: available_bytes
         )
 
     def test_plentiful_memory_grants_the_request(self, monkeypatch):
@@ -476,7 +476,7 @@ class TestHoldbackPlans:
         # memory cap for the lone conversion, and these assertions are
         # about the comparison, not the running machine's RAM.
         monkeypatch.setattr(
-            render_pool_module, "_available_memory_bytes", lambda: memory
+            render_pool_module, "available_memory_bytes", lambda: memory
         )
         return converter._holdback_plans(plans, job_budget=jobs, render_budget=render)
 
@@ -566,6 +566,55 @@ class TestHoldbackPlans:
         assert self._held([*rest, giant], monkeypatch, memory=2 * 1024**3) == []
 
 
+class TestFragmentStoreMemoryValve:
+    """The fragment store is a RAM-for-CPU trade (+~0.35x transcript bytes
+    at peak, measured); on a machine without that RAM to spare the valve
+    declines it and the conversion runs store-less — the pre-store
+    footprint — instead of trading its last memory for CPU."""
+
+    GB = 1024**3
+
+    def _make(self, monkeypatch, available, **kwargs):
+        monkeypatch.delenv("CLAUDE_CODE_LOG_FRAGMENT_STORE", raising=False)
+        monkeypatch.setattr(
+            render_pool_module, "available_memory_bytes", lambda: available
+        )
+        return converter._make_fragment_store("html", **kwargs)
+
+    def test_ample_memory_keeps_the_store(self, monkeypatch):
+        assert (
+            self._make(monkeypatch, 16 * self.GB, transcript_bytes=self.GB) is not None
+        )
+
+    def test_tight_memory_skips_the_store(self, monkeypatch):
+        # 1GB of transcripts wants ~2.4GB available; 2GB is inside the margin.
+        assert self._make(monkeypatch, 2 * self.GB, transcript_bytes=self.GB) is None
+
+    def test_explicit_enable_overrides_the_valve(self, monkeypatch):
+        monkeypatch.setattr(
+            render_pool_module, "available_memory_bytes", lambda: 2 * self.GB
+        )
+        monkeypatch.setenv("CLAUDE_CODE_LOG_FRAGMENT_STORE", "1")
+        assert (
+            converter._make_fragment_store("html", transcript_bytes=self.GB) is not None
+        )
+
+    def test_unknown_memory_keeps_the_store(self, monkeypatch):
+        # An unreadable probe must not cost the optimisation; the render
+        # pool is where unknown memory has to be conservative.
+        assert self._make(monkeypatch, None, transcript_bytes=self.GB) is not None
+
+    def test_unknown_bytes_skip_the_valve(self, monkeypatch):
+        assert self._make(monkeypatch, 2 * self.GB) is not None
+
+    def test_off_switch_still_wins_over_everything(self, monkeypatch):
+        monkeypatch.setattr(
+            render_pool_module, "available_memory_bytes", lambda: 64 * self.GB
+        )
+        monkeypatch.setenv("CLAUDE_CODE_LOG_FRAGMENT_STORE", "0")
+        assert converter._make_fragment_store("html", transcript_bytes=1) is None
+
+
 class TestDarwinMemoryProbe:
     """macOS has neither MemAvailable nor SC_AVPHYS_PAGES.
 
@@ -653,5 +702,5 @@ class TestWindowsMemoryProbe:
             render_pool_module, "_windows_available_bytes", lambda: None
         )
         # Whatever this machine reports, it must be a size or an honest None.
-        result = render_pool_module._available_memory_bytes()
+        result = render_pool_module.available_memory_bytes()
         assert result is None or result > 0

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -444,14 +444,18 @@ class TestMemoryCap:
         assert memory_capped_workers(1, 1) == 1
 
 
-class TestDominantPlan:
-    """Hold-back selection: which stale project gets the machine to itself.
+class TestHoldbackPlans:
+    """Hold-back selection: which stale projects get the machine to themselves.
 
-    The full-rebuild wall collapses to the dominant project's serial time
+    The full-rebuild wall collapses to the largest projects' serial time
     when every project gets the same static render share, so the
-    all-projects loop holds a dominant project out of the pool and
-    converts it last with the full render budget. These pin the
-    selection heuristic (converter._dominant_plan)."""
+    all-projects loop holds pool-bounding projects out and converts them
+    afterwards, each with the full render budget. These pin the greedy
+    makespan comparison (converter._holdback_plans): hold the largest
+    while pool(rest) + fanned(largest) beats pooling everything, stop at
+    the first losing hold."""
+
+    MB = 1024**2
 
     @staticmethod
     def _plan(source_bytes, messages=None):
@@ -467,36 +471,99 @@ class TestDominantPlan:
             cached_message_count=messages,
         )
 
-    def test_dominant_by_messages_is_selected(self):
+    def _held(self, plans, monkeypatch, jobs=8, render=8, memory=64 * 1024**3):
+        # Pin available memory: the fanned-speedup estimate consults the
+        # memory cap for the lone conversion, and these assertions are
+        # about the comparison, not the running machine's RAM.
+        monkeypatch.setattr(
+            render_pool_module, "_available_memory_bytes", lambda: memory
+        )
+        return converter._holdback_plans(plans, job_budget=jobs, render_budget=render)
+
+    def test_dominant_by_messages_is_held(self, monkeypatch):
         # The reference archive's shape: only 1.08x the runner-up's bytes
-        # but 2.07x its messages — and messages are what cost.
-        giant = self._plan(329, messages=97_000)
-        rest = [self._plan(304, messages=47_000), self._plan(139, messages=46_900)]
-        assert converter._dominant_plan([*rest, giant]) is giant
-
-    def test_bytes_fallback_misses_the_dense_giant(self):
-        # Same shape without cached counts: the comparison falls back to
-        # bytes, 1.08x is under the bar, and nothing is held back —
-        # the safe direction (hold-back on level sizes is a certain loss).
-        giant = self._plan(329)
-        assert converter._dominant_plan([self._plan(304), giant]) is None
-
-    def test_level_sizes_hold_nothing_back(self):
-        plans = [
-            self._plan(100, messages=10_000),
-            self._plan(90, messages=9_000),
+        # but 2.07x its messages — and messages are what cost. The level
+        # 47k twins that then bound the pool stay pooled: holding one
+        # would add its fanned time without moving the pool wall.
+        giant = self._plan(329 * self.MB, messages=97_000)
+        rest = [
+            self._plan(304 * self.MB, messages=47_000),
+            self._plan(139 * self.MB, messages=46_900),
         ]
-        assert converter._dominant_plan(plans) is None
+        assert self._held([*rest, giant], monkeypatch) == [giant]
 
-    def test_dominant_by_bytes_when_any_count_is_missing(self):
+    def test_a_pool_bounding_runner_up_is_held_too(self, monkeypatch):
+        # The shape the single-dominant heuristic missed: after the giant
+        # is held, a 47k project still bounds a pool of small ones (and is
+        # nowhere near 2x any of them). pool(smalls) + fanned(47k)
+        # undercuts the 47k serial wall, so it holds as well.
+        giant = self._plan(329 * self.MB, messages=97_000)
+        runner_up = self._plan(304 * self.MB, messages=47_000)
+        smalls = [
+            self._plan(30 * self.MB, messages=15_000),
+            self._plan(25 * self.MB, messages=12_000),
+            self._plan(20 * self.MB, messages=10_000),
+        ]
+        assert self._held([*smalls, runner_up, giant], monkeypatch) == [
+            giant,
+            runner_up,
+        ]
+
+    def test_bytes_fallback_misses_the_dense_giant(self, monkeypatch):
+        # Same shape without cached counts: the comparison falls back to
+        # bytes, the pool stays bounded by the 304MB runner-up either
+        # way, and holding the 329MB project would just append its fanned
+        # time — nothing is held back.
+        giant = self._plan(329 * self.MB)
+        assert self._held([self._plan(304 * self.MB), giant], monkeypatch) == []
+
+    def test_level_sizes_hold_nothing_back(self, monkeypatch):
+        plans = [
+            self._plan(100 * self.MB, messages=47_000),
+            self._plan(90 * self.MB, messages=46_000),
+        ]
+        assert self._held(plans, monkeypatch) == []
+
+    def test_sub_pool_threshold_projects_never_hold(self, monkeypatch):
+        # 10k messages can't use the render pool at all, so a lone
+        # conversion runs serial and holding it back gains nothing.
+        plans = [
+            self._plan(100 * self.MB, messages=10_000),
+            self._plan(9 * self.MB, messages=1_000),
+        ]
+        assert self._held(plans, monkeypatch) == []
+
+    def test_dominant_by_bytes_when_any_count_is_missing(self, monkeypatch):
         # One project without a cache row poisons the count comparison,
-        # so every plan is ranked by bytes — consistently one unit.
-        giant = self._plan(1000)
-        rest = [self._plan(400, messages=50_000), self._plan(100)]
-        assert converter._dominant_plan([*rest, giant]) is giant
+        # so every plan is ranked by bytes — consistently one unit. The
+        # 400MB project holds too: with the giant gone it would bound
+        # the pool on its own, and its fanned time undercuts that.
+        giant = self._plan(1000 * self.MB)
+        runner_up = self._plan(400 * self.MB, messages=50_000)
+        rest = [runner_up, self._plan(100 * self.MB)]
+        assert self._held([*rest, giant], monkeypatch) == [giant, runner_up]
 
-    def test_a_single_plan_is_never_held_back(self):
-        assert converter._dominant_plan([self._plan(1000, messages=99_000)]) is None
+    def test_a_single_plan_is_never_held_back(self, monkeypatch):
+        assert (
+            self._held([self._plan(1000 * self.MB, messages=99_000)], monkeypatch) == []
+        )
+
+    def test_a_core_bound_pool_keeps_its_projects(self, monkeypatch):
+        # Eight level projects on two cores: the pool already saturates
+        # the machine (wall ≈ total/2), and serializing any of them
+        # replaces hidden concurrency with appended fanned time.
+        plans = [self._plan(100 * self.MB, messages=47_000 - i) for i in range(8)]
+        assert self._held(plans, monkeypatch, jobs=2, render=2) == []
+
+    def test_memory_that_cannot_fan_never_holds(self, monkeypatch):
+        # A machine whose memory caps a lone conversion at one worker
+        # gets no speedup from holding anything back.
+        giant = self._plan(329 * self.MB, messages=97_000)
+        rest = [
+            self._plan(30 * self.MB, messages=15_000),
+            self._plan(25 * self.MB, messages=12_000),
+        ]
+        assert self._held([*rest, giant], monkeypatch, memory=2 * 1024**3) == []
 
 
 class TestDarwinMemoryProbe:

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -80,7 +80,7 @@ class TestEnvironmentConfiguration:
         monkeypatch.setenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB", "4")
         cache = ByteBoundedCache()
         assert cache.enabled
-        assert cache._budget == 4 * 1024 * 1024
+        assert cache.budget_bytes == 4 * 1024 * 1024
 
     def test_zero_disables_memoization(self, monkeypatch):
         monkeypatch.setenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB", "0")
@@ -91,7 +91,7 @@ class TestEnvironmentConfiguration:
         # not crash a conversion.
         monkeypatch.setenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB", "not-a-number")
         cache = ByteBoundedCache()
-        assert cache._budget == render_cache.DEFAULT_CACHE_MB * 1024 * 1024
+        assert cache.budget_bytes == render_cache.DEFAULT_CACHE_MB * 1024 * 1024
 
 
 class TestPygmentsMemo:

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -15,8 +15,11 @@ import pytest
 from claude_code_log import converter, render_cache
 from claude_code_log.models import DEFAULT_DEPTH
 from claude_code_log import render_pool as render_pool_module
+from claude_code_log.dag import SessionTree, slim_session_tree
 from claude_code_log.render_pool import (
     RENDER_JOBS_ENV,
+    RenderPool,
+    RenderUnit,
     _parse_vm_stat,
     memory_capped_workers,
     resolve_render_jobs,
@@ -252,6 +255,9 @@ class TestRenderPoolCreation:
             image_export_mode=None,
             archive_search_link=None,
             render_jobs=None,
+            session_tree=SessionTree(
+                nodes={}, sessions={}, roots=[], junction_points={}
+            ),
         )
         kwargs.update(overrides)
         return converter._make_render_pool(**kwargs)  # type: ignore[arg-type]
@@ -299,9 +305,16 @@ class TestRenderPoolCreation:
         assert self._make(tmp_path, monkeypatch, image_export_mode="referenced") is None
 
     def test_no_pool_without_a_cache_manager(self, tmp_path, monkeypatch):
-        """Workers reload from cache; without one they'd re-parse every file."""
+        """Staleness planning (and the unit slicing it drives) needs one."""
         monkeypatch.setenv(RENDER_JOBS_ENV, "4")
         assert self._make(tmp_path, monkeypatch, cache_manager=None) is None
+
+    def test_no_pool_without_a_session_tree(self, tmp_path, monkeypatch):
+        """Workers render fed slices against the conversion's tree; a
+        worker-side rebuild from a slice alone can genuinely differ
+        (missing cross-session hierarchy), so no tree means no pool."""
+        monkeypatch.setenv(RENDER_JOBS_ENV, "4")
+        assert self._make(tmp_path, monkeypatch, session_tree=None) is None
 
     def test_no_pool_for_single_file_mode(self, tmp_path, monkeypatch):
         monkeypatch.setenv(RENDER_JOBS_ENV, "4")
@@ -310,13 +323,81 @@ class TestRenderPoolCreation:
         assert self._make(tmp_path, monkeypatch, input_path=transcript) is None
 
 
-class TestMemoryCap:
-    """Peak memory is workers x project size, so the cap is load-bearing.
+class TestSlimSessionTree:
+    """What crosses the process boundary to render workers.
 
-    Each worker holds the project's whole transcript (~3x its bytes on
-    disk). Without a cap, `auto` on a large archive exhausts RAM and drives
-    the machine into swap, where it pegs every core and stops responding —
-    a much worse outcome than rendering serially.
+    The slim tree exists so the per-message ``nodes`` mapping — whose
+    pickled size is the whole transcript — never ships to a worker. The
+    render path must not read it, and if a future change does, it must
+    fail loudly in the worker rather than render from an empty mapping.
+    """
+
+    @staticmethod
+    def _tree():
+        from claude_code_log.dag import SessionDAGLine
+
+        return SessionTree(
+            nodes={"u1": object()},  # type: ignore[dict-item]
+            sessions={
+                "s1": SessionDAGLine(
+                    session_id="s1", uuids=["u1"], first_timestamp="2026-01-01"
+                )
+            },
+            roots=["s1"],
+            junction_points={},
+        )
+
+    def test_render_fields_are_shared_not_copied(self):
+        tree = self._tree()
+        slim = slim_session_tree(tree)
+        assert slim.sessions is tree.sessions
+        assert slim.roots is tree.roots
+        assert slim.junction_points is tree.junction_points
+        assert slim.workflow_runs is tree.workflow_runs
+        assert slim.workflow_links is tree.workflow_links
+
+    def test_nodes_lookups_fail_loudly(self):
+        slim = slim_session_tree(self._tree())
+        with pytest.raises(RuntimeError, match="slim"):
+            slim.nodes["u1"]
+        with pytest.raises(RuntimeError, match="slim"):
+            slim.nodes.get("u1")
+        with pytest.raises(RuntimeError, match="slim"):
+            "u1" in slim.nodes
+
+    def test_survives_pickling_without_the_transcript(self):
+        import pickle
+
+        slim = slim_session_tree(self._tree())
+        clone = pickle.loads(pickle.dumps(slim))
+        assert clone.sessions["s1"].uuids == ["u1"]
+        # The loud-fail contract survives the round trip too.
+        with pytest.raises(RuntimeError, match="slim"):
+            clone.nodes["u1"]
+
+
+class TestSubmitRequiresEntries:
+    """Workers never load the transcript, so an entry-less unit can only
+    be rendered by the parent's inline path — submit must decline it."""
+
+    def test_entryless_unit_is_declined_before_any_worker_starts(self):
+        pool = RenderPool.__new__(RenderPool)
+        pool._executor = None
+        pool._broken = False
+        unit = RenderUnit(kind="page", key=1, file_name="x.html", title="t")
+        assert pool.submit(unit) is None
+        # Declining must not have started (or broken) anything.
+        assert pool._executor is None and not pool.broken
+
+
+class TestMemoryCap:
+    """The cap is load-bearing: swap-thrash is worse than rendering serially.
+
+    The formula still charges each worker a whole transcript copy (~3x its
+    bytes on disk) even though workers are now fed per-unit slices — a
+    deliberate over-charge until the re-size is measured
+    (work/render-format-once.md § 7.5). These tests pin the formula as it
+    stands; loosen them together with it.
     """
 
     @staticmethod

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -10,6 +10,7 @@ both the eviction mechanics and that keying contract.
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -394,11 +395,11 @@ class TestSubmitRequiresEntries:
 class TestMemoryCap:
     """The cap is load-bearing: swap-thrash is worse than rendering serially.
 
-    The formula still charges each worker a whole transcript copy (~3x its
-    bytes on disk) even though workers are now fed per-unit slices — a
-    deliberate over-charge until the re-size is measured
-    (work/render-format-once.md § 7.5). These tests pin the formula as it
-    stands; loosen them together with it.
+    The formula charges the parent its measured master-list + fragment
+    store footprint (~4.5x transcript bytes) and each fed worker only its
+    measured slice-holding cost (a flat base + a weak multiple) — the
+    § 7.5 re-size of work/render-format-once.md, measured 2026-08-26.
+    These tests pin the formula's shape, not its constants.
     """
 
     @staticmethod
@@ -436,6 +437,61 @@ class TestMemoryCap:
     def test_a_request_of_one_stays_one(self, monkeypatch):
         self._with_memory(monkeypatch, 64 * 1024**3)
         assert memory_capped_workers(1, 1) == 1
+
+
+class TestDominantPlan:
+    """Hold-back selection: which stale project gets the machine to itself.
+
+    The full-rebuild wall collapses to the dominant project's serial time
+    when every project gets the same static render share, so the
+    all-projects loop holds a dominant project out of the pool and
+    converts it last with the full render budget. These pin the
+    selection heuristic (converter._dominant_plan)."""
+
+    @staticmethod
+    def _plan(source_bytes, messages=None):
+        return converter._ProjectPlan(
+            project_dir=Path("p"),
+            dest_dir=Path("p"),
+            cache_manager=None,
+            output_path=Path("p/combined_transcripts.html"),
+            needs_work=True,
+            archived_count=0,
+            stats=converter.GenerationStats(),
+            source_bytes=source_bytes,
+            cached_message_count=messages,
+        )
+
+    def test_dominant_by_messages_is_selected(self):
+        # The reference archive's shape: only 1.08x the runner-up's bytes
+        # but 2.07x its messages — and messages are what cost.
+        giant = self._plan(329, messages=97_000)
+        rest = [self._plan(304, messages=47_000), self._plan(139, messages=46_900)]
+        assert converter._dominant_plan([*rest, giant]) is giant
+
+    def test_bytes_fallback_misses_the_dense_giant(self):
+        # Same shape without cached counts: the comparison falls back to
+        # bytes, 1.08x is under the bar, and nothing is held back —
+        # the safe direction (hold-back on level sizes is a certain loss).
+        giant = self._plan(329)
+        assert converter._dominant_plan([self._plan(304), giant]) is None
+
+    def test_level_sizes_hold_nothing_back(self):
+        plans = [
+            self._plan(100, messages=10_000),
+            self._plan(90, messages=9_000),
+        ]
+        assert converter._dominant_plan(plans) is None
+
+    def test_dominant_by_bytes_when_any_count_is_missing(self):
+        # One project without a cache row poisons the count comparison,
+        # so every plan is ranked by bytes — consistently one unit.
+        giant = self._plan(1000)
+        rest = [self._plan(400, messages=50_000), self._plan(100)]
+        assert converter._dominant_plan([*rest, giant]) is giant
+
+    def test_a_single_plan_is_never_held_back(self):
+        assert converter._dominant_plan([self._plan(1000, messages=99_000)]) is None
 
 
 class TestDarwinMemoryProbe:

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -8,9 +8,18 @@ plugin makes output depend on the active render repo cwd. These tests pin
 both the eviction mechanics and that keying contract.
 """
 
+import os
+
 import pytest
 
-from claude_code_log import render_cache
+from claude_code_log import converter, render_cache
+from claude_code_log.models import DEFAULT_DEPTH
+from claude_code_log import render_pool as render_pool_module
+from claude_code_log.render_pool import (
+    RENDER_JOBS_ENV,
+    memory_capped_workers,
+    resolve_render_jobs,
+)
 from claude_code_log.git_remote import render_with_repo_context
 from claude_code_log.html.renderer_code import highlight_code_with_pygments
 from claude_code_log.html.utils import render_markdown, render_user_markdown
@@ -165,3 +174,160 @@ class TestMarkdownMemo:
         render_user_markdown(text)
         assert render_cache.markdown_cache.stats()["hits"] == 0
         assert render_cache.markdown_cache.stats()["misses"] == 2
+
+
+class TestRenderJobsEnvironment:
+    """The render fan-out is opt-in; ``--jobs`` alone must not enable it."""
+
+    def test_unset_means_serial(self, monkeypatch):
+        monkeypatch.delenv(RENDER_JOBS_ENV, raising=False)
+        assert resolve_render_jobs(None) == 1
+
+    def test_auto_means_cpu_count(self, monkeypatch):
+        monkeypatch.setenv(RENDER_JOBS_ENV, "auto")
+        assert resolve_render_jobs(None) == max(1, os.cpu_count() or 1)
+
+    def test_explicit_worker_count(self, monkeypatch):
+        monkeypatch.setenv(RENDER_JOBS_ENV, "3")
+        assert resolve_render_jobs(None) == 3
+
+    def test_unparseable_or_empty_means_serial(self, monkeypatch):
+        # Off is the safe reading of a broken setting: the fan-out is a
+        # performance trade, never a correctness requirement.
+        for value in ("", "   ", "yes", "-1"):
+            monkeypatch.setenv(RENDER_JOBS_ENV, value)
+            assert resolve_render_jobs(None) == 1, value
+
+    def test_explicit_argument_overrides_the_environment(self, monkeypatch):
+        monkeypatch.setenv(RENDER_JOBS_ENV, "8")
+        assert resolve_render_jobs(2) == 2
+        monkeypatch.delenv(RENDER_JOBS_ENV, raising=False)
+        assert resolve_render_jobs(2) == 2
+
+
+class TestRenderPoolCreation:
+    """`_make_render_pool` is the gate; everything downstream assumes it."""
+
+    @staticmethod
+    def _make(tmp_path, monkeypatch=None, **overrides):
+        # Pin available memory so these assertions are about the gate being
+        # tested, not about how much RAM the machine running them has.
+        if monkeypatch is not None:
+            monkeypatch.setattr(
+                render_pool_module, "_available_memory_bytes", lambda: 64 * 1024**3
+            )
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+        kwargs = dict(
+            format="html",
+            input_path=project,
+            effective_output_dir=project,
+            cache_manager=object(),
+            message_count=1_000_000,
+            from_date=None,
+            to_date=None,
+            depth=DEFAULT_DEPTH,
+            compact=False,
+            no_timestamps=False,
+            no_recaps=False,
+            image_export_mode=None,
+            archive_search_link=None,
+            render_jobs=None,
+        )
+        kwargs.update(overrides)
+        return converter._make_render_pool(**kwargs)  # type: ignore[arg-type]
+
+    def test_no_pool_without_the_env_var(self, tmp_path, monkeypatch):
+        """The whole point of the default: no worker processes at all."""
+        monkeypatch.delenv(RENDER_JOBS_ENV, raising=False)
+        assert self._make(tmp_path) is None
+
+    def test_env_var_creates_a_pool(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(RENDER_JOBS_ENV, "2")
+        assert self._make(tmp_path, monkeypatch) is not None
+
+    def test_no_pool_when_memory_is_too_tight(self, tmp_path, monkeypatch):
+        """A machine that can't hold a second copy renders serially.
+
+        This is the guard that stops a large archive from driving the box
+        into swap; the fan-out is an optimisation, never a requirement.
+        """
+        monkeypatch.setenv(RENDER_JOBS_ENV, "4")
+        monkeypatch.setattr(
+            render_pool_module, "_available_memory_bytes", lambda: 256 * 1024**2
+        )
+        assert self._make(tmp_path) is None
+
+    def test_small_projects_stay_serial_even_when_enabled(self, tmp_path, monkeypatch):
+        """Below the crossover the fan-out is a measured regression."""
+        monkeypatch.setenv(RENDER_JOBS_ENV, "4")
+        assert (
+            self._make(
+                tmp_path,
+                monkeypatch,
+                message_count=converter._MIN_MESSAGES_FOR_RENDER_POOL - 1,
+            )
+            is None
+        )
+
+    def test_referenced_images_stay_serial(self, tmp_path, monkeypatch):
+        """Concurrent renders would collide on images/image_NNNN.png."""
+        monkeypatch.setenv(RENDER_JOBS_ENV, "4")
+        assert self._make(tmp_path, monkeypatch, image_export_mode="referenced") is None
+
+    def test_no_pool_without_a_cache_manager(self, tmp_path, monkeypatch):
+        """Workers reload from cache; without one they'd re-parse every file."""
+        monkeypatch.setenv(RENDER_JOBS_ENV, "4")
+        assert self._make(tmp_path, monkeypatch, cache_manager=None) is None
+
+    def test_no_pool_for_single_file_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(RENDER_JOBS_ENV, "4")
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text("")
+        assert self._make(tmp_path, monkeypatch, input_path=transcript) is None
+
+
+class TestMemoryCap:
+    """Peak memory is workers x project size, so the cap is load-bearing.
+
+    Each worker holds the project's whole transcript (~3x its bytes on
+    disk). Without a cap, `auto` on a large archive exhausts RAM and drives
+    the machine into swap, where it pegs every core and stops responding —
+    a much worse outcome than rendering serially.
+    """
+
+    @staticmethod
+    def _with_memory(monkeypatch, available_bytes):
+        monkeypatch.setattr(
+            render_pool_module, "_available_memory_bytes", lambda: available_bytes
+        )
+
+    def test_plentiful_memory_grants_the_request(self, monkeypatch):
+        self._with_memory(monkeypatch, 64 * 1024**3)
+        assert memory_capped_workers(8, 100 * 1024**2) == 8
+
+    def test_tight_memory_falls_back_to_serial(self, monkeypatch):
+        # 2GB available against a 1GB project (~3GB per worker).
+        self._with_memory(monkeypatch, 2 * 1024**3)
+        assert memory_capped_workers(8, 1024**3) == 1
+
+    def test_bigger_projects_get_fewer_workers(self, monkeypatch):
+        self._with_memory(monkeypatch, 32 * 1024**3)
+        small = memory_capped_workers(16, 50 * 1024**2)
+        large = memory_capped_workers(16, 2 * 1024**3)
+        assert small > large >= 1
+
+    def test_concurrent_projects_divide_the_budget(self, monkeypatch):
+        """The two pool levels multiply, so the budget splits before it's spent."""
+        self._with_memory(monkeypatch, 32 * 1024**3)
+        alone = memory_capped_workers(16, 200 * 1024**2)
+        shared = memory_capped_workers(16, 200 * 1024**2, concurrent_projects=8)
+        assert shared < alone
+
+    def test_unknown_memory_is_conservative(self, monkeypatch):
+        self._with_memory(monkeypatch, None)
+        assert memory_capped_workers(16, 100 * 1024**2) == 2
+
+    def test_a_request_of_one_stays_one(self, monkeypatch):
+        self._with_memory(monkeypatch, 64 * 1024**3)
+        assert memory_capped_workers(1, 1) == 1

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -301,10 +301,15 @@ class TestRenderPoolCreation:
             is None
         )
 
-    def test_referenced_images_stay_serial(self, tmp_path, monkeypatch):
-        """Concurrent renders would collide on images/image_NNNN.png."""
+    def test_referenced_images_pool_too(self, tmp_path, monkeypatch):
+        """Content-addressed image names made referenced mode pool-safe:
+        concurrent workers exporting the same image write the same file
+        atomically with identical bytes, so the old decline is gone."""
         monkeypatch.setenv(RENDER_JOBS_ENV, "4")
-        assert self._make(tmp_path, monkeypatch, image_export_mode="referenced") is None
+        assert (
+            self._make(tmp_path, monkeypatch, image_export_mode="referenced")
+            is not None
+        )
 
     def test_no_pool_without_a_cache_manager(self, tmp_path, monkeypatch):
         """Staleness planning (and the unit slicing it drives) needs one."""

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -9,6 +9,7 @@ both the eviction mechanics and that keying contract.
 """
 
 import os
+import sys
 
 import pytest
 
@@ -502,9 +503,20 @@ class TestWindowsMemoryProbe:
 
     def test_probe_never_raises(self, monkeypatch):
         """A failed foreign-function call must degrade, not crash a run."""
+        # Capture before patching: render_pool_module.sys IS the sys
+        # module, so the setattr below changes sys.platform globally for
+        # the duration of the test.
+        actually_windows = sys.platform == "win32"
         monkeypatch.setattr(render_pool_module.sys, "platform", "win32")
-        # No ctypes.windll off Windows, so this exercises the failure path.
-        assert render_pool_module._windows_available_bytes() is None
+        result = render_pool_module._windows_available_bytes()
+        if actually_windows:
+            # On real Windows the foreign call genuinely succeeds; what
+            # this test pins is that the probe returns rather than raises.
+            assert result is not None and result > 0
+        else:
+            # No ctypes.windll off Windows, so this exercises the failure
+            # path: the call fails inside the probe and degrades to None.
+            assert result is None
 
     def test_available_memory_still_resolves_when_probes_fail(self, monkeypatch):
         """The dispatcher tolerates every probe returning None."""

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -178,11 +178,11 @@ class TestMarkdownMemo:
 
 
 class TestRenderJobsEnvironment:
-    """The render fan-out is opt-in; ``--jobs`` alone must not enable it."""
+    """The fan-out defaults on; the env var is the off switch and the dial."""
 
-    def test_unset_means_serial(self, monkeypatch):
+    def test_unset_means_cpu_count(self, monkeypatch):
         monkeypatch.delenv(RENDER_JOBS_ENV, raising=False)
-        assert resolve_render_jobs(None) == 1
+        assert resolve_render_jobs(None) == max(1, os.cpu_count() or 1)
 
     def test_auto_means_cpu_count(self, monkeypatch):
         monkeypatch.setenv(RENDER_JOBS_ENV, "auto")
@@ -192,12 +192,30 @@ class TestRenderJobsEnvironment:
         monkeypatch.setenv(RENDER_JOBS_ENV, "3")
         assert resolve_render_jobs(None) == 3
 
-    def test_unparseable_or_empty_means_serial(self, monkeypatch):
-        # Off is the safe reading of a broken setting: the fan-out is a
-        # performance trade, never a correctness requirement.
-        for value in ("", "   ", "yes", "-1"):
+    def test_one_disables_the_fan_out(self, monkeypatch):
+        """The documented off switch — it must actually reach the inline path."""
+        monkeypatch.setenv(RENDER_JOBS_ENV, "1")
+        assert resolve_render_jobs(None) == 1
+
+    def test_wordy_off_values_disable_it(self, monkeypatch):
+        for value in ("off", "no", "false", "serial", "OFF"):
             monkeypatch.setenv(RENDER_JOBS_ENV, value)
             assert resolve_render_jobs(None) == 1, value
+
+    def test_zero_and_negatives_disable_it(self, monkeypatch):
+        """Mirrors CLAUDE_CODE_LOG_RENDER_CACHE_MB=0 — a number below 1
+        is a request for none of it, not a broken setting."""
+        for value in ("0", "-1", "-4"):
+            monkeypatch.setenv(RENDER_JOBS_ENV, value)
+            assert resolve_render_jobs(None) == 1, value
+
+    def test_unparseable_or_empty_falls_back_to_the_default(self, monkeypatch):
+        # A broken setting shouldn't silently change behaviour in either
+        # direction; the default is the least surprising reading.
+        expected = max(1, os.cpu_count() or 1)
+        for value in ("", "   ", "yes", "3.5"):
+            monkeypatch.setenv(RENDER_JOBS_ENV, value)
+            assert resolve_render_jobs(None) == expected, value
 
     def test_explicit_argument_overrides_the_environment(self, monkeypatch):
         monkeypatch.setenv(RENDER_JOBS_ENV, "8")
@@ -238,10 +256,14 @@ class TestRenderPoolCreation:
         kwargs.update(overrides)
         return converter._make_render_pool(**kwargs)  # type: ignore[arg-type]
 
-    def test_no_pool_without_the_env_var(self, tmp_path, monkeypatch):
-        """The whole point of the default: no worker processes at all."""
+    def test_a_pool_is_created_by_default(self, tmp_path, monkeypatch):
+        """The fan-out is on unless something turns it off."""
         monkeypatch.delenv(RENDER_JOBS_ENV, raising=False)
-        assert self._make(tmp_path) is None
+        assert self._make(tmp_path, monkeypatch) is not None
+
+    def test_env_var_can_turn_it_off(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(RENDER_JOBS_ENV, "1")
+        assert self._make(tmp_path, monkeypatch) is None
 
     def test_env_var_creates_a_pool(self, tmp_path, monkeypatch):
         monkeypatch.setenv(RENDER_JOBS_ENV, "2")

--- a/test/test_render_cache.py
+++ b/test/test_render_cache.py
@@ -1,0 +1,167 @@
+"""Tests for the byte-bounded memo caches on the pure render leaves.
+
+The caches exist because a project conversion formats every message twice
+(once for its combined page, once for its ``session-*.html``). They are
+only safe as long as the memoized functions really are pure with respect
+to their keys — the interesting case being Markdown, whose SHA-linkifier
+plugin makes output depend on the active render repo cwd. These tests pin
+both the eviction mechanics and that keying contract.
+"""
+
+import pytest
+
+from claude_code_log import render_cache
+from claude_code_log.git_remote import render_with_repo_context
+from claude_code_log.html.renderer_code import highlight_code_with_pygments
+from claude_code_log.html.utils import render_markdown, render_user_markdown
+from claude_code_log.render_cache import ByteBoundedCache
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    """Each test starts from empty module-level caches and leaves them empty."""
+    render_cache.clear_all()
+    yield
+    render_cache.clear_all()
+
+
+class TestByteBoundedCache:
+    def test_round_trips_a_value(self):
+        cache = ByteBoundedCache(budget_bytes=1024)
+        assert cache.get("k") is None
+        cache.put("k", "value")
+        assert cache.get("k") == "value"
+        assert cache.stats()["hits"] == 1
+        assert cache.stats()["misses"] == 1
+
+    def test_evicts_least_recently_used_when_over_budget(self):
+        # The per-entry ceiling is 1/8 of the budget, so a full cache
+        # holds 8 max-size entries: 8 * 50 exactly fills a 400-byte budget.
+        cache = ByteBoundedCache(budget_bytes=400)
+        keys = "abcdefgh"
+        for key in keys:
+            cache.put(key, key * 50)
+        assert cache.stats()["entries"] == len(keys)
+
+        # Touch "a" so "b" becomes the least-recently-used entry.
+        assert cache.get("a") is not None
+        cache.put("i", "i" * 50)
+
+        assert cache.get("a") is not None, "recently used entry must survive"
+        assert cache.get("b") is None, "least-recently-used entry is evicted"
+        assert cache.get("i") is not None
+
+    def test_refuses_entries_larger_than_the_per_entry_ceiling(self):
+        # One oversized value must not be admitted, or it would evict
+        # every cheap entry behind it and thrash the cache to 0% hits.
+        cache = ByteBoundedCache(budget_bytes=1000)
+        cache.put("small", "s" * 10)
+        cache.put("huge", "h" * 900)
+
+        assert cache.get("huge") is None
+        assert cache.get("small") is not None
+
+    def test_budget_of_zero_disables_the_cache(self):
+        cache = ByteBoundedCache(budget_bytes=0)
+        assert not cache.enabled
+        cache.put("k", "value")
+        assert cache.get("k") is None
+
+    def test_reinserting_a_key_does_not_double_count_its_bytes(self):
+        cache = ByteBoundedCache(budget_bytes=1000)
+        cache.put("k", "x" * 50)
+        cache.put("k", "y" * 50)
+        assert cache.stats()["bytes"] == 50
+        assert cache.get("k") == "y" * 50
+
+
+class TestEnvironmentConfiguration:
+    def test_cache_mb_env_var_sets_the_budget(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB", "4")
+        cache = ByteBoundedCache()
+        assert cache.enabled
+        assert cache._budget == 4 * 1024 * 1024
+
+    def test_zero_disables_memoization(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB", "0")
+        assert not ByteBoundedCache().enabled
+
+    def test_unparseable_value_falls_back_to_the_default(self, monkeypatch):
+        # An unreadable setting should degrade to the built-in budget,
+        # not crash a conversion.
+        monkeypatch.setenv("CLAUDE_CODE_LOG_RENDER_CACHE_MB", "not-a-number")
+        cache = ByteBoundedCache()
+        assert cache._budget == render_cache.DEFAULT_CACHE_MB * 1024 * 1024
+
+
+class TestPygmentsMemo:
+    def test_repeat_call_hits_the_cache_and_returns_identical_html(self):
+        code = "def f():\n    return 1\n"
+        first = highlight_code_with_pygments(code, "example.py")
+        assert render_cache.pygments_cache.stats()["hits"] == 0
+
+        second = highlight_code_with_pygments(code, "example.py")
+        assert second == first
+        assert render_cache.pygments_cache.stats()["hits"] == 1
+
+    def test_arguments_participate_in_the_key(self):
+        code = "x = 1\n"
+        # Same code, different lexer / line-number settings must not
+        # collide — each is a distinct rendering.
+        variants = [
+            highlight_code_with_pygments(code, "a.py"),
+            highlight_code_with_pygments(code, "a.txt"),
+            highlight_code_with_pygments(code, "a.py", show_linenos=False),
+            highlight_code_with_pygments(code, "a.py", linenostart=7),
+        ]
+        assert len(set(variants)) == len(variants)
+        assert render_cache.pygments_cache.stats()["hits"] == 0
+
+
+class TestMarkdownMemo:
+    def test_repeat_call_hits_the_cache(self):
+        text = "# Title\n\nSome *body* text.\n"
+        first = render_markdown(text)
+        second = render_markdown(text)
+        assert second == first
+        assert render_cache.markdown_cache.stats()["hits"] == 1
+
+    def test_repo_cwd_participates_in_the_key(self, tmp_path):
+        """Two repos must not share a Markdown cache entry.
+
+        The SHA-linkifier resolves commit hashes against the active render
+        cwd, so identical text can legitimately render different links in
+        different projects. Keying on text alone would serve one project's
+        commit URLs inside another's page.
+        """
+        text = "See 5baac35 for details.\n"
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        with render_with_repo_context(str(repo_a)):
+            render_markdown(text)
+        with render_with_repo_context(str(repo_b)):
+            render_markdown(text)
+
+        stats = render_cache.markdown_cache.stats()
+        assert stats["hits"] == 0, "distinct repo cwds must not share an entry"
+        assert stats["misses"] == 2
+
+        # Re-entering the first context still hits its own entry.
+        with render_with_repo_context(str(repo_a)):
+            render_markdown(text)
+        assert render_cache.markdown_cache.stats()["hits"] == 1
+
+    def test_the_two_renderer_singletons_do_not_share_entries(self):
+        """``render_markdown`` and ``render_user_markdown`` are distinct.
+
+        They use separate mistune singletons; sharing a cache entry would
+        let one's output be served for the other's call site.
+        """
+        text = "plain paragraph\n"
+        render_markdown(text)
+        render_user_markdown(text)
+        assert render_cache.markdown_cache.stats()["hits"] == 0
+        assert render_cache.markdown_cache.stats()["misses"] == 2

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -156,20 +156,46 @@ def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch
     # Count what the pool actually accepted. Every path in the fan-out
     # falls back to inline rendering on trouble, so without this a broken
     # pool would compare the serial path against itself and pass.
-    dispatched: list[str] = []
+    dispatched: list[RenderUnit] = []
     original_submit = RenderPool.submit
 
     def counting_submit(self: RenderPool, unit: RenderUnit):
         future = original_submit(self, unit)
         if future is not None:
-            dispatched.append(unit.kind)
+            dispatched.append(unit)
         return future
 
     monkeypatch.setattr(RenderPool, "submit", counting_submit)
+
+    # Capture the conversion's fragment store to prove the worker deltas
+    # actually flowed back to the parent (page workers export their
+    # fragments; the dispatch loop absorbs them). Without this, a broken
+    # return path would silently degrade the session feed to nothing.
+    stores = []
+    original_make = converter._make_fragment_store
+
+    def capturing_make(format_: str):
+        store = original_make(format_)
+        if store is not None:
+            stores.append(store)
+        return store
+
+    monkeypatch.setattr(converter, "_make_fragment_store", capturing_make)
 
     serial = _convert_copy(tmp_path, "serial", render_jobs=1)
     parallel = _convert_copy(tmp_path, "parallel", render_jobs=2)
 
     _assert_same(serial, parallel, "the render fan-out")
-    assert "page" in dispatched, "no combined page went through a worker"
-    assert "session" in dispatched, "no session file went through a worker"
+    kinds = [unit.kind for unit in dispatched]
+    assert "page" in kinds, "no combined page went through a worker"
+    assert "session" in kinds, "no session file went through a worker"
+    # The fed-fragment path (work/render-format-once.md § 2): page workers
+    # return fragment deltas, the parent absorbs them, and dispatched
+    # session units carry their session's slice.
+    assert any(unit.kind == "session" and unit.fed_fragments for unit in dispatched), (
+        "no session unit was fed fragments — the feed never engaged"
+    )
+    parallel_store = stores[-1]
+    assert parallel_store.stats()["entries"] > 0, (
+        "the parent store absorbed no worker fragment deltas"
+    )

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -97,6 +97,45 @@ def test_memoized_render_is_byte_identical_to_unmemoized(tmp_path: Path):
     assert stats["hits"] > 0, "memo never hit — the comparison proved nothing"
 
 
+def test_fragment_store_render_is_byte_identical(tmp_path: Path, monkeypatch):
+    """The fragment store must be invisible in the output — only in the clock.
+
+    Both runs disable the leaf memo so the comparison isolates the store:
+    a fragment served from the store replaces a *complete* title/html/
+    timestamp computation, so any key too coarse for real data (uuid reuse
+    across forked sessions, part-ordinal drift between the combined and
+    per-session passes) shows up here as changed bytes.
+    """
+    from claude_code_log.fragment_store import RenderFragmentStore
+
+    monkeypatch.setenv("CLAUDE_CODE_LOG_FRAGMENT_STORE", "0")
+    with render_cache.disabled():
+        baseline = _convert_copy(tmp_path, "no-fragments")
+    monkeypatch.delenv("CLAUDE_CODE_LOG_FRAGMENT_STORE")
+
+    # Capture the store the conversion creates, to prove it engaged —
+    # otherwise a future refactor that silently stops attaching it would
+    # make this comparison vacuous.
+    stores: list[RenderFragmentStore] = []
+    original_make = converter._make_fragment_store
+
+    def capturing_make(format_: str):
+        store = original_make(format_)
+        if store is not None:
+            stores.append(store)
+        return store
+
+    monkeypatch.setattr(converter, "_make_fragment_store", capturing_make)
+
+    with render_cache.disabled():
+        fragmented = _convert_copy(tmp_path, "fragments")
+
+    _assert_same(baseline, fragmented, "the fragment store")
+    assert stores, "no fragment store was created"
+    hits = sum(store.stats()["hits"] for store in stores)
+    assert hits > 0, "fragment store never hit — the comparison proved nothing"
+
+
 def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch):
     """Fanning the render out over worker processes must not change output.
 

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -1,0 +1,128 @@
+"""End-to-end proof that the render optimisations don't change output.
+
+Both optimisations in this area are pure performance work, and both are
+easy to get subtly wrong in ways unit tests won't catch:
+
+- **Memoization** trades a recompute for a cached string. It is only sound
+  if the memoized function is genuinely pure with respect to its key —
+  Markdown is not purely a function of its text (the SHA-linkifier reads
+  the active render repo cwd), so a missing key component would show up
+  here as a rendered difference rather than an exception.
+- **The render fan-out** re-derives each worker's state from the cache
+  instead of inheriting the parent's, and moves the paginated "reveal the
+  Next link" fixup from a per-page step to a single post-pass. Either
+  could plausibly diverge from the serial path.
+
+So this converts a real multi-session project three ways and compares the
+bytes. It runs the conversion for real rather than stubbing the renderer:
+the whole point is to exercise the integration, and a project directory
+from ``test_data/real_projects`` covers Pygments-heavy tool output,
+Markdown, sub-agents and multiple sessions.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from claude_code_log import converter, render_cache
+from claude_code_log.converter import convert_jsonl_to
+from claude_code_log.render_pool import RenderPool, RenderUnit
+
+# Real project with 40 session files — enough for several combined pages
+# and a wide spread of message types.
+SOURCE_PROJECT = (
+    Path(__file__).parent
+    / "test_data"
+    / "real_projects"
+    / "-Users-dain-workspace-coderabbit-review-helper"
+)
+
+# Small enough to force several combined pages out of this project, so the
+# pagination path (and its Next-link fixup) is exercised, not just the
+# single-file path.
+PAGE_SIZE = 200
+
+
+def _convert_copy(tmp_path: Path, name: str, **kwargs: object) -> dict[str, bytes]:
+    """Convert a fresh copy of the project and return {filename: bytes}.
+
+    Each run gets its own copy so it also gets its own cache DB (which
+    lives beside the project directory) — otherwise the second run would
+    find the first's output current and skip it, comparing nothing.
+
+    The copy keeps the project's *own* directory name and varies only the
+    parent, because the rendered title is derived from the project
+    directory name: copying to ``<tmp>/memoized`` would make every page
+    differ on the title alone and the comparison would be meaningless.
+    """
+    work_dir = tmp_path / name / SOURCE_PROJECT.name
+    shutil.copytree(SOURCE_PROJECT, work_dir)
+
+    convert_jsonl_to("html", work_dir, page_size=PAGE_SIZE, silent=True, **kwargs)  # type: ignore[arg-type]
+
+    rendered = {
+        path.name: path.read_bytes() for path in sorted(work_dir.glob("*.html"))
+    }
+    assert rendered, "conversion produced no HTML"
+    return rendered
+
+
+def _assert_same(
+    baseline: dict[str, bytes], other: dict[str, bytes], what: str
+) -> None:
+    assert set(other) == set(baseline), f"{what} produced a different set of files"
+    differing = [name for name in baseline if baseline[name] != other[name]]
+    assert not differing, f"{what} changed the bytes of: {', '.join(sorted(differing))}"
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    render_cache.clear_all()
+    yield
+    render_cache.clear_all()
+
+
+def test_memoized_render_is_byte_identical_to_unmemoized(tmp_path: Path):
+    """The memo must be invisible in the output — only in the clock."""
+    with render_cache.disabled():
+        baseline = _convert_copy(tmp_path, "unmemoized")
+    memoized = _convert_copy(tmp_path, "memoized")
+
+    _assert_same(baseline, memoized, "memoization")
+    # Guard against the test silently passing because the memo never
+    # engaged (e.g. a future refactor routes around it).
+    stats = render_cache.pygments_cache.stats()
+    assert stats["hits"] > 0, "memo never hit — the comparison proved nothing"
+
+
+def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch):
+    """Fanning the render out over worker processes must not change output.
+
+    The thresholds that normally keep small projects off the pool are
+    lowered here: this fixture is far below them, and the point is to
+    exercise the worker path, not the heuristic that avoids it.
+    """
+    monkeypatch.setattr(converter, "_MIN_MESSAGES_FOR_RENDER_POOL", 0)
+    monkeypatch.setattr(converter, "_MIN_UNITS_FOR_RENDER_POOL", 2)
+
+    # Count what the pool actually accepted. Every path in the fan-out
+    # falls back to inline rendering on trouble, so without this a broken
+    # pool would compare the serial path against itself and pass.
+    dispatched: list[str] = []
+    original_submit = RenderPool.submit
+
+    def counting_submit(self: RenderPool, unit: RenderUnit):
+        future = original_submit(self, unit)
+        if future is not None:
+            dispatched.append(unit.kind)
+        return future
+
+    monkeypatch.setattr(RenderPool, "submit", counting_submit)
+
+    serial = _convert_copy(tmp_path, "serial", render_jobs=1)
+    parallel = _convert_copy(tmp_path, "parallel", render_jobs=2)
+
+    _assert_same(serial, parallel, "the render fan-out")
+    assert "page" in dispatched, "no combined page went through a worker"
+    assert "session" in dispatched, "no session file went through a worker"

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -189,6 +189,14 @@ def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch
     kinds = [unit.kind for unit in dispatched]
     assert "page" in kinds, "no combined page went through a worker"
     assert "session" in kinds, "no session file went through a worker"
+    # Workers never load the transcript — every dispatched unit must carry
+    # its own entry slice (with aligned master-list ordinals), or the pool
+    # would be quietly rendering from nothing / falling back inline.
+    for unit in dispatched:
+        assert unit.entries, f"{unit.kind} {unit.key} dispatched without entries"
+        assert unit.entry_ordinals is not None and len(unit.entry_ordinals) == len(
+            unit.entries
+        ), f"{unit.kind} {unit.key} ordinals not aligned with its entries"
     # The fed-fragment path (work/render-format-once.md § 2): page workers
     # return fragment deltas, the parent absorbs them, and dispatched
     # session units carry their session's slice.

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import pytest
 
 from claude_code_log import converter, render_cache
+from claude_code_log import render_pool as render_pool_module
 from claude_code_log.converter import convert_jsonl_to
 from claude_code_log.render_pool import RenderPool, RenderUnit
 
@@ -105,6 +106,13 @@ def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch
     """
     monkeypatch.setattr(converter, "_MIN_MESSAGES_FOR_RENDER_POOL", 0)
     monkeypatch.setattr(converter, "_MIN_UNITS_FOR_RENDER_POOL", 2)
+    # Pin available memory too. The pool declines when memory is tight, so
+    # on a small CI runner this test would otherwise compare the inline
+    # path against itself — or fail its dispatch assertion — depending on
+    # what else happened to be resident.
+    monkeypatch.setattr(
+        render_pool_module, "_available_memory_bytes", lambda: 64 * 1024**3
+    )
 
     # Count what the pool actually accepted. Every path in the fan-out
     # falls back to inline rendering on trouble, so without this a broken

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -143,6 +143,9 @@ def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch
     lowered here: this fixture is far below them, and the point is to
     exercise the worker path, not the heuristic that avoids it.
     """
+    # The fragment store must be on regardless of the parent environment —
+    # the fed-fragment assertions below are vacuous with it disabled.
+    monkeypatch.delenv("CLAUDE_CODE_LOG_FRAGMENT_STORE", raising=False)
     monkeypatch.setattr(converter, "_MIN_MESSAGES_FOR_RENDER_POOL", 0)
     monkeypatch.setattr(converter, "_MIN_UNITS_FOR_RENDER_POOL", 2)
     # Pin available memory too. The pool declines when memory is tight, so

--- a/test/test_render_cache_equivalence.py
+++ b/test/test_render_cache_equivalence.py
@@ -119,8 +119,8 @@ def test_fragment_store_render_is_byte_identical(tmp_path: Path, monkeypatch):
     stores: list[RenderFragmentStore] = []
     original_make = converter._make_fragment_store
 
-    def capturing_make(format_: str):
-        store = original_make(format_)
+    def capturing_make(format_: str, **kwargs: int):
+        store = original_make(format_, **kwargs)
         if store is not None:
             stores.append(store)
         return store
@@ -153,7 +153,7 @@ def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch
     # path against itself — or fail its dispatch assertion — depending on
     # what else happened to be resident.
     monkeypatch.setattr(
-        render_pool_module, "_available_memory_bytes", lambda: 64 * 1024**3
+        render_pool_module, "available_memory_bytes", lambda: 64 * 1024**3
     )
 
     # Count what the pool actually accepted. Every path in the fan-out
@@ -177,8 +177,8 @@ def test_parallel_render_is_byte_identical_to_serial(tmp_path: Path, monkeypatch
     stores = []
     original_make = converter._make_fragment_store
 
-    def capturing_make(format_: str):
-        store = original_make(format_)
+    def capturing_make(format_: str, **kwargs: int):
+        store = original_make(format_, **kwargs)
         if store is not None:
             stores.append(store)
         return store

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -41,6 +41,42 @@ store picklable/spillable — measured peak-RSS-neutral, see § 4.9).
 Remaining: §§ 2's phases 2+ below, and the traps in § 4.8 discovered
 while landing phase 1.
 
+**Phase 3 progress (no per-worker transcript copy):** render workers no
+longer load the transcript at all. Every dispatched unit carries its own
+slice of the parent's master list (`RenderUnit.entries`) plus those
+entries' master-list ordinals; session units are sliced by the same
+trunk predicate every renderer's `generate_session` filters by (HTML/MD
+use `sessionId == sid or startswith(f"{sid}#agent-")`, JSON uses
+`get_parent_session_id(...) == sid` — same set), so the worker's
+re-filter is idempotent. The one per-worker piece of state is a *slim*
+SessionTree (`dag.slim_session_tree`, via the pool initializer): the
+render path reads only `sessions`/`junction_points`/`workflow_*`, and
+the per-message `nodes` mapping — whose pickled size is the whole
+transcript — stays in the parent, with lookups on the slim form raising
+so a future render-path consumer of `nodes` fails loudly rather than
+silently diverging (`workflow_runs` still carries each workflow agent's
+entries; small slice, and the renderer does read them). `RenderPool.submit`
+declines entry-less units to the inline path, and `_make_render_pool`
+declines when there is no pre-built session tree (a worker-side DAG
+rebuild from a slice alone can genuinely differ). The memory cap and
+the pool thresholds still assume the old full-copy footprint —
+deliberately over-conservative until the § 7.5 re-size is measured.
+
+Measured on the 8-core / 16GB VM, same archive as the post-feeding
+table below, byte-identical in every configuration:
+
+- `-app` single project: both (auto) went 12.4s / 59.8s CPU →
+  **9.9s / 29.1s CPU** (2.69x over memo-only, from 2.11x). Per-worker
+  CPU overhead at 8 workers fell ~4.4s → ~0.7s — the transcript-load
+  tax is gone, and the worker-count knee should move with it.
+- Hierarchy incremental (329MB stale): 30.6s / 108.4s CPU →
+  **21.8s / 62.5s CPU** (2.87x, at +3% CPU over serial — down from
+  +76%; the pre-feeding baseline was +305%). An 8-core VM now beats
+  the same morning's 16-core Mac run (29.4s) on this scenario.
+- Hierarchy full rebuild: unchanged (1.00x) — the still-unrevised
+  memory cap grants 1 worker/project on 16GB, so the fan-out stays
+  inert there until the § 7.5 re-size.
+
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.
 Everything below was measured, not assumed — the numbers are here so you
@@ -119,6 +155,55 @@ seven cost 7.6s of wall clock between them, so the run is within 8% of
 hands that project `jobs // stale projects` = 2 render workers while the
 small ones finish and 13 cores idle. Same project alone gets 16 workers
 and reaches 2.70x.
+
+**Post-feeding re-measure (2026-08-24).** Both machines, same archive
+(`downloads/projects`, 1539MB, largest 329MB), all rows byte-identical:
+
+| machine | scenario | config | wall | CPU |
+|---|---|---|---|---|
+| 16-core Mac (63GB) | full rebuild, 8 stale | memo only | 98.5s | 223.2s |
+| 16-core Mac (63GB) | full rebuild, 8 stale | both (3 workers/project) | 65.8s (1.50x) | 277.1s |
+| 16-core Mac (63GB) | incremental, 1 stale | memo only | 93.6s | 91.1s |
+| 16-core Mac (63GB) | incremental, 1 stale | both (16 workers) | **29.4s (3.18x)** | 286.1s |
+| 8-core VM (16GB) | full rebuild, 8 stale | memo only | 62.3s | 188.2s |
+| 8-core VM (16GB) | full rebuild, 8 stale | both (capped 1 worker/project) | 65.0s (0.96x) | 191.2s |
+| 8-core VM (16GB) | incremental, 1 stale | memo only | 63.7s | 61.7s |
+| 8-core VM (16GB) | incremental, 1 stale | both (capped 5 workers) | 30.6s (2.08x) | 108.4s |
+
+Single-project sweep on `-app` (140MB), wall / CPU:
+
+| workers | 16-core Mac | 8-core VM |
+|---|---|---|
+| serial (memo only) | 21.5s / 21.5s | 26.2s / 25.3s |
+| 2 | 16.4s / 29.5s | 19.2s / 32.7s |
+| 4 | 12.1s / 37.5s | 14.6s / 42.4s |
+| 8 | **10.2s** / 54.8s | 12.7s / 60.6s |
+| 16 | 10.9s / 99.8s | — |
+
+What the numbers settle, in order of consequence:
+
+1. **Feeding worked as designed**: incremental went 2.70x → 3.18x wall
+   and 367.9s → 286.1s CPU against the pre-feeding table above.
+2. **Per-worker bootstrap is now the whole remaining overhead, and it
+   scales with project size**: ~5s CPU/worker on the 140MB project
+   (99.8−21.5 over 16), ~12s/worker on the 329MB one (286.1−91.1 over
+   16). That is the transcript reload — § 2's "no per-worker copy" is
+   confirmed as the top item.
+3. **The sweep saturates at 8 workers, and `auto` overshoots on big
+   machines**: 16 workers is *slower* than 8 on the Mac (10.9s vs
+   10.2s) at nearly double the CPU. The § 7.5 revisit has its answer:
+   until the per-worker copy is gone, worker counts past ~8 are pure
+   cost, so `resolve_render_jobs`'s auto should be capped (or scaled
+   against project size) in the interim.
+4. **The wall floor is the parent, not the workers**: the Mac at 16
+   workers (29.4s) and the VM at 5 workers (30.6s) land on the same
+   incremental wall. The residue is the serial parent bootstrap
+   (load + parse + plan of the 329MB project). More workers cannot
+   help; only the restructuring can.
+5. **Full rebuild improved (1.27x → 1.50x) but stays the unsolved
+   case**, and on a 16GB machine the memory cap makes the fan-out
+   fully inert there (1 worker/project, 0.96x). The flat pool + cap
+   relaxation remain the fix, both unlocked by item 2.
 
 ---
 

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -172,15 +172,49 @@ hold. On the measured archives that residual is roughly 1.1-1.3x of
 the full-rebuild scenario. Worth having eventually — (c) is the most
 implementable shape — but it is no longer the dominant term.
 
-**Still open after phase 6:** the flat pool (above — residual ~1.1-1.3x
-on measured archives, token-governed nested pools the most
-implementable shape); the fragment-text spill (§ 4.9 made the store
-spillable, nothing spills yet — 186MB held in RAM on the 803MB
-archive; note that fed session slices re-materialize fragments at
-dispatch time, so a spill that matters must also throttle unit
-submission); and a >8-worker sweep on the 16-core Mac now that the
-per-worker transcript tax is gone (the knee at 8 was measured
-pre-feeding; `auto` may no longer overshoot).
+**Phase 7 progress (fragment-store memory valve, 2026-08-27):**
+`_make_fragment_store` now declines the store when available memory is
+under 2.4x the project's transcript bytes (the measured store-on
+serial peak, 1521MB on the 803MB project, plus margin), so a
+memory-tight machine converts at its pre-store footprint instead of
+trading its last RAM for CPU. `CLAUDE_CODE_LOG_FRAGMENT_STORE=1`
+forces the store past the valve; whenever the valve trips the render
+pool's own (far higher) memory bar has already declined, so the
+store-less conversion is always serial. Unit-pinned in
+`test_render_cache.py::TestFragmentStoreMemoryValve`.
+
+**Still open after phase 7:**
+
+- **The flat pool** (above — residual ~1.1-1.3x on measured archives,
+  token-governed nested pools the most implementable shape).
+- **Streaming conversion — the actual fix for peak memory.** Named
+  here so it stops hiding behind the spill: converting a project has
+  *always* loaded its entire transcript (master entry list + DAG +
+  trees), so peak RAM is bounded below by the largest single project
+  regardless of every knob — measured 1252MB store-less serial on the
+  803MB project (~1.56x bytes on disk), ~1.9x with the store. A
+  machine under ~2x its largest project cannot convert it, and no
+  optimisation on this branch moves that floor; the valve above only
+  stops the store from lowering the cliff's edge. The fix is a
+  metadata-planned streaming pass (the cache DB already holds
+  session-level metadata): plan sessions/pages from cache, then load,
+  render and drop one session or page at a time. Hard parts, from the
+  code as-built: dedup and cross-session tool_use/result pairing
+  assume the whole list is resident, the DAG builds from all entries,
+  combined pages need global session ordering, and fragment-store
+  ordinals are master-list positions. Big feature; nothing else on
+  this list delivers the "no archive too big for the machine"
+  property.
+- **The fragment-text spill** — demoted from headline to footnote by
+  the § 4.9 measurement: it bounds only the store's own +269MB, not
+  the master-list floor above, so it is a ~15-20% peak shave, not a
+  boundedness fix. If implemented, fed session slices re-materialize
+  fragments at dispatch time, so a spill that holds under the fan-out
+  must also throttle unit submission. With the valve landed, this is
+  no longer urgent on any measured machine shape.
+- **A >8-worker sweep on the 16-core Mac** now that the per-worker
+  transcript tax is gone (the knee at 8 was measured pre-feeding;
+  `auto` may no longer overshoot).
 
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -77,6 +77,49 @@ table below, byte-identical in every configuration:
   memory cap grants 1 worker/project on 16GB, so the fan-out stays
   inert there until the § 7.5 re-size.
 
+**Phase 4 progress (§ 7 item 5 re-size, 2026-08-26):** the memory cap
+now charges measured post-feeding footprints instead of the old
+full-copy-per-worker model. VmHWM polling across fanned conversions of
+the 140MB/47k and 329MB/97k projects on the 8-core/16GB VM measured:
+conversion parent 598MB / 1458MB (~4.4x transcript bytes — master list
++ fragment store + in-flight slices), largest worker 218MB / 329MB
+(~136MB + 0.59x). `memory_capped_workers` now charges the parent
+4.5x + base and each worker 0.8x + base (~1.2–1.35x margin over the
+fit; the one under-charged pathology — a single session spanning most
+of the transcript, whose slice re-inflates in its worker — is noted at
+the constants). On this VM the incremental cap went 5 → 8 of 8 workers
+and the measured scenario went 21.8s → **19.1s wall (3.24x over the
+61.8s serial, at +6% CPU)**, byte-identical in every configuration.
+Full rebuild on 8 cores stays 1 worker/project because the *core* split
+(`jobs // stale`) binds before memory does — the § "flat pool" remains
+the fix for that tail, with a cheaper interim below.
+
+**Interim tail fix (landed with the re-size):** the all-projects loop
+now holds a *dominant* stale project out of the pool and converts it
+last, alone, with the whole render budget
+(`converter._dominant_plan` + the hold-back wiring in phase 2).
+Dominance is 2x the runner-up, compared on cached message counts when
+every plan has one (bytes when not — and note bytes alone would *miss*
+the reference giant: 1.08x runner-up's bytes, 2.07x its messages).
+Measured on the 8-core VM: full rebuild 65.4s → **58.5s (1.12x)**,
+byte-identical. The modest factor is the archive's shape, not the
+mechanism: once the 97k-message giant is held back, the 47k runner-up
+becomes the new pool wall and the sizes below it are level — exactly
+the case the guard declines to hold back. An archive shaped
+"one giant + dwarfs" gains more; several level-sized bigs need the
+true flat pool (one worker pool over render units across projects,
+per-project setups registered with workers, parse/plan still
+per-project, cache writes still parent-owned per project), which
+stays the end state.
+
+**Still open after phase 4:** the flat pool (above); the fragment-text
+spill (§ 4.9 made the store spillable, nothing spills yet — 186MB held
+in RAM on the 803MB archive); allocating referenced-mode image names in
+the format phase (§ 4.3 — would fix the existing combined-vs-session
+name collision *and* make the mode pool-safe); and a >8-worker sweep on
+the 16-core Mac now that the per-worker transcript tax is gone (the
+knee at 8 was measured pre-feeding; `auto` may no longer overshoot).
+
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.
 Everything below was measured, not assumed — the numbers are here so you
@@ -91,12 +134,16 @@ Six commits, oldest first:
 
 | commit | what |
 |---|---|
-| `f136c32` | Memoize the pure render leaves (Pygments, Markdown) |
-| `31b09e6` | Fan a project's own pages and session files out over workers |
-| `69ccbe3` | Make the render fan-out opt-in and memory-safe |
-| `687bc7a` | Detect available memory on macOS, and report the cap up front |
-| `eb152da` | Support Windows in the memory probe and the benchmark |
-| `f66c759` | Turn the render fan-out on by default |
+| `0f70250` | Memoize the pure render leaves (Pygments, Markdown) |
+| `9312ec1` | Fan a project's own pages and session files out over workers |
+| `e8b732d` | Make the render fan-out opt-in and memory-safe |
+| `84dad33` | Detect available memory on macOS, and report the cap up front |
+| `fe273dd` | Support Windows in the memory probe and the benchmark |
+| `dbc888d` | Turn the render fan-out on by default |
+
+(then the phase 1–3 commits described in the status block above:
+`3d4a967` fragment store, `bfdbb4c` digest verification, `58f62a0`
+ordinal keys, `4b6f654` fed fragments, `dc02828` fed entry slices.)
 
 Read `dev-docs/application_model.md` §§ 2.9–2.10 first — that is the
 as-built reference for both, and it is current.

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -13,8 +13,11 @@ Phase 1 confirmed the duplicate work is structurally gone (64,968 lookups
 win on top of a warm leaf memo is modest (~1s of 27s CPU) — the value is
 what it unblocks: § 2's parallel format phase, fed workers, and the spill
 that bounds fragment memory (186MB held in-memory on the 803MB archive,
-~24% of disk bytes on smaller ones). Remaining: §§ 2's phases 2+ below,
-and the traps in § 4.8 discovered while landing phase 1.
+~24% of disk bytes on smaller ones). The § 4.9 content-ref retention is
+since resolved (equality guard replaced by a content digest, making the
+store picklable/spillable — measured peak-RSS-neutral, see § 4.9).
+Remaining: §§ 2's phases 2+ below, and the traps in § 4.8 discovered
+while landing phase 1.
 
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.
@@ -255,13 +258,35 @@ them). Assume any new per-tree state is a divergence source until proven
 otherwise, and verify with hash runs over `downloads/projects/` — the
 fixture project exercises none of these classes.
 
-### 4.9 Storing content refs retains memory
+### 4.9 Storing content refs retains memory (RESOLVED — with a corrected premise)
 
-The content-equality guard keeps a reference to one MessageContent per
-fragment, which retains object graphs beyond the fragment strings
-(measured on the 803MB archive: maxrss 1236MB → 1507MB store-on, of which
-186MB is fragment text). The phase-2 spill design must either drop the
-content refs (replace with a content hash) or spill them too.
+The content-equality guard originally kept a reference to one
+MessageContent per fragment. Resolved by replacing the retained ref
+with a 16-byte content digest (`fragment_store.content_digest`) — a
+canonical BLAKE2b walk with the same field coverage as dataclass
+`__eq__` (compare=True fields only), so the hit-verification
+semantics are unchanged. Where Python `==` is looser than the
+canonical form (bool/int unification, dict insertion order,
+identity-`repr` objects) the digests differ and the lookup counts as
+a conflict served fresh — divergence is only ever in the safe
+direction. Unit-pinned in `test/test_fragment_store.py`; hash-runs
+over five real archives byte-identical with unchanged hit rates
+(32,441/64,968 on the 803MB archive; conflict counts 0–48 per
+project, all served fresh).
+
+**The premise needed correcting, though.** A direct A/B on the 803MB
+archive (dev VM, serial, warm nothing) measured maxrss 1521MB with
+the ref-retaining store and 1521MB with the digest store — dropping
+the refs moves the *peak* not at all on this workload. The peak lands
+at the end of the combined-page pass, where the stored content
+objects alias strings the master entry list and the live tree hold
+anyway; the +269MB store-on delta over store-off (1252MB) is the
+186MB of fragment text plus per-entry dict/string overhead, not the
+refs. So the digest's value is structural, not a memory win: the
+store now holds only strings and bytes (picklable, spillable, cannot
+pin object graphs in differently-shaped workloads), which is the
+property the fed-worker format phase needs. Any future memory
+bounding must target the fragment text itself.
 
 ---
 

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -118,11 +118,69 @@ the combined-vs-session overwrite bug and lifts both the pool gate and
 the fragment-store exclusion for the mode — see § 4.3 (RESOLVED) for
 the details and the two latent inconsistencies it flushed out.
 
-**Still open after phase 5:** the flat pool (above); the fragment-text
-spill (§ 4.9 made the store spillable, nothing spills yet — 186MB held
-in RAM on the 803MB archive); and a >8-worker sweep on the 16-core Mac
-now that the per-worker transcript tax is gone (the knee at 8 was
-measured pre-feeding; `auto` may no longer overshoot).
+**Phase 6 progress (generalized hold-back, 2026-08-27):**
+`_dominant_plan` (one project, 2x the runner-up) became
+`_holdback_plans`: a greedy makespan comparison, largest project
+first — hold while `pool(rest) + fanned(largest)` beats pooling
+everything, with the fanned time taken from a deliberately
+conservative speedup table (`_fanned_speedup`: 2.5x at 8+ workers vs
+2.7-3.2x measured, because over-estimating serializes projects that
+were better off pooled — the costly direction) over the workers a
+lone conversion would actually get (memory-capped against the
+project's own bytes, so a machine that can't fan never holds). It
+reproduces every decision the 2x rule made — including the reference
+archive, where after the 97k giant the twin 47k projects keep each
+other's pool bounded and nothing more holds — and additionally holds
+the shapes the 2x bar missed (a runner-up bounding a pool of smalls
+without being 2x any of them; unit-pinned in
+`test_render_cache.py::TestHoldbackPlans`). Multiple held projects
+convert sequentially after the pool, smallest first, each with the
+full render budget. Re-benchmarked over the reference archive on the
+8-core box (where the held set is identical, so this is a
+no-regression check plus fresher baselines): full rebuild 62.0s
+memo-only → 53.9s both (1.15x, vs 1.12x measured for the
+single-dominant rule), incremental 59.2s → 17.0s (3.48x),
+byte-identical in every configuration.
+
+**Flat-pool design analysis (2026-08-27, so nobody re-derives it):**
+the true flat pool's *residual* win over the generalized hold-back is
+smaller than it looks, and each candidate architecture has a sharp
+edge. (a) A parent-serial flat pool (parent parses each project,
+dispatches units to one shared pool) sinks the full rebuild: Σ parse
+across the archive is ~50-60s of inherently serial work on the 8-core
+VM, at or above today's whole full-rebuild wall — parallel parse
+across project workers is load-bearing, so the parent-serial shape is
+only viable with pipelined overlap, and even then bounded below by the
+biggest parse chain. (b) Keeping parse in project workers means units
+(carrying entry slices) must flow worker→parent→render-worker — double
+pickling of the whole transcript — or through a Manager queue with the
+same cost. (c) A token-governed variant (nested pools as today, but a
+machine-wide render-slot semaphore so finished projects' capacity
+flows to the still-running ones) preserves parallel parse and needs no
+unit shipping, but its memory story is subtle: spawned-but-idle
+workers retain their base+memo RSS across the shifting token
+assignment, and the two-level cap formula would need rethinking.
+(d) For *level-sized* projects specifically, concurrent-static is
+already near-optimal once the machine is saturated (speedup is concave
+in workers, so spreading cores across projects beats fanning one
+wide); the static split's real failures are skew (now held back) and
+the memory-capped regime where per-project jobs collapse to 1 (held
+back too, when the makespan math clears). What a flat pool uniquely
+adds: reclaiming the idle cores during a held-back project's serial
+parse phase, and the drained-pool tail among projects too level to
+hold. On the measured archives that residual is roughly 1.1-1.3x of
+the full-rebuild scenario. Worth having eventually — (c) is the most
+implementable shape — but it is no longer the dominant term.
+
+**Still open after phase 6:** the flat pool (above — residual ~1.1-1.3x
+on measured archives, token-governed nested pools the most
+implementable shape); the fragment-text spill (§ 4.9 made the store
+spillable, nothing spills yet — 186MB held in RAM on the 803MB
+archive; note that fed session slices re-materialize fragments at
+dispatch time, so a spill that matters must also throttle unit
+submission); and a >8-worker sweep on the 16-core Mac now that the
+per-worker transcript tax is gone (the knee at 8 was measured
+pre-feeding; `auto` may no longer overshoot).
 
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.
@@ -491,23 +549,22 @@ Full suite before pushing: `just ci`.
 
 ---
 
-## 6. Environment notes for the dev VM
+## 6. Environment notes for the dev box
 
-- **The 4-core / 4GB VM cannot measure the fan-out.** `memory_capped_workers`
-  correctly declines on every real project there, so `auto` is
-  indistinguishable from serial. Correctness work is fine locally;
-  performance claims need the Mac and `scripts/bench_render.py`.
-- **Don't run unbounded benchmarks on the VM.** An earlier
-  `--all-projects` benchmark exhausted RAM and wedged it (all four cores
-  pegged, unresponsive, hard restart). The memory cap now prevents the
-  worker explosion, but copying multi-GB project trees to `/tmp` is still
-  worth sizing first.
-- **`.venv` is shared with the host Mac over the mount.** A `uv run` on
-  either side replaces it with that platform's binaries and the other side
-  then fails with `Exec format error` until it re-syncs. `uv sync` fixes
-  it; pointing `UV_PROJECT_ENVIRONMENT` at different paths per platform
-  would fix it properly.
-- Real transcripts for local testing: `downloads/projects/` (7.8GB, 84
+- **The 8-core / 16GB box measures the fan-out fine** — it is the
+  "8-core VM" every post-feeding table in this doc quotes. Core count
+  changes the fan-out's answer, so cross-check performance claims on
+  the 16-core Mac with `scripts/bench_render.py` before generalizing.
+- **Don't run unbounded benchmarks without sizing them first.** An
+  earlier `--all-projects` benchmark on a smaller VM exhausted RAM and
+  wedged it (every core pegged, unresponsive, hard restart). The memory
+  cap now prevents the worker explosion, but copying multi-GB project
+  trees to scratch space is still worth sizing against free disk.
+- The box runs the full suite, browser tests included (`just
+  test-browser` — Chromium and its system libraries are provisioned by
+  the box config). `.venv` lives on a box-local shadow volume, so host
+  and box binaries never clobber each other.
+- Real transcripts for local testing: `downloads/projects/` (7.9GB, 84
   projects, with a warm cache DB). Test fixtures:
   `test/test_data/real_projects/`.
 

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -1,0 +1,282 @@
+# Render step 3: format once, assemble many
+
+**Status:** proposed. Steps 1 and 2 have landed on
+`perf/render-memo-and-intra-project-jobs` (stacked on
+`feat/archive-search-server`); this is the follow-up they were built to
+make safe to attempt.
+
+This is a handover note. It exists because the two landed optimisations
+each hit a ceiling, and *the same restructuring removes both ceilings*.
+Everything below was measured, not assumed — the numbers are here so you
+don't have to re-derive them, and the traps are here because each one cost
+real time to find.
+
+---
+
+## 1. Where things stand
+
+Six commits, oldest first:
+
+| commit | what |
+|---|---|
+| `f136c32` | Memoize the pure render leaves (Pygments, Markdown) |
+| `31b09e6` | Fan a project's own pages and session files out over workers |
+| `69ccbe3` | Make the render fan-out opt-in and memory-safe |
+| `687bc7a` | Detect available memory on macOS, and report the cap up front |
+| `eb152da` | Support Windows in the memory probe and the benchmark |
+| `f66c759` | Turn the render fan-out on by default |
+
+Read `dev-docs/application_model.md` §§ 2.9–2.10 first — that is the
+as-built reference for both, and it is current.
+
+### The problem both steps attacked
+
+A project conversion renders **every message twice**: once into its
+combined-transcript page and once into its own `session-*.html`. Both go
+through `HtmlRenderer.generate`, which rebuilds the tree from the same
+source entries, so all per-message formatting is duplicated. Measured on a
+118-file / 12k-message project: **22,420 `format_content` calls covering
+11,113 distinct messages**.
+
+- **Step 1 (memo)** caches the two expensive leaves — Pygments
+  highlighting and mistune Markdown. 12.4s → 8.7s on that project.
+- **Step 2 (fan-out)** renders the independent output files (combined
+  pages + session files) in worker processes. 2.70x on a 16-core Mac for
+  an incremental run.
+
+### The two ceilings
+
+**They fight each other.** Splitting units across processes gives every
+worker a cold memo cache, so the page-vs-session duplication comes back.
+On 4 cores, 47k messages:
+
+| | wall | total CPU |
+|---|---|---|
+| neither | 44.8s | 43.5s |
+| memo only | 27.6s | 26.2s |
+| fan-out only | 22.5s | 57.0s |
+| both | **20.0s** | 48.8s |
+
+Both together is fastest, so they compose — but only sub-additively. The
+fan-out alone is 2.0x; on top of the memo it is 1.38x.
+
+**Workers are memory-hungry.** Each holds a full copy of the transcript
+(they reload from cache rather than being fed), and a loaded transcript
+costs 2–3x its bytes on disk (measured: 118MB → 236MB RSS; 140MB → 418MB).
+Peak is `workers × project size`, multiplied again by the project pool
+under `--all-projects`. This drove a 4GB dev VM into swap and wedged it,
+which is why `render_pool.memory_capped_workers` exists.
+
+16-core Mac, 8 real projects (1543MB of transcripts, largest 329MB):
+
+| scenario | config | wall | CPU | cores used |
+|---|---|---|---|---|
+| full rebuild, 8 stale | memo only | 100.8s | 226.0s | 2.2 of 16 |
+| full rebuild, 8 stale | both | 79.3s (1.27x) | 324.8s | 4.1 of 16 |
+| incremental, 1 stale | memo only | 93.2s | 90.8s | 1.0 of 16 |
+| incremental, 1 stale | both | **34.6s (2.70x)** | 367.9s | 10.6 of 16 |
+
+**The full-rebuild row is the unsolved case.** Converting the largest
+project alone takes 93.2s; converting all eight takes 100.8s — the other
+seven cost 7.6s of wall clock between them, so the run is within 8% of
+"how long does the biggest project take". The static budget split then
+hands that project `jobs // stale projects` = 2 render workers while the
+small ones finish and 13 cores idle. Same project alone gets 16 workers
+and reaches 2.70x.
+
+---
+
+## 2. What step 3 is
+
+Split rendering into two phases:
+
+1. **Format once.** Compute each distinct message's rendered fragment
+   exactly once, in parallel.
+2. **Assemble many.** Build every combined page and every session file
+   from those fragments.
+
+Assembly is nearly free — `[TIMING] Template rendering (20022484 chars)
+0.082s` for a 20MB page, against 0.776s of content formatting for the same
+page. The expensive 72% is the formatting, and it is currently done twice.
+
+### Why this removes both ceilings at once
+
+- **No memo/parallelism conflict.** The duplication is eliminated
+  structurally rather than papered over with a cache, so splitting work
+  across processes no longer re-creates it. The leaf memo in
+  `render_cache.py` stays useful for *intra*-pass repeats (the same file
+  Read many times — Pygments hit rate was ~69%, well above the 50% that
+  page-vs-session duplication alone implies), but it stops being
+  load-bearing.
+- **No per-worker transcript copy.** Fragments are small strings keyed by
+  message, so a worker can be *fed* its slice instead of reloading the
+  whole project. That removes the `workers × project size` memory
+  multiplication, which in turn removes the reason for
+  `memory_capped_workers` to be so conservative — and unblocks the
+  full-rebuild tail, since the budget stops being rationed by RAM.
+- **Enables a flat pool.** With units this cheap, the two nested pool
+  levels (projects × render workers) can collapse into one pool over
+  format units, which is the real fix for the static-split tail problem.
+
+---
+
+## 3. The seams
+
+| what | where |
+|---|---|
+| Per-message formatting (the pre-order walk to split) | `html/renderer.py:1493` `_annotate_tree_for_render` |
+| Render entry point | `html/renderer.py:1592` `generate` → `1642` `_generate_inner` |
+| Session filter + back-link | `html/renderer.py:1735` `generate_session` |
+| Tree construction (format-neutral) | `renderer.py:717` `generate_template_messages` |
+| Combined-page loop | `converter.py:1696` `_generate_paginated_html` |
+| Session-file loop | `converter.py:2789` `_generate_individual_session_files` |
+| Unit dispatch (inline or pooled) | `converter.py:2728` `_dispatch_render_units` |
+| Pool gating | `converter.py:2648` `_make_render_pool` |
+| Worker implementation | `render_pool.py` |
+
+`_annotate_tree_for_render` is the fulcrum. It walks the tree depth-first
+and writes `rendered_title` / `rendered_html` / `rendered_timestamp` onto
+each `TemplateMessage`, then the Jinja macro recurses over
+`message.children`. Step 3 means computing that annotation once per
+distinct message and reusing it across every tree that contains the
+message.
+
+---
+
+## 4. Traps
+
+Each of these cost real time to discover. None are obvious from the code.
+
+### 4.1 `uuid` is NOT a safe key for a message fragment
+
+Instrumenting a real project found 22,420 `format_content` calls, 11,113
+distinct uuids, and **196 cases where the same uuid rendered different
+HTML**. Those are genuine uuid *collisions* across distinct messages
+(resumed/forked sessions re-use them), not context-sensitivity — one
+sample showed an assistant text message and a todo-list tool use sharing
+a uuid. Key on content, or on the identity of the source `TranscriptEntry`
+(the `messages` list is shared across both render passes within one
+`convert_jsonl_to` call). Do not key on uuid.
+
+### 4.2 Markdown is not a pure function of its text
+
+`html/utils.py::render_markdown` runs the SHA-linkifier plugin, which
+resolves commit hashes against the per-render repo cwd carried by
+`git_remote._render_repo_cwd` (a `ContextVar`, read via the public
+`current_render_repo_cwd()`). The same text legitimately renders different
+links in different projects. Any cache or fragment store must include that
+cwd in its key, or a long-lived host (`serve`, the TUI) will serve one
+project's commit links inside another's page. Pygments has no such
+coupling. This is the *only* ContextVar affecting render output — verified
+by grepping the package.
+
+### 4.3 `image_export_mode="referenced"` is not parallel-safe
+
+Renders write `images/image_NNNN.png` from `self._image_counter`, which
+resets per `generate()` call (`html/renderer.py:1661`). Those filenames
+already collide between the combined and per-session passes today;
+concurrency would let two processes write one file at once.
+`_make_render_pool` declines for this mode. Step 3 could actually *fix*
+this properly by allocating image names once during the format phase —
+worth doing, but out of scope unless it falls out naturally.
+
+### 4.4 Pages have a write-ordering dependency (already fixed — don't reintroduce)
+
+`_generate_paginated_html` used to call
+`_enable_next_link_on_previous_page(output_dir, page_num - 1, suffix)`
+*while generating page N*, so page N's render edited page N-1's file on
+disk. `31b09e6` moved that to a single idempotent post-pass over pages
+`1..N-1` after all pages land. Keep it that way.
+
+### 4.5 Output is written with `errors="replace"`
+
+Transcripts can carry lone surrogates (issue #139). Every write uses
+`write_text(..., encoding="utf-8", errors="replace")`. Match it, or you
+will crash on real data that currently renders fine.
+
+### 4.6 The parent owns every cache write
+
+Workers render and write output files, nothing else. Staleness checks and
+`update_html_cache` / `update_page_cache` stay in the parent so the SQLite
+DB keeps a single writer. `_dispatch_render_units` takes an `on_written`
+callback for exactly this. Preserve the property.
+
+### 4.7 Every fallback path must stay a fallback
+
+A pool that can't bootstrap (a library caller without the
+`if __name__ == "__main__"` guard `spawn` needs), or a worker that dies,
+must still produce complete correct output by rendering inline. Never let
+a performance feature become a correctness requirement.
+
+---
+
+## 5. How to verify
+
+**Byte-equivalence is the acceptance test.** Any restructuring must
+produce identical output to the serial, un-memoized path.
+
+```bash
+uv run pytest test/test_render_cache_equivalence.py -v
+```
+
+That converts a real 40-session project three ways (memo off, memo on,
+fanned out over workers) and compares bytes, with guards so a silent
+fallback to the inline path can't make the comparison vacuous. Extend it
+with a step-3 configuration rather than writing a new harness.
+
+Then the wider check, which hashes output across far more real data:
+
+```bash
+uv run python scripts/bench_render.py ~/.claude/projects/<big-project>
+uv run python scripts/bench_render.py ~/.claude/projects --all-projects --projects 8
+```
+
+It copies to scratch space (never touches the real tree), warms the cache,
+times every configuration, prints the memory cap up front, and fails loudly
+if any configuration's output differs. A 233-file run confirmed all six
+configurations byte-identical.
+
+Full suite before pushing: `just ci`.
+
+---
+
+## 6. Environment notes for the dev VM
+
+- **The 4-core / 4GB VM cannot measure the fan-out.** `memory_capped_workers`
+  correctly declines on every real project there, so `auto` is
+  indistinguishable from serial. Correctness work is fine locally;
+  performance claims need the Mac and `scripts/bench_render.py`.
+- **Don't run unbounded benchmarks on the VM.** An earlier
+  `--all-projects` benchmark exhausted RAM and wedged it (all four cores
+  pegged, unresponsive, hard restart). The memory cap now prevents the
+  worker explosion, but copying multi-GB project trees to `/tmp` is still
+  worth sizing first.
+- **`.venv` is shared with the host Mac over the mount.** A `uv run` on
+  either side replaces it with that platform's binaries and the other side
+  then fails with `Exec format error` until it re-syncs. `uv sync` fixes
+  it; pointing `UV_PROJECT_ENVIRONMENT` at different paths per platform
+  would fix it properly.
+- Real transcripts for local testing: `downloads/projects/` (7.8GB, 84
+  projects, with a warm cache DB). Test fixtures:
+  `test/test_data/real_projects/`.
+
+---
+
+## 7. Suggested order
+
+1. Read `dev-docs/application_model.md` §§ 2.9–2.10.
+2. Extract the format phase behind the existing seam — produce a
+   fragment store keyed per § 4.1, consumed by `_annotate_tree_for_render`.
+   Keep it serial at first; prove byte-equivalence.
+3. Confirm the duplicate work is gone (instrument `format_content` call
+   counts: they should fall from ~22,420 to ~11,113 on the reference
+   project), and measure serial wall clock.
+4. Only then parallelise the format phase, and only then consider
+   collapsing the two pool levels into one flat pool.
+5. Revisit `memory_capped_workers`, `_MIN_MESSAGES_FOR_RENDER_POOL`
+   (`converter.py:2645`) and `per_project_render_jobs`
+   (`converter.py:4204`) — all three were sized around a per-worker
+   transcript copy that step 3 should make unnecessary.
+
+If step 3 turns out to be too invasive, the three landed pieces are
+independently useful and each commit reverts cleanly.

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -1,9 +1,20 @@
 # Render step 3: format once, assemble many
 
-**Status:** proposed. Steps 1 and 2 have landed on
-`perf/render-memo-and-intra-project-jobs` (stacked on
-`feat/archive-search-server`); this is the follow-up they were built to
-make safe to attempt.
+**Status:** phase 1 (serial fragment store) landed on
+`perf/render-memo-and-intra-project-jobs`. Each entry-derived message is
+now formatted once per conversion and reused across the combined pages
+and session files — `fragment_store.py`, consumed by
+`_annotate_tree_for_render`, wired in `convert_jsonl_to`. Verified
+byte-identical on five real projects (including the 803MB / 187-file
+claude-code-log archive at a 50% hit rate) and by
+`test_render_cache_equivalence.py::test_fragment_store_render_is_byte_identical`.
+Phase 1 confirmed the duplicate work is structurally gone (64,968 lookups
+→ 32,441 formats on that archive), but also that its *serial* wall-clock
+win on top of a warm leaf memo is modest (~1s of 27s CPU) — the value is
+what it unblocks: § 2's parallel format phase, fed workers, and the spill
+that bounds fragment memory (186MB held in-memory on the 803MB archive,
+~24% of disk bytes on smaller ones). Remaining: §§ 2's phases 2+ below,
+and the traps in § 4.8 discovered while landing phase 1.
 
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.
@@ -207,6 +218,50 @@ A pool that can't bootstrap (a library caller without the
 `if __name__ == "__main__"` guard `spawn` needs), or a worker that dies,
 must still produce complete correct output by rendering inline. Never let
 a performance feature become a correctness requirement.
+
+### 4.8 A message's rendered fragment is NOT a pure function of its entry
+
+Discovered by hash-diffing real projects after the fixture-based
+equivalence test already passed — fixture coverage was not enough. Three
+distinct classes of cross-tree divergence exist, each with its own guard
+in the landed phase 1 (all in `_annotate_tree_for_render` /
+`fragment_store.py`):
+
+1. **Per-tree `#msg-d-{N}` anchors.** Async task forward/back-links,
+   background-job links and hook parent links embed the *partner*
+   message's `message_index`, which is assigned per render tree — the
+   same message links to `#msg-d-253` in its session tree and
+   `#msg-d-893` in the combined tree. Guard: any fragment whose output
+   contains `msg-d-` is never stored (output scan — catches every
+   emitter, present and future; a false positive only declines caching).
+2. **Tree-derived TemplateMessage flags.** `display_model` (a Task spawn
+   card shows the sub-agent's model badge only in a tree that contains
+   the sub-agent's transcript), `agent_depth`, pair presence,
+   `spawns_collapsed_transcript`, `in_workflow_sidechannel`. Guard: a
+   signature of these fields is part of the store key, so each variant
+   occupies its own slot.
+3. **Content built from cross-message ctx lookups.** A tool result whose
+   paired `tool_use` lives in *another session* resolves its tool name in
+   the combined tree but not in the session tree, producing different
+   MessageContent for the same entry (observed: generic collapsible
+   rendering vs. specialized). Guard: `get()` verifies the stored content
+   object compares equal to the requesting tree's content (dataclass
+   equality; `message_index`/`fragment_key` are `compare=False`), else
+   it's a counted conflict served fresh.
+
+The uuid-collision instrumentation quoted in § 4.1 could not have found
+classes 1–3 (it compared within one project that happened not to exercise
+them). Assume any new per-tree state is a divergence source until proven
+otherwise, and verify with hash runs over `downloads/projects/` — the
+fixture project exercises none of these classes.
+
+### 4.9 Storing content refs retains memory
+
+The content-equality guard keeps a reference to one MessageContent per
+fragment, which retains object graphs beyond the fragment strings
+(measured on the 803MB archive: maxrss 1236MB → 1507MB store-on, of which
+186MB is fragment text). The phase-2 spill design must either drop the
+content refs (replace with a content hash) or spill them too.
 
 ---
 

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -112,13 +112,17 @@ per-project setups registered with workers, parse/plan still
 per-project, cache writes still parent-owned per project), which
 stays the end state.
 
-**Still open after phase 4:** the flat pool (above); the fragment-text
+**Phase 5 progress (§ 4.3 referenced-image names, 2026-08-27):**
+referenced-mode image filenames are now content-addressed, which fixes
+the combined-vs-session overwrite bug and lifts both the pool gate and
+the fragment-store exclusion for the mode — see § 4.3 (RESOLVED) for
+the details and the two latent inconsistencies it flushed out.
+
+**Still open after phase 5:** the flat pool (above); the fragment-text
 spill (§ 4.9 made the store spillable, nothing spills yet — 186MB held
-in RAM on the 803MB archive); allocating referenced-mode image names in
-the format phase (§ 4.3 — would fix the existing combined-vs-session
-name collision *and* make the mode pool-safe); and a >8-worker sweep on
-the 16-core Mac now that the per-worker transcript tax is gone (the
-knee at 8 was measured pre-feeding; `auto` may no longer overshoot).
+in RAM on the 803MB archive); and a >8-worker sweep on the 16-core Mac
+now that the per-worker transcript tax is gone (the knee at 8 was
+measured pre-feeding; `auto` may no longer overshoot).
 
 This is a handover note. It exists because the two landed optimisations
 each hit a ceiling, and *the same restructuring removes both ceilings*.
@@ -338,15 +342,28 @@ project's commit links inside another's page. Pygments has no such
 coupling. This is the *only* ContextVar affecting render output — verified
 by grepping the package.
 
-### 4.3 `image_export_mode="referenced"` is not parallel-safe
+### 4.3 `image_export_mode="referenced"` is not parallel-safe (RESOLVED)
 
-Renders write `images/image_NNNN.png` from `self._image_counter`, which
-resets per `generate()` call (`html/renderer.py:1661`). Those filenames
-already collide between the combined and per-session passes today;
-concurrency would let two processes write one file at once.
-`_make_render_pool` declines for this mode. Step 3 could actually *fix*
-this properly by allocating image names once during the format phase —
-worth doing, but out of scope unless it falls out naturally.
+Renders used to write `images/image_NNNN.png` from a per-`generate()`
+counter, so the combined and per-session passes assigned the same names
+to *different* images (the last pass overwrote the other's files), and
+concurrency would have let two processes write one file at once —
+`_make_render_pool` declined for the mode, and the fragment store
+excluded it. Resolved by content-addressing the filenames
+(`image_export.export_image`: `image_<blake2b-of-decoded-bytes>.<ext>`,
+written via unique temp file + atomic `os.replace`, skipped when the
+file already exists): every pass, run, and worker converges on the same
+file per image, so the pool gate and the fragment-store exclusion are
+lifted. This also fixed two latent inconsistencies found on the way:
+paginated combined pages ignored the conversion's image mode entirely
+(built a default embedded renderer, both inline and in workers), and a
+default Markdown conversion resolved to referenced *inside*
+`get_renderer` while the pool gate checked the raw `None` param — so
+pooled Markdown renders were already running the colliding counter.
+Regression coverage: `test_image_export.py`
+(`TestReferencedModeAcrossRenderPasses` parametrized over the paginated
+and single-file combined paths, plus content-addressing unit tests) and
+the inverted pool-gate test in `test_render_cache.py`.
 
 ### 4.4 Pages have a write-ordering dependency (already fixed — don't reintroduce)
 

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -560,10 +560,12 @@ Full suite before pushing: `just ci`.
   wedged it (every core pegged, unresponsive, hard restart). The memory
   cap now prevents the worker explosion, but copying multi-GB project
   trees to scratch space is still worth sizing against free disk.
-- The box runs the full suite, browser tests included (`just
-  test-browser` — Chromium and its system libraries are provisioned by
-  the box config). `.venv` lives on a box-local shadow volume, so host
-  and box binaries never clobber each other.
+- The box runs all of `just ci`: the full suite including browser
+  tests (Chromium and its system libraries are provisioned by the box
+  config) and the pyright leg (Debian's nodejs is provisioned so the
+  pyright wrapper uses its bundled JS instead of fetching node past
+  the wall). `.venv` lives on a box-local shadow volume, so host and
+  box binaries never clobber each other.
 - Real transcripts for local testing: `downloads/projects/` (7.9GB, 84
   projects, with a warm cache DB). Test fixtures:
   `test/test_data/real_projects/`.

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -8,6 +8,28 @@ and session files — `fragment_store.py`, consumed by
 byte-identical on five real projects (including the 803MB / 187-file
 claude-code-log archive at a 50% hit rate) and by
 `test_render_cache_equivalence.py::test_fragment_store_render_is_byte_identical`.
+
+**Phase 2 progress (fed fragments):** three follow-up commits made the
+store process-portable and wired it through the fan-out — the
+hit-verification now stores a content *digest* instead of a retained
+`MessageContent` ref (§ 4.9, premise corrected there), keys are
+master-list *ordinals* instead of `id(entry)`, and the render pool now
+moves fragments across the process boundary: page workers export their
+store as a delta in the result tuple, the parent absorbs the deltas,
+and each session unit is dispatched carrying its session's slice
+(`RenderUnit.fed_fragments`), which the worker seeds its own store
+from. Worker session hit rates measured 96–100% (they were 0 — workers
+had no store at all), for −14% total CPU and a small wall win on an
+8-core VM over a 34k-message archive (78.6s → 67.7s CPU, 15.3s → 14.3s
+wall at 8 workers; serial 28.7s CPU). Byte-identical across every
+configuration on that archive, and the pool equivalence test now
+asserts the feed engaged. The remaining worker CPU is dominated by
+bootstrap — each worker still loads the whole transcript — which is
+the next target (§ 2's "no per-worker transcript copy"), along with
+the flat pool and the § 7.5 threshold revisit. Also fixed:
+`scripts/bench_render.py`'s serial-labeled rows now pin
+`RENDER_JOBS=off` (they had been silently running the fan-out since
+its default flipped on, making the table labels lie).
 Phase 1 confirmed the duplicate work is structurally gone (64,968 lookups
 → 32,441 formats on that archive), but also that its *serial* wall-clock
 win on top of a warm leaf memo is modest (~1s of 27s CPU) — the value is


### PR DESCRIPTION
## Measured effect (8-core / 16 GB Linux VM)

All timings from `scripts/bench_render.py` at this branch's HEAD over the same real
archive (8 projects, 1539 MB of transcripts; largest 329 MB / 97k messages). "Off"
disables both optimisations (`CLAUDE_CODE_LOG_RENDER_CACHE_MB=0`,
`CLAUDE_CODE_LOG_RENDER_JOBS=off`), i.e. the pre-branch behaviour. **Every
configuration produced byte-identical output.**

| scenario | off (wall / CPU) | memo only | memo + fan-out | end-to-end |
|---|---|---|---|---|
| incremental — 1 stale project, the everyday run | 62.5 s / 60.7 s | 59.2 s / 57.6 s | **17.0 s / 61.5 s** | **3.7×** |
| full rebuild — all 8 stale | 64.6 s / 198.4 s | 62.0 s / 185.2 s | **53.9 s / 183.1 s** | **1.20×** |

The incremental 3.7× now costs ~+1 % total CPU over serial. That's the fragment/entry
feeding at work: earlier on this branch the fan-out burned +76 % CPU on this machine
(and ~+300 % before fragment feeding), because every worker reloaded the whole
transcript and re-formatted what the serial path would have cached. Workers are now
*fed* their unit's entry slice and pre-formatted fragments, so per-worker CPU overhead
at 8 workers fell from ~4.4 s to ~0.7 s. The full-rebuild gain comes from the
hold-back: pool-bounding projects are converted after the pool with the whole machine
(the fan-out is otherwise inert there — 8 concurrent projects on 16 GB leave 1 render
worker each).

### Memory

Two deliberate costs and one big saving, all measured on the box:

- **Serial peak is higher.** The fragment store holds every formatted fragment for
  the length of a conversion, in serial mode too: on the largest project measured
  (803 MB of transcripts) peak RSS went 1252 MB → 1521 MB (**+269 MB, ~+21 %**).
  The leaf memo adds a little more (13–16 MB measured, hard-capped at 192 MB per
  cache). Both have kill switches (`CLAUDE_CODE_LOG_FRAGMENT_STORE=0`,
  `CLAUDE_CODE_LOG_RENDER_CACHE_MB=0`); spilling the fragment text to disk is the
  recorded follow-up in `work/render-format-once.md`.
- **Per-worker cost collapsed.** Peak RSS per process (kernel VmHWM, polled) on the
  140 MB and 329 MB projects: conversion parent 598 MB / 1458 MB ≈ 4.4× transcript
  bytes; largest fed render worker 218 MB / 329 MB ≈ 136 MB + 0.59×. Before
  worker-feeding each worker held its own ~3× transcript copy — 8 workers on the
  329 MB project would have cost ~8 GB where they now cost ~2.6 GB.
- The memory cap charges these measured footprints (parent 4.5× + 150 MB base,
  worker 0.8× + 150 MB, against 60 % of available memory): on 16 GB the incremental
  case now gets all 8 workers (previously 5), and smaller machines degrade to
  serial instead of swapping.
- Update: A memory valve now auto-skips the fragment store when available memory is
   under ~2.4× the project's transcript bytes, so memory-tight machines keep their
   pre-branch footprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance**
  * Faster rendering through memoization, fragment reuse, and optional parallel processing.
  * Added memory-aware worker limits and cache statistics.
  * Improved referenced-image exports with stable, content-based filenames.

* **Configuration**
  * Expanded `--jobs` to control per-project rendering concurrency.
  * Added settings for render workers and cache capacity.

* **Bug Fixes**
  * Improved archive search behavior when opened from local files.

* **Documentation**
  * Expanded profiling, architecture, and benchmarking guidance.

* **Quality**
  * Added benchmarks and output-equivalence verification tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->