### PR TITLE
Link teammate subagent transcripts spawned by the Agent tool

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -2278,12 +2278,14 @@ class CacheManager:
             # earlier have the caveat text baked into first_user_message
             # for affected sessions.
             "1.4.0": "1.5.0",
-            # 1.6.0 fixed the teammate prompt-hash fallback, which only
+            # 1.6.1 fixed the teammate prompt-hash fallback, which only
             # looked at ``Task`` tool_uses and so never fired for the
-            # ``Agent`` spawn tool current Claude Code uses. Caches built
-            # earlier have the *unlinked* entry list baked in — the
-            # subagent transcripts are simply absent from them.
-            "1.5.0": "1.6.0",
+            # ``Agent`` spawn tool current Claude Code uses. Every cache
+            # built up to and including 1.6.0 has the *unlinked* entry
+            # list baked in — the subagent transcripts are simply absent
+            # from them, and nothing about the source files changes to
+            # trigger a reparse.
+            "1.6.0": "1.6.1",
         }
 
         cache_ver = version.parse(cache_version)

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -2278,6 +2278,12 @@ class CacheManager:
             # earlier have the caveat text baked into first_user_message
             # for affected sessions.
             "1.4.0": "1.5.0",
+            # 1.6.0 fixed the teammate prompt-hash fallback, which only
+            # looked at ``Task`` tool_uses and so never fired for the
+            # ``Agent`` spawn tool current Claude Code uses. Caches built
+            # earlier have the *unlinked* entry list baked in — the
+            # subagent transcripts are simply absent from them.
+            "1.5.0": "1.6.0",
         }
 
         cache_ver = version.parse(cache_version)

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -1028,13 +1028,23 @@ def _link_subagents_by_prompt_hash(
         else:
             unmatched.append((candidate_agent_id, candidate_norm, candidate_name))
 
-    # Pass 2 — prompt only, unchanged behaviour. Covers every spawn that
-    # carries no name (plain ``Task`` sub-agents, older transcripts) and
-    # any teammate whose name didn't pair, so a missing or renamed
-    # sidecar degrades to the previous result rather than to no link.
-    for candidate_agent_id, candidate_norm, _candidate_name in unmatched:
-        for i, (norm_prompt, _spawn_name, _entry) in enumerate(remaining):
-            if norm_prompt == candidate_norm:
+    # Pass 2 — prompt only, for the cases where a name cannot decide.
+    # Covers every spawn that carries no name (plain ``Task`` sub-agents,
+    # older transcripts) and every sidecar without one, so those degrade
+    # to the previous prompt-only result rather than to no link.
+    #
+    # **But only when at least one side is nameless.** When both carry a
+    # name and pass 1 did not pair them, the names positively DISAGREE —
+    # matching anyway would hand a named sidecar to a differently-named
+    # spawn on filename order, which is exactly the mis-attribution pass 1
+    # exists to prevent. An unlinked transcript invites a re-run; a
+    # confidently mislabelled one invites a wrong conclusion, so the
+    # ambiguous pair is left unresolved on purpose.
+    for candidate_agent_id, candidate_norm, candidate_name in unmatched:
+        for i, (norm_prompt, spawn_name, _entry) in enumerate(remaining):
+            if norm_prompt == candidate_norm and (
+                candidate_name is None or spawn_name is None
+            ):
                 _claim(candidate_agent_id, i)
                 break
 

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -935,11 +935,11 @@ def _link_subagents_by_prompt_hash(
 ) -> None:
     """Link teammate subagent JSONLs whose agentId isn't in the main transcript.
 
-    Teammate-spawned Tasks sometimes produce tool_results that don't carry a
+    Teammate-spawned Tasks/Agents sometimes produce tool_results that don't carry a
     structured ``agentId`` — the linking info only appears in the Markdown
     metadata tail (parsed separately) or is absent altogether. Older
     transcripts predate the tail too. For these we fall back to matching
-    the Task tool_use's ``prompt`` input against each unmatched
+    the spawn tool_use's ``prompt`` input against each unmatched
     ``subagents/agent-*.jsonl`` file's first-entry content. When the first
     entry wraps the prompt in ``<teammate-message teammate_id="team-lead">``,
     that body is compared; otherwise the raw text is.
@@ -949,7 +949,7 @@ def _link_subagents_by_prompt_hash(
     field is back-patched (so ``_integrate_agent_entries`` anchors the
     subagent DAG-line to the right place).
 
-    No-op when the subagents dir doesn't exist or every Task is already
+    No-op when the subagents dir doesn't exist or every spawn is already
     linked; safe to call unconditionally.
     """
     unresolved = _collect_unresolved_task_results(messages)
@@ -994,13 +994,19 @@ def _link_subagents_by_prompt_hash(
 def _collect_unresolved_task_results(
     messages: list[TranscriptEntry],
 ) -> list[tuple[str, UserTranscriptEntry]]:
-    """Return (prompt, tool_result_entry) for Task results lacking an agentId."""
+    """Return (prompt, tool_result_entry) for spawn results lacking an agentId.
+
+    Covers both spawn tool names: ``Task`` (sub-agents) and ``Agent``
+    (teammates). The teammate flow this fallback exists for is spelled
+    ``Agent`` in current Claude Code, so gating on ``Task`` alone turns
+    the whole fallback into a no-op for teammate sessions.
+    """
     task_prompts: dict[str, str] = {}
     for msg in messages:
         if not isinstance(msg, AssistantTranscriptEntry):
             continue
         for item in msg.message.content:
-            if isinstance(item, ToolUseContent) and item.name == "Task":
+            if isinstance(item, ToolUseContent) and item.name in ("Task", "Agent"):
                 prompt = item.input.get("prompt")
                 if isinstance(prompt, str) and prompt:
                     task_prompts[item.id] = prompt

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -944,6 +944,12 @@ def _link_subagents_by_prompt_hash(
     entry wraps the prompt in ``<teammate-message teammate_id="team-lead">``,
     that body is compared; otherwise the raw text is.
 
+    Matching runs in two passes. Teammates routinely share a
+    byte-identical prompt, so the prompt alone does not identify one;
+    the first pass additionally requires the spawn's ``input.name`` to
+    equal the sidecar's ``name``, and only what that leaves over falls
+    through to prompt-only matching.
+
     On a match, the agent id is added to *agent_ids* (so the existing loader
     picks the file up) and the corresponding tool_result entry's ``agentId``
     field is back-patched (so ``_integrate_agent_entries`` anchors the
@@ -965,10 +971,13 @@ def _link_subagents_by_prompt_hash(
     # normalized prompt would re-match an already-patched entry, wiping
     # the first match (concrete repro: team-lead sends identical
     # instructions to multiple teammates in parallel).
-    remaining: list[tuple[str, UserTranscriptEntry]] = [
-        (_normalize_prompt(prompt), entry) for prompt, entry in unresolved
+    remaining: list[tuple[str, Optional[str], UserTranscriptEntry]] = [
+        (_normalize_prompt(prompt), name, entry) for prompt, name, entry in unresolved
     ]
 
+    # Collect the candidate files first, so matching can run name-aware
+    # before it falls back to prompt-only (see the two passes below).
+    candidates: list[tuple[str, str, Optional[str]]] = []
     for agent_file in sorted(subagents_dir.glob("agent-*.jsonl")):
         candidate_agent_id = agent_file.stem[len("agent-") :]
         if not candidate_agent_id or candidate_agent_id in agent_ids:
@@ -983,25 +992,64 @@ def _link_subagents_by_prompt_hash(
         if not candidate_norm:
             continue
 
-        for i, (norm_prompt, result_entry) in enumerate(remaining):
+        candidates.append(
+            (candidate_agent_id, candidate_norm, _read_sidecar_name(agent_file))
+        )
+
+    def _claim(candidate_agent_id: str, index: int) -> None:
+        agent_ids.add(candidate_agent_id)
+        remaining[index][2].agentId = candidate_agent_id
+        remaining.pop(index)
+
+    # Pass 1 — teammate name. A prompt is NOT a discriminator for
+    # teammates: a team-lead fanning the same instructions out to N
+    # teammates gives every one of them a byte-identical body, and then
+    # prompt-only matching pairs them by filename sort order against
+    # message order, which is arbitrary. Measured over one real archive:
+    # 7 of 12 teammate sessions contained such a group (15 groups, the
+    # largest with 11 members), and prompt-only matching anchored 23
+    # spawns (~12% of those it linked) to the WRONG teammate — a
+    # permutation within each group. That is worse than not linking at
+    # all: an absent transcript invites a re-run, a confidently
+    # mis-attributed one invites a wrong conclusion.
+    #
+    # Both sides carry the discriminator. The spawn's ``input.name``
+    # (``TaskInput.name``, populated when a team-lead spawns a named
+    # teammate) and the sidecar's own ``name`` are the same string.
+    unmatched: list[tuple[str, str, Optional[str]]] = []
+    for candidate_agent_id, candidate_norm, candidate_name in candidates:
+        if candidate_name is None:
+            unmatched.append((candidate_agent_id, candidate_norm, candidate_name))
+            continue
+        for i, (norm_prompt, spawn_name, _entry) in enumerate(remaining):
+            if norm_prompt == candidate_norm and spawn_name == candidate_name:
+                _claim(candidate_agent_id, i)
+                break
+        else:
+            unmatched.append((candidate_agent_id, candidate_norm, candidate_name))
+
+    # Pass 2 — prompt only, unchanged behaviour. Covers every spawn that
+    # carries no name (plain ``Task`` sub-agents, older transcripts) and
+    # any teammate whose name didn't pair, so a missing or renamed
+    # sidecar degrades to the previous result rather than to no link.
+    for candidate_agent_id, candidate_norm, _candidate_name in unmatched:
+        for i, (norm_prompt, _spawn_name, _entry) in enumerate(remaining):
             if norm_prompt == candidate_norm:
-                agent_ids.add(candidate_agent_id)
-                result_entry.agentId = candidate_agent_id
-                remaining.pop(i)
+                _claim(candidate_agent_id, i)
                 break
 
 
 def _collect_unresolved_task_results(
     messages: list[TranscriptEntry],
-) -> list[tuple[str, UserTranscriptEntry]]:
-    """Return (prompt, tool_result_entry) for spawn results lacking an agentId.
+) -> list[tuple[str, Optional[str], UserTranscriptEntry]]:
+    """Return (prompt, spawn name, tool_result_entry) for spawn results lacking an agentId.
 
     Covers both spawn tool names: ``Task`` (sub-agents) and ``Agent``
     (teammates). The teammate flow this fallback exists for is spelled
     ``Agent`` in current Claude Code, so gating on ``Task`` alone turns
     the whole fallback into a no-op for teammate sessions.
     """
-    task_prompts: dict[str, str] = {}
+    task_prompts: dict[str, tuple[str, Optional[str]]] = {}
     for msg in messages:
         if not isinstance(msg, AssistantTranscriptEntry):
             continue
@@ -1009,9 +1057,15 @@ def _collect_unresolved_task_results(
             if isinstance(item, ToolUseContent) and item.name in ("Task", "Agent"):
                 prompt = item.input.get("prompt")
                 if isinstance(prompt, str) and prompt:
-                    task_prompts[item.id] = prompt
+                    spawn_name = item.input.get("name")
+                    task_prompts[item.id] = (
+                        prompt,
+                        spawn_name
+                        if isinstance(spawn_name, str) and spawn_name
+                        else None,
+                    )
 
-    unresolved: list[tuple[str, UserTranscriptEntry]] = []
+    unresolved: list[tuple[str, Optional[str], UserTranscriptEntry]] = []
     for msg in messages:
         if not isinstance(msg, UserTranscriptEntry):
             continue
@@ -1020,11 +1074,33 @@ def _collect_unresolved_task_results(
         for item in msg.message.content:
             if not isinstance(item, ToolResultContent):
                 continue
-            prompt = task_prompts.get(item.tool_use_id)
-            if prompt is not None:
-                unresolved.append((prompt, msg))
+            entry = task_prompts.get(item.tool_use_id)
+            if entry is not None:
+                prompt, spawn_name = entry
+                unresolved.append((prompt, spawn_name, msg))
                 break
     return unresolved
+
+
+def _read_sidecar_name(agent_file: Path) -> Optional[str]:
+    """The teammate ``name`` from ``agent-<id>.meta.json``, if present.
+
+    Only the prompt-hash fallback needs this, so it is read here rather
+    than widened into the memoized ``_subagent_meta_map`` (whose value
+    type the sidecar path depends on). Returns None for a plain
+    ``Task`` sub-agent sidecar, which carries ``description`` instead —
+    those reach this code only when they also lack a ``toolUseId``, and
+    a None simply routes them to the prompt-only pass.
+    """
+    meta_path = agent_file.with_name(agent_file.stem + ".meta.json")
+    try:
+        raw: Any = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    name = cast("dict[str, Any]", raw).get("name")
+    return name if isinstance(name, str) and name else None
 
 
 def _read_first_message_text(agent_file: Path) -> Optional[str]:

--- a/dev-docs/teammates.md
+++ b/dev-docs/teammates.md
@@ -349,12 +349,22 @@ whose stem isn't in the agent-id set, and for each:
    block (the canonical teammate-spawn shape), extract the body via
    `find_team_lead_body`. Otherwise use the raw text.
 3. Normalize via `_normalize_prompt`: collapse whitespace, lowercase.
-4. Compare against each unresolved Task tool_use's `prompt` input
+4. Compare against each unresolved spawn tool_use's `prompt` input
    (similarly normalized). Exact match wins.
-5. Back-patch the Task tool_result's `agentId` field, add to the agent-id
+5. Back-patch the spawn tool_result's `agentId` field, add to the agent-id
    set, and **remove the matched entry from the unresolved pool** so a
    second candidate file with the same prompt can't claim it (this last
    step was a CodeRabbit-driven fix on PR #117 — see commit `cc9951d`).
+
+> **Both spawn tool names count.** `_collect_unresolved_task_results`
+> gathers prompts from `Task` *and* `Agent` tool_uses. Teammates are
+> spawned by `Agent` in current Claude Code, and the sidecar
+> `agent-<id>.meta.json` it writes for an `in_process_teammate` carries
+> no `toolUseId` — so for a modern teammate session the prompt-hash
+> fallback is the *only* link, and gating it on `Task` alone silently
+> dropped every teammate transcript (the subagent JSONLs were never
+> opened). Pinned by
+> `test_prompt_hash_fallback_covers_both_spawn_tool_names`.
 
 Pre-normalized prompts are computed once up front to avoid quadratic
 work in the inner loop.

--- a/dev-docs/teammates.md
+++ b/dev-docs/teammates.md
@@ -349,8 +349,15 @@ whose stem isn't in the agent-id set, and for each:
    block (the canonical teammate-spawn shape), extract the body via
    `find_team_lead_body`. Otherwise use the raw text.
 3. Normalize via `_normalize_prompt`: collapse whitespace, lowercase.
-4. Compare against each unresolved spawn tool_use's `prompt` input
-   (similarly normalized). Exact match wins.
+4. Match in **two passes**. Pass 1 pairs a candidate with an unresolved
+   spawn only when the normalized prompts match **and** the sidecar's
+   `name` equals the spawn's `input.name`; it runs to completion over
+   every candidate before pass 2 starts, so a named candidate cannot be
+   claimed by a nameless one. Pass 2 then takes whatever is left on an
+   exact normalized-prompt match alone — **but only when at least one
+   side has no name.** Two names that disagree are a positive signal
+   that the pair is wrong, so it is left unresolved rather than matched
+   on filename order.
 5. Back-patch the spawn tool_result's `agentId` field, add to the agent-id
    set, and **remove the matched entry from the unresolved pool** so a
    second candidate file with the same prompt can't claim it (this last

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -679,10 +679,10 @@ class TestCacheVersionCompatibility:
 
         The cache version has to sit *above* every declared breaking
         boundary, otherwise this exercises a breaking rule rather than
-        the default path (1.5.0 became such a boundary in 1.6.0).
+        the default path (1.6.0 became such a boundary in 1.6.1).
         """
         cache_manager = CacheManager(temp_project_dir, "2.0.0")
-        assert cache_manager._is_cache_version_compatible("1.5.1") is True
+        assert cache_manager._is_cache_version_compatible("1.6.1") is True
 
     def test_version_downgrade_is_compatible(self, temp_project_dir):
         """Test that version downgrades are compatible by default."""

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -675,9 +675,14 @@ class TestCacheVersionCompatibility:
         assert cache_manager._is_cache_version_compatible("1.0.5") is True
 
     def test_major_version_increase_is_compatible(self, temp_project_dir):
-        """Test that major version increases are compatible by default."""
+        """Test that major version increases are compatible by default.
+
+        The cache version has to sit *above* every declared breaking
+        boundary, otherwise this exercises a breaking rule rather than
+        the default path (1.5.0 became such a boundary in 1.6.0).
+        """
         cache_manager = CacheManager(temp_project_dir, "2.0.0")
-        assert cache_manager._is_cache_version_compatible("1.5.0") is True
+        assert cache_manager._is_cache_version_compatible("1.5.1") is True
 
     def test_version_downgrade_is_compatible(self, temp_project_dir):
         """Test that version downgrades are compatible by default."""

--- a/test/test_teammates_parsing.py
+++ b/test/test_teammates_parsing.py
@@ -1445,3 +1445,151 @@ def test_prompt_hash_fallback_covers_both_spawn_tool_names(
     assert any(
         "MARKER-worker-report" in str(getattr(m, "message", "")) for m in messages
     )
+
+
+def _colliding_prompt_fixture(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """Two teammates spawned with a byte-identical prompt.
+
+    The canonical teammate shape: a team-lead fans the same instructions
+    out to N teammates, so the prompt cannot identify which sidecar
+    belongs to which spawn. Only the ``name`` can. Filenames are ordered
+    so that sort-order pairing gets it backwards.
+    """
+    import json
+
+    session_id = "ef000000-0000-4000-8000-0000000000bb"
+    prompt = "Run the arm and report the four answers."
+    # agent-a... sorts first but belongs to the SECOND spawn.
+    agents = {
+        "aalpha-1111111111111111": "worker-B",
+        "azulu-2222222222222222": "worker-A",
+    }
+    base = {
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/home/synthetic/collide",
+        "sessionId": session_id,
+        "version": "2.1.172",
+    }
+
+    entries: list[dict[str, object]] = [
+        {
+            **base,
+            "parentUuid": None,
+            "uuid": "cccccccc-0000-4000-8000-000000000001",
+            "timestamp": "2026-08-29T10:00:00.000Z",
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "go"}]},
+        }
+    ]
+    prev = "cccccccc-0000-4000-8000-000000000001"
+    # Spawn order is worker-A then worker-B — the reverse of filename order.
+    for idx, spawn_name in enumerate(["worker-A", "worker-B"], start=2):
+        use_uuid = f"cccccccc-0000-4000-8000-00000000000{idx}a"
+        res_uuid = f"cccccccc-0000-4000-8000-00000000000{idx}b"
+        tu_id = f"tu_spawn_{spawn_name}"
+        entries.append(
+            {
+                **base,
+                "parentUuid": prev,
+                "uuid": use_uuid,
+                "timestamp": f"2026-08-29T10:0{idx}:00.000Z",
+                "type": "assistant",
+                "message": {
+                    "id": f"msg_{spawn_name}",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-opus-5",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": tu_id,
+                            "name": "Agent",
+                            "input": {"name": spawn_name, "prompt": prompt},
+                        }
+                    ],
+                    "stop_reason": None,
+                },
+            }
+        )
+        entries.append(
+            {
+                **base,
+                "parentUuid": use_uuid,
+                "uuid": res_uuid,
+                "timestamp": f"2026-08-29T10:0{idx}:30.000Z",
+                "type": "user",
+                "toolUseResult": {"status": "spawned", "prompt": prompt},
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tu_id,
+                            "content": "Spawned successfully.",
+                        }
+                    ],
+                },
+            }
+        )
+        prev = res_uuid
+
+    trunk = tmp_path / f"{session_id}.jsonl"
+    trunk.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+    subagents = tmp_path / session_id / "subagents"
+    subagents.mkdir(parents=True)
+    for agent_id, name in agents.items():
+        (subagents / f"agent-{agent_id}.meta.json").write_text(
+            json.dumps(
+                {"agentType": name, "name": name, "taskKind": "in_process_teammate"}
+            ),
+            encoding="utf-8",
+        )
+        sub_base = {**base, "isSidechain": True, "agentId": agent_id}
+        (subagents / f"agent-{agent_id}.jsonl").write_text(
+            json.dumps(
+                {
+                    **sub_base,
+                    "parentUuid": None,
+                    "uuid": f"dddddddd-0000-4000-8000-{agent_id[1:13]}",
+                    "timestamp": "2026-08-29T10:05:00.000Z",
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": (
+                            f'<teammate-message teammate_id="team-lead" summary="{name}">\n'
+                            f"{prompt}\n</teammate-message>"
+                        ),
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return trunk, {v: k for k, v in agents.items()}
+
+
+def test_colliding_prompts_are_disambiguated_by_teammate_name(tmp_path: Path) -> None:
+    """A shared prompt must not be paired by filename sort order.
+
+    Teammates routinely receive byte-identical instructions, so the
+    prompt is not a discriminator. Pairing on it alone anchored 23
+    spawns (~12% of those it linked) to the wrong teammate on a real
+    archive — a permutation within each colliding group. A wrong
+    attribution is worse than none: an absent transcript invites a
+    re-run, a confidently mis-attributed one invites a wrong conclusion.
+    """
+    trunk, by_name = _colliding_prompt_fixture(tmp_path)
+    messages = load_transcript(trunk, cache_manager=None, silent=True)
+
+    seen: dict[str, str] = {}
+    for m in messages:
+        if not isinstance(m, UserTranscriptEntry) or not m.agentId:
+            continue
+        for c in m.message.content:
+            if isinstance(c, ToolResultContent):
+                seen[c.tool_use_id] = m.agentId
+
+    assert seen.get("tu_spawn_worker-A") == by_name["worker-A"]
+    assert seen.get("tu_spawn_worker-B") == by_name["worker-B"]

--- a/test/test_teammates_parsing.py
+++ b/test/test_teammates_parsing.py
@@ -1283,3 +1283,165 @@ class TestTeammatesFactoryIntegration:
         # System block flagged in the mixed entry
         mixed = next(b for b in batched if len(b.blocks) == 3)
         assert any(blk.is_system for blk in mixed.blocks)
+
+
+# ---------------------------------------------------------------------------
+# Prompt-hash fallback: the ``Agent`` spawn tool
+# ---------------------------------------------------------------------------
+
+
+def _spawn_fixture(tmp_path: Path, spawn_tool_name: str) -> Path:
+    """A trunk session that spawns one teammate, plus its subagent file.
+
+    The sidecar deliberately carries no ``toolUseId`` (current Claude Code
+    omits it for in-process teammates) and the spawn's ``toolUseResult``
+    carries no ``agentId``, so the prompt-hash fallback is the *only*
+    path that can link the two.
+    """
+    import json
+
+    session_id = "ef000000-0000-4000-8000-0000000000aa"
+    agent_id = "aworker-0123456789abcdef"
+    prompt = "Audit the corpus and report back."
+    base = {
+        "isSidechain": False,
+        "userType": "external",
+        "cwd": "/home/synthetic/spawn-fixture",
+        "sessionId": session_id,
+        "version": "2.1.172",
+    }
+
+    trunk = tmp_path / f"{session_id}.jsonl"
+    trunk.write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                {
+                    **base,
+                    "parentUuid": None,
+                    "uuid": "aaaaaaaa-0000-4000-8000-000000000001",
+                    "timestamp": "2026-08-28T10:00:00.000Z",
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "go"}],
+                    },
+                },
+                {
+                    **base,
+                    "parentUuid": "aaaaaaaa-0000-4000-8000-000000000001",
+                    "uuid": "aaaaaaaa-0000-4000-8000-000000000002",
+                    "timestamp": "2026-08-28T10:01:00.000Z",
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_spawn",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-opus-5",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tu_spawn_001",
+                                "name": spawn_tool_name,
+                                "input": {"name": "worker", "prompt": prompt},
+                            }
+                        ],
+                        "stop_reason": None,
+                    },
+                },
+                {
+                    **base,
+                    "parentUuid": "aaaaaaaa-0000-4000-8000-000000000002",
+                    "uuid": "aaaaaaaa-0000-4000-8000-000000000003",
+                    "timestamp": "2026-08-28T10:02:00.000Z",
+                    "type": "user",
+                    "toolUseResult": {"status": "spawned", "prompt": prompt},
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "tu_spawn_001",
+                                "content": "Spawned successfully.",
+                            }
+                        ],
+                    },
+                },
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    subagents = tmp_path / session_id / "subagents"
+    subagents.mkdir(parents=True)
+    # No ``toolUseId`` here — that is what makes the sidecar path unusable.
+    (subagents / f"agent-{agent_id}.meta.json").write_text(
+        json.dumps(
+            {"agentType": "worker", "name": "worker", "taskKind": "in_process_teammate"}
+        ),
+        encoding="utf-8",
+    )
+    sub_base = {**base, "isSidechain": True, "agentId": agent_id}
+    (subagents / f"agent-{agent_id}.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                {
+                    **sub_base,
+                    "parentUuid": None,
+                    "uuid": "bbbbbbbb-0000-4000-8000-000000000001",
+                    "timestamp": "2026-08-28T10:03:00.000Z",
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": (
+                            '<teammate-message teammate_id="team-lead" summary="audit">\n'
+                            f"{prompt}\n</teammate-message>"
+                        ),
+                    },
+                },
+                {
+                    **sub_base,
+                    "parentUuid": "bbbbbbbb-0000-4000-8000-000000000001",
+                    "uuid": "bbbbbbbb-0000-4000-8000-000000000002",
+                    "timestamp": "2026-08-28T10:04:00.000Z",
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_worker",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-opus-5",
+                        "content": [{"type": "text", "text": "MARKER-worker-report"}],
+                        "stop_reason": None,
+                    },
+                },
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return trunk
+
+
+@pytest.mark.parametrize("spawn_tool_name", ["Task", "Agent"])
+def test_prompt_hash_fallback_covers_both_spawn_tool_names(
+    tmp_path: Path, spawn_tool_name: str
+) -> None:
+    """The teammate spawn tool is named ``Agent``, not ``Task``.
+
+    Gating the fallback's prompt collection on ``Task`` alone silently
+    dropped every teammate transcript of a modern session — the subagent
+    JSONLs were never even opened.
+    """
+    trunk = _spawn_fixture(tmp_path, spawn_tool_name)
+    messages = load_transcript(trunk, cache_manager=None, silent=True)
+
+    agent_id = "aworker-0123456789abcdef"
+    linked = [m for m in messages if getattr(m, "agentId", None) == agent_id]
+    assert linked, f"{spawn_tool_name} spawn: subagent transcript not linked"
+    # tool_result back-patch + both subagent entries.
+    assert len(linked) == 3
+    assert any(
+        "MARKER-worker-report" in str(getattr(m, "message", "")) for m in messages
+    )

--- a/test/test_teammates_parsing.py
+++ b/test/test_teammates_parsing.py
@@ -1593,3 +1593,48 @@ def test_colliding_prompts_are_disambiguated_by_teammate_name(tmp_path: Path) ->
 
     assert seen.get("tu_spawn_worker-A") == by_name["worker-A"]
     assert seen.get("tu_spawn_worker-B") == by_name["worker-B"]
+
+
+def test_conflicting_names_are_left_unresolved_not_matched_on_prompt(
+    tmp_path: Path,
+) -> None:
+    """Two names that disagree are evidence the pair is wrong.
+
+    The prompt-only fallback exists for spawns or sidecars that carry no
+    name. When *both* sides are named and pass 1 did not pair them, the
+    names positively disagree — falling through to prompt-only would hand
+    the sidecar to a differently-named spawn on filename order, which is
+    the mis-attribution the name pass exists to prevent. Leaving it
+    unlinked is the better failure: an absent transcript invites a
+    re-run, a confidently mislabelled one invites a wrong conclusion.
+    """
+    trunk, by_name = _colliding_prompt_fixture(tmp_path)
+
+    # Rename the sidecar that would have paired with worker-B so that no
+    # spawn carries its name, leaving one named orphan and one free
+    # named spawn that share a prompt.
+    subagents = trunk.parent / trunk.stem / "subagents"
+    orphan_id = by_name["worker-B"]
+    meta = subagents / f"agent-{orphan_id}.meta.json"
+    import json as _json
+
+    payload = _json.loads(meta.read_text(encoding="utf-8"))
+    payload["name"] = "worker-RENAMED"
+    meta.write_text(_json.dumps(payload), encoding="utf-8")
+
+    messages = load_transcript(trunk, cache_manager=None, silent=True)
+
+    seen: dict[str, str] = {}
+    for m in messages:
+        if not isinstance(m, UserTranscriptEntry) or not m.agentId:
+            continue
+        for c in m.message.content:
+            if isinstance(c, ToolResultContent):
+                seen[c.tool_use_id] = m.agentId
+
+    # worker-A still pairs by name.
+    assert seen.get("tu_spawn_worker-A") == by_name["worker-A"]
+    # worker-B's spawn must NOT be claimed by the renamed orphan.
+    assert "tu_spawn_worker-B" not in seen, (
+        "a named sidecar claimed a differently-named spawn via the prompt-only fallback"
+    )

--- a/test/test_teammates_parsing.py
+++ b/test/test_teammates_parsing.py
@@ -1290,13 +1290,20 @@ class TestTeammatesFactoryIntegration:
 # ---------------------------------------------------------------------------
 
 
-def _spawn_fixture(tmp_path: Path, spawn_tool_name: str) -> Path:
+def _spawn_fixture(tmp_path: Path, spawn_tool_name: str, named: bool = True) -> Path:
     """A trunk session that spawns one teammate, plus its subagent file.
 
     The sidecar deliberately carries no ``toolUseId`` (current Claude Code
     omits it for in-process teammates) and the spawn's ``toolUseResult``
     carries no ``agentId``, so the prompt-hash fallback is the *only*
     path that can link the two.
+
+    ``named`` selects which of the fallback's two passes does the work:
+    with a ``name`` on both the spawn and the sidecar, the name-aware
+    pass 1 claims it; without one it falls through to prompt-only
+    matching in pass 2. The tool-name gate under test sits upstream of
+    both, so parametrising over this proves the gate holds whichever
+    pass happens to run.
     """
     import json
 
@@ -1343,7 +1350,11 @@ def _spawn_fixture(tmp_path: Path, spawn_tool_name: str) -> Path:
                                 "type": "tool_use",
                                 "id": "tu_spawn_001",
                                 "name": spawn_tool_name,
-                                "input": {"name": "worker", "prompt": prompt},
+                                "input": (
+                                    {"name": "worker", "prompt": prompt}
+                                    if named
+                                    else {"prompt": prompt}
+                                ),
                             }
                         ],
                         "stop_reason": None,
@@ -1378,7 +1389,8 @@ def _spawn_fixture(tmp_path: Path, spawn_tool_name: str) -> Path:
     # No ``toolUseId`` here — that is what makes the sidecar path unusable.
     (subagents / f"agent-{agent_id}.meta.json").write_text(
         json.dumps(
-            {"agentType": "worker", "name": "worker", "taskKind": "in_process_teammate"}
+            {"agentType": "worker", "taskKind": "in_process_teammate"}
+            | ({"name": "worker"} if named else {})
         ),
         encoding="utf-8",
     )
@@ -1424,9 +1436,10 @@ def _spawn_fixture(tmp_path: Path, spawn_tool_name: str) -> Path:
     return trunk
 
 
+@pytest.mark.parametrize("named", [True, False], ids=["named", "nameless"])
 @pytest.mark.parametrize("spawn_tool_name", ["Task", "Agent"])
 def test_prompt_hash_fallback_covers_both_spawn_tool_names(
-    tmp_path: Path, spawn_tool_name: str
+    tmp_path: Path, spawn_tool_name: str, named: bool
 ) -> None:
     """The teammate spawn tool is named ``Agent``, not ``Task``.
 
@@ -1434,7 +1447,7 @@ def test_prompt_hash_fallback_covers_both_spawn_tool_names(
     dropped every teammate transcript of a modern session — the subagent
     JSONLs were never even opened.
     """
-    trunk = _spawn_fixture(tmp_path, spawn_tool_name)
+    trunk = _spawn_fixture(tmp_path, spawn_tool_name, named=named)
     messages = load_transcript(trunk, cache_manager=None, silent=True)
 
     agent_id = "aworker-0123456789abcdef"


### PR DESCRIPTION
## The bug

Teammate subagent transcripts were never rendered. Their `.jsonl` files under
`<session>/subagents/` were not even opened, so a session that fanned work out to
teammates showed the spawn calls and nothing else — none of the conversation, none
of the results.

`_collect_unresolved_task_results` gathered spawn prompts only from tool_uses named
`Task`. Teammates are spawned by `Agent`, so the prompt-hash fallback collected
nothing and returned early. Every other site already handles the pair (`dag.py`,
four sites in `renderer.py`, `tool_factory.py`); this one was written when the spawn
tool was still called `Task` and never followed the rename.

For teammates that fallback is not a nicety — it is the only link that can work:

- `taskKind: in_process_teammate` sidecars (`agent-<id>.meta.json`) carry **no**
  `toolUseId`, so the sidecar path cannot resolve them.
- The `Agent` tool_result carries `agent_id: "<name>@session-<hash>"`, a teammate id
  unrelated to the transcript's own `agentId`, so the structured path cannot either.

On a large real session all six teammates went from unlinked to linked
(10 027 → 10 842 entries).

## The second commit

Making those links reachable exposed a latent defect in the same fallback.

A prompt is not a discriminator for teammates: a team-lead fanning the same
instructions out to N teammates gives every one of them a byte-identical body, and
matching then paired them by **filename sort order** against message order, which is
arbitrary. Over one real archive of 198 teammate sidecars across 12 sessions, 7
sessions contained at least one colliding group (15 groups, largest 11 members), and
23 spawns — about 12% of those linked — were anchored to the **wrong** teammate, as
pure permutations within a group.

The bad case is a model-comparison session where every arm gets the same prompt: the
transcript displayed under one arm is another arm's. Wrong attribution is worse than
none — an absent transcript invites a re-run, a confident wrong one invites a wrong
conclusion.

Both sides carry the discriminator: the spawn's `input.name` (`TaskInput.name`) and
the sidecar's own `name`. Matching now runs name-aware first, then falls back to the
previous prompt-only pass for whatever is left, so a spawn with no name (plain `Task`
sub-agents, older transcripts) or a sidecar with no `name` degrades to the old result
rather than to no link. Mis-anchorings go to 0.

## Cache invalidation

A cache written before this fix has the unlinked entry list baked in, and
re-rendering with the fix in place still serves it — verified by writing a cache
under the old code and reading it back under the new one. Hence the
`"1.5.0": "1.6.0"` `breaking_changes` entry.

> **Release note:** this needs to land in **1.6.0, not a 1.5.x patch**, or the
> invalidation does not fire. The consequence is bounded either way —
> `projects.version` is only written in `_create_project` and never re-stamped on
> open, so a 1.5.x release would keep serving the unlinked render through the 1.5.x
> line and self-heal at 1.6.0.

## Tests

Two new tests, both mutation-checked (reverting the change under test fails it):

- `test_prompt_hash_fallback_covers_both_spawn_tool_names` — parametrised over
  `Task` and `Agent`.
- `test_colliding_prompts_are_disambiguated_by_teammate_name` — its fixture orders
  filenames so that sort-order pairing produces the wrong answer.

`just ci` green: 3068 unit, 68 TUI, 90 browser, 78 integration; ruff, pyright and ty
clean.

## Not included

`<agent-message from="…">` peer messages (#309) are a different carrier — an
`attachment` of type `queued_command` whose `origin` object we currently ignore —
and are handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved teammate session linking for both supported spawn methods.
  - Matching now prioritizes matching teammate names, with prompt-based fallback when names are unavailable.
  - Conflicting names remain unresolved rather than being linked incorrectly.
  - Older caches created with version 1.6.0 or earlier are now recognized as incompatible and rebuilt when needed.

- **Documentation**
  - Updated teammate-linking documentation to cover spawn methods, name-based matching, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->