### PR TITLE
Watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+- **Watch mode (`claude-code-log watch`)** — re-converts transcripts as they are
+  written, so Markdown open in an editor or an Obsidian vault stays current.
+  Defaults to the current directory's project.
+- **Live page updates (`claude-code-log serve --watch`)** — an open session page
+  grows as messages arrive, in place: scroll position, folded sections and open
+  disclosures survive, new messages fade in, and a follow pill pins the page to
+  the newest message. Only over the server; `file://` pages are unchanged.
+
+### Changed
+
+- Generated output is now written atomically (temp file + rename), so a reader
+  can never observe a truncated page or document.
+- The cache records each source file's size as well as its mtime (migration
+  011). The 1-second mtime tolerance could hide a write landing inside it,
+  which stranded the last message of a turn until something else touched the
+  file.
+- The session-scoped render path is now reachable after an append-only cache
+  refresh, which is what makes a watch tick cheap.
+
 ## [1.5.0] - 2026-07-09
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,6 +333,20 @@ full-load refresh. Set `CLAUDE_CODE_LOG_INCREMENTAL_CACHE=0` to force
 the full refresh when bisecting. See
 [dev-docs/application_model.md § 2.14](dev-docs/application_model.md).
 
+That refresh parses each modified file from source, and the loads that
+follow it — the closure load and the session-scoped render — used to
+rebuild those same entries from the rows it had just written, twice.
+A per-conversion parsed-entry store
+(`claude_code_log/entry_store.py`) serves the refresh's list to both
+instead, taking a watch tick on an 803MB archive from 1.03s to 0.72s.
+Only the incremental refresh fills it, and only with the files that
+changed, so a cold conversion and the streaming path (whose bounded
+residency depends on dropping each page) carry no extra memory. Set
+`CLAUDE_CODE_LOG_ENTRY_STORE=0` to disable it when bisecting; a
+per-file memory valve declines to hold a file when available memory is
+under ~6× its bytes, and an explicit `=1` overrides that valve. See
+[dev-docs/application_model.md § 2.16](dev-docs/application_model.md).
+
 To re-measure on your own hardware (core count changes the answer for
 the fan-out), point the benchmark at a real project:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,9 +341,20 @@ A per-conversion parsed-entry store
 instead, taking a watch tick on an 803MB archive from 1.03s to 0.72s.
 Only the incremental refresh fills it, and only with the files that
 changed, so a cold conversion and the streaming path (whose bounded
-residency depends on dropping each page) carry no extra memory. Set
-`CLAUDE_CODE_LOG_ENTRY_STORE=0` to disable it when bisecting; a
-per-file memory valve declines to hold a file when available memory is
+residency depends on dropping each page) carry no extra memory.
+
+Held *across* ticks — which `watch` does, owning one for the life of the
+loop — the same store also resumes. It pins its entries to a byte offset
+plus a hash of the bytes below it, so a tick hashes that prefix (32ms
+over 39.7MB, against 143ms to re-parse it), reads only what was
+appended, and appends just the new cache rows rather than rewriting the
+file's. That takes the same tick to **0.26s**. It applies only where the
+rows are provably the file's own lines: a trunk's rows carry its
+subagents' spliced transcripts, so a running subagent grows a block
+mid-sequence and those files take the unchanged full rewrite.
+
+Set `CLAUDE_CODE_LOG_ENTRY_STORE=0` to disable all of it when bisecting;
+a per-file memory valve declines to hold a file when available memory is
 under ~6× its bytes, and an explicit `=1` overrides that valve. See
 [dev-docs/application_model.md § 2.16](dev-docs/application_model.md).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ uvx claude-code-log@latest --open-browser
 ## Key Features
 
 - **Interactive TUI (Terminal User Interface)**: Browse and manage Claude Code sessions with real-time navigation, summaries, and quick actions for HTML export and session resuming
+- **Watch Mode**: `claude-code-log watch` re-converts as a session is written, so Markdown in an editor or Obsidian stays current; `claude-code-log serve --watch` makes an open session page grow as messages arrive, keeping your scroll position and folded sections
 - **Project Hierarchy Processing**: Process entire `~/.claude/projects/` directory with linked index page
 - **Individual Session Files**: Generate separate HTML files for each session with navigation links
 - **Single File or Directory Processing**: Convert individual JSONL files or specific directories

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """SQLite-based cache management for Claude Code Log."""
 
+import functools
 import hashlib
 import json
 import logging
@@ -239,8 +240,19 @@ def scrub_surrogates(s: Optional[str]) -> Optional[str]:
     return s.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
 
 
+@functools.lru_cache(maxsize=1)
 def get_library_version() -> str:
-    """Get the current library version from package metadata or pyproject.toml."""
+    """Get the current library version from package metadata or pyproject.toml.
+
+    Memoised because it is called *per rendered file* on the staleness
+    path (``is_transcript_stale`` → ``is_html_outdated``), and each call
+    re-parses the installed package metadata through
+    ``importlib.metadata``: 173 calls and 35 ms of a 1.1 s watch tick on
+    a 217-session project, scaling with the session count rather than
+    with anything that changed. An installed version cannot change inside
+    a process, so a one-slot cache is exact; tests that need a different
+    value patch this name on the module, which is unaffected.
+    """
     # First try to get version from installed package metadata
     try:
         from importlib.metadata import version as get_version
@@ -1903,15 +1915,33 @@ class CacheManager:
         if self._project_id is None:
             return []
 
+        from .renderer import is_html_outdated
+
         stale_sessions: List[tuple[str, str]] = []
+        base_dir = output_dir or self.project_path
 
         with self._get_connection() as conn:
-            # Get all sessions
+            # Both tables are read whole, once, rather than per session.
+            # `is_transcript_stale` issues two queries per call, so a
+            # project with many sessions spent most of this function in
+            # SQLite round-trips for rows it was going to read anyway
+            # (work/watch-mode.md, C15). The per-session logic below is a
+            # faithful inline of that method — same order of checks, same
+            # reason strings — minus the queries.
             session_rows = conn.execute(
-                """SELECT session_id, last_timestamp FROM sessions
+                """SELECT session_id, message_count FROM sessions
                    WHERE project_id = ? AND hidden = 0""",
                 (self._project_id,),
             ).fetchall()
+            html_rows = conn.execute(
+                """SELECT html_path, message_count, library_version
+                   FROM html_cache WHERE project_id = ?""",
+                (self._project_id,),
+            ).fetchall()
+            html_cache = {
+                r["html_path"]: (r["message_count"] or 0, r["library_version"])
+                for r in html_rows
+            }
 
             for row in session_rows:
                 session_id = row["session_id"]
@@ -1924,12 +1954,26 @@ class CacheManager:
                     continue
 
                 html_path = f"session-{session_id}{variant}.{ext}"
-
-                is_stale, reason = self.is_transcript_stale(
-                    html_path, session_id, output_dir=output_dir
-                )
-                if is_stale:
-                    stale_sessions.append((session_id, reason))
+                cached = html_cache.get(html_path)
+                if cached is None:
+                    stale_sessions.append((session_id, "not_cached"))
+                    continue
+                cached_count, cached_version = cached
+                if cached_version != self.library_version:
+                    stale_sessions.append((session_id, "version_mismatch"))
+                    continue
+                actual_file = base_dir / html_path
+                if not actual_file.exists():
+                    stale_sessions.append((session_id, "file_missing"))
+                    continue
+                if is_html_outdated(actual_file):
+                    stale_sessions.append((session_id, "file_version_mismatch"))
+                    continue
+                # `session_not_found` cannot arise here — the candidate
+                # list *is* the sessions table — so only the count check
+                # remains of `is_transcript_stale`'s session branch.
+                if row["message_count"] != cached_count:
+                    stale_sessions.append((session_id, "session_updated"))
 
         return stale_sessions
 

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -457,17 +457,20 @@ def is_corrupt_database_error(exc: BaseException) -> bool:
 
 
 def discard_database_files(db_path: Path) -> bool:
-    """Delete a cache database and its WAL sidecars. True if the .db is gone.
+    """Delete a cache database and its WAL sidecars. True if all are gone.
 
     The sidecars have to go with it: a ``-wal`` left beside a recreated
     database is a mismatched log, which is its own route back into
-    "malformed".
+    "malformed". So a surviving sidecar is a failure just as much as a
+    surviving ``.db`` — the caller should run cacheless rather than
+    recreate a database next to a stale log.
     """
-    for path in (
+    paths = (
         db_path,
         db_path.with_name(db_path.name + "-wal"),
         db_path.with_name(db_path.name + "-shm"),
-    ):
+    )
+    for path in paths:
         try:
             path.unlink()
         except FileNotFoundError:
@@ -476,7 +479,7 @@ def discard_database_files(db_path: Path) -> bool:
             # Windows refuses to unlink a file another process still holds
             # open (WinError 32). Report and let the caller decide.
             print(f"  Warning: could not delete {path.name}: {e}")
-    return not db_path.exists()
+    return not any(path.exists() for path in paths)
 
 
 # ========== Cache Manager ==========

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -902,6 +902,7 @@ class CacheManager:
         jsonl_path: Path,
         entries: List[TranscriptEntry],
         subagents_fp: Optional[str] = None,
+        source_stat: Optional[os.stat_result] = None,
     ) -> None:
         """Save parsed transcript entries to cache.
 
@@ -911,11 +912,19 @@ class CacheManager:
         next read and forces a reparse (over-invalidation; computing it
         here at save time would instead validate a parse that never saw
         the late sidecar). Falls back to computing now when omitted.
+
+        ``source_stat`` is the file's identity as of the parse, and is
+        the same argument one level down: a session that grew *while*
+        being read would otherwise be stamped with the size and mtime it
+        reached, marking a cache that is missing those lines as current —
+        and if the file then never changes again, permanently so. Stamped
+        with what was actually parsed, the growth invalidates instead.
         """
         if self._project_id is None:
             return
 
-        source_stat = jsonl_path.stat()
+        if source_stat is None:
+            source_stat = jsonl_path.stat()
         source_mtime = source_stat.st_mtime
         source_size = source_stat.st_size
         cached_mtime = datetime.now().timestamp()
@@ -1005,6 +1014,7 @@ class CacheManager:
         all_entries: List[TranscriptEntry],
         appended: List[TranscriptEntry],
         subagents_fp: Optional[str] = None,
+        source_stat: Optional[os.stat_result] = None,
     ) -> bool:
         """Insert only ``appended``, leaving the file's existing rows in place.
 
@@ -1022,6 +1032,9 @@ class CacheManager:
         have rewritten them since. Returns False whenever the row count
         disagrees, and the caller falls back to the full rewrite; that
         check is why the two stores cannot silently drift apart.
+
+        ``source_stat`` is the file's identity AS OF THE PARSE, for the
+        same reason as ``subagents_fp`` — see ``save_cached_entries``.
         """
         if self._project_id is None or not appended:
             return False
@@ -1029,70 +1042,111 @@ class CacheManager:
         if expected_existing <= 0:
             return False
 
-        source_stat = jsonl_path.stat()
+        if source_stat is None:
+            source_stat = jsonl_path.stat()
         if subagents_fp is None:
             subagents_fp = subagents_fingerprint(jsonl_path)
 
         with self._get_connection() as conn:
-            row = conn.execute(
-                "SELECT id FROM cached_files WHERE project_id = ? AND file_name = ?",
-                (self._project_id, jsonl_path.name),
-            ).fetchone()
-            if row is None:
-                return False
-            file_id = row["id"]
-
-            count = conn.execute(
-                "SELECT COUNT(*) AS n FROM messages WHERE file_id = ?", (file_id,)
-            ).fetchone()["n"]
-            if count != expected_existing:
-                return False
-
-            conn.execute(
-                """UPDATE cached_files
-                   SET file_path = ?, source_mtime = ?, source_size = ?,
-                       cached_mtime = ?, message_count = ?, subagents_fingerprint = ?
-                   WHERE id = ?""",
-                (
-                    str(jsonl_path),
-                    source_stat.st_mtime,
-                    source_stat.st_size,
-                    datetime.now().timestamp(),
-                    len(all_entries),
+            # The count and the insert have to be one transaction. Python's
+            # sqlite3 opens one on the first *write*, not on a SELECT, so
+            # without this another writer sharing the cache (a second
+            # `watch`, or a TUI beside one) can append in the window
+            # between them, and both appends land — the row check would
+            # have refused had it seen them. `BEGIN IMMEDIATE` takes the
+            # write lock up front; inside a `batch()` scope the connection
+            # is in a transaction already and that one covers it.
+            own_transaction = not conn.in_transaction
+            if own_transaction:
+                conn.execute("BEGIN IMMEDIATE")
+            try:
+                return self._append_under_lock(
+                    conn,
+                    jsonl_path,
+                    all_entries,
+                    appended,
+                    expected_existing,
+                    source_stat,
                     subagents_fp,
-                    file_id,
-                ),
-            )
-            conn.executemany(
-                """
-                INSERT INTO messages (
-                    project_id, file_id, type, timestamp, session_id,
-                    _uuid, _parent_uuid, _is_sidechain, _user_type, _cwd, _version,
-                    _is_meta, _agent_id, _request_id,
-                    input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-                    _leaf_uuid, _level, _operation, content
-                ) VALUES (
-                    :project_id, :file_id, :type, :timestamp, :session_id,
-                    :_uuid, :_parent_uuid, :_is_sidechain, :_user_type, :_cwd, :_version,
-                    :_is_meta, :_agent_id, :_request_id,
-                    :input_tokens, :output_tokens, :cache_creation_tokens, :cache_read_tokens,
-                    :_leaf_uuid, :_level, :_operation, :content
                 )
-                """,
-                [self._serialize_entry(entry, file_id) for entry in appended],
+            finally:
+                # A refusal wrote nothing, but it still holds the write
+                # lock this method took; an exception may have written.
+                # Either way, only ever unwind our own transaction — a
+                # rollback inside a `batch()` would discard the caller's.
+                if own_transaction and conn.in_transaction:
+                    conn.rollback()
+
+    def _append_under_lock(
+        self,
+        conn: sqlite3.Connection,
+        jsonl_path: Path,
+        all_entries: List[TranscriptEntry],
+        appended: List[TranscriptEntry],
+        expected_existing: int,
+        source_stat: os.stat_result,
+        subagents_fp: Optional[str],
+    ) -> bool:
+        """The checked append itself, run under the caller's write lock."""
+        row = conn.execute(
+            "SELECT id FROM cached_files WHERE project_id = ? AND file_name = ?",
+            (self._project_id, jsonl_path.name),
+        ).fetchone()
+        if row is None:
+            return False
+        file_id = row["id"]
+
+        count = conn.execute(
+            "SELECT COUNT(*) AS n FROM messages WHERE file_id = ?", (file_id,)
+        ).fetchone()["n"]
+        if count != expected_existing:
+            return False
+
+        conn.execute(
+            """UPDATE cached_files
+               SET file_path = ?, source_mtime = ?, source_size = ?,
+                   cached_mtime = ?, message_count = ?, subagents_fingerprint = ?
+               WHERE id = ?""",
+            (
+                str(jsonl_path),
+                source_stat.st_mtime,
+                source_stat.st_size,
+                datetime.now().timestamp(),
+                len(all_entries),
+                subagents_fp,
+                file_id,
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO messages (
+                project_id, file_id, type, timestamp, session_id,
+                _uuid, _parent_uuid, _is_sidechain, _user_type, _cwd, _version,
+                _is_meta, _agent_id, _request_id,
+                input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                _leaf_uuid, _level, _operation, content
+            ) VALUES (
+                :project_id, :file_id, :type, :timestamp, :session_id,
+                :_uuid, :_parent_uuid, :_is_sidechain, :_user_type, :_cwd, :_version,
+                :_is_meta, :_agent_id, :_request_id,
+                :input_tokens, :output_tokens, :cache_creation_tokens, :cache_read_tokens,
+                :_leaf_uuid, :_level, :_operation, :content
             )
+            """,
+            [self._serialize_entry(entry, file_id) for entry in appended],
+        )
 
-            # The index still refreshes the whole file: `reindex_files`
-            # deletes and re-adds its rows, and an append-only variant
-            # would need its own correctness argument. Only users who have
-            # built an index pay it, exactly as before.
-            from .search import auto_index_enabled, reindex_files
+        # The index still refreshes the whole file: `reindex_files`
+        # deletes and re-adds its rows, and an append-only variant
+        # would need its own correctness argument. Only users who have
+        # built an index pay it, exactly as before.
+        from .search import auto_index_enabled, reindex_files
 
-            if auto_index_enabled():
-                reindex_files(conn, [file_id], commit=False)
+        if auto_index_enabled():
+            reindex_files(conn, [file_id], commit=False)
 
-            self._update_last_updated(conn)
-            conn.commit()
+        self._update_last_updated(conn)
+        conn.commit()
         return True
 
     def update_session_cache(self, session_data: Dict[str, SessionCacheData]) -> None:

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -977,6 +977,102 @@ class CacheManager:
             self._update_last_updated(conn)
             conn.commit()
 
+    def extend_cached_entries(
+        self,
+        jsonl_path: Path,
+        all_entries: List[TranscriptEntry],
+        appended: List[TranscriptEntry],
+        subagents_fp: Optional[str] = None,
+    ) -> bool:
+        """Insert only ``appended``, leaving the file's existing rows in place.
+
+        ``save_cached_entries`` deletes every row for a file and rewrites
+        it, which costs a ``json.dumps`` + ``zlib.compress`` per entry —
+        310 ms to add one line to a 39.7 MB session, and the largest item
+        in a watch tick (work/watch-mode.md). When the caller can show the
+        new entries are exactly the old ones plus a tail, only the tail
+        needs writing.
+
+        The caller owns that proof (a byte-verified file prefix, plus no
+        agent splicing — see ``load_transcript``); this method owns the
+        one part the caller cannot see, which is whether the *rows*
+        still match what the caller thinks it wrote. Another process may
+        have rewritten them since. Returns False whenever the row count
+        disagrees, and the caller falls back to the full rewrite; that
+        check is why the two stores cannot silently drift apart.
+        """
+        if self._project_id is None or not appended:
+            return False
+        expected_existing = len(all_entries) - len(appended)
+        if expected_existing <= 0:
+            return False
+
+        source_stat = jsonl_path.stat()
+        if subagents_fp is None:
+            subagents_fp = subagents_fingerprint(jsonl_path)
+
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT id FROM cached_files WHERE project_id = ? AND file_name = ?",
+                (self._project_id, jsonl_path.name),
+            ).fetchone()
+            if row is None:
+                return False
+            file_id = row["id"]
+
+            count = conn.execute(
+                "SELECT COUNT(*) AS n FROM messages WHERE file_id = ?", (file_id,)
+            ).fetchone()["n"]
+            if count != expected_existing:
+                return False
+
+            conn.execute(
+                """UPDATE cached_files
+                   SET file_path = ?, source_mtime = ?, source_size = ?,
+                       cached_mtime = ?, message_count = ?, subagents_fingerprint = ?
+                   WHERE id = ?""",
+                (
+                    str(jsonl_path),
+                    source_stat.st_mtime,
+                    source_stat.st_size,
+                    datetime.now().timestamp(),
+                    len(all_entries),
+                    subagents_fp,
+                    file_id,
+                ),
+            )
+            conn.executemany(
+                """
+                INSERT INTO messages (
+                    project_id, file_id, type, timestamp, session_id,
+                    _uuid, _parent_uuid, _is_sidechain, _user_type, _cwd, _version,
+                    _is_meta, _agent_id, _request_id,
+                    input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                    _leaf_uuid, _level, _operation, content
+                ) VALUES (
+                    :project_id, :file_id, :type, :timestamp, :session_id,
+                    :_uuid, :_parent_uuid, :_is_sidechain, :_user_type, :_cwd, :_version,
+                    :_is_meta, :_agent_id, :_request_id,
+                    :input_tokens, :output_tokens, :cache_creation_tokens, :cache_read_tokens,
+                    :_leaf_uuid, :_level, :_operation, :content
+                )
+                """,
+                [self._serialize_entry(entry, file_id) for entry in appended],
+            )
+
+            # The index still refreshes the whole file: `reindex_files`
+            # deletes and re-adds its rows, and an append-only variant
+            # would need its own correctness argument. Only users who have
+            # built an index pay it, exactly as before.
+            from .search import auto_index_enabled, reindex_files
+
+            if auto_index_enabled():
+                reindex_files(conn, [file_id], commit=False)
+
+            self._update_last_updated(conn)
+            conn.commit()
+        return True
+
     def update_session_cache(self, session_data: Dict[str, SessionCacheData]) -> None:
         """Update cached session information."""
         if self._project_id is None:

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -422,6 +422,63 @@ def get_cache_db_path(projects_dir: Path) -> Path:
     return projects_dir / "claude-code-log-cache.db"
 
 
+# SQLite error text meaning "this file is damaged past the point of being
+# read at all". Matched on the message because Python funnels every one of
+# them into the same `sqlite3.DatabaseError` — there is no distinct class
+# to catch. Deliberately narrow: "database is locked" and "database or disk
+# is full" are also DatabaseErrors, and neither is a reason to delete a
+# perfectly good cache.
+_CORRUPTION_MARKERS = (
+    # SQLITE_CORRUPT. Observed shape: a cache truncated to 2833 pages while
+    # its header still claimed 14189, which fails every read including
+    # `PRAGMA page_count`. That one came from the virtiofs mount the file
+    # lived on, so it is the filesystem's kind of damage, not the writer's —
+    # expect it to recur wherever the cache sits on a shared/virtualised
+    # mount.
+    "database disk image is malformed",
+    # SQLITE_NOTADB — a garbage or encrypted header.
+    "file is not a database",
+    # A virtual-table declaration in sqlite_master that no longer parses,
+    # e.g. an FTS5 index carrying an option this SQLite build lacks.
+    "malformed database schema",
+)
+
+
+def is_corrupt_database_error(exc: BaseException) -> bool:
+    """Whether ``exc`` says the database file itself is unusable.
+
+    Note a zero-byte file is *not* corruption — SQLite happily adopts one as
+    a new database — so an interrupted create heals on its own.
+    """
+    if not isinstance(exc, sqlite3.DatabaseError):
+        return False
+    message = str(exc).lower()
+    return any(marker in message for marker in _CORRUPTION_MARKERS)
+
+
+def discard_database_files(db_path: Path) -> bool:
+    """Delete a cache database and its WAL sidecars. True if the .db is gone.
+
+    The sidecars have to go with it: a ``-wal`` left beside a recreated
+    database is a mismatched log, which is its own route back into
+    "malformed".
+    """
+    for path in (
+        db_path,
+        db_path.with_name(db_path.name + "-wal"),
+        db_path.with_name(db_path.name + "-shm"),
+    ):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            # Windows refuses to unlink a file another process still holds
+            # open (WinError 32). Report and let the caller decide.
+            print(f"  Warning: could not delete {path.name}: {e}")
+    return not db_path.exists()
+
+
 # ========== Cache Manager ==========
 
 
@@ -487,8 +544,13 @@ class CacheManager:
             self._lookup_project_id()
         else:
             # Initialise database and ensure project exists
-            self._init_database()
-            self._ensure_project_exists()
+            try:
+                self._init_database()
+                self._ensure_project_exists()
+            except sqlite3.DatabaseError as exc:
+                if not is_corrupt_database_error(exc):
+                    raise
+                self._rebuild_corrupt_database(exc)
 
     def _configure_connection(self, conn: sqlite3.Connection) -> None:
         """Apply the standard pragmas/row factory to a fresh connection."""
@@ -593,6 +655,40 @@ class CacheManager:
             return
         run_migrations(self.db_path)
         _migrated_db_paths.add(key)
+
+    def _rebuild_corrupt_database(self, exc: sqlite3.DatabaseError) -> None:
+        """Delete an unreadable cache database and build a fresh one.
+
+        The cache is derived data, regenerable in full from the JSONL
+        source, so discarding it costs only the next run's rebuild time —
+        whereas keeping it costs every run, forever. Corruption is sticky:
+        `apply_migration` only records a migration that completed, so a
+        `CREATE INDEX` that hits a damaged page is re-attempted and re-fails
+        on every subsequent invocation.
+
+        Nothing is salvaged first. In the case this was written for, the
+        file was truncated to a fifth of the size its own header claimed,
+        and *no* statement against it succeeded — not even `PRAGMA
+        page_count`. A partial-salvage path would be untested code guarding
+        against a case we have not seen.
+
+        Only reached from the writing constructor. A ``read_only``
+        instance — every spawned render worker — must never delete the
+        database out from under its siblings, and doesn't need to:
+        `_lookup_project_id` already degrades to "no cached data".
+        """
+        print(f"Cache database is corrupt ({exc}): {self.db_path}")
+        if not discard_database_files(self.db_path):
+            # Couldn't remove it, so a retry would just fail the same way.
+            # Re-raise and let the caller degrade to running cacheless.
+            print("  Could not delete it; continuing without a cache.")
+            raise exc
+        # The memo records "migrations already checked for this path", which
+        # the file we just deleted is no longer evidence of.
+        _migrated_db_paths.discard(str(self.db_path))
+        print("  Deleted it and rebuilding from scratch (this run will be slower).")
+        self._init_database()
+        self._ensure_project_exists()
 
     def _lookup_project_id(self) -> None:
         """Read-only counterpart of ``_ensure_project_exists``: find, never create.

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -329,7 +329,10 @@ def subagents_fingerprint(jsonl_path: Path) -> str:
 
 
 def _cache_row_is_fresh(
-    row: sqlite3.Row, source_mtime: float, current_fp: Callable[[], str]
+    row: sqlite3.Row,
+    source_mtime: float,
+    current_fp: Callable[[], str],
+    source_size: Optional[int] = None,
 ) -> bool:
     """Decide whether a cached_files row is still fresh.
 
@@ -339,13 +342,28 @@ def _cache_row_is_fresh(
     check passes (and get_modified_files() can plug in its
     scandir-optimized variant).
 
-    Cache is valid if modification times match (within 1 second
-    tolerance) and the sidecar inputs of spawn discovery (#213) match
-    too — new agent-*.meta.json files appear without touching the
-    source jsonl. Pre-007 rows carry NULL: accept those only when the
-    file has no sidecars today (nothing to miss), so legacy caches
-    don't mass-invalidate while sessions WITH sidecars reparse once.
+    Cache is valid if the size matches, modification times match
+    (within 1 second tolerance), and the sidecar inputs of spawn
+    discovery (#213) match too — new agent-*.meta.json files appear
+    without touching the source jsonl. Pre-007 rows carry a NULL
+    fingerprint: accept those only when the file has no sidecars today
+    (nothing to miss), so legacy caches don't mass-invalidate while
+    sessions WITH sidecars reparse once.
+
+    The size check exists because the mtime tolerance — which is there
+    for coarse filesystem timestamp granularity — hides any write that
+    lands within a second of the mtime recorded at cache time. Appending
+    to a transcript and converting immediately alternates between seeing
+    and missing the change; the last message of a turn can stay stranded
+    indefinitely. Size is exact and free (callers already stat the
+    file), and the combined rule is strictly tightening: it marks more
+    files stale, never fewer. Pre-011 rows carry NULL and fall back to
+    the mtime-only check so a populated cache doesn't mass-invalidate.
     """
+    if source_size is not None:
+        cached_size = row["source_size"]
+        if cached_size is not None and cached_size != source_size:
+            return False
     if abs(source_mtime - row["source_mtime"]) >= 1.0:
         return False
     cached_fp = row["subagents_fingerprint"]
@@ -749,7 +767,8 @@ class CacheManager:
 
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT source_mtime, subagents_fingerprint FROM cached_files"
+                "SELECT source_mtime, source_size, subagents_fingerprint"
+                " FROM cached_files"
                 " WHERE project_id = ? AND file_name = ?",
                 (self._project_id, jsonl_path.name),
             ).fetchone()
@@ -757,10 +776,12 @@ class CacheManager:
         if not row:
             return False
 
+        source_stat = jsonl_path.stat()
         return _cache_row_is_fresh(
             row,
-            jsonl_path.stat().st_mtime,
+            source_stat.st_mtime,
             lambda: subagents_fingerprint(jsonl_path),
+            source_stat.st_size,
         )
 
     def load_cached_entries(self, jsonl_path: Path) -> Optional[List[TranscriptEntry]]:
@@ -860,7 +881,9 @@ class CacheManager:
         if self._project_id is None:
             return
 
-        source_mtime = jsonl_path.stat().st_mtime
+        source_stat = jsonl_path.stat()
+        source_mtime = source_stat.st_mtime
+        source_size = source_stat.st_size
         cached_mtime = datetime.now().timestamp()
         if subagents_fp is None:
             subagents_fp = subagents_fingerprint(jsonl_path)
@@ -871,12 +894,13 @@ class CacheManager:
             conn.execute(
                 """
                 INSERT INTO cached_files
-                (project_id, file_name, file_path, source_mtime, cached_mtime,
-                 message_count, subagents_fingerprint)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (project_id, file_name, file_path, source_mtime, source_size,
+                 cached_mtime, message_count, subagents_fingerprint)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(project_id, file_name) DO UPDATE SET
                     file_path = excluded.file_path,
                     source_mtime = excluded.source_mtime,
+                    source_size = excluded.source_size,
                     cached_mtime = excluded.cached_mtime,
                     message_count = excluded.message_count,
                     subagents_fingerprint = excluded.subagents_fingerprint
@@ -886,6 +910,7 @@ class CacheManager:
                     jsonl_path.name,
                     str(jsonl_path),
                     source_mtime,
+                    source_size,
                     cached_mtime,
                     len(entries),
                     subagents_fp,
@@ -1507,7 +1532,8 @@ class CacheManager:
 
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT file_name, source_mtime, subagents_fingerprint"
+                "SELECT file_name, source_mtime, source_size,"
+                " subagents_fingerprint"
                 " FROM cached_files WHERE project_id = ?",
                 (self._project_id,),
             ).fetchall()
@@ -1542,7 +1568,8 @@ class CacheManager:
                 continue
 
             try:
-                source_mtime = jsonl_file.stat().st_mtime
+                # One stat serves both checks — st_size rides along free.
+                source_stat = jsonl_file.stat()
             except OSError:
                 # Missing file: same outcome as is_file_cached()'s
                 # exists() check returning False.
@@ -1550,7 +1577,10 @@ class CacheManager:
                 continue
 
             if not _cache_row_is_fresh(
-                row, source_mtime, lambda file=jsonl_file: current_fp(file)
+                row,
+                source_stat.st_mtime,
+                lambda file=jsonl_file: current_fp(file),
+                source_stat.st_size,
             ):
                 modified.append(jsonl_file)
 

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -1477,7 +1477,7 @@ class CacheManager:
                 # The `session_id IS NOT NULL` filter is applied in Python
                 # rather than SQL, and the difference is not cosmetic: as a
                 # SQL predicate SQLite can satisfy it from
-                # `idx_messages_project_session_file` as a range scan —
+                # `idx_messages_project_session_ts` as a range scan —
                 # walking every session-bearing row in the project — and
                 # prefers that to seeking the uuids actually asked for.
                 # Measured on a 38,706-row archive, 500 uuids: **17.2 ms

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -1358,23 +1358,47 @@ class CacheManager:
 
         Files without cached rows simply have no key in the result —
         that is the "new file" signature.
+
+        Resolves names to ``file_id`` first and filters the messages
+        table on that, rather than joining ``cached_files`` and filtering
+        on ``file_name``. The join form gives SQLite no indexed way in:
+        it falls back to ``idx_messages_project_timestamp`` and walks
+        every row in the project, which on a real archive is ~16 ms a
+        call to read a handful of files. Filtering on ``file_id`` uses
+        ``idx_messages_file`` and the same call measures 0.0 ms.
         """
         result: Dict[str, CachedFileState] = {}
         if self._project_id is None or not file_names:
             return result
         with self._get_connection() as conn:
+            names_by_id: Dict[int, str] = {}
             for i in range(0, len(file_names), self._IN_CHUNK):
                 chunk = file_names[i : i + self._IN_CHUNK]
                 placeholders = ",".join("?" * len(chunk))
                 for row in conn.execute(
-                    f"""SELECT cf.file_name, m.session_id, m._uuid, m._parent_uuid,
-                               m._request_id, m.type, m._leaf_uuid, m.content
-                        FROM messages m JOIN cached_files cf ON m.file_id = cf.id
-                        WHERE m.project_id = ? AND cf.file_name IN ({placeholders})
-                        ORDER BY cf.file_name, m.id""",
+                    f"""SELECT id, file_name FROM cached_files
+                        WHERE project_id = ? AND file_name IN ({placeholders})""",
                     (self._project_id, *chunk),
                 ):
-                    state = result.setdefault(row["file_name"], CachedFileState())
+                    names_by_id[row["id"]] = row["file_name"]
+
+            file_ids = sorted(names_by_id)
+            for i in range(0, len(file_ids), self._IN_CHUNK):
+                chunk_ids = file_ids[i : i + self._IN_CHUNK]
+                placeholders = ",".join("?" * len(chunk_ids))
+                # Ordering within a file is what matters — row_fingerprints
+                # is positional — and `file_id, id` gives it.
+                for row in conn.execute(
+                    f"""SELECT file_id, session_id, _uuid, _parent_uuid,
+                               _request_id, type, _leaf_uuid, content
+                        FROM messages
+                        WHERE file_id IN ({placeholders})
+                        ORDER BY file_id, id""",
+                    chunk_ids,
+                ):
+                    state = result.setdefault(
+                        names_by_id[row["file_id"]], CachedFileState()
+                    )
                     state.row_fingerprints.append(
                         hashlib.sha256(bytes(row["content"])).digest()
                     )
@@ -1397,14 +1421,13 @@ class CacheManager:
                         state.type_counts[row_type] = (
                             state.type_counts.get(row_type, 0) + 1
                         )
-                # A cached file whose rows are all filtered (e.g. empty
-                # file) still needs a key, or it would read as "new".
-                for row in conn.execute(
-                    f"""SELECT file_name FROM cached_files
-                        WHERE project_id = ? AND file_name IN ({placeholders})""",
-                    (self._project_id, *chunk),
-                ):
-                    result.setdefault(row["file_name"], CachedFileState())
+
+            # A cached file whose rows are all filtered (e.g. an empty
+            # file) still needs a key, or it would read as "new". The
+            # name resolution above already enumerated exactly those
+            # files, so no second query is needed.
+            for name in names_by_id.values():
+                result.setdefault(name, CachedFileState())
         return result
 
     def get_parent_uuid_dependents(self, uuids: List[str]) -> Dict[str, set[str]]:
@@ -1421,13 +1444,20 @@ class CacheManager:
             for i in range(0, len(uuids), self._IN_CHUNK):
                 chunk = uuids[i : i + self._IN_CHUNK]
                 placeholders = ",".join("?" * len(chunk))
+                # `session_id IS NOT NULL` is filtered in Python, not SQL:
+                # as a SQL predicate it lets the planner satisfy the query
+                # with the (project_id, session_id, …) index as a range
+                # scan over every session-bearing row, instead of seeking
+                # the handful of uuids asked for. See `get_uuid_owners`.
                 for row in conn.execute(
                     f"""SELECT _parent_uuid, session_id FROM messages
-                        WHERE project_id = ? AND _parent_uuid IN ({placeholders})
-                          AND session_id IS NOT NULL""",
+                        WHERE project_id = ? AND _parent_uuid IN ({placeholders})""",
                     (self._project_id, *chunk),
                 ):
-                    result.setdefault(row["_parent_uuid"], set()).add(row["session_id"])
+                    if row["session_id"] is not None:
+                        result.setdefault(row["_parent_uuid"], set()).add(
+                            row["session_id"]
+                        )
         return result
 
     def get_uuid_owners(self, uuids: List[str]) -> Dict[str, set[Tuple[str, str]]]:
@@ -1444,15 +1474,23 @@ class CacheManager:
             for i in range(0, len(uuids), self._IN_CHUNK):
                 chunk = uuids[i : i + self._IN_CHUNK]
                 placeholders = ",".join("?" * len(chunk))
+                # The `session_id IS NOT NULL` filter is applied in Python
+                # rather than SQL, and the difference is not cosmetic: as a
+                # SQL predicate SQLite can satisfy it from
+                # `idx_messages_project_session_file` as a range scan —
+                # walking every session-bearing row in the project — and
+                # prefers that to seeking the uuids actually asked for.
+                # Measured on a 38,706-row archive, 500 uuids: **17.2 ms
+                # with the predicate in SQL, 0.9 ms without**.
                 for row in conn.execute(
                     f"""SELECT _uuid, session_id, type FROM messages
-                        WHERE project_id = ? AND _uuid IN ({placeholders})
-                          AND session_id IS NOT NULL""",
+                        WHERE project_id = ? AND _uuid IN ({placeholders})""",
                     (self._project_id, *chunk),
                 ):
-                    result.setdefault(row["_uuid"], set()).add(
-                        (row["session_id"], row["type"])
-                    )
+                    if row["session_id"] is not None:
+                        result.setdefault(row["_uuid"], set()).add(
+                            (row["session_id"], row["type"])
+                        )
         return result
 
     def get_request_id_entries(
@@ -1473,15 +1511,16 @@ class CacheManager:
             for i in range(0, len(rids), self._IN_CHUNK):
                 chunk = rids[i : i + self._IN_CHUNK]
                 placeholders = ",".join("?" * len(chunk))
+                # Filtered in Python for the reason `get_uuid_owners` gives.
                 for row in conn.execute(
                     f"""SELECT _request_id, _uuid, session_id FROM messages
-                        WHERE project_id = ? AND _request_id IN ({placeholders})
-                          AND session_id IS NOT NULL""",
+                        WHERE project_id = ? AND _request_id IN ({placeholders})""",
                     (self._project_id, *chunk),
                 ):
-                    result.setdefault(row["_request_id"], set()).add(
-                        (row["_uuid"] or "", row["session_id"])
-                    )
+                    if row["session_id"] is not None:
+                        result.setdefault(row["_request_id"], set()).add(
+                            (row["_uuid"] or "", row["session_id"])
+                        )
         return result
 
     def get_session_request_ids(self, session_ids: List[str]) -> set[str]:

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -240,6 +240,27 @@ def scrub_surrogates(s: Optional[str]) -> Optional[str]:
     return s.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
 
 
+# Compression level for a cached entry's content blob. zlib's default
+# (6) spends most of its time for the last few percent of size, and
+# rewriting a file's rows is the largest item in a watch tick.
+#
+# The size cost is much smaller than a single-file measurement suggests.
+# Over one atypical 207-entry, 40 MB session (~190 KB per entry) level 6
+# takes 183 ms to reach 2.92 MB against level 3's 81 ms to reach 3.44 MB
+# — 18% more bytes. But zlib levels only diverge on large payloads, and a
+# real archive is mostly small entries: across a 49 MB archive's 18,288
+# rows the blobs grow 26.37 MB -> 27.05 MB, i.e. **2.6%**, for a cold
+# conversion 11% faster (6.15 s -> 5.49 s) and a tick ~20% faster.
+#
+# Decompression is unaffected (~50 ms either way) and level-agnostic, so
+# this is backward compatible: rows written at any level still read. The
+# only visible transition is that re-serialising an existing entry
+# changes its blob, hence its row fingerprint, so the first incremental
+# refresh over a level-6 cache declines to a full refresh once and is
+# consistent thereafter.
+CONTENT_COMPRESSION_LEVEL = 3
+
+
 @functools.lru_cache(maxsize=1)
 def get_library_version() -> str:
     """Get the current library version from package metadata or pyproject.toml.
@@ -718,7 +739,8 @@ class CacheManager:
             "_level": None,
             "_operation": None,
             "content": zlib.compress(
-                json.dumps(entry.model_dump(), separators=(",", ":")).encode("utf-8")
+                json.dumps(entry.model_dump(), separators=(",", ":")).encode("utf-8"),
+                CONTENT_COMPRESSION_LEVEL,
             ),
         }
 

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -7,6 +7,7 @@ import os
 import signal
 import sqlite3
 import sys
+import threading
 import time
 import traceback
 from pathlib import Path
@@ -2111,6 +2112,16 @@ def convert(
         "page will report the index as unavailable."
     ),
 )
+@click.option(
+    "--watch",
+    "watch_sources",
+    is_flag=True,
+    default=False,
+    help=(
+        "Keep the served pages current: re-convert whenever a transcript "
+        "changes, in the background. Reload a page to see new messages."
+    ),
+)
 def serve(
     port: int,
     projects_dir: Optional[Path],
@@ -2120,6 +2131,7 @@ def serve(
     index_fields: Optional[str],
     reindex: bool,
     no_index: bool,
+    watch_sources: bool,
 ) -> None:
     """Serve the projects directory over loopback, with full-archive search.
 
@@ -2175,11 +2187,38 @@ def serve(
     if open_browser:
         click.launch(f"{server.url}/index.html")
 
+    watch_stop: Optional[threading.Event] = None
+    watch_thread: Optional[threading.Thread] = None
+    if watch_sources:
+        from .watch import WatchEngine
+
+        def reconvert(_changed: set[Path]) -> None:
+            # The server never renders. It re-runs the ordinary conversion
+            # and lets the pages on disk stay canonical, so a page served
+            # over http and the same file opened from file:// can never
+            # disagree.
+            process_projects_hierarchy(projects_path, silent=True)
+
+        def report(exc: BaseException) -> None:
+            click.echo(f"  watch: conversion failed: {exc!r}", err=True)
+
+        engine = WatchEngine([projects_path], reconvert, on_error=report)
+        # Prime before starting the thread so the baseline is taken at a
+        # known moment rather than whenever the thread gets scheduled.
+        engine.prime()
+        watch_stop = threading.Event()
+        watch_thread = engine.run_in_thread(watch_stop)
+        click.echo("  watching for changes (reload a page to see new messages)")
+
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         click.echo("\nStopping...")
     finally:
+        if watch_stop is not None:
+            watch_stop.set()
+        if watch_thread is not None:
+            watch_thread.join(timeout=5)
         server.stop()
 
 

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -2390,6 +2390,16 @@ def watch(
     write_combined = combined != "no"
     individual = combined != "only"
 
+    # One store for the whole watch, not one per tick: it lets each tick
+    # resume its parse from the bytes the previous tick already read,
+    # instead of re-reading a growing session's whole history every time
+    # a line lands (entry_store.py, work/watch-mode.md Fix B). Only the
+    # single-project path takes one — `--all-projects` re-converts a
+    # hierarchy and has no single growing file to follow.
+    from .entry_store import ParsedEntryStore, entry_store_enabled
+
+    store = ParsedEntryStore() if (entry_store_enabled() and not all_projects) else None
+
     def convert(_changed: set[Path]) -> None:
         started = time.monotonic()
         if all_projects:
@@ -2412,6 +2422,7 @@ def watch(
                 silent=True,
                 write_combined=write_combined,
                 generate_individual_sessions=individual,
+                entry_store=store,
             )
         click.echo(
             f"  {time.strftime('%H:%M:%S')}  converted in "

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -39,6 +39,7 @@ from .cache import (
     get_all_cached_projects,
     get_cache_db_path,
     get_library_version,
+    is_corrupt_database_error,
 )
 from .models import RenderingDepth
 from .render_pool import resolve_render_jobs
@@ -2261,9 +2262,27 @@ def _build_search_index(
                 bar.__enter__()
             bar.update(1)
 
-        status = ensure_index(
-            conn, index_fields=index_fields, progress=report, rebuild=rebuild
-        )
+        try:
+            status = ensure_index(
+                conn, index_fields=index_fields, progress=report, rebuild=rebuild
+            )
+        except sqlite3.DatabaseError as e:
+            if not is_corrupt_database_error(e):
+                raise
+            # The ordinary conversion heals a corrupt cache when it builds a
+            # CacheManager, so the only way to arrive here is --no-convert,
+            # which skipped it. Don't delete the database behind the user's
+            # back on the one flag that asked us to touch nothing; serving
+            # the pages without search beats refusing to start.
+            if bar is not None:
+                bar.__exit__(None, None, None)
+            click.echo(f"Cache database is corrupt ({e}): {db_path}", err=True)
+            click.echo(
+                "  Search is unavailable. Re-run without --no-convert to "
+                "rebuild the cache.",
+                err=True,
+            )
+            return
         if bar is not None:
             bar.__exit__(None, None, None)
             click.echo(

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -7,12 +7,19 @@ import os
 import signal
 import sqlite3
 import sys
+import time
+import traceback
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 import click
 from git import Repo, InvalidGitRepositoryError
 
+from .watch import (
+    DEFAULT_MAX_LATENCY,
+    DEFAULT_POLL_INTERVAL,
+    DEFAULT_QUIET_PERIOD,
+)
 from .converter import (
     RegenerationReport,
     convert_jsonl_to,
@@ -2226,6 +2233,209 @@ def _build_search_index(
             )
     finally:
         conn.close()
+
+
+@main.command(name="watch")
+@click.argument(
+    "input_path",
+    type=click.Path(exists=True, path_type=Path, file_okay=False),
+    required=False,
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    help=(
+        "Output destination, as for `convert`. Pair with --format md to "
+        "keep an Obsidian vault current."
+    ),
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["html", "md", "markdown"]),
+    default="html",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--combined",
+    type=click.Choice(["yes", "no", "only"]),
+    default="no",
+    show_default=True,
+    help=(
+        "As for `convert`, but defaulting to 'no'. Per-session files are "
+        "what a watch is for, and skipping the combined page is what lets "
+        "a tick regenerate just the changed session instead of reloading "
+        "the whole project."
+    ),
+)
+@click.option(
+    "--projects-dir",
+    type=click.Path(exists=True, path_type=Path, file_okay=False),
+    help="Projects directory (default: ~/.claude/projects/).",
+)
+@click.option(
+    "--all-projects",
+    is_flag=True,
+    default=False,
+    help=(
+        "Watch every project instead of one. Off by default: a tick over a "
+        "large archive is far more expensive than over a single project."
+    ),
+)
+@click.option(
+    "--interval",
+    type=float,
+    default=DEFAULT_POLL_INTERVAL,
+    show_default=True,
+    help="Seconds between filesystem polls.",
+)
+@click.option(
+    "--quiet-period",
+    type=float,
+    default=DEFAULT_QUIET_PERIOD,
+    show_default=True,
+    help=(
+        "Seconds of no further change before converting. Claude Code writes "
+        "several entries per turn; without this every one would trigger its "
+        "own render."
+    ),
+)
+@click.option(
+    "--max-latency",
+    type=float,
+    default=DEFAULT_MAX_LATENCY,
+    show_default=True,
+    help=(
+        "Convert anyway after this long, so an unbroken stream of appends "
+        "still surfaces instead of starving behind the quiet period."
+    ),
+)
+@click.option("--debug", is_flag=True, default=False, help="Show full tracebacks.")
+def watch(
+    input_path: Optional[Path],
+    output: Optional[Path],
+    output_format: str,
+    combined: str,
+    projects_dir: Optional[Path],
+    all_projects: bool,
+    interval: float,
+    quiet_period: float,
+    max_latency: float,
+    debug: bool,
+) -> None:
+    """Re-convert transcripts as they change, until interrupted.
+
+    Points at one project by default -- the one for the current directory
+    if it has transcripts, otherwise the given INPUT_PATH. Watching the
+    whole archive is available via --all-projects but is rarely what you
+    want: a tick's cost scales with the project, and only one project is
+    ever being written to.
+
+    The generated files on disk stay canonical, so anything that reloads
+    them picks the changes up: an editor or Obsidian for Markdown, a
+    browser refresh for HTML.
+    """
+    from .watch import WatchEngine
+
+    projects_path = projects_dir or get_default_projects_dir()
+    root = _resolve_watch_root(input_path, projects_path, all_projects)
+    if root is None:
+        sys.exit(1)
+
+    fmt = "markdown" if output_format == "md" else output_format
+    write_combined = combined != "no"
+    individual = combined != "only"
+
+    def convert(_changed: set[Path]) -> None:
+        started = time.monotonic()
+        if all_projects:
+            process_projects_hierarchy(
+                root,
+                silent=True,
+                output_format=fmt,
+                output_dir=output,
+                write_combined=write_combined,
+                generate_individual_sessions=individual,
+            )
+        else:
+            convert_jsonl_to(
+                fmt,
+                root,
+                # `output_root` is the directory form; leaving output_path
+                # unset lets the converter derive the filenames, which is
+                # what keeps the destination-aware freshness check working.
+                output_root=output,
+                silent=True,
+                write_combined=write_combined,
+                generate_individual_sessions=individual,
+            )
+        click.echo(
+            f"  {time.strftime('%H:%M:%S')}  converted in "
+            f"{time.monotonic() - started:.2f}s"
+        )
+
+    def report(exc: BaseException) -> None:
+        if debug:
+            traceback.print_exc()
+        click.echo(f"  conversion failed: {exc!r}", err=True)
+
+    engine = WatchEngine(
+        [root],
+        convert,
+        poll_interval=interval,
+        quiet_period=quiet_period,
+        max_latency=max_latency,
+        on_error=report,
+    )
+
+    click.echo(f"Watching {root}")
+    click.echo("Press Ctrl+C to stop.")
+    # Convert once up front so the output is current before the first
+    # change, then prime -- priming after means our own output writes are
+    # already in the baseline and can't trigger a spurious first tick.
+    convert(set())
+    engine.prime()
+    try:
+        engine.run()
+    except KeyboardInterrupt:
+        click.echo("\nStopping.")
+    click.echo(
+        f"{engine.stats.conversions} conversions, "
+        f"{engine.stats.polls} polls, {engine.stats.errors} errors."
+    )
+
+
+def _resolve_watch_root(
+    input_path: Optional[Path], projects_path: Path, all_projects: bool
+) -> Optional[Path]:
+    """Pick the directory to watch, or report why we can't.
+
+    Order: an explicit path wins; --all-projects means the hierarchy;
+    otherwise the project for the current directory, which is what someone
+    running this alongside a live session almost always means.
+    """
+    if input_path is not None:
+        return input_path
+    if all_projects:
+        return projects_path
+
+    from .utils import real_path_to_project_dirname
+
+    encoded = real_path_to_project_dirname(Path.cwd())
+    candidate = projects_path / encoded
+    if candidate.is_dir():
+        return candidate
+
+    click.echo(
+        f"No transcripts found for the current directory ({Path.cwd()}).\n"
+        f"  Looked for: {candidate}\n"
+        "  Pass a project directory explicitly, or use --all-projects.",
+        err=True,
+    )
+    return None
 
 
 convert.epilog = _subcommand_epilog(main)

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -2382,7 +2382,9 @@ def watch(
     projects_path = projects_dir or get_default_projects_dir()
     root = _resolve_watch_root(input_path, projects_path, all_projects)
     if root is None:
-        sys.exit(1)
+        # `raise` rather than `sys.exit` so the type checkers can see that
+        # `root` is a Path from here on.
+        raise SystemExit(1)
 
     fmt = "markdown" if output_format == "md" else output_format
     write_combined = combined != "no"

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -2448,7 +2448,19 @@ def watch(
     # Convert once up front so the output is current before the first
     # change, then prime -- priming after means our own output writes are
     # already in the baseline and can't trigger a spurious first tick.
-    convert(set())
+    #
+    # A failure here is a misconfigured watch, not a transient one: the
+    # root doesn't exist, or `--all-projects` was pointed at a single
+    # project rather than an archive. `report` is for the per-tick case
+    # where the loop should carry on; this one is fatal, and gets the
+    # same one-line diagnosis `convert` gives rather than a traceback.
+    try:
+        convert(set())
+    except Exception as e:
+        if debug:
+            traceback.print_exc()
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
     engine.prime()
     try:
         engine.run()

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
 from .utils import (
     atomic_write_text,
+    real_path_to_project_dirname,
     coalesce_trunk_session_id,
     collect_trunk_session_ids,
     format_timestamp_range,
@@ -4954,7 +4955,7 @@ def _provider_project_dirname(cwd: Optional[Path]) -> str:
     index always has a home for them (DECIDED #3)."""
     if cwd is None:
         return "no-project"
-    return str(cwd).replace("/", "-").replace("\\", "-")
+    return real_path_to_project_dirname(cwd)
 
 
 def _entry_timestamp_range(

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -318,6 +318,28 @@ class _ByteParse:
     start_line: int
     resumed: bool
     held_count: int
+    # What the parse had produced when it reached the first line past the
+    # prefix cut — i.e. the products of complete lines only. None until
+    # that line is reached, which for a newline-terminated tail is the
+    # empty string after the last ``\n``, so the common case still holds
+    # everything. See :meth:`mark_incomplete` and :meth:`commit`.
+    complete_count: Optional[int] = None
+    complete_agent_ids: Optional[set[str]] = None
+
+    @property
+    def mark_line(self) -> int:
+        """Line number of the first line whose bytes fall outside the cut."""
+        return (
+            self.start_line + self.tail[: self.tail.rfind(b"\n") + 1].count(b"\n") + 1
+        )
+
+    def mark_incomplete(
+        self, messages: list[TranscriptEntry], agent_ids: set[str]
+    ) -> None:
+        """Snapshot what complete lines produced, before the trailing fragment."""
+        if self.complete_count is None:
+            self.complete_count = len(messages)
+            self.complete_agent_ids = set(agent_ids)
 
     def lines(self) -> Generator[tuple[int, str], None, None]:
         """Yield ``(line_no, text)`` for the bytes past the held prefix."""
@@ -339,6 +361,13 @@ class _ByteParse:
         A torn final line (mid-append, C12) is parsed as before — it just
         fails and is skipped — but its bytes stay out of the prefix, so
         the next tick re-reads and parses it properly once it lands.
+
+        The cut is on **entries as well as bytes**, and it has to be:
+        a final line whose newline hasn't landed yet can be a whole,
+        valid record (a flush that split on the newline, or simply a file
+        stored without a trailing one). That parses into an entry whose
+        bytes are below the cut, so holding it would have the next tick
+        parse the same line again and hand back the entry twice.
         """
         complete = self.tail.rfind(b"\n") + 1
         if complete <= 0 and self.start_offset == 0:
@@ -346,6 +375,9 @@ class _ByteParse:
         self.hasher.update(self.tail[:complete])
         consumed = self.start_offset + complete
         line_count = self.start_line + self.tail[:complete].count(b"\n")
+        if self.complete_count is not None:
+            messages = messages[: self.complete_count]
+            agent_ids = self.complete_agent_ids or set()
         entry_store.put_prefix(
             self.path,
             consumed,
@@ -528,6 +560,9 @@ def load_transcript(
         messages = byte_parse.entries
         agent_ids = byte_parse.agent_ids
         line_source = byte_parse.lines()
+        # The first line whose bytes fall outside the prefix cut: reaching
+        # it is what tells `commit` where the holdable entries stop.
+        mark_line = byte_parse.mark_line
     else:
         try:
             f = open(jsonl_path, "r", encoding="utf-8", errors="replace")
@@ -538,11 +573,14 @@ def load_transcript(
                 print(f"Warning: File not found (may have been deleted): {jsonl_path}")
             return []
         line_source = _text_file_lines(f)
+        mark_line = -1
 
     with contextlib.closing(line_source):
         if not silent:
             print(f"Processing {jsonl_path}...")
         for line_no, line in line_source:
+            if line_no == mark_line and byte_parse is not None:
+                byte_parse.mark_incomplete(messages, agent_ids)
             line = line.strip()
             if line:
                 try:

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -15,6 +15,7 @@ from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 import traceback
 from urllib.parse import quote
@@ -3029,7 +3030,7 @@ def _try_current_or_session_scoped(
     output_path: Path,
     effective_output_dir: Path,
     cache_manager: Optional["CacheManager"],
-    cache_was_updated: bool,
+    cache_refresh: "CacheRefresh",
     format: str,
     ext: str,
     suffix: str,
@@ -3061,12 +3062,33 @@ def _try_current_or_session_scoped(
     function rather than two: splitting them would compute
     ``_combined_output_is_stale`` and ``get_stale_sessions`` twice.
 
+    **On ``cache_refresh``.** This used to refuse outright whenever the
+    cache had been updated, which made the path unreachable for the case
+    it helps most: a live session gaining messages, where every run has
+    new bytes by definition. The refusal was really about one risk — the
+    staleness check here is per-session *message counts*, so a session
+    whose content changed without its count changing would be missed.
+
+    An INCREMENTAL refresh rules that out. It only succeeds after
+    proving every modified file's cached rows are an exact prefix of its
+    current rows (``_incremental_cache_refresh``), i.e. the change was a
+    pure append; with append-only sources a changed session always
+    changes its count. It also keeps the cross-session sidecar current
+    (``merge_session_sidecar``), which is the other thing the partial
+    load needs. A FULL refresh carries neither guarantee, so it still
+    refuses.
+
+    Note this mostly unlocks ``--combined no``: when a combined output
+    exists, the session's growth makes it stale and
+    ``_combined_output_is_stale`` bails us out to the streaming path
+    anyway.
+
     Returns ``None`` when the preconditions don't hold, when the combined
     output is stale, or when the session-scoped load declines.
     """
     if (
         cache_manager is None
-        or cache_was_updated
+        or cache_refresh is CacheRefresh.FULL
         or from_date is not None
         or to_date is not None
         or force_regenerate
@@ -3359,7 +3381,8 @@ def convert_jsonl_to(
         # directory mode) so DAG-based ordering handles sidechain placement.
         _integrate_agent_entries(messages)
         title = f"Claude Transcript - {input_path.stem}"
-        cache_was_updated = False  # No cache in single file mode
+        cache_refresh = CacheRefresh.NONE  # No cache in single file mode
+        cache_was_updated = False
 
         # Single-file workflow support (#174 PR3): a lone ``<SID>.jsonl`` still
         # has its run data in the sibling ``<SID>/subagents/workflows/`` dir, so
@@ -3393,9 +3416,10 @@ def convert_jsonl_to(
             output_path = effective_output_dir / f"combined_transcripts{suffix}.{ext}"
 
         # Phase 1: Ensure cache is fresh and populated
-        cache_was_updated = ensure_fresh_cache(
+        cache_refresh = ensure_fresh_cache_detailed(
             input_path, cache_manager, from_date, to_date, silent
         )
+        cache_was_updated = bool(cache_refresh)
 
         # Phase 1b: finish without loading the project at all, if the
         # cache says we can.
@@ -3404,7 +3428,7 @@ def convert_jsonl_to(
             output_path=output_path,
             effective_output_dir=effective_output_dir,
             cache_manager=cache_manager,
-            cache_was_updated=cache_was_updated,
+            cache_refresh=cache_refresh,
             format=format,
             ext=ext,
             suffix=suffix,
@@ -4158,6 +4182,32 @@ def _incremental_cache_refresh(
     return True
 
 
+class CacheRefresh(Enum):
+    """How `ensure_fresh_cache` brought the cache up to date.
+
+    The distinction that matters to callers is INCREMENTAL vs FULL, not
+    "did anything change". The incremental path only runs after proving
+    that every modified file's cached rows are an exact *prefix* of its
+    current rows — i.e. the change was a pure append and no existing
+    entry was rewritten (`_incremental_cache_refresh`). That proof is
+    what lets the session-scoped render path trust a per-session
+    staleness check based on message counts: with append-only sources a
+    changed session always changes its count, so nothing can change
+    underneath a count that stayed the same.
+
+    A FULL refresh carries no such proof — it is the fallback for
+    rewritten history, deleted files, and everything else hairy — so
+    callers that need the guarantee must treat it like a cold cache.
+    """
+
+    NONE = "none"
+    INCREMENTAL = "incremental"
+    FULL = "full"
+
+    def __bool__(self) -> bool:
+        return self is not CacheRefresh.NONE
+
+
 def ensure_fresh_cache(
     project_dir: Path,
     cache_manager: Optional[CacheManager],
@@ -4167,10 +4217,29 @@ def ensure_fresh_cache(
 ) -> bool:
     """Ensure cache is fresh and populated. Returns True if cache was updated.
 
+    Thin bool wrapper over `ensure_fresh_cache_detailed` for callers that
+    only need "did anything change".
+    """
+    return bool(
+        ensure_fresh_cache_detailed(
+            project_dir, cache_manager, from_date, to_date, silent
+        )
+    )
+
+
+def ensure_fresh_cache_detailed(
+    project_dir: Path,
+    cache_manager: Optional[CacheManager],
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    silent: bool = False,
+) -> CacheRefresh:
+    """Ensure cache is fresh and populated, reporting *how*.
+
     This does the heavy lifting of loading and parsing files.
     """
     if cache_manager is None:
-        return False
+        return CacheRefresh.NONE
 
     # Check if cache needs updating
     # Exclude agent files from direct check - they are loaded via session references
@@ -4178,7 +4247,7 @@ def ensure_fresh_cache(
     # This is acceptable since agent files typically change alongside their sessions.
     session_jsonl_files = trunk_jsonl_files(project_dir)
     if not session_jsonl_files:
-        return False
+        return CacheRefresh.NONE
 
     # Reuse one connection for the invalidation reads AND the whole populate
     # pass (per-file load + save + the session/aggregate writes) instead of
@@ -4202,7 +4271,7 @@ def ensure_fresh_cache(
         )
 
         if not needs_update:
-            return False  # Cache is already fresh
+            return CacheRefresh.NONE  # Cache is already fresh
 
         # Streaming stage 4: when the update is driven purely by changed
         # files over a populated cache, refresh from those files' bounded
@@ -4223,7 +4292,7 @@ def ensure_fresh_cache(
                 modified_files,
                 silent,
             ):
-                return True
+                return CacheRefresh.INCREMENTAL
 
         # Load and process messages to populate cache
         if not silent:
@@ -4243,7 +4312,7 @@ def ensure_fresh_cache(
 
         # Update cache with fresh data
         _update_cache_with_session_data(cache_manager, messages)
-    return True
+    return CacheRefresh.FULL
 
 
 def _update_cache_with_session_data(

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -538,6 +538,15 @@ def load_transcript(
     from .cache import subagents_fingerprint
 
     subagents_fp = subagents_fingerprint(jsonl_path)
+    # The file's own identity, for the same reason and at the same moment:
+    # a session appended to *during* this read must leave the cache
+    # stamped with what we parsed, not with what the file reached, or the
+    # next run finds a fresh-looking cache missing those lines. Unreadable
+    # here means the writers stat it themselves, exactly as before.
+    try:
+        source_stat: Optional[os.stat_result] = jsonl_path.stat()
+    except OSError:
+        source_stat = None
     messages: list[TranscriptEntry] = []
     agent_ids: set[str] = set()  # Collect agentId references while parsing
     # Track unrecognized message types already warned about so we emit at
@@ -801,10 +810,14 @@ def load_transcript(
             spliced_agents,
         )
         if appended is None or not cache_manager.extend_cached_entries(
-            jsonl_path, messages, appended, subagents_fp=subagents_fp
+            jsonl_path,
+            messages,
+            appended,
+            subagents_fp=subagents_fp,
+            source_stat=source_stat,
         ):
             cache_manager.save_cached_entries(
-                jsonl_path, messages, subagents_fp=subagents_fp
+                jsonl_path, messages, subagents_fp=subagents_fp, source_stat=source_stat
             )
 
     return messages

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from .cache import CacheManager, SessionSidecar
+    from .entry_store import ParsedEntryStore
     from .fragment_store import RenderFragmentStore
     from .providers.base import ProviderTokenTotals
     from .render_pool import RenderPool
@@ -293,10 +294,16 @@ def load_transcript(
     silent: bool = False,
     _loaded_files: Optional[set[Path]] = None,
     _meta_maps: Optional[dict[Path, dict[str, str]]] = None,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> list[TranscriptEntry]:
     """Load and parse JSONL transcript file, using cache if available.
 
     Args:
+        entry_store: Optional per-conversion store of entries this
+            conversion has already materialised (``entry_store.py``).
+            Consulted ahead of the cache, which it saves a
+            decompress + parse + validate pass over; a store miss or a
+            changed file falls through to exactly the path below.
         _loaded_files: Internal parameter to track loaded files and prevent infinite recursion.
         _meta_maps: Internal per-load memo of ``{dir: {toolUseId: agentId}}``
             sidecar maps, so one flat ``subagents/`` family is scanned once
@@ -313,6 +320,15 @@ def load_transcript(
         return []
 
     _loaded_files.add(jsonl_path)
+    # Entries this conversion already parsed beat both the cache and the
+    # source. Date filtering is excluded: the store holds whole files,
+    # and the filtered read below returns a subset.
+    if entry_store is not None and not from_date and not to_date:
+        held = entry_store.get(jsonl_path)
+        if held is not None:
+            if not silent:
+                print(f"Loading {jsonl_path} from this run's parsed entries...")
+            return held
     # Try to load from cache first
     if cache_manager is not None:
         # Use filtered loading if date parameters are provided
@@ -1141,6 +1157,7 @@ def _load_stale_session_transcripts(
     cache_manager: "CacheManager",
     stale_session_ids: list[str],
     silent: bool = False,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> Optional[tuple[list[TranscriptEntry], SessionTree]]:
     """Load only the named trunk sessions, faithful to the full load.
 
@@ -1206,7 +1223,12 @@ def _load_stale_session_transcripts(
         return None
 
     return _load_sessions_partial(
-        directory_path, cache_manager, sidecar, trunk_files, silent
+        directory_path,
+        cache_manager,
+        sidecar,
+        trunk_files,
+        silent,
+        entry_store=entry_store,
     )
 
 
@@ -1262,6 +1284,7 @@ def _load_sessions_partial(
     silent: bool,
     reelect_uuids: Optional[set[str]] = None,
     native_junction_uuids: Optional[set[str]] = None,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> tuple[list[TranscriptEntry], SessionTree]:
     """Load the given trunk files into a faithful partial (entries, tree).
 
@@ -1298,9 +1321,19 @@ def _load_sessions_partial(
     with cache_manager.batch():
         for jsonl_file in trunk_files:
             all_messages.extend(
-                load_transcript(jsonl_file, cache_manager, None, None, silent)
+                load_transcript(
+                    jsonl_file,
+                    cache_manager,
+                    None,
+                    None,
+                    silent,
+                    entry_store=entry_store,
+                )
             )
 
+    # NB: this mutates entries in place and is not idempotent (it appends
+    # `#agent-{id}` to sessionId), which is why the store hands out deep
+    # copies rather than the objects it holds.
     _integrate_agent_entries(all_messages)
 
     # Enforce the whole-project dedup outcome: drop every duplicated
@@ -3048,6 +3081,7 @@ def _try_current_or_session_scoped(
     no_recaps: bool,
     silent: bool,
     report: Optional["RegenerationReport"],
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> Optional[Path]:
     """Finish from the cache alone, when the combined output is current.
 
@@ -3139,6 +3173,7 @@ def _try_current_or_session_scoped(
         cache_manager,
         [sid for sid, _reason in stale_sessions],
         silent,
+        entry_store=entry_store,
     )
     if partial is None:
         return None
@@ -3416,9 +3451,21 @@ def convert_jsonl_to(
         if output_path is None:
             output_path = effective_output_dir / f"combined_transcripts{suffix}.{ext}"
 
+        # One store per conversion, holding whatever the cache refresh
+        # parses so Phase 1b doesn't rebuild it from the rows the refresh
+        # just wrote (entry_store.py). Deliberately not handed to the
+        # streaming path below, whose bounded residency depends on
+        # dropping each page's entries before the next page loads.
+        entry_store = _make_entry_store()
+
         # Phase 1: Ensure cache is fresh and populated
         cache_refresh = ensure_fresh_cache_detailed(
-            input_path, cache_manager, from_date, to_date, silent
+            input_path,
+            cache_manager,
+            from_date,
+            to_date,
+            silent,
+            entry_store=entry_store,
         )
         cache_was_updated = bool(cache_refresh)
 
@@ -3446,9 +3493,15 @@ def convert_jsonl_to(
             no_recaps=no_recaps,
             silent=silent,
             report=report,
+            entry_store=entry_store,
         )
         if settled is not None:
             return settled
+
+        # Past Phase 1b nothing reuses the store, and what it holds is a
+        # whole session's entries — drop it before the paths that load
+        # the project (or stream it page by page) start allocating.
+        entry_store = None
 
         # Phase 1c: convert a paginated project page-by-page instead of
         # loading it whole.
@@ -3801,6 +3854,7 @@ def _incremental_cache_refresh(
     session_jsonl_files: list[Path],
     modified_files: list[Path],
     silent: bool,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> bool:
     """Refresh the cache from the modified files alone, never loading whole.
 
@@ -3839,6 +3893,7 @@ def _incremental_cache_refresh(
     full path's.
     """
     from .cache import CachedFileState
+    from .entry_store import stamp_file
 
     if not modified_files:
         return False
@@ -3875,7 +3930,13 @@ def _incremental_cache_refresh(
         old_rows = cache_manager.get_all_session_rows()
 
         for f in modified_files:
-            load_transcript(f, cache_manager, None, None, silent)
+            # Stamp BEFORE the parse: a file that grows while we read it
+            # must make the store decline (its stamp would then be older
+            # than the file), never serve a list its stamp misdescribes.
+            stamp = stamp_file(f)
+            parsed = load_transcript(f, cache_manager, None, None, silent)
+            if entry_store is not None:
+                entry_store.put(f, stamp, parsed)
         new_states = cache_manager.get_file_states(modified_names)
 
         closure: set[str] = set()
@@ -4061,6 +4122,7 @@ def _incremental_cache_refresh(
             silent,
             reelect_uuids=exempt_uuids,
             native_junction_uuids=native_junction_uuids,
+            entry_store=entry_store,
         )
 
         # Compute every write, validate, then write — no fact lands
@@ -4234,10 +4296,16 @@ def ensure_fresh_cache_detailed(
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
     silent: bool = False,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> CacheRefresh:
     """Ensure cache is fresh and populated, reporting *how*.
 
     This does the heavy lifting of loading and parsing files.
+
+    ``entry_store`` is the caller's per-conversion store
+    (``entry_store.py``); the incremental refresh fills it with the files
+    it parses, so the conversion's later loads can reuse them instead of
+    rebuilding them from the rows just written.
     """
     if cache_manager is None:
         return CacheRefresh.NONE
@@ -4292,6 +4360,7 @@ def ensure_fresh_cache_detailed(
                 session_jsonl_files,
                 modified_files,
                 silent,
+                entry_store=entry_store,
             ):
                 return CacheRefresh.INCREMENTAL
 
@@ -4456,6 +4525,22 @@ def build_session_title(
                 preview = preview[:50] + "..."
             return f"{project_title}: {preview}"
     return f"{project_title}: Session {session_id[:8]}"
+
+
+def _make_entry_store() -> "Optional[ParsedEntryStore]":
+    """Create the per-conversion parsed-entry store, unless disabled.
+
+    ``CLAUDE_CODE_LOG_ENTRY_STORE=0`` opts out, for bisecting. There is
+    no memory valve here because an empty store costs nothing and the
+    only thing that can fill it — ``_incremental_cache_refresh`` — checks
+    available memory per file at ``put`` time, where the file's size is
+    actually known.
+    """
+    from .entry_store import ParsedEntryStore, entry_store_enabled
+
+    if not entry_store_enabled():
+        return None
+    return ParsedEntryStore()
 
 
 def _make_fragment_store(

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from .render_pool import RenderPool
 
 from .utils import (
+    atomic_write_text,
     coalesce_trunk_session_id,
     collect_trunk_session_ids,
     format_timestamp_range,
@@ -1827,7 +1828,7 @@ def _enable_next_link_on_previous_page(
     new_content, count = _NEXT_LINK_PATTERN.subn(r"\1\2", content)
 
     if count > 0:
-        page_path.write_text(new_content, encoding="utf-8", errors="replace")
+        atomic_write_text(page_path, new_content)
         return True
 
     return False
@@ -2274,9 +2275,7 @@ def _render_page_unit_inline(
     # JSONL may carry lone surrogates (issue #139); strict UTF-8
     # encoding crashes here. Replace with U+FFFD so output stays
     # valid UTF-8.
-    (output_dir / unit.file_name).write_text(
-        html_content, encoding="utf-8", errors="replace"
-    )
+    atomic_write_text(output_dir / unit.file_name, html_content)
 
 
 def _generate_paginated_html(
@@ -3695,7 +3694,7 @@ def convert_jsonl_to(
                 )
                 assert content is not None
                 # See issue #139: errors="replace" for lone-surrogate safety.
-                output_path.write_text(content, encoding="utf-8", errors="replace")
+                atomic_write_text(output_path, content)
 
                 # Update html_cache for the combined transcript. Written for the
                 # marker-tracked formats (HTML + Markdown); JSON tracks its own
@@ -4611,9 +4610,7 @@ def _generate_individual_session_files(
             )
             assert session_content is not None
             # See issue #139: errors="replace" for lone-surrogate safety.
-            (output_dir / unit.file_name).write_text(
-                session_content, encoding="utf-8", errors="replace"
-            )
+            atomic_write_text(output_dir / unit.file_name, session_content)
 
         def _record_session(unit: RenderUnit) -> None:
             """Cache bookkeeping for one written session file."""
@@ -4832,7 +4829,7 @@ def generate_single_session_file(
     )
     assert session_content is not None
     # See issue #139: errors="replace" for lone-surrogate safety.
-    output_file.write_text(session_content, encoding="utf-8", errors="replace")
+    atomic_write_text(output_file, session_content)
 
     return output_file
 
@@ -4878,7 +4875,7 @@ def render_normalized_session_file(
     )
     assert content is not None
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(content, encoding="utf-8", errors="replace")
+    atomic_write_text(output, content)
     return output
 
 
@@ -5330,9 +5327,7 @@ def render_provider_wholesale(
                 )
                 assert combined_content is not None
                 dest_dir.mkdir(parents=True, exist_ok=True)
-                (dest_dir / combined_name).write_text(
-                    combined_content, encoding="utf-8", errors="replace"
-                )
+                atomic_write_text(dest_dir / combined_name, combined_content)
                 if cache is not None:
                     cache.update_html_cache(combined_name, None, len(combined_messages))
 
@@ -5386,7 +5381,7 @@ def render_provider_wholesale(
     assert index_content is not None
     index_path = output_root / get_index_filename(output_format)
     output_root.mkdir(parents=True, exist_ok=True)
-    index_path.write_text(index_content, encoding="utf-8", errors="replace")
+    atomic_write_text(index_path, index_content)
 
     if not silent:
         print(
@@ -6522,7 +6517,7 @@ def process_projects_hierarchy(
     # Ensure the index root exists when projecting into a fresh dir.
     index_path.parent.mkdir(parents=True, exist_ok=True)
     # See issue #139: errors="replace" for lone-surrogate safety.
-    index_path.write_text(index_content, encoding="utf-8", errors="replace")
+    atomic_write_text(index_path, index_content)
 
     # The archive-wide search page sits next to the index. It is static and
     # self-contained; it only *works* when served (it needs the API to reach
@@ -6531,8 +6526,8 @@ def process_projects_hierarchy(
     if output_format == "html":
         from .html.renderer import generate_archive_search_html
 
-        (index_path.parent / "search.html").write_text(
-            generate_archive_search_html(), encoding="utf-8", errors="replace"
+        atomic_write_text(
+            index_path.parent / "search.html", generate_archive_search_html()
         )
 
     # Count total sessions from project summaries

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -11,7 +11,7 @@ import os
 import re
 import time
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -19,7 +19,7 @@ from enum import Enum
 from pathlib import Path
 import traceback
 from urllib.parse import quote
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
+from typing import Any, Dict, List, Optional, TextIO, TYPE_CHECKING, cast
 
 import dateparser
 
@@ -286,6 +286,160 @@ def filter_messages_by_date(
     return filtered_messages
 
 
+def _text_file_lines(f: "TextIO") -> Generator[tuple[int, str], None, None]:
+    """The historical line source: iterate an open text file, closing it after."""
+    try:
+        yield from enumerate(f, 1)  # Start counting from 1
+    finally:
+        f.close()
+
+
+@dataclass
+class _ByteParse:
+    """A byte-level parse that may resume from a previously held prefix.
+
+    Reading bytes rather than text is what makes resumption possible: the
+    store pins entries to a byte offset plus a hash of the bytes below it,
+    so the next tick can prove the file still *starts* with what it parsed
+    before and read only what was appended (work/watch-mode.md, Fix B).
+
+    Splitting on ``b"\\n"`` and decoding per line is equivalent to the
+    text read it replaces: a UTF-8 continuation byte is never 0x0A, so no
+    multi-byte sequence spans the split, and the same
+    ``errors="replace"`` applies either way.
+    """
+
+    path: Path
+    entries: list[TranscriptEntry]
+    agent_ids: set[str]
+    tail: bytes
+    hasher: Any
+    start_offset: int
+    start_line: int
+    resumed: bool
+    held_count: int
+
+    def lines(self) -> Generator[tuple[int, str], None, None]:
+        """Yield ``(line_no, text)`` for the bytes past the held prefix."""
+
+        def _iter() -> Generator[tuple[int, str], None, None]:
+            for offset, raw in enumerate(self.tail.split(b"\n"), self.start_line + 1):
+                yield offset, raw.decode("utf-8", errors="replace")
+
+        return _iter()
+
+    def commit(
+        self,
+        entry_store: "ParsedEntryStore",
+        messages: list[TranscriptEntry],
+        agent_ids: set[str],
+    ) -> None:
+        """Hold the parse for the next tick, up to the last *complete* line.
+
+        A torn final line (mid-append, C12) is parsed as before — it just
+        fails and is skipped — but its bytes stay out of the prefix, so
+        the next tick re-reads and parses it properly once it lands.
+        """
+        complete = self.tail.rfind(b"\n") + 1
+        if complete <= 0 and self.start_offset == 0:
+            return
+        self.hasher.update(self.tail[:complete])
+        consumed = self.start_offset + complete
+        line_count = self.start_line + self.tail[:complete].count(b"\n")
+        entry_store.put_prefix(
+            self.path,
+            consumed,
+            self.hasher.digest(),
+            messages,
+            agent_ids,
+            line_count,
+        )
+
+
+def _appended_rows(
+    byte_parse: "Optional[_ByteParse]",
+    messages: list[TranscriptEntry],
+    parsed_line_count: int,
+    any_agent_refs: bool,
+    any_subagent_meta: bool,
+    spliced_agents: bool,
+) -> Optional[list[TranscriptEntry]]:
+    """The entries a cache write may append, or None to rewrite the file.
+
+    The cached rows for a transcript are not simply its lines: agent
+    transcripts are spliced in at their anchors, and the sidecar passes
+    back-patch ``spawnedAgentId`` onto entries parsed long ago. So "the
+    file grew by an append" does **not** by itself imply "the rows grew by
+    an append" — a subagent running alongside the trunk inserts rows in
+    the *middle* of the sequence, which is common in exactly the watch
+    scenario this optimises.
+
+    Rather than track every way that can happen, this refuses unless the
+    row list is provably just the file's own lines:
+
+    * the parse resumed from a byte-verified prefix, so every entry below
+      the resume point came from bytes that have not changed;
+    * the file references no agents, has no sidecars, and spliced no agent
+      blocks, so none of the whole-file passes could add or alter an
+      entry;
+    * and nothing appeared in the list except those parsed lines.
+
+    On the reference archive that covers 136 of 185 trunk files. The rest
+    take the full rewrite, unchanged.
+    """
+    if byte_parse is None or not byte_parse.resumed:
+        return None
+    if any_agent_refs or any_subagent_meta or spliced_agents:
+        return None
+    if len(messages) != parsed_line_count:
+        return None
+    held = byte_parse.held_count
+    if held <= 0 or held > len(messages):
+        return None
+    appended = messages[held:]
+    return appended or None
+
+
+def _begin_byte_parse(
+    jsonl_path: Path, entry_store: "ParsedEntryStore"
+) -> "Optional[_ByteParse]":
+    """Read `jsonl_path`, resuming from the store's held prefix if it still fits.
+
+    The held prefix is accepted only when the file's first ``prefix_len``
+    bytes hash to the digest recorded with it — a *stronger* check than
+    the row-fingerprint prefix comparison it saves, since identical bytes
+    imply identical rows. A mismatch (rewound session, replayed history,
+    a shorter file) drops the prefix and re-reads from the top, which is
+    what the caller would have done anyway.
+    """
+    from .entry_store import new_hasher, read_prefix_and_tail
+
+    held = entry_store.get_prefix(jsonl_path)
+    hasher = new_hasher()
+    tail = read_prefix_and_tail(jsonl_path, held.prefix_len if held else 0, hasher)
+    if held is not None and (tail is None or hasher.digest() != held.digest):
+        entry_store.drop_prefix(jsonl_path)
+        entry_store.prefix_misses += 1
+        held = None
+        hasher = new_hasher()
+        tail = read_prefix_and_tail(jsonl_path, 0, hasher)
+    if tail is None:
+        return None  # unreadable — let the text path report it as before
+    if held is not None:
+        entry_store.prefix_hits += 1
+    return _ByteParse(
+        path=jsonl_path,
+        entries=held.entries if held else [],
+        agent_ids=set(held.agent_ids) if held else set(),
+        tail=tail,
+        hasher=hasher,
+        start_offset=held.prefix_len if held else 0,
+        start_line=held.line_count if held else 0,
+        resumed=held is not None,
+        held_count=len(held.entries) if held else 0,
+    )
+
+
 def load_transcript(
     jsonl_path: Path,
     cache_manager: Optional["CacheManager"] = None,
@@ -358,19 +512,37 @@ def load_transcript(
     # most one warning per distinct type per file (these tend to repeat a lot).
     warned_unrecognized_types: set[str | None] = set()
 
-    try:
-        f = open(jsonl_path, "r", encoding="utf-8", errors="replace")
-    except FileNotFoundError:
-        # Handle race condition: file may have been deleted between glob and open
-        # (e.g., Claude Code session cleanup)
-        if not silent:
-            print(f"Warning: File not found (may have been deleted): {jsonl_path}")
-        return []
+    # With a store, read bytes rather than text: that yields both the
+    # offset and the rolling hash a later tick needs to resume from what
+    # it already parsed, instead of re-reading the file's whole history
+    # (entry_store.py). A decline — no store, date filtering, an
+    # unreadable file — falls through to the pre-existing text read,
+    # which is left exactly as it was.
+    byte_parse = (
+        _begin_byte_parse(jsonl_path, entry_store)
+        if entry_store is not None and not from_date and not to_date
+        else None
+    )
 
-    with f:
+    if byte_parse is not None:
+        messages = byte_parse.entries
+        agent_ids = byte_parse.agent_ids
+        line_source = byte_parse.lines()
+    else:
+        try:
+            f = open(jsonl_path, "r", encoding="utf-8", errors="replace")
+        except FileNotFoundError:
+            # Handle race condition: file may have been deleted between glob and open
+            # (e.g., Claude Code session cleanup)
+            if not silent:
+                print(f"Warning: File not found (may have been deleted): {jsonl_path}")
+            return []
+        line_source = _text_file_lines(f)
+
+    with contextlib.closing(line_source):
         if not silent:
             print(f"Processing {jsonl_path}...")
-        for line_no, line in enumerate(f, 1):  # Start counting from 1
+        for line_no, line in line_source:
             line = line.strip()
             if line:
                 try:
@@ -475,15 +647,28 @@ def load_transcript(
                         f"\n{traceback.format_exc()}"
                     )
 
+    # Hold what we just parsed for the next tick, BEFORE the whole-file
+    # passes below — they mutate entries in place (back-patching
+    # `spawnedAgentId`) and splice agent blocks in, and a resumed parse
+    # must start from the raw per-line products and re-run them.
+    if byte_parse is not None and entry_store is not None:
+        byte_parse.commit(entry_store, messages, agent_ids)
+
+    # How many entries came straight off the file's own lines, before any
+    # of the whole-file passes below can add or alter one. The append-only
+    # cache write is gated on this being the whole story (see
+    # `_appended_rows`).
+    parsed_line_count = len(messages)
+    had_agent_refs = bool(agent_ids)
+
     # Sidecar-driven spawn linking (issue #213): resolve each spawning
     # tool_use to its sub-agent via the agent-<id>.meta.json files. This is
     # what makes NESTED spawns discoverable — a sub-agent's own spawn
     # tool_results carry no ``toolUseResult.agentId`` (trunk-only
     # enrichment), and an interrupted spawn has no usable tool_result at
     # all; the sidecar's ``toolUseId`` covers both.
-    _apply_subagent_meta_links(
-        messages, _subagent_meta_map(jsonl_path, _meta_maps), agent_ids, jsonl_path
-    )
+    subagent_meta = _subagent_meta_map(jsonl_path, _meta_maps)
+    _apply_subagent_meta_links(messages, subagent_meta, agent_ids, jsonl_path)
 
     # Prompt-hash fallback: link Task tool_results that lack a structured
     # agentId (common for true teammate subagents) by matching the
@@ -531,6 +716,11 @@ def load_transcript(
                 )
                 agent_messages_map[agent_id] = agent_messages
 
+    # `agent_messages_map` is drained by the splice below, so record now
+    # whether any splicing is about to happen — the append-only cache
+    # write needs to know, and by then the map would read as empty.
+    spliced_agents = bool(agent_messages_map)
+
     # Insert agent messages at their point of use (only once per agent)
     if agent_messages_map:
         # Iterate through messages and insert agent messages after the FIRST
@@ -557,11 +747,27 @@ def load_transcript(
 
         messages = result_messages
 
-    # Save to cache if cache manager is available
+    # Save to cache if cache manager is available. When this parse resumed
+    # from a verified prefix and nothing but the file's own new lines
+    # reached the list, the rows are the old rows plus a tail and only the
+    # tail needs writing — which is most of a watch tick (see
+    # `_appended_rows` for what has to hold, and `extend_cached_entries`
+    # for the row-level check that can still refuse).
     if cache_manager is not None:
-        cache_manager.save_cached_entries(
-            jsonl_path, messages, subagents_fp=subagents_fp
+        appended = _appended_rows(
+            byte_parse,
+            messages,
+            parsed_line_count,
+            had_agent_refs or bool(agent_ids),
+            bool(subagent_meta),
+            spliced_agents,
         )
+        if appended is None or not cache_manager.extend_cached_entries(
+            jsonl_path, messages, appended, subagents_fp=subagents_fp
+        ):
+            cache_manager.save_cached_entries(
+                jsonl_path, messages, subagents_fp=subagents_fp
+            )
 
     return messages
 
@@ -3329,6 +3535,7 @@ def convert_jsonl_to(
     report: Optional["RegenerationReport"] = None,
     archive_search_link: Optional[str] = None,
     render_jobs: Optional[int] = None,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> Path:
     """Convert JSONL transcript(s) to the specified format.
 
@@ -3451,12 +3658,19 @@ def convert_jsonl_to(
         if output_path is None:
             output_path = effective_output_dir / f"combined_transcripts{suffix}.{ext}"
 
-        # One store per conversion, holding whatever the cache refresh
-        # parses so Phase 1b doesn't rebuild it from the rows the refresh
-        # just wrote (entry_store.py). Deliberately not handed to the
-        # streaming path below, whose bounded residency depends on
-        # dropping each page's entries before the next page loads.
-        entry_store = _make_entry_store()
+        # A store holds whatever the cache refresh parses, so Phase 1b
+        # doesn't rebuild it from the rows the refresh just wrote
+        # (entry_store.py). Deliberately not handed to the streaming path
+        # below, whose bounded residency depends on dropping each page's
+        # entries before the next page loads.
+        #
+        # A caller may own one instead — `watch` does, so that a tick can
+        # resume its parse from the bytes the previous tick already read.
+        # Ownership decides lifetime: ours dies with this call, theirs
+        # doesn't, which is the whole point of a resident loop having one.
+        caller_owned = entry_store is not None
+        if entry_store is None:
+            entry_store = _make_entry_store()
 
         # Phase 1: Ensure cache is fresh and populated
         cache_refresh = ensure_fresh_cache_detailed(
@@ -3499,9 +3713,12 @@ def convert_jsonl_to(
             return settled
 
         # Past Phase 1b nothing reuses the store, and what it holds is a
-        # whole session's entries — drop it before the paths that load
-        # the project (or stream it page by page) start allocating.
-        entry_store = None
+        # whole session's entries — stop referencing it before the paths
+        # that load the project (or stream it page by page) start
+        # allocating. A caller-owned store outlives us either way; this
+        # only drops *our* reference.
+        if not caller_owned:
+            entry_store = None
 
         # Phase 1c: convert a paginated project page-by-page instead of
         # loading it whole.
@@ -3934,7 +4151,9 @@ def _incremental_cache_refresh(
             # must make the store decline (its stamp would then be older
             # than the file), never serve a list its stamp misdescribes.
             stamp = stamp_file(f)
-            parsed = load_transcript(f, cache_manager, None, None, silent)
+            parsed = load_transcript(
+                f, cache_manager, None, None, silent, entry_store=entry_store
+            )
             if entry_store is not None:
                 entry_store.put(f, stamp, parsed)
         new_states = cache_manager.get_file_states(modified_names)

--- a/claude_code_log/entry_store.py
+++ b/claude_code_log/entry_store.py
@@ -193,13 +193,22 @@ class ParsedEntryStore:
         post-processing that mutates entries in place (see the module
         docstring) and a later tick must resume from the pre-mutation
         state.
+
+        Charged against the same budget as :meth:`put`, and for the same
+        reason twice over: a ``watch`` owns one store for the life of the
+        loop, so every trunk file touched over a long session would
+        otherwise pin its parsed entries forever — and the per-file
+        memory valve, which only ever sees one file, cannot notice the
+        total.
         """
         if prefix_len <= 0 or not entries:
             return
         if prefix_len > self._budget or not self._has_memory_for(prefix_len):
             self.declines += 1
-            self._prefixes.pop(str(path), None)
+            self.drop_prefix(path)
             return
+        self.drop_prefix(path)
+        self._bytes += prefix_len
         self._prefixes[str(path)] = HeldPrefix(
             prefix_len=prefix_len,
             digest=digest,
@@ -207,6 +216,7 @@ class ParsedEntryStore:
             agent_ids=set(agent_ids),
             line_count=line_count,
         )
+        self._evict_to_budget()
 
     def get_prefix(self, path: Path) -> Optional[HeldPrefix]:
         """The held prefix for ``path``, entries copied, or None.
@@ -229,7 +239,9 @@ class ParsedEntryStore:
 
     def drop_prefix(self, path: Path) -> None:
         """Forget the held prefix — its file no longer starts with those bytes."""
-        self._prefixes.pop(str(path), None)
+        dropped = self._prefixes.pop(str(path), None)
+        if dropped is not None:
+            self._bytes -= dropped.prefix_len
 
     # ---- writing ---------------------------------------------------------
 
@@ -272,11 +284,20 @@ class ParsedEntryStore:
         return available >= size * MIN_AVAILABLE_MEMORY_PER_FILE_BYTE
 
     def _evict_to_budget(self) -> None:
-        """Drop oldest entries until the held source bytes fit the budget."""
+        """Drop oldest entries until the held source bytes fit the budget.
+
+        Whole-file entries go first: they serve the conversion that is
+        running now and the cache can rebuild them, whereas a prefix is
+        the only thing standing between the next tick and re-parsing a
+        file's whole history. Both are pure performance either way.
+        """
         while self._bytes > self._budget and self._held:
             _key, (stamp, _entries) = next(iter(self._held.items()))
             self._held.pop(_key)
             self._bytes -= stamp[0]
+        while self._bytes > self._budget and self._prefixes:
+            key = next(iter(self._prefixes))
+            self._bytes -= self._prefixes.pop(key).prefix_len
 
     # ---- reading ---------------------------------------------------------
 

--- a/claude_code_log/entry_store.py
+++ b/claude_code_log/entry_store.py
@@ -53,14 +53,71 @@ from __future__ import annotations
 
 import copy
 import os
+from dataclasses import dataclass, field
+from hashlib import blake2b
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from .models import TranscriptEntry
 
 FileStamp = tuple[int, int]
 """``(size, mtime_ns)`` — the identity a stored list is pinned to."""
+
+# Prefix hashing reads the file, so the digest is chosen for speed over
+# collision margin beyond what a local cache needs: 16 bytes of BLAKE2b
+# runs at ~1.2 GB/s, i.e. 32 ms over a 39.7 MB session — against 143 ms
+# to re-parse the same bytes, which is what it buys.
+_HASH_DIGEST_SIZE = 16
+_READ_CHUNK = 1 << 20
+
+
+def new_hasher() -> Any:
+    """A fresh hasher for prefix identity."""
+    return blake2b(digest_size=_HASH_DIGEST_SIZE)
+
+
+def read_prefix_and_tail(path: Path, prefix_len: int, hasher: Any) -> Optional[bytes]:
+    """Feed the first ``prefix_len`` bytes into ``hasher``; return the rest.
+
+    None when the file is shorter than ``prefix_len`` (truncated or
+    replaced) or unreadable — both of which mean "no usable prefix", and
+    the caller re-reads from the top.
+    """
+    try:
+        with path.open("rb") as fh:
+            remaining = prefix_len
+            while remaining > 0:
+                chunk = fh.read(min(_READ_CHUNK, remaining))
+                if not chunk:
+                    return None
+                hasher.update(chunk)
+                remaining -= len(chunk)
+            return fh.read()
+    except OSError:
+        return None
+
+
+@dataclass
+class HeldPrefix:
+    """Entries covering the first ``prefix_len`` bytes of a source file.
+
+    ``entries`` are the *pre-post-processing* parse products — before
+    subagent meta linking, prompt-hash linking and agent-block splicing,
+    all of which are whole-file functions re-run over the concatenated
+    list. They cost 0.1 ms together on the reference file, so re-running
+    them is free; reusing their *output* would not be sound, because a
+    new sidecar can relink an entry that was parsed ticks ago.
+
+    ``line_count`` continues the line numbering that parse warnings quote.
+    """
+
+    prefix_len: int
+    digest: bytes
+    entries: list["TranscriptEntry"] = field(default_factory=list["TranscriptEntry"])
+    agent_ids: set[str] = field(default_factory=set[str])
+    line_count: int = 0
+
 
 # Total source bytes the store will hold before evicting in insertion
 # order. It only ever holds files a refresh actually parsed, so this is a
@@ -111,10 +168,68 @@ class ParsedEntryStore:
     def __init__(self, budget_bytes: int = DEFAULT_BUDGET_BYTES) -> None:
         self._budget = budget_bytes
         self._held: dict[str, tuple[FileStamp, list["TranscriptEntry"]]] = {}
+        self._prefixes: dict[str, HeldPrefix] = {}
         self._bytes = 0
         self.hits = 0
         self.misses = 0
         self.declines = 0
+        self.prefix_hits = 0
+        self.prefix_misses = 0
+
+    # ---- prefixes (across ticks) -----------------------------------------
+
+    def put_prefix(
+        self,
+        path: Path,
+        prefix_len: int,
+        digest: bytes,
+        entries: list["TranscriptEntry"],
+        agent_ids: set[str],
+        line_count: int,
+    ) -> None:
+        """Hold ``entries`` as the parse of ``path``'s first ``prefix_len`` bytes.
+
+        Copied on the way in, because the caller goes on to run
+        post-processing that mutates entries in place (see the module
+        docstring) and a later tick must resume from the pre-mutation
+        state.
+        """
+        if prefix_len <= 0 or not entries:
+            return
+        if prefix_len > self._budget or not self._has_memory_for(prefix_len):
+            self.declines += 1
+            self._prefixes.pop(str(path), None)
+            return
+        self._prefixes[str(path)] = HeldPrefix(
+            prefix_len=prefix_len,
+            digest=digest,
+            entries=copy.deepcopy(entries),
+            agent_ids=set(agent_ids),
+            line_count=line_count,
+        )
+
+    def get_prefix(self, path: Path) -> Optional[HeldPrefix]:
+        """The held prefix for ``path``, entries copied, or None.
+
+        The digest is **not** checked here — verifying it means hashing
+        the file's first ``prefix_len`` bytes, which the caller does
+        anyway on its way to reading the tail. The caller compares and
+        calls :meth:`drop_prefix` on a mismatch.
+        """
+        held = self._prefixes.get(str(path))
+        if held is None:
+            return None
+        return HeldPrefix(
+            prefix_len=held.prefix_len,
+            digest=held.digest,
+            entries=copy.deepcopy(held.entries),
+            agent_ids=set(held.agent_ids),
+            line_count=held.line_count,
+        )
+
+    def drop_prefix(self, path: Path) -> None:
+        """Forget the held prefix — its file no longer starts with those bytes."""
+        self._prefixes.pop(str(path), None)
 
     # ---- writing ---------------------------------------------------------
 

--- a/claude_code_log/entry_store.py
+++ b/claude_code_log/entry_store.py
@@ -1,0 +1,199 @@
+"""Per-conversion store of parsed transcript entries.
+
+A conversion that refreshes the cache incrementally materialises the same
+entries up to three times: ``_incremental_cache_refresh`` parses each
+modified file from source, then the closure load
+(``_load_sessions_partial``) and the session-scoped render
+(``_load_stale_session_transcripts``) each rebuild those same entries
+from the rows just written — ``zlib.decompress`` + ``json.loads`` +
+Pydantic validation, once per consumer. On a 39.7 MB session file that
+was 488 ms + 129 ms + 141 ms of a 1.1 s watch tick, all three
+proportional to the *file* rather than to the handful of appended lines
+(work/watch-mode.md, C14).
+
+This store keeps the list the first pass already produced and serves it
+to the other two.
+
+Scope and lifetime are deliberately narrow — the same posture as
+``fragment_store.py``, one layer down:
+
+- **One store per conversion, threaded explicitly.** Never a global and
+  never hung off ``CacheManager``, which long-lived hosts (the TUI) keep
+  across many conversions. A store cannot outlive the conversion that
+  made it.
+- **Only the incremental-refresh path fills it.** ``put`` is called from
+  ``_incremental_cache_refresh`` alone, with the files it just parsed, so
+  a cold or full conversion never stores anything and its residency is
+  unchanged. The streaming page loads (application_model.md § 2.13)
+  deliberately do *not* get a store: their whole point is that a page's
+  entries are dropped before the next page loads, and a store spanning
+  pages would pin every one of them. What this holds is therefore bounded
+  by *what changed*, not by the archive.
+- **Hits are verified against the file.** ``get`` re-stats and compares
+  ``(size, mtime_ns)`` against the stamp captured *before* the parse; any
+  mismatch declines to the cache. A stamp taken before the parse can only
+  be older than the entries describe, so a file that grew mid-parse
+  declines rather than serving a list that does not match its stamp.
+- **Handouts are deep copies.** The pipeline mutates entries in place —
+  ``_integrate_agent_entries`` appends ``#agent-{id}`` to ``sessionId``
+  (not idempotent) and dedup re-parents around dropped copies — and today
+  each consumer gets freshly deserialised objects. Serving the same
+  objects twice would let one consumer's mutations leak into another's
+  view, so ``get`` returns a ``deepcopy``. That is cheap and stays cheap
+  because the bulk of an entry is immutable strings, which ``deepcopy``
+  shares rather than copies: measured **2.0 ms and 0.83 MB** for the
+  207-entry, 39.7 MB session above, against 123 ms to rebuild it from the
+  cache.
+
+The store is a pure performance feature: a conversion with no store (or
+a declined ``put``) behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .models import TranscriptEntry
+
+FileStamp = tuple[int, int]
+"""``(size, mtime_ns)`` — the identity a stored list is pinned to."""
+
+# Total source bytes the store will hold before evicting in insertion
+# order. It only ever holds files a refresh actually parsed, so this is a
+# backstop against a pathological closure, not a tuning knob.
+DEFAULT_BUDGET_BYTES = 256 * 1024 * 1024
+
+# A parsed transcript costs roughly 3x its bytes on disk in RAM
+# (CONTRIBUTING, "A note on memory"). Require headroom well above that
+# before holding one, so a tight machine keeps today's footprint instead
+# of trading into swap for 270 ms.
+MIN_AVAILABLE_MEMORY_PER_FILE_BYTE = 6.0
+
+
+def entry_store_enabled() -> bool:
+    """Whether the entry store may be used, per the environment.
+
+    ``CLAUDE_CODE_LOG_ENTRY_STORE=0`` (or ``off``/``false``) disables it,
+    mirroring the branch's other kill switches — for bisecting a
+    rendering difference, not for tuning.
+    """
+    value = os.environ.get("CLAUDE_CODE_LOG_ENTRY_STORE", "").strip().lower()
+    return value not in ("0", "off", "false")
+
+
+def entry_store_forced() -> bool:
+    """Whether the environment *explicitly* asks for the store.
+
+    An explicit ``=1`` (or ``on``/``true``) overrides the memory valve in
+    :meth:`ParsedEntryStore.put`. Unset means "enabled, but let the valve
+    decide".
+    """
+    value = os.environ.get("CLAUDE_CODE_LOG_ENTRY_STORE", "").strip().lower()
+    return value in ("1", "on", "true")
+
+
+def stamp_file(path: Path) -> Optional[FileStamp]:
+    """``(size, mtime_ns)`` for ``path``, or None if it can't be stat'd."""
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return (st.st_size, st.st_mtime_ns)
+
+
+class ParsedEntryStore:
+    """Entries a conversion has already parsed, keyed by source file."""
+
+    def __init__(self, budget_bytes: int = DEFAULT_BUDGET_BYTES) -> None:
+        self._budget = budget_bytes
+        self._held: dict[str, tuple[FileStamp, list["TranscriptEntry"]]] = {}
+        self._bytes = 0
+        self.hits = 0
+        self.misses = 0
+        self.declines = 0
+
+    # ---- writing ---------------------------------------------------------
+
+    def put(
+        self, path: Path, stamp: Optional[FileStamp], entries: list["TranscriptEntry"]
+    ) -> None:
+        """Hold ``entries`` for ``path``, pinned to ``stamp``.
+
+        ``stamp`` must be the file's identity as captured *before* the
+        parse (see the module docstring); None — an unstattable file —
+        declines, as does an empty list, since there is nothing to save.
+        """
+        if stamp is None or not entries:
+            return
+        size = stamp[0]
+        if size > self._budget:
+            self.declines += 1
+            return
+        if not self._has_memory_for(size):
+            self.declines += 1
+            return
+
+        key = str(path)
+        existing = self._held.pop(key, None)
+        if existing is not None:
+            self._bytes -= existing[0][0]
+        self._held[key] = (stamp, entries)
+        self._bytes += size
+        self._evict_to_budget()
+
+    def _has_memory_for(self, size: int) -> bool:
+        """Whether the machine has room to hold a file of ``size`` bytes."""
+        if entry_store_forced():
+            return True
+        from .render_pool import available_memory_bytes
+
+        available = available_memory_bytes()
+        if available is None:  # unreadable probe — don't second-guess it
+            return True
+        return available >= size * MIN_AVAILABLE_MEMORY_PER_FILE_BYTE
+
+    def _evict_to_budget(self) -> None:
+        """Drop oldest entries until the held source bytes fit the budget."""
+        while self._bytes > self._budget and self._held:
+            _key, (stamp, _entries) = next(iter(self._held.items()))
+            self._held.pop(_key)
+            self._bytes -= stamp[0]
+
+    # ---- reading ---------------------------------------------------------
+
+    def get(self, path: Path) -> Optional[list["TranscriptEntry"]]:
+        """The stored entries for ``path``, or None to fall back to the cache.
+
+        Declines whenever the file's current ``(size, mtime_ns)`` differs
+        from the stamp the entries were pinned to — the file changed
+        under us, so the cache (which the refresh has just rewritten) is
+        the authority, not this.
+        """
+        held = self._held.get(str(path))
+        if held is None:
+            self.misses += 1
+            return None
+        stamp, entries = held
+        if stamp_file(path) != stamp:
+            self.misses += 1
+            return None
+        self.hits += 1
+        # Deep copy, because consumers mutate: see the module docstring.
+        return copy.deepcopy(entries)
+
+    # ---- introspection ---------------------------------------------------
+
+    @property
+    def held_bytes(self) -> int:
+        """Source bytes currently pinned (the residency this store adds)."""
+        return self._bytes
+
+    def stats_line(self) -> str:
+        return (
+            f"entry store: {self.hits} hit(s), {self.misses} miss(es), "
+            f"{self.declines} decline(s), {self._bytes / 1e6:.1f} MB held"
+        )

--- a/claude_code_log/html/templates/components/global_styles.css
+++ b/claude_code_log/html/templates/components/global_styles.css
@@ -21,6 +21,11 @@
     --session-bg-dimmed: #e8f4fd66;
     --ide-notification-dimmed: #d2d6d966;
 
+    /* Where the resume-session button sits in the floating stack. Named
+     * because its toast is positioned beside it and must follow it when
+     * the stack is reordered. */
+    --resume-btn-bottom: 380px;
+
     /* Fully transparent variants (88 = ~53% opacity) */
     --highlight-semi: #e3f2fd88;
     --error-semi: #ffebee88;
@@ -361,18 +366,28 @@ body.show-raw-user .user-content:not([data-user-view="md"]) .user-raw {
 /* Resume-session button (single-session pages only): copies the
  * `pushd … && claude -r <session-id>` command to the clipboard. */
 .resume-session.floating-btn {
-    bottom: 380px;
+    bottom: var(--resume-btn-bottom);
 }
 
 /* Transient confirmation shown after the resume command is copied.
  * Opaque background (not the `…-dimmed` variant the buttons use) so
  * the transcript text underneath doesn't bleed through the message.
- * Sits above the follow toggle (440px), which is the top of the stack. */
+ *
+ * Sits to the *left* of its own button, centred on it: stacking it above
+ * the buttons meant every new one added to the stack pushed the toast up
+ * too, over buttons it has nothing to do with. Anchoring it beside the
+ * button it belongs to keeps that a one-number change
+ * (`--resume-btn-bottom`), and the column to the left is empty.
+ *
+ * The centring is height-agnostic — bottom edge at the button's middle,
+ * then shifted down by half the toast's own height — because the message
+ * wraps to one or two lines depending on the viewport. */
 .resume-toast {
     position: fixed;
-    right: 20px;
-    bottom: 500px;
-    max-width: 320px;
+    right: calc(20px + 50px + 12px);  /* button right + width + gap */
+    bottom: calc(var(--resume-btn-bottom) + 25px);
+    transform: translateY(50%);
+    max-width: min(320px, calc(100vw - 120px));
     padding: 8px 12px;
     background-color: #e8f4fd;
     color: var(--text-muted);

--- a/claude_code_log/html/templates/components/global_styles.css
+++ b/claude_code_log/html/templates/components/global_styles.css
@@ -366,11 +366,12 @@ body.show-raw-user .user-content:not([data-user-view="md"]) .user-raw {
 
 /* Transient confirmation shown after the resume command is copied.
  * Opaque background (not the `…-dimmed` variant the buttons use) so
- * the transcript text underneath doesn't bleed through the message. */
+ * the transcript text underneath doesn't bleed through the message.
+ * Sits above the follow toggle (440px), which is the top of the stack. */
 .resume-toast {
     position: fixed;
     right: 20px;
-    bottom: 440px;
+    bottom: 500px;
     max-width: 320px;
     padding: 8px 12px;
     background-color: #e8f4fd;

--- a/claude_code_log/html/templates/components/live_update.js
+++ b/claude_code_log/html/templates/components/live_update.js
@@ -44,6 +44,14 @@
     // (This is the same trap as the cache's mtime tolerance, one layer up,
     // and it has the same fix: compare the size too. `Content-Length` is
     // exact, free, and already on the HEAD response.)
+    //
+    // Size closes most of that gap but not all of it: a re-render can
+    // change content without changing length — a counter, a status word
+    // or a timestamp keeping its width — and inside one `Last-Modified`
+    // second such a rewrite is invisible to both headers. So `serve` also
+    // sends `X-Content-Revision`, a digest of the bytes themselves
+    // (server.py), and it joins the comparison. `ETag` stays in the list
+    // for any other server that sets one; ours deliberately does not.
     let lastStamp = null;
     let stopped = false;
     let following = false;
@@ -517,6 +525,7 @@
                 head.headers.get('Last-Modified') || '',
                 length,
                 head.headers.get('ETag') || '',
+                head.headers.get('X-Content-Revision') || '',
             ].join('|');
             const served = lastStamp === null ? loadedLength() : null;
             const missedOnLoad = !!served && !!length && Number(length) !== served;

--- a/claude_code_log/html/templates/components/live_update.js
+++ b/claude_code_log/html/templates/components/live_update.js
@@ -485,17 +485,42 @@
     // instead leaves the page wrong until something else changes.)
     let polling = false;
 
+    // How many bytes this document actually was, as the browser received
+    // it. The first poll cannot happen until the document has loaded, and
+    // that takes as long as it takes — tens of MB on the pages this
+    // feature is for. A conversion completing in that window would be
+    // adopted as the baseline and never applied, leaving the page
+    // permanently one update behind if the session then went quiet.
+    //
+    // The navigation timing entry is the one thing that knows what we were
+    // served, so the first poll compares against it rather than trusting
+    // whatever the server holds by then. Responses are not
+    // content-encoded, so this is directly comparable to `Content-Length`;
+    // anything that makes it unavailable (or zero) falls back to adopting
+    // the baseline, which is where this started.
+    function loadedLength() {
+        try {
+            const nav = performance.getEntriesByType('navigation')[0];
+            return (nav && nav.encodedBodySize) || null;
+        } catch (err) {
+            return null;
+        }
+    }
+
     async function poll() {
         if (stopped || polling) return;
         polling = true;
         try {
             const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+            const length = head.headers.get('Content-Length') || '';
             const stamp = [
                 head.headers.get('Last-Modified') || '',
-                head.headers.get('Content-Length') || '',
+                length,
                 head.headers.get('ETag') || '',
             ].join('|');
-            if (lastStamp === null) {
+            const served = lastStamp === null ? loadedLength() : null;
+            const missedOnLoad = !!served && !!length && Number(length) !== served;
+            if (lastStamp === null && !missedOnLoad) {
                 lastStamp = stamp;
             } else if (stamp !== lastStamp) {
                 const res = await fetch(location.href, { cache: 'no-store' });

--- a/claude_code_log/html/templates/components/live_update.js
+++ b/claude_code_log/html/templates/components/live_update.js
@@ -10,8 +10,9 @@
 //
 //   * The server never renders. `serve --watch` re-runs the ordinary
 //     conversion and the files on disk stay canonical, so this page just
-//     re-fetches its own URL. A conditional GET makes the idle case free
-//     (304 in ~1ms) and needs no endpoint of its own.
+//     re-fetches its own URL. A HEAD for the page's own metadata makes
+//     the idle case free (~1ms, no body) and needs no endpoint of its
+//     own; the full GET follows only when that metadata moved.
 //   * We never reload. A reload loses fold state and re-parses a
 //     document that can reach tens of MB.
 //   * When the new render extends the one on screen, we patch the nodes
@@ -27,8 +28,9 @@
 
     if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
 
-    // A conditional GET costs ~1ms and 304s while nothing changes, so the
-    // interval is set by how fresh the page should feel, not by load.
+    // A metadata HEAD costs ~1ms and carries no body while nothing
+    // changes, so the interval is set by how fresh the page should feel,
+    // not by load.
     const POLL_MS = 1000;
     const container = () => document.getElementById('transcript');
     if (!container()) return;
@@ -466,8 +468,26 @@
         if (following) scrollToEnd();
     }
 
+    // One poll at a time. The interval keeps firing while a full GET is in
+    // flight, and a page slow enough to fetch — which is exactly the large
+    // page all of this is for — would then have two updates racing:
+    // whichever *response* lands last wins, so an older render overwrites a
+    // newer one and the page loses messages it had already shown. Measured
+    // by holding one response for 3s: the newest message appeared at 2.0s,
+    // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+    //
+    // Serialising is what stops it, and skipping a tick costs nothing:
+    // `lastStamp` only advances once an update has actually been applied,
+    // so the next tick still sees the change. (That ordering is also what
+    // bounds the damage above to one second rather than forever — the
+    // stale apply rewinds `lastStamp` to its own older value, so the next
+    // HEAD finds a difference again. Recording the stamp before the GET
+    // instead leaves the page wrong until something else changes.)
+    let polling = false;
+
     async function poll() {
-        if (stopped) return;
+        if (stopped || polling) return;
+        polling = true;
         try {
             const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
             const stamp = [
@@ -478,14 +498,18 @@
             if (lastStamp === null) {
                 lastStamp = stamp;
             } else if (stamp !== lastStamp) {
-                lastStamp = stamp;
                 const res = await fetch(location.href, { cache: 'no-store' });
-                if (res.ok) await applyUpdate(await res.text());
+                if (res.ok) {
+                    await applyUpdate(await res.text());
+                    lastStamp = stamp;
+                }
             }
         } catch (err) {
             // A dropped server is the normal end of a watch session, not an
             // error worth shouting about. Keep polling: `serve` may come back.
             console.debug('live update poll failed', err);
+        } finally {
+            polling = false;
         }
     }
 

--- a/claude_code_log/html/templates/components/live_update.js
+++ b/claude_code_log/html/templates/components/live_update.js
@@ -12,16 +12,16 @@
 //     conversion and the files on disk stay canonical, so this page just
 //     re-fetches its own URL. A conditional GET makes the idle case free
 //     (304 in ~1ms) and needs no endpoint of its own.
-//   * We swap #transcript rather than reloading. A reload loses fold
-//     state and re-parses a document that can reach tens of MB; a swap
-//     keeps scroll position for free, because everything above the
-//     viewport is untouched.
-//   * We do not patch in individual messages. New entries do not always
-//     belong at the end (a transcript's appends are not in timestamp
-//     order), one entry can render as several cards, and the `msg-d-N`
-//     anchors are positional — inserting anywhere but the tail renumbers
-//     them and breaks the fork/tool-pair links already on the page.
-//     Replacing the whole container sidesteps all three.
+//   * We never reload. A reload loses fold state and re-parses a
+//     document that can reach tens of MB.
+//   * When the new render extends the one on screen, we patch the nodes
+//     that changed and leave the rest alone (see "patching" below). When
+//     it does not, we replace #transcript wholesale — which keeps scroll
+//     position for free, because everything above the viewport is
+//     untouched, and is the fallback for every shape the patch declines:
+//     entries that do not belong at the end (a transcript's appends are
+//     not in timestamp order) and the `msg-d-N` renumbering that follows,
+//     which would break the fork/tool-pair links already on the page.
 (function () {
     'use strict';
 
@@ -130,39 +130,316 @@
         return count;
     }
 
-    // ---- the update ------------------------------------------------------
+    // ---- patching, for the case that is almost always the real one -------
+    //
+    // Replacing #transcript wholesale costs work proportional to the *page*
+    // for a change proportional to the *append*: on a 4MB session page,
+    // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+    // new cards. It also reconstructs fold and disclosure state from a
+    // heuristic key rather than keeping the nodes that already hold it.
+    //
+    // So when the new render is a pure *extension* of the one on screen —
+    // the same cards, in the same order, followed by new ones — we patch
+    // instead: replace the handful of cards whose own markup actually
+    // changed, insert the new ones, and leave every other node untouched.
+    // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+    //
+    // Anything else falls back to the swap, which is unchanged and stays the
+    // definition of correct. Replaying three real sessions through the
+    // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+    // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+    // they take the swap. That ratio is why the fallback is acceptable and
+    // why patching the general case is not worth its complexity yet.
 
-    function announce(added) {
-        let pill = document.getElementById('live-update-pill');
-        if (!pill) {
-            pill = document.createElement('button');
-            pill.id = 'live-update-pill';
-            pill.className = 'floating-btn live-update-pill';
-            pill.addEventListener('click', () => {
-                following = !following;
-                if (following) scrollToEnd();
-                render();
-            });
-            document.body.appendChild(pill);
-        }
-        pill.dataset.following = following ? 'yes' : 'no';
-        pill.unseen = (pill.unseen || 0) + added;
-        render();
+    // The hashes the cards on screen were rendered from, keyed by card id.
+    // Taken from pristine parsed markup, never from the live DOM: by update
+    // time the live tree has been rewritten by decoration (timestamp
+    // localisation replaces innerHTML), so a hash taken from it would never
+    // match one taken from the server's bytes.
+    let cardHashes = null;
 
-        function render() {
-            if (following) pill.unseen = 0;
-            pill.textContent = following
-                ? '⏬ following'
-                : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-            pill.title = following
-                ? 'Following new messages — click to stop'
-                : 'Scroll to new messages as they arrive';
+    // FNV-1a. A collision would show one stale card, not break the page, and
+    // needs a *changed* card to land on its own previous value: 1 in 2^32.
+    function hashOf(s) {
+        let h = 0x811c9dc5;
+        for (let i = 0; i < s.length; i++) {
+            h ^= s.charCodeAt(i);
+            h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
         }
+        return h.toString(36);
     }
 
+    // What belongs to a node itself rather than to its descendants. That is
+    // the card — but not only the card: a fork point renders as a box inside
+    // `.children` so that folding hides it with the subtree, and on a
+    // fork-only slot that box is the node's *only* content and carries its
+    // id. Both kinds also hold positional `#msg-d-N` branch links, so
+    // treating them as part of the node is what keeps a changed fork point
+    // from being missed.
+    //
+    // The template always emits them after the child nodes, which is what
+    // lets `applyOwn` below put replacements back by appending.
+    function ownParts(node) {
+        const parts = [];
+        const card = node.querySelector(':scope > .message');
+        if (card) parts.push(card);
+        const kids = node.querySelector(':scope > .children');
+        if (kids) {
+            Array.from(kids.children).forEach(el => {
+                if (!el.classList.contains('message-node')) parts.push(el);
+            });
+        }
+        return parts;
+    }
+
+    // A node's identity: its card's id, or — for a fork-only slot, which has
+    // no card — the fork-point box's.
+    function nodeKey(node) {
+        const card = node.querySelector(':scope > .message');
+        if (card && card.id) return card.id;
+        const fork = node.querySelector(':scope > .children > .fork-point[id]');
+        return fork ? fork.id : null;
+    }
+
+    // Node keys in document order, plus a hash of each node's own markup.
+    // A node with no key at all makes the whole update unpatchable, because
+    // the extension test below is only meaningful over a complete sequence.
+    // `withHashes` is off for the live tree: only its key sequence is
+    // wanted there, and hashing it would serialise the whole page — the
+    // very cost this is here to avoid. Its hashes would be meaningless
+    // anyway, having been taken after decoration rewrote the markup.
+    function scanTree(root, withHashes) {
+        const ids = [];
+        const hashes = new Map();
+        let ok = true;
+        root.querySelectorAll('.message-node').forEach(node => {
+            const key = nodeKey(node);
+            if (!key) { ok = false; return; }
+            ids.push(key);
+            if (withHashes) {
+                hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+            }
+        });
+        return { ids, hashes, ok };
+    }
+
+    // Swap a node's own markup for the new render's, leaving its children
+    // alone. The card is replaced in place; the trailing parts are dropped
+    // and re-appended, which is correct because the template emits them
+    // after the child nodes.
+    //
+    // Returns the elements it actually put on the page, or null if the node
+    // is not a shape it can handle. Returning *those* rather than the node
+    // matters: the caller rehydrates what comes back, and a node's subtree
+    // is not what changed. The session header is the case that makes this
+    // sharp — its fold bar counts descendants, so it is replaced on every
+    // single append, and its node is the whole page.
+    function applyOwn(liveNode, newNode) {
+        const liveCard = liveNode.querySelector(':scope > .message');
+        const newCard = newNode.querySelector(':scope > .message');
+        if (!!liveCard !== !!newCard) return null;
+
+        const placed = [];
+        if (liveCard && newCard) {
+            const imported = document.importNode(newCard, true);
+            liveCard.replaceWith(imported);
+            placed.push(imported);
+        }
+
+        const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+        const liveKids = liveNode.querySelector(':scope > .children');
+        if (!liveKids) return newTrailing.length === 0 ? placed : null;
+        Array.from(liveKids.children).forEach(el => {
+            if (!el.classList.contains('message-node')) el.remove();
+        });
+        newTrailing.forEach(el => {
+            const imported = document.importNode(el, true);
+            liveKids.appendChild(imported);
+            placed.push(imported);
+        });
+        return placed;
+    }
+
+    // Where a new node belongs in the live tree: inside its parent's
+    // `.children`, after the last card already there. Because the id
+    // sequence is an extension, every new card follows every existing one in
+    // document order, so appending after the last `.message-node` is the
+    // right place — and going through `.message-node` rather than the
+    // container's last child keeps any trailing junction-link markup last.
+    function liveNodeFor(key) {
+        const el = document.getElementById(key);
+        return el ? el.closest('.message-node') : null;
+    }
+
+    function insertNode(newNode, imported) {
+        const parentNode = newNode.parentElement
+            && newNode.parentElement.closest('.message-node');
+        let liveKids;
+        if (!parentNode) {
+            liveKids = container();
+        } else {
+            const key = nodeKey(parentNode);
+            const holder = key && liveNodeFor(key);
+            if (!holder) return false;
+            liveKids = holder.querySelector(':scope > .children');
+            if (!liveKids) {
+                // The parent had no children until now, so it has no
+                // container to put them in; take the new one wholesale.
+                const newKids = parentNode.querySelector(':scope > .children');
+                if (!newKids) return false;
+                holder.appendChild(document.importNode(newKids, true));
+                return true;
+            }
+        }
+        if (!liveKids) return false;
+        const existing = liveKids.querySelectorAll(':scope > .message-node');
+        if (existing.length) existing[existing.length - 1].after(imported);
+        else liveKids.prepend(imported);
+        return true;
+    }
+
+    // Returns the number of cards added, or null if this update is not a
+    // shape we patch — in which case the caller swaps.
+    function tryPatch(nextRoot, next) {
+        if (!cardHashes || !next.ok) return null;
+        const live = scanTree(container(), false);
+        if (!live.ok) return null;
+
+        // A pure extension: every node on screen is still there, with the
+        // same key, in the same order. This is what fails when an
+        // out-of-order arrival renumbers the positional ids, and it is
+        // deliberately an all-or-nothing test — a single mismatch means the
+        // ids no longer mean what they meant, so nothing keyed on them is
+        // trustworthy.
+        if (next.ids.length < live.ids.length) return null;
+        for (let i = 0; i < live.ids.length; i++) {
+            if (next.ids[i] !== live.ids[i]) return null;
+        }
+
+        const changed = [];
+        for (const key of live.ids) {
+            if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+        }
+        // A broad edit is cheaper to apply wholesale than node by node. An
+        // append moves only the ancestors' descendant counts, so this stays
+        // in single digits in practice.
+        if (changed.length > 40) return null;
+
+        // Resolve everything before touching the live DOM, so a shape we
+        // cannot handle leaves the page untouched for the swap to redo.
+        const edits = [];
+        for (const key of changed) {
+            const liveNode = liveNodeFor(key);
+            const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+            const newNode = newAnchor && newAnchor.closest('.message-node');
+            if (!liveNode || !newNode) return null;
+            edits.push([liveNode, newNode]);
+        }
+
+        const known = new Set(live.ids);
+        const additions = [];
+        for (const key of next.ids) {
+            if (known.has(key)) continue;
+            const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+            const newNode = newAnchor && newAnchor.closest('.message-node');
+            if (!newNode) return null;
+            // A new node nested inside another new node arrives with it;
+            // `next.ids` is in document order, so the outer one comes first.
+            if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+            additions.push([key, newNode]);
+        }
+
+        const fresh = [];
+        // Nodes already on screen whose own markup legitimately changed: an
+        // ancestor's descendant count, or a `pair_first` class arriving with
+        // the other half of a pair. The subtree underneath is kept, and with
+        // it every bit of state the card holds.
+        for (const [liveNode, newNode] of edits) {
+            const placed = applyOwn(liveNode, newNode);
+            if (!placed) return null;
+            placed.forEach(el => fresh.push(el));
+        }
+
+        // New nodes. These carry the fade-in; the ones replaced above
+        // deliberately do not, since they were already on screen.
+        let added = 0;
+        for (const [key, newNode] of additions) {
+            const imported = document.importNode(newNode, true);
+            if (!insertNode(newNode, imported)) return null;
+            added += imported.querySelectorAll('.message').length;
+            imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+            fresh.push(imported);
+        }
+
+        // Rehydrate over what actually changed, not over the whole tree.
+        if (window.claudeLogRehydrate) {
+            fresh.forEach(el => window.claudeLogRehydrate(el));
+        }
+        return added;
+    }
+
+    // ---- the update ------------------------------------------------------
+
+    // The toggle is part of the page's floating-button stack rather than
+    // something this script builds, so it is styled with the rest of the
+    // toolbar and cannot drift from it. It is revealed only here, because
+    // reaching this point is the proof that polling is possible at all.
+    const followBtn = document.getElementById('followUpdates');
+    let unseen = 0;
+
+    function renderFollowBtn() {
+        if (!followBtn) return;
+        if (following) unseen = 0;
+        followBtn.classList.toggle('following', following);
+        followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+        followBtn.dataset.unseen = String(unseen);
+        followBtn.title = following
+            ? 'Following new messages — click to stop'
+            : (unseen
+                ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                : 'Follow new messages as they arrive');
+        document.body.classList.toggle('live-following', following);
+    }
+
+    function setFollowing(next) {
+        following = !!next;
+        renderFollowBtn();
+        if (following) scrollToEnd();
+    }
+
+    if (followBtn) {
+        followBtn.classList.add('live-active');
+        followBtn.addEventListener('click', () => setFollowing(!following));
+        renderFollowBtn();
+    }
+
+    function announce(added) {
+        unseen += added;
+        renderFollowBtn();
+    }
+
+    // Scroll the document to its end rather than aligning the last card,
+    // which is what `scrollIntoView({block: 'end'})` did: that puts the
+    // card's bottom edge *exactly* on the viewport's, measured at a 0px
+    // gap. `body.live-following`'s padding supplies the space this then
+    // scrolls into. Both halves are needed — measured on a real page, the
+    // padding alone still gives 0px (the alignment ignores it) and a
+    // scroll-margin alone gives 25px (there is no room left to give).
     function scrollToEnd() {
-        const c = container();
-        if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+        window.scrollTo({
+            top: document.documentElement.scrollHeight,
+            behavior: 'smooth',
+        });
+    }
+
+    function swapIn(next, current) {
+        const before = captureState(current);
+        current.replaceWith(next);
+        restoreState(next, before);
+        const added = markNew(next, before.keys);
+        // Everything that decorated the old markup after load.
+        if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+        return added;
     }
 
     async function applyUpdate(html) {
@@ -171,13 +448,13 @@
         const current = container();
         if (!next || !current) return;
 
-        const before = captureState(current);
-        current.replaceWith(next);
-        restoreState(next, before);
-        const added = markNew(next, before.keys);
-
-        // Everything that decorated the old markup after load.
-        if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+        // Hashes come from the parsed bytes, before anything is put on the
+        // page, and are kept whichever route the update took — the swap is a
+        // valid starting point for the next patch.
+        const scan = scanTree(next, true);
+        let added = tryPatch(next, scan);
+        if (added === null) added = swapIn(next, current);
+        cardHashes = scan.hashes;
 
         // The title carries the message/token counts, and the session nav
         // its summaries; both go stale otherwise.
@@ -226,6 +503,6 @@
     window.claudeLogLiveUpdate = {
         poll,
         stop() { stopped = true; },
-        setFollowing(v) { following = !!v; },
+        setFollowing,
     };
 })();

--- a/claude_code_log/html/templates/components/live_update.js
+++ b/claude_code_log/html/templates/components/live_update.js
@@ -1,0 +1,231 @@
+// Keep this page current while the session it shows is still running.
+//
+// Only active over http(s): a page loaded from file:// cannot fetch
+// anything at all — not itself, not a sibling, not even a HEAD (verified
+// in Chromium; script tags are the only channel a file:// page has). So
+// this is a `serve` feature, and the generated HTML stays exactly as
+// useful from file:// as it was before.
+//
+// The shape, and why:
+//
+//   * The server never renders. `serve --watch` re-runs the ordinary
+//     conversion and the files on disk stay canonical, so this page just
+//     re-fetches its own URL. A conditional GET makes the idle case free
+//     (304 in ~1ms) and needs no endpoint of its own.
+//   * We swap #transcript rather than reloading. A reload loses fold
+//     state and re-parses a document that can reach tens of MB; a swap
+//     keeps scroll position for free, because everything above the
+//     viewport is untouched.
+//   * We do not patch in individual messages. New entries do not always
+//     belong at the end (a transcript's appends are not in timestamp
+//     order), one entry can render as several cards, and the `msg-d-N`
+//     anchors are positional — inserting anywhere but the tail renumbers
+//     them and breaks the fork/tool-pair links already on the page.
+//     Replacing the whole container sidesteps all three.
+(function () {
+    'use strict';
+
+    if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+
+    // A conditional GET costs ~1ms and 304s while nothing changes, so the
+    // interval is set by how fresh the page should feel, not by load.
+    const POLL_MS = 1000;
+    const container = () => document.getElementById('transcript');
+    if (!container()) return;
+
+    // The page's identity as of the last poll. `Last-Modified` alone is
+    // not enough: HTTP dates have **one-second granularity**, so two
+    // conversions inside the same second produce an identical header and
+    // the second update is invisible. Observed directly — a third append
+    // never arrived until length was added to the comparison.
+    //
+    // (This is the same trap as the cache's mtime tolerance, one layer up,
+    // and it has the same fix: compare the size too. `Content-Length` is
+    // exact, free, and already on the HEAD response.)
+    let lastStamp = null;
+    let stopped = false;
+    let following = false;
+
+    // ---- state that a swap would otherwise destroy -----------------------
+
+    // A key that survives a re-render, for every card that can hold state.
+    //
+    // `data-uuid` is stable but is NOT unique per card (one entry can
+    // render as sibling text + tool_use cards), so it is paired with its
+    // ordinal among cards sharing it. Two kinds of card have no uuid at
+    // all and are exactly the ones that fold: **session headers** (keyed
+    // by `data-session-id`) and fork points. Missing the session header
+    // is not a corner case — on a single-session page it is the only
+    // foldable node there is.
+    //
+    // The `id` (`msg-d-N`) is unique but positional, so it is the last
+    // resort rather than the first choice: it is correct for appends at
+    // the tail and wrong the moment something lands earlier in the tree.
+    function stableKeys(root) {
+        const seen = new Map();
+        const keys = new Map();
+        root.querySelectorAll('.message, .fork-point').forEach(el => {
+            const uuid = el.getAttribute('data-uuid');
+            const session = el.getAttribute('data-session-id');
+            let base;
+            if (uuid) base = 'u:' + uuid;
+            else if (session) base = 's:' + session;
+            else base = 'p:' + (el.id || 'anon');
+            const n = seen.get(base) || 0;
+            seen.set(base, n + 1);
+            keys.set(el, base + '#' + n);
+        });
+        return keys;
+    }
+
+    // The children container a card's fold bar controls: a *sibling* of
+    // the card inside the shared `.message-node`, not a descendant.
+    function childrenOf(el) {
+        const node = el.closest('.message-node');
+        return node ? node.querySelector(':scope > .children') : null;
+    }
+
+    function captureState(root) {
+        const folds = new Map();
+        const keys = stableKeys(root);
+        keys.forEach((key, el) => {
+            const children = childrenOf(el);
+            if (children) folds.set(key, children.style.display);
+        });
+        const details = new Map();
+        root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+        return { folds, details, keys: new Set(keys.values()) };
+    }
+
+    function restoreState(root, state) {
+        stableKeys(root).forEach((key, el) => {
+            if (!state.folds.has(key)) return;
+            const children = childrenOf(el);
+            if (!children) return;
+            children.style.display = state.folds.get(key);
+            // Keep the fold bar's arrows honest about what it is showing.
+            const bar = el.querySelector(':scope > .fold-bar');
+            if (!bar) return;
+            const folded = children.style.display === 'none';
+            bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                section.classList.toggle('folded', folded);
+            });
+        });
+        // `<details>` has no stable identity of its own; index order is the
+        // best available and is exact for the common case (appends at the
+        // tail leave every earlier disclosure at the same index).
+        const all = root.querySelectorAll('details');
+        state.details.forEach((open, i) => {
+            if (all[i]) all[i].open = open;
+        });
+    }
+
+    function markNew(root, previousKeys) {
+        let count = 0;
+        stableKeys(root).forEach((key, el) => {
+            if (previousKeys.has(key) || !el.classList.contains('message')) return;
+            el.classList.add('live-new');
+            count += 1;
+        });
+        return count;
+    }
+
+    // ---- the update ------------------------------------------------------
+
+    function announce(added) {
+        let pill = document.getElementById('live-update-pill');
+        if (!pill) {
+            pill = document.createElement('button');
+            pill.id = 'live-update-pill';
+            pill.className = 'floating-btn live-update-pill';
+            pill.addEventListener('click', () => {
+                following = !following;
+                if (following) scrollToEnd();
+                render();
+            });
+            document.body.appendChild(pill);
+        }
+        pill.dataset.following = following ? 'yes' : 'no';
+        pill.unseen = (pill.unseen || 0) + added;
+        render();
+
+        function render() {
+            if (following) pill.unseen = 0;
+            pill.textContent = following
+                ? '⏬ following'
+                : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+            pill.title = following
+                ? 'Following new messages — click to stop'
+                : 'Scroll to new messages as they arrive';
+        }
+    }
+
+    function scrollToEnd() {
+        const c = container();
+        if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    }
+
+    async function applyUpdate(html) {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const next = doc.getElementById('transcript');
+        const current = container();
+        if (!next || !current) return;
+
+        const before = captureState(current);
+        current.replaceWith(next);
+        restoreState(next, before);
+        const added = markNew(next, before.keys);
+
+        // Everything that decorated the old markup after load.
+        if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+
+        // The title carries the message/token counts, and the session nav
+        // its summaries; both go stale otherwise.
+        const nextTitle = doc.getElementById('title');
+        const title = document.getElementById('title');
+        if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+
+        if (added) announce(added);
+        if (following) scrollToEnd();
+    }
+
+    async function poll() {
+        if (stopped) return;
+        try {
+            const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+            const stamp = [
+                head.headers.get('Last-Modified') || '',
+                head.headers.get('Content-Length') || '',
+                head.headers.get('ETag') || '',
+            ].join('|');
+            if (lastStamp === null) {
+                lastStamp = stamp;
+            } else if (stamp !== lastStamp) {
+                lastStamp = stamp;
+                const res = await fetch(location.href, { cache: 'no-store' });
+                if (res.ok) await applyUpdate(await res.text());
+            }
+        } catch (err) {
+            // A dropped server is the normal end of a watch session, not an
+            // error worth shouting about. Keep polling: `serve` may come back.
+            console.debug('live update poll failed', err);
+        }
+    }
+
+    // Don't poll a page nobody is looking at.
+    function schedule() {
+        if (document.hidden) return;
+        poll();
+    }
+    setInterval(schedule, POLL_MS);
+    document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) poll();
+    });
+    poll();
+
+    window.claudeLogLiveUpdate = {
+        poll,
+        stop() { stopped = true; },
+        setFollowing(v) { following = !!v; },
+    };
+})();

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -1859,18 +1859,61 @@ img.artifact-favicon {
     }
 }
 
-.live-update-pill {
-    bottom: 20px;
-    left: 20px;
-    width: auto;
-    min-width: 3em;
-    padding: 0 0.9em;
-    border-radius: 999px;
-    font-size: 0.85em;
-    white-space: nowrap;
+/* Follow toggle (`serve --watch`): a member of the floating stack, at the
+   top of it. It is rendered on every transcript page but stays hidden
+   until the poller actually starts — a `file://` page cannot poll at all
+   (see live_update.js), and a visible control there would promise
+   something it can never do.
+
+   It was previously built in JS as a wide `.live-update-pill`, which set
+   `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+   auto`, a fixed box with both insets stretches, and the "pill" was
+   measured at 1360px across a 1400px viewport. */
+.follow-updates.floating-btn {
+    bottom: 440px;
+    display: none;
 }
 
-.live-update-pill[data-following="yes"] {
-    background-color: var(--highlight-light);
+.follow-updates.floating-btn.live-active {
+    display: flex;
+}
+
+/* Opaque, as `.debug-toggle.active` is. The old pill signalled
+   "following" with `--highlight-light`, which computes to
+   rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+   rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+   than the disengaged one. */
+.follow-updates.floating-btn.following {
+    background-color: #d4e8f7;
+    color: #333;
+}
+
+/* Unseen-message count, as a corner badge so the button keeps the round
+   50px footprint the rest of the stack has. */
+.follow-updates[data-unseen]:not([data-unseen="0"])::after {
+    content: attr(data-unseen);
+    position: absolute;
+    top: 0;
+    right: 0;
+    box-sizing: border-box;
+    min-width: 17px;
+    height: 17px;
+    padding: 0 4px;
+    border-radius: 9px;
+    background-color: #d64545;
+    color: #fff;
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    font-size: 10px;
     font-weight: 600;
+    line-height: 17px;
+}
+
+/* Room under the last card while following, so a newly-arrived message
+   lands clear of the viewport edge instead of flush against it.
+   Measured: with neither, the gap is 0px — the last card's bottom is
+   exactly the viewport bottom. The padding is what supplies the
+   scrollable space; `scrollToEnd` then scrolls the document to its end
+   rather than aligning the card, and the gap becomes this much. */
+body.live-following {
+    padding-bottom: 120px;
 }

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -1832,3 +1832,45 @@ img.artifact-favicon {
     width: 1em;
     vertical-align: -0.125em;
 }
+
+/* Live update (serve --watch): a message that arrived since the last
+   poll. The fade is the whole "streaming" illusion — transcripts record
+   one complete message at a time, never partial tokens, so a card can
+   only ever appear whole. Announcing that arrival is the most honest
+   thing the page can do. */
+@keyframes live-new-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.message.live-new {
+    animation: live-new-in 320ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .message.live-new {
+        animation: none;
+    }
+}
+
+.live-update-pill {
+    bottom: 20px;
+    left: 20px;
+    width: auto;
+    min-width: 3em;
+    padding: 0 0.9em;
+    border-radius: 999px;
+    font-size: 0.85em;
+    white-space: nowrap;
+}
+
+.live-update-pill[data-following="yes"] {
+    background-color: var(--highlight-light);
+    font-weight: 600;
+}

--- a/claude_code_log/html/templates/components/message_styles.css
+++ b/claude_code_log/html/templates/components/message_styles.css
@@ -1913,7 +1913,9 @@ img.artifact-favicon {
    Measured: with neither, the gap is 0px — the last card's bottom is
    exactly the viewport bottom. The padding is what supplies the
    scrollable space; `scrollToEnd` then scrolls the document to its end
-   rather than aligning the card, and the gap becomes this much. */
+   rather than aligning the card, and the gap becomes this much. Kept
+   small deliberately — enough to read as breathing room, not enough to
+   leave the newest message stranded above a band of empty page. */
 body.live-following {
-    padding-bottom: 120px;
+    padding-bottom: 20px;
 }

--- a/claude_code_log/html/templates/components/timeline.html
+++ b/claude_code_log/html/templates/components/timeline.html
@@ -537,10 +537,30 @@
             applySearchFilter();
         }
 
+        // The rehydrate contract passes a subtree, and calls the hooks once
+        // per changed element — which is what the other two hooks want,
+        // since they only touch what they are given. This one is the
+        // exception: it reads the whole document, so a patch touching a
+        // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+        // exactly the work the patch path exists to avoid. Collapse a
+        // burst into one rebuild after the current task instead.
+        let rebuildScheduled = false;
+        function scheduleRebuild() {
+            if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+            if (rebuildScheduled) return;
+            rebuildScheduled = true;
+            const run = function () {
+                rebuildScheduled = false;
+                rebuildTimeline();
+            };
+            if (window.queueMicrotask) window.queueMicrotask(run);
+            else setTimeout(run, 0);
+        }
+
         // Export functions to global scope
         window.rebuildTimeline = rebuildTimeline;
         if (window.claudeLogOnRehydrate) {
-            window.claudeLogOnRehydrate(rebuildTimeline);
+            window.claudeLogOnRehydrate(scheduleRebuild);
         }
         window.toggleTimeline = toggleTimeline;
         window.applyTimelineFilters = applyFilters;

--- a/claude_code_log/html/templates/components/timeline.html
+++ b/claude_code_log/html/templates/components/timeline.html
@@ -517,7 +517,31 @@
             });
         }
 
+        // Rebuild from the current DOM after a live update swapped the
+        // transcript. The timeline reads message types out of CSS classes,
+        // so new cards are invisible to it until this runs.
+        //
+        // A timeline that was never opened needs nothing: it is built
+        // lazily, and will read the new DOM when it is.
+        function rebuildTimeline() {
+            if (!timeline || !itemsDataSet) return;
+            const { timelineItems, timelineGroups } = buildTimelineData();
+            items = timelineItems;
+            groups = timelineGroups;
+            // Replace the contents rather than the DataSet so the user's
+            // current zoom/pan window survives the update.
+            itemsDataSet.clear();
+            itemsDataSet.add(items);
+            timeline.setGroups(new vis.DataSet(groups));
+            applyFilters();
+            applySearchFilter();
+        }
+
         // Export functions to global scope
+        window.rebuildTimeline = rebuildTimeline;
+        if (window.claudeLogOnRehydrate) {
+            window.claudeLogOnRehydrate(rebuildTimeline);
+        }
         window.toggleTimeline = toggleTimeline;
         window.applyTimelineFilters = applyFilters;
         window.applyTimelineSearchFilter = applySearchFilter;

--- a/claude_code_log/html/templates/components/timezone_converter.js
+++ b/claude_code_log/html/templates/components/timezone_converter.js
@@ -1,8 +1,14 @@
 // Convert timestamps to user's timezone
 // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
 (function() {
-    function convertTimestampsToLocalTimezone() {
-        const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+    // `root` scopes the work to a subtree. A live update replaces only the
+    // transcript container, and its new cards carry raw ISO timestamps;
+    // re-converting the whole document would redo every card that is
+    // already localised (and `innerHTML` has been rewritten on those, so
+    // they no longer match `[data-timestamp]`'s original text anyway).
+    function convertTimestampsToLocalTimezone(root) {
+        const scope = root || document;
+        const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
 
         if (timestampElements.length === 0) return;
 
@@ -112,4 +118,12 @@
 
     // Execute immediately - assumes this is included within a DOMContentLoaded handler
     convertTimestampsToLocalTimezone();
+
+    // Exposed so a live update can re-run it over freshly swapped-in
+    // markup. Registered with the rehydrate contract when one is present
+    // (transcript pages); harmless on pages without it (the index).
+    window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+    if (window.claudeLogOnRehydrate) {
+        window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+    }
 })();

--- a/claude_code_log/html/templates/components/timezone_converter.js
+++ b/claude_code_log/html/templates/components/timezone_converter.js
@@ -41,78 +41,97 @@
             timeZone: userTimezone
         });
 
-        // Process timestamps in batches to keep page responsive
-        const batchSize = 25;
-        const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+        function localizeOne(element) {
+            const rawTimestamp = element.getAttribute('data-timestamp');
+            const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+            const duration = element.getAttribute('data-duration');
 
-        function processBatch(startIndex) {
-            const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+            if (!rawTimestamp) return;
 
-            for (let i = startIndex; i < endIndex; i++) {
-                const element = timestampElements[i];
-                const rawTimestamp = element.getAttribute('data-timestamp');
-                const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                const duration = element.getAttribute('data-duration');
+            try {
+                // Parse the ISO timestamp
+                const date = new Date(rawTimestamp);
+                if (isNaN(date.getTime())) return; // Invalid date
 
-                if (!rawTimestamp) continue;
+                const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
 
-                try {
-                    // Parse the ISO timestamp
-                    const date = new Date(rawTimestamp);
-                    if (isNaN(date.getTime())) continue; // Invalid date
+                // Get timezone abbreviation (reuse formatter)
+                const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
 
-                    const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                    const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                // Handle time ranges (earliest to latest)
+                if (rawTimestampEnd) {
+                    const dateEnd = new Date(rawTimestampEnd);
+                    if (!isNaN(dateEnd.getTime())) {
+                        const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                        const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
 
-                    // Get timezone abbreviation (reuse formatter)
-                    const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-
-                    // Handle time ranges (earliest to latest)
-                    if (rawTimestampEnd) {
-                        const dateEnd = new Date(rawTimestampEnd);
-                        if (!isNaN(dateEnd.getTime())) {
-                            const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                            const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-
-                            // Update the element with range
-                            if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                            } else {
-                                // If they're the same (user is in UTC), just show UTC
-                                element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                            }
-                        }
-                    } else {
-                        // Single timestamp
-                        if (localTime !== utcTime) {
-                            element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                            element.title = duration ? duration : 'UTC: ' + utcTime;
+                        // Update the element with range
+                        if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                            element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                            element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                         } else {
                             // If they're the same (user is in UTC), just show UTC
-                            element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                            element.title = duration ? duration : 'UTC: ' + utcTime;
+                            element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                            element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                         }
                     }
-
-                } catch (error) {
-                    // If conversion fails, leave the original timestamp
-                    console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                } else {
+                    // Single timestamp
+                    if (localTime !== utcTime) {
+                        element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                        element.title = duration ? duration : 'UTC: ' + utcTime;
+                    } else {
+                        // If they're the same (user is in UTC), just show UTC
+                        element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                        element.title = duration ? duration : 'UTC: ' + utcTime;
+                    }
                 }
-            }
 
-            // Schedule next batch if there are more timestamps
-            if (endIndex < timestampElements.length) {
-                scheduleWork(function() {
-                    processBatch(endIndex);
-                });
+            } catch (error) {
+                // If conversion fails, leave the original timestamp
+                console.warn('Failed to convert timestamp:', rawTimestamp, error);
             }
         }
 
-        // Start processing the first batch
-        scheduleWork(function() {
-            processBatch(0);
+        // Drain the queue against the idle deadline rather than a fixed batch
+        // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+        // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+        // count* the cost: 48 idle turns for that page, measured at 766ms of
+        // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+        // order, so cards appended by a live update localise last and the
+        // fade-in plays over a raw ISO string.
+        //
+        // Draining on the deadline instead takes those to 13ms and 35ms —
+        // within a few ms of a straight synchronous pass, while still handing
+        // the main thread back whenever the browser wants it.
+        const scheduleWork = window.requestIdleCallback
+            ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+            // No requestIdleCallback (Safari < 16): a macrotask still yields
+            // between slices, and the synthetic deadline keeps them bounded.
+            : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+
+        let cursor = 0;
+        function drain(deadline) {
+            // timeRemaining() is not free, so check it per chunk rather than
+            // per element; 32 conversions cost well under a millisecond.
+            const chunk = 32;
+            while (cursor < timestampElements.length) {
+                if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                const end = Math.min(cursor + chunk, timestampElements.length);
+                for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+            }
+            if (cursor < timestampElements.length) scheduleWork(drain);
+        }
+
+        // The first slice runs on the current task, so a live update's new
+        // cards are localised before the browser paints them rather than an
+        // idle turn later. It gets a real budget rather than an unbounded
+        // one, so the largest pages yield instead of blocking on load.
+        const firstSliceEnds = performance.now() + 24;
+        drain({
+            timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+            didTimeout: false
         });
     }
 

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -24,6 +24,34 @@
 </head>
 
 <body>
+    <script>
+        // ---- rehydrate contract -------------------------------------------
+        // A live update (see live_update.js) replaces #transcript wholesale.
+        // Anything that decorated the old markup after load has to run again
+        // over the new markup: timestamp localisation rewrites innerHTML,
+        // the timeline parses message types out of CSS classes, the filter
+        // toolbar hides message types, in-page search highlights matches.
+        //
+        // Delegated listeners (bound on `document`) and everything bound to
+        // the toolbar or the floating buttons survive a swap untouched and
+        // must NOT be registered here.
+        //
+        // Defined before any component script so registration never depends
+        // on include order.
+        (function () {
+            const hooks = [];
+            window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+            window.claudeLogRehydrate = function (root) {
+                hooks.forEach(function (fn) {
+                    // One broken hook must not strand the rest — a page that
+                    // updated but lost its timeline is better than one that
+                    // silently stopped updating.
+                    try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                });
+            };
+        })();
+    </script>
+
     <h1 id="title">{{ title }}</h1>
 
     {% if page_info %}
@@ -288,6 +316,9 @@
 
             // Timezone conversion (included as component)
             {% include 'components/timezone_converter.js' %}
+
+            // Live update (no-op unless served over http -- see the file)
+            {% include 'components/live_update.js' %}
 
             // Debug UUID toggle
             debugButton.addEventListener('click', function () {

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -249,7 +249,18 @@
     {% endif %}
     {% endmacro %}
 
-    {% for root in roots %}{{ render_message(root) }}{% endfor %}
+    {#
+      The message tree lives in one addressable container so a client can
+      replace it wholesale — that is what `serve --watch` needs to update
+      a page in place without a navigation, and it keeps scroll position
+      because everything above the viewport is untouched.
+
+      Deliberately unstyled: `body` is already the 1200px centred column,
+      so a plain block wrapper is layout-neutral (verified by comparing
+      full-page screenshots and the first message's box before and after
+      adding it).
+    #}
+    <div id="transcript">{% for root in roots %}{{ render_message(root) }}{% endfor %}</div>
 
     {% if resume_command %}
     <button class="resume-session floating-btn" id="resumeSession" data-command="{{ resume_command }}"

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -295,6 +295,15 @@
         title="Resume session: copy the command that resumes this session in Claude Code"
         aria-label="Resume session">▶️</button>
     {% endif %}
+    {#
+      Follow toggle for `serve --watch`. Rendered unconditionally but
+      hidden by CSS until live_update.js finds it can actually poll, so
+      the markup stays identical between a served page and the same file
+      opened from disk.
+    #}
+    <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+        title="Follow new messages as they arrive" aria-label="Follow new messages"
+        aria-pressed="false">⏬</button>
     <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
     <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
     <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>

--- a/claude_code_log/html/templates/transcript.html
+++ b/claude_code_log/html/templates/transcript.html
@@ -913,24 +913,30 @@
             // Apply all filters on page load
             applyFilter();
 
-            // Fold/unfold functionality with horizontal fold bars
-            const foldBarSections = document.querySelectorAll('.fold-bar-section');
+            // Fold/unfold functionality with horizontal fold bars.
+            //
+            // Delegated on `document` rather than bound per section, because
+            // a live update (`serve --watch`) replaces fold bars: a card's
+            // bar carries its descendant count, so every append re-renders
+            // the ancestors' bars, and the container swap replaces all of
+            // them. Bound directly, those listeners died with the elements
+            // and the fold controls silently stopped responding — measured:
+            // one update was enough to leave every bar on the page inert.
+            document.addEventListener('click', function (event) {
+                const section = event.target.closest('.fold-bar-section');
+                if (!section) return;
+                event.stopPropagation();
+                const action = section.getAttribute('data-action');
+                const targetId = section.getAttribute('data-target');
+                const isFolded = section.classList.contains('folded');
 
-            foldBarSections.forEach(section => {
-                section.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    const action = this.getAttribute('data-action');
-                    const targetId = this.getAttribute('data-target');
-                    const isFolded = this.classList.contains('folded');
-
-                    if (action === 'fold-one') {
-                        // Fold/unfold immediate children only
-                        handleFoldOne(targetId, isFolded, this);
-                    } else if (action === 'fold-all') {
-                        // Fold/unfold all descendants recursively
-                        handleFoldAll(targetId, isFolded, this);
-                    }
-                });
+                if (action === 'fold-one') {
+                    // Fold/unfold immediate children only
+                    handleFoldOne(targetId, isFolded, section);
+                } else if (action === 'fold-all') {
+                    // Fold/unfold all descendants recursively
+                    handleFoldAll(targetId, isFolded, section);
+                }
             });
 
             // Update tooltip based on fold state
@@ -1055,6 +1061,42 @@
 
             // Apply initial fold state
             setInitialFoldState();
+
+            // Re-sync a fold bar to what its children container is actually
+            // doing. A live update re-renders a card whenever its descendant
+            // count changes — which is every ancestor of every append — and
+            // the replacement arrives with the server's default icons, not
+            // the state the user left it in. The children container is never
+            // replaced, so its own `display` is the truth; without this the
+            // bar claims "unfolded" over a hidden subtree, and the next
+            // click folds what is already folded and appears to do nothing.
+            function syncFoldBar(card) {
+                const foldBar = card.querySelector(':scope > .fold-bar');
+                if (!foldBar) return;
+                const cc = getChildrenContainer(card);
+                const oneSection = foldBar.querySelector('.fold-one-level');
+                const allSection = foldBar.querySelector('.fold-all-levels');
+                if (!cc || cc.style.display === 'none') {
+                    setSectionState(oneSection, true, '⏵');
+                    setSectionState(allSection, true, '⏵⏵');
+                    return;
+                }
+                // Immediate children are visible; `fold-all` reads as open
+                // only when their own subtrees are open too.
+                const kids = getImmediateChildMessages(card);
+                const allOpen = kids.every(child => {
+                    const childCc = getChildrenContainer(child);
+                    return !childCc || childCc.style.display !== 'none';
+                });
+                setSectionState(oneSection, false, '⏷');
+                setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+            }
+            if (window.claudeLogOnRehydrate) {
+                window.claudeLogOnRehydrate(function (root) {
+                    if (root.matches && root.matches('.message')) syncFoldBar(root);
+                    root.querySelectorAll('.message').forEach(syncFoldBar);
+                });
+            }
 
             // Unfold any folded ancestors so an anchor target (e.g. a tool_use
             // jumped to from the session index) is actually visible. In the

--- a/claude_code_log/migrations/011_cached_file_size.sql
+++ b/claude_code_log/migrations/011_cached_file_size.sql
@@ -1,0 +1,24 @@
+-- Detect appends the mtime tolerance hides
+-- Migration: 011
+-- Description: Add a `source_size` column to `cached_files`.
+-- Freshness compared source mtimes with a 1.0s tolerance, which exists
+-- because filesystem timestamp granularity varies (and is coarse on
+-- some network filesystems). The cost is that a write landing within a
+-- second of the mtime recorded at cache time is invisible: appending to
+-- a transcript and converting immediately alternates between seeing and
+-- missing the change. It fails in the worst shape for a watch loop --
+-- the last message of a turn, landing just after a tick and followed by
+-- silence, stays stranded until something else touches the file.
+--
+-- Size is exact, and free: get_modified_files() already stats every
+-- file, so st_size costs no extra syscall. The rule becomes "stale if
+-- the size differs OR the mtime moved past tolerance", which is
+-- strictly tightening -- it can only mark more files stale, never
+-- fewer -- so it cannot invalidate anything the old rule accepted for
+-- good reason.
+--
+-- Backward-compatible in the same shape as 007: existing rows get NULL
+-- and fall back to the mtime-only check, so a populated cache does not
+-- mass-invalidate. Rows written from here on carry the size.
+
+ALTER TABLE cached_files ADD COLUMN source_size INTEGER;

--- a/claude_code_log/migrations/012_message_lookup_indexes.sql
+++ b/claude_code_log/migrations/012_message_lookup_indexes.sql
@@ -13,7 +13,7 @@
 --   get_parent_uuid_dependents     21.5 ms -> 0.6 ms   (project_id, _parent_uuid)
 --   get_request_id_entries         17.0 ms -> 0.3 ms   (project_id, _request_id)
 --   get_metadata_target_files      14.5 ms -> 0.2 ms   partial, on type
---   get_session_file_map           16.8 ms -> 2.5 ms   (project_id, session_id, file_id)
+--   get_session_file_map           16.8 ms -> 2.5 ms   (project_id, session_id, …)
 --
 -- `get_uuid_owners` is the instructive one: an `idx_messages_uuid(_uuid)`
 -- index has existed since 001, but the query filters `project_id = ? AND
@@ -55,5 +55,27 @@ CREATE INDEX IF NOT EXISTS idx_messages_project_request_id
 CREATE INDEX IF NOT EXISTS idx_messages_project_metadata_type
     ON messages(project_id, type) WHERE type IN ('summary', 'ai-title');
 
-CREATE INDEX IF NOT EXISTS idx_messages_project_session_file
-    ON messages(project_id, session_id, file_id);
+-- `timestamp` sits before `file_id` deliberately, and it is what makes
+-- this index serve a second caller outside the refresh entirely:
+-- `load_session_entries` / `export_session_to_jsonl` (the TUI, and
+-- rendering an archived session) filter `project_id AND session_id` but
+-- order by `timestamp`. Given only (project_id, session_id, file_id) the
+-- planner takes the *timestamp* index instead — the sort comes free and
+-- it filters session_id row by row — and walks the whole project to load
+-- one session: 84.5 ms for the twelve busiest sessions of a 19k-row
+-- archive. With `timestamp` in the index the seek and the ordering are
+-- both satisfied, no sort is needed, and the same work takes **7.2 ms**.
+-- End to end the method also decompresses and validates its entries, so
+-- what a caller sees is 21.7 ms -> 15.0 ms per session; the extra column
+-- costs 0.4 MB on a 45 MB cache.
+--
+-- (Statistics were the other candidate fix and are worse: `ANALYZE` gets
+-- to 15.8 ms, `PRAGMA optimize` writes partial stats that do not change
+-- the plan at all, and either way the plan then depends on when stats
+-- were last gathered. An index that dominates needs no stats.)
+--
+-- Verified not to change the order rows come back in — 234 sessions,
+-- 29,605 rows sharing a timestamp with another row, 1,237 NULL
+-- timestamps, zero ordering differences.
+CREATE INDEX IF NOT EXISTS idx_messages_project_session_ts
+    ON messages(project_id, session_id, timestamp, file_id);

--- a/claude_code_log/migrations/012_message_lookup_indexes.sql
+++ b/claude_code_log/migrations/012_message_lookup_indexes.sql
@@ -1,0 +1,59 @@
+-- Let the incremental refresh's lookups use an index
+-- Migration: 012
+-- Description: Composite indexes on `messages` for the lookups the
+-- incremental cache refresh makes on every watch tick.
+--
+-- All of them were scanning the whole project. `EXPLAIN QUERY PLAN` on a
+-- real 38,706-row archive showed each as
+--     SEARCH m USING INDEX idx_messages_project_timestamp (project_id=?)
+-- i.e. walking every row the project has, to read a handful. Measured
+-- per call on that archive, before -> after:
+--
+--   get_uuid_owners                17.2 ms -> 0.9 ms   (project_id, _uuid)
+--   get_parent_uuid_dependents     21.5 ms -> 0.6 ms   (project_id, _parent_uuid)
+--   get_request_id_entries         17.0 ms -> 0.3 ms   (project_id, _request_id)
+--   get_metadata_target_files      14.5 ms -> 0.2 ms   partial, on type
+--   get_session_file_map           16.8 ms -> 2.5 ms   (project_id, session_id, file_id)
+--
+-- `get_uuid_owners` is the instructive one: an `idx_messages_uuid(_uuid)`
+-- index has existed since 001, but the query filters `project_id = ? AND
+-- _uuid IN (...)` and SQLite uses one index per table reference, so it
+-- took the project one and scanned. The composite covers both terms.
+--
+-- The session index below is double-edged and its callers know it: as
+-- well as serving `get_session_file_map` (which must touch every session
+-- anyway, and now does so as an index-only scan), it gives the planner a
+-- way to satisfy a bare `session_id IS NOT NULL` as a range scan over
+-- every session-bearing row — which it will happily prefer to seeking
+-- the handful of uuids a query actually asked for. Three queries were
+-- measurably *slower* with this index until that predicate moved out of
+-- SQL and into Python; see the comment on `get_uuid_owners`.
+--
+-- The metadata index is partial (288 of 38,706 rows here), which is why
+-- it costs 0.01% rather than the ~1% a full index on `type` would.
+--
+-- Cost, measured on a 49 MB archive: the cache grows 39.5 MB -> 42.8 MB
+-- (**+8.4%**), and the write path — where rewriting a file's rows is a
+-- watch tick's largest item — does not regress: a cold conversion goes
+-- 5.85 s -> 5.79 s, because five more indexes on an INSERT are small
+-- next to compressing the row's content blob. Ticks over the same
+-- archive: 0.379 s -> 0.317 s (full rewrite), 0.267 s -> 0.228 s
+-- (resumed).
+--
+-- Pure performance: no column changes, nothing to backfill, and an older
+-- library reading this database simply ignores them.
+
+CREATE INDEX IF NOT EXISTS idx_messages_project_uuid
+    ON messages(project_id, _uuid);
+
+CREATE INDEX IF NOT EXISTS idx_messages_project_parent_uuid
+    ON messages(project_id, _parent_uuid);
+
+CREATE INDEX IF NOT EXISTS idx_messages_project_request_id
+    ON messages(project_id, _request_id);
+
+CREATE INDEX IF NOT EXISTS idx_messages_project_metadata_type
+    ON messages(project_id, type) WHERE type IN ('summary', 'ai-title');
+
+CREATE INDEX IF NOT EXISTS idx_messages_project_session_file
+    ON messages(project_id, session_id, file_id);

--- a/claude_code_log/render_pool.py
+++ b/claude_code_log/render_pool.py
@@ -66,6 +66,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from .utils import atomic_write_text
+
 if TYPE_CHECKING:
     from .models import RenderingDepth, TranscriptEntry
 
@@ -567,9 +569,7 @@ def _render_unit_worker(
             )
 
         # errors="replace" for lone-surrogate safety — see issue #139.
-        (output_dir / unit.file_name).write_text(
-            content, encoding="utf-8", errors="replace"
-        )
+        atomic_write_text(output_dir / unit.file_name, content)
     except Exception:
         return unit.kind, unit.key, traceback.format_exc(), None
     delta = (

--- a/claude_code_log/server.py
+++ b/claude_code_log/server.py
@@ -21,22 +21,47 @@ Design notes, in case the shape looks arbitrary:
   exists, not after.
 * **The search core is HTTP-free.** Everything interesting lives in
   `search.py` as plain functions; this module is the adapter.
+* **File responses carry `X-Content-Revision`.** The live page asks "did
+  this change?" with a HEAD, and the stock validators cannot always
+  answer: `Last-Modified` has one-second granularity and `Content-Length`
+  is blind to an edit that keeps the size. See `_content_revision`.
 """
 
 from __future__ import annotations
 
 import functools
+import hashlib
 import http.server
 import json
+import os
+import stat
 import threading
+import time
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, BinaryIO, Callable, Optional
 
 from .cache import get_library_version
 
 # Requests under this prefix are the JSON API and never hit the filesystem.
 # Reserved so a project directory literally named `api` can't shadow it.
 API_PREFIX = "/api/"
+
+# The header the live page adds to its change comparison (see
+# `_content_revision` and `live_update.js`). Deliberately *not* `ETag`:
+# the stock `send_head` skips its `If-Modified-Since` check whenever the
+# request carries an `If-None-Match`, and it never evaluates one — so
+# advertising an ETag would make browsers stop getting 304s on the
+# multi-MB pages that make 304s worth having.
+REVISION_HEADER = "X-Content-Revision"
+
+# How long a file's mtime must have been in the past before a cached
+# digest for it can be trusted. A write landing after we hashed can only
+# reuse the same (mtime_ns, size) key if the filesystem's timestamp
+# resolution is coarse enough to give it the same mtime — so once the
+# recorded mtime is a full second old, no later write can hide behind it,
+# whatever the resolution. Below that, re-hash: an actively-written page
+# is exactly the case this header exists for.
+_REVISION_SETTLE_NS = 1_000_000_000
 
 
 class ArchiveHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
@@ -47,6 +72,16 @@ class ArchiveHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     allowed_hosts: frozenset[str] = frozenset()
     server_version = f"claude-code-log/{get_library_version()}"
     sys_version = ""
+
+    # Digest of the file this request is answering with, computed in
+    # `send_head` and emitted by `end_headers`. `None` for everything
+    # that is not a file response (the API, errors, directory listings).
+    _revision: Optional[str] = None
+
+    # (path, mtime_ns, size) -> digest, shared by every request. Written
+    # from several server threads: dict get/set are atomic, and the worst
+    # a race can do is hash the same file twice.
+    _revision_cache: dict[tuple[str, int, int], str] = {}
 
     # ---- security -------------------------------------------------------
 
@@ -92,6 +127,67 @@ class ArchiveHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         self.wfile.write(body)
+
+    # ---- content revision -----------------------------------------------
+
+    def _content_revision(self, path: str) -> Optional[str]:
+        """A validator derived from the bytes, not from the metadata.
+
+        `live_update.js` polls a HEAD of its own URL and re-fetches when
+        the response's identity moves. `Last-Modified` alone misses two
+        conversions inside one second (HTTP dates are second-granular),
+        and adding `Content-Length` still misses a rewrite that changes
+        content without changing size — a re-render where a counter, a
+        status word or a timestamp keeps its width. Watch mode produces
+        rewrites a few hundred ms apart, so both gaps are reachable.
+
+        Hashing the file closes them for any filesystem. It is not free
+        on a 27 MB page, so a settled file (see `_REVISION_SETTLE_NS`)
+        answers from the cache and only a file being written right now
+        is re-read — which is the case that has to be exact.
+        """
+        try:
+            st = os.stat(path)
+        except OSError:
+            return None
+        if not stat.S_ISREG(st.st_mode):
+            return None
+
+        key = (path, st.st_mtime_ns, st.st_size)
+        settled = time.time_ns() - st.st_mtime_ns > _REVISION_SETTLE_NS
+        if settled:
+            cached = self._revision_cache.get(key)
+            if cached is not None:
+                return cached
+
+        digest = hashlib.blake2b(digest_size=16)
+        try:
+            with open(path, "rb") as handle:
+                for chunk in iter(lambda: handle.read(1 << 20), b""):
+                    digest.update(chunk)
+        except OSError:
+            return None
+        revision = digest.hexdigest()
+
+        if settled:
+            # One entry per served file; a long-running server over a
+            # whole archive would otherwise accumulate them forever.
+            if len(self._revision_cache) > 256:
+                self._revision_cache.clear()
+            self._revision_cache[key] = revision
+        return revision
+
+    def send_head(self) -> Optional[BinaryIO]:
+        self._revision = None
+        path = self.translate_path(self.path)
+        if not os.path.isdir(path):
+            self._revision = self._content_revision(path)
+        return super().send_head()
+
+    def end_headers(self) -> None:
+        if self._revision is not None:
+            self.send_header(REVISION_HEADER, self._revision)
+        super().end_headers()
 
     def _split_query(self) -> tuple[str, dict[str, str]]:
         from urllib.parse import parse_qs, urlparse

--- a/claude_code_log/tui.py
+++ b/claude_code_log/tui.py
@@ -36,7 +36,7 @@ from .converter import (
     load_directory_transcripts,
 )
 from .renderer import get_renderer
-from .utils import get_project_display_name
+from .utils import atomic_write_text, get_project_display_name
 
 
 class ProjectSelector(App[Path]):
@@ -1876,7 +1876,7 @@ class SessionBrowser(App[Optional[str]]):
                 # is the worst outcome (worse than the CLI's loud crash,
                 # which is how #139 surfaced in the first place).
                 scrubbed = scrub_surrogates(session_content) or session_content
-                session_file.write_text(scrubbed, encoding="utf-8", errors="replace")
+                atomic_write_text(session_file, scrubbed)
                 return session_file
         except Exception:
             return None

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -955,6 +956,29 @@ def generate_unified_diff(old_string: str, new_string: str) -> str:
     return "".join(diff_lines).rstrip("\n")
 
 
+# Windows refuses to replace a file another process holds open unless
+# that process opened it with FILE_SHARE_DELETE, which Python's `open`
+# does not — so a reader (an editor, a vault indexer, the browser poll
+# this helper exists for) makes `os.replace` fail with PermissionError
+# until it closes, rather than the write being torn. A read of even a
+# 27 MB page is short, so a brief retry outlasts one; POSIX never takes
+# this path, where the replace succeeds with readers mid-read.
+_REPLACE_ATTEMPTS = 10
+_REPLACE_BACKOFF_S = 0.02
+
+
+def _replace_with_retry(tmp_path: Path, path: Path) -> None:
+    """`os.replace`, retried briefly past a concurrent reader on Windows."""
+    for attempt in range(_REPLACE_ATTEMPTS):
+        try:
+            os.replace(tmp_path, path)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_ATTEMPTS - 1:
+                raise
+            time.sleep(_REPLACE_BACKOFF_S)
+
+
 def atomic_write_text(
     path: Path, content: str, *, encoding: str = "utf-8", errors: str = "replace"
 ) -> None:
@@ -984,6 +1008,9 @@ def atomic_write_text(
     write through it, and would clobber a fifo or device node outright —
     both worse surprises than a non-atomic write to something the user
     deliberately put there.
+
+    On Windows the replace is retried briefly, because a reader holding
+    the target open blocks it there — see `_replace_with_retry`.
     """
     if path.is_symlink() or (path.exists() and not path.is_file()):
         path.write_text(content, encoding=encoding, errors=errors)
@@ -992,7 +1019,7 @@ def atomic_write_text(
     tmp_path = path.parent / f".{path.name}.{os.getpid()}.tmp"
     try:
         tmp_path.write_text(content, encoding=encoding, errors=errors)
-        os.replace(tmp_path, path)
+        _replace_with_retry(tmp_path, path)
     except BaseException:
         # Includes KeyboardInterrupt: a half-written temp file left in an
         # output directory is litter that the next run would not clean up.

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Utility functions for message filtering and processing."""
 
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -942,3 +943,51 @@ def generate_unified_diff(old_string: str, new_string: str) -> str:
         diff_lines = diff_lines[2:]
 
     return "".join(diff_lines).rstrip("\n")
+
+
+def atomic_write_text(
+    path: Path, content: str, *, encoding: str = "utf-8", errors: str = "replace"
+) -> None:
+    """Write ``content`` to ``path`` so a concurrent reader never sees a partial file.
+
+    ``Path.write_text`` truncates and then writes, so anything reading the
+    file during the write gets a torn document. That is a narrow race for
+    a one-shot conversion, but watch mode rewrites the same file every few
+    seconds while an editor, a vault indexer, or a browser poll re-reads
+    it, which makes it routine — and a 27 MB session page is a wide window
+    to be caught in.
+
+    The fix is the one ``image_export.export_image`` already uses: write a
+    uniquely-named temp file beside the target, then ``os.replace`` it into
+    position. ``os.replace`` is atomic on POSIX and on Windows, and "beside
+    the target" matters — a temp file on another filesystem would make the
+    replace a copy, which is not atomic.
+
+    The temp name carries the pid so concurrent render workers writing the
+    same path (the fan-out can, harmlessly, since they write identical
+    bytes) cannot clobber each other's partial file. It is dot-prefixed so
+    a crash between write and replace leaves something obviously
+    disposable rather than a plausible-looking output file.
+
+    Falls back to a plain write when the target exists but is not a
+    regular file. ``os.replace`` would *replace* a symlink rather than
+    write through it, and would clobber a fifo or device node outright —
+    both worse surprises than a non-atomic write to something the user
+    deliberately put there.
+    """
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        path.write_text(content, encoding=encoding, errors=errors)
+        return
+
+    tmp_path = path.parent / f".{path.name}.{os.getpid()}.tmp"
+    try:
+        tmp_path.write_text(content, encoding=encoding, errors=errors)
+        os.replace(tmp_path, path)
+    except BaseException:
+        # Includes KeyboardInterrupt: a half-written temp file left in an
+        # output directory is litter that the next run would not clean up.
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise

--- a/claude_code_log/utils.py
+++ b/claude_code_log/utils.py
@@ -307,6 +307,16 @@ def _split_real_path_for_join(real_path_str: str) -> list[str]:
     return list(p_posix.parts)
 
 
+def real_path_to_project_dirname(cwd: Path) -> str:
+    """Encode a real path the way Claude Code names its project directory.
+
+    ``/home/joe/proj`` → ``-home-joe-proj``. The inverse,
+    `project_dir_to_real_path`, is lossy and needs the cache to
+    disambiguate; this direction is not.
+    """
+    return str(cwd).replace("/", "-").replace("\\", "-")
+
+
 def project_dir_to_real_path(
     project_dir: Path,
     cached_working_directories: Optional[list[str]] = None,

--- a/claude_code_log/watch.py
+++ b/claude_code_log/watch.py
@@ -189,6 +189,14 @@ class WatchEngine:
         self.stats.conversions += 1
         try:
             self.on_change(set(delivered))
+        except (KeyboardInterrupt, SystemExit):
+            # Asking the watch to stop is not a conversion failing. The
+            # `watch` command runs this loop on the main thread, so a
+            # Ctrl+C lands wherever the thread is — on an active project
+            # that is usually inside the conversion rather than the sleep
+            # below — and swallowing it here would leave the operator
+            # pressing Ctrl+C until one happened to hit `stop.wait`.
+            raise
         except BaseException as exc:  # noqa: BLE001 - reported, never fatal
             # One bad conversion must not end the watch. A transcript can
             # be mid-write, a disk can fill, a plugin can throw; the next

--- a/claude_code_log/watch.py
+++ b/claude_code_log/watch.py
@@ -1,0 +1,231 @@
+"""Watch a project's transcripts and re-convert as they grow.
+
+The engine is deliberately small and knows nothing about HTTP, the CLI,
+or rendering. It answers one question on a timer — *might something have
+changed?* — debounces the answer, and calls a callback. Everything else
+is the callback's problem.
+
+That division is the point. The watcher's scan is a cheap trigger, not a
+source of truth: a false positive costs one no-op conversion (~0.2s on a
+warm cache), while the conversion itself already knows precisely what is
+stale. Duplicating the cache's freshness semantics out here would mean
+two implementations that could disagree, and the cache is the one that
+gets it right — since migration 011 it compares size as well as mtime,
+so it no longer misses an append that lands inside the mtime tolerance.
+
+Why polling rather than inotify/FSEvents: no dependency, works on network
+filesystems, and at watch scope (one project, a few dozen files) a scan
+is one `scandir` per directory. The latency floor that matters is the
+conversion's, not the detector's.
+
+Testability comes from injecting the clock and from splitting "poll"
+(`tick`) from "wait" (`run`). Unit tests call `tick()` by hand against a
+fake clock and never sleep; a watcher tested with real timing is a
+flaky-test generator.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+# One poll every quarter second. Below the debounce quiet period, so the
+# debounce (not the poll rate) decides latency.
+DEFAULT_POLL_INTERVAL = 0.25
+
+# Claude Code appends several entries per turn, each landing within a
+# second or so of the last. Without a quiet period every one of them
+# would trigger its own conversion, and most of a turn would be spent
+# rendering states nobody sees.
+DEFAULT_QUIET_PERIOD = 0.3
+
+# ...but a long unbroken stream of appends must still surface. This caps
+# how long a change can sit undelivered while its neighbours keep
+# resetting the quiet period.
+DEFAULT_MAX_LATENCY = 2.0
+
+# Files whose content feeds a render. Agent sidecars are included because
+# spawn discovery reads them, and one can appear without the trunk
+# transcript being touched at all (#213).
+WATCHED_GLOBS = ("**/*.jsonl", "**/agent-*.meta.json")
+
+# The watcher writes generated output into the tree it is watching, and
+# atomic writes leave a `.name.pid.tmp` file there for an instant. Seeing
+# our own output as a change would make the loop feed itself forever.
+IGNORED_PREFIXES = (".",)
+
+
+FileStamp = tuple[int, int]
+"""(size, mtime_ns) — the pair a change has to preserve to go unnoticed."""
+
+
+def scan(roots: Iterable[Path]) -> dict[Path, FileStamp]:
+    """Stamp every watched file under `roots`.
+
+    Missing files are simply absent from the result, which makes deletion
+    a change like any other. A file that vanishes mid-scan is skipped
+    rather than raising: the next tick will see the settled state.
+    """
+    stamps: dict[Path, FileStamp] = {}
+    for root in roots:
+        for pattern in WATCHED_GLOBS:
+            for path in root.glob(pattern):
+                if path.name.startswith(IGNORED_PREFIXES):
+                    continue
+                try:
+                    st = path.stat()
+                except OSError:
+                    continue
+                stamps[path] = (st.st_size, st.st_mtime_ns)
+    return stamps
+
+
+@dataclass
+class WatchStats:
+    """Counters worth surfacing when someone asks why nothing happened."""
+
+    polls: int = 0
+    changes_seen: int = 0
+    conversions: int = 0
+    errors: int = 0
+
+
+@dataclass
+class _Pending:
+    paths: set[Path] = field(default_factory=set[Path])
+    first_seen: float = 0.0
+    last_seen: float = 0.0
+
+
+class WatchEngine:
+    """Poll `roots`, debounce, and call `on_change` with the changed paths.
+
+    `on_change` receives the set of paths that changed since the last
+    delivery. It is called on the engine's own thread, one call at a
+    time — never concurrently with itself — so it does not need to be
+    reentrant, and a slow conversion simply delays the next poll rather
+    than piling up.
+    """
+
+    def __init__(
+        self,
+        roots: Iterable[Path],
+        on_change: Callable[[set[Path]], None],
+        *,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        quiet_period: float = DEFAULT_QUIET_PERIOD,
+        max_latency: float = DEFAULT_MAX_LATENCY,
+        clock: Callable[[], float] = time.monotonic,
+        on_error: Optional[Callable[[BaseException], None]] = None,
+    ) -> None:
+        self.roots = [Path(r) for r in roots]
+        self.on_change = on_change
+        self.poll_interval = poll_interval
+        self.quiet_period = quiet_period
+        self.max_latency = max_latency
+        self._clock = clock
+        self._on_error = on_error
+        self.stats = WatchStats()
+        self._stamps: dict[Path, FileStamp] = {}
+        self._pending = _Pending()
+        self._primed = False
+
+    # ---- state ----------------------------------------------------------
+
+    def prime(self) -> None:
+        """Adopt the current tree as the baseline, without firing.
+
+        Called once before the loop so an existing archive isn't reported
+        as one enormous change on the first tick.
+        """
+        self._stamps = scan(self.roots)
+        self._primed = True
+
+    @property
+    def pending_paths(self) -> frozenset[Path]:
+        return frozenset(self._pending.paths)
+
+    # ---- the unit of work -----------------------------------------------
+
+    def tick(self) -> Optional[set[Path]]:
+        """Poll once. Returns the delivered paths, or None if nothing fired.
+
+        Separating "poll" from "wait" is what makes this testable: tests
+        drive `tick()` against a fake clock and never sleep.
+        """
+        if not self._primed:
+            self.prime()
+
+        self.stats.polls += 1
+        now = self._clock()
+
+        stamps = scan(self.roots)
+        changed = {
+            path for path, stamp in stamps.items() if self._stamps.get(path) != stamp
+        }
+        changed |= set(self._stamps) - set(stamps)  # deletions
+        self._stamps = stamps
+
+        if changed:
+            self.stats.changes_seen += len(changed)
+            if not self._pending.paths:
+                self._pending.first_seen = now
+            self._pending.paths |= changed
+            self._pending.last_seen = now
+
+        if not self._pending.paths:
+            return None
+
+        quiet_enough = now - self._pending.last_seen >= self.quiet_period
+        waited_long_enough = now - self._pending.first_seen >= self.max_latency
+        if not (quiet_enough or waited_long_enough):
+            return None
+
+        delivered = self._pending.paths
+        self._pending = _Pending()
+        self.stats.conversions += 1
+        try:
+            self.on_change(set(delivered))
+        except BaseException as exc:  # noqa: BLE001 - reported, never fatal
+            # One bad conversion must not end the watch. A transcript can
+            # be mid-write, a disk can fill, a plugin can throw; the next
+            # tick usually succeeds, and a dead watcher is worse than a
+            # skipped render.
+            self.stats.errors += 1
+            if self._on_error is None:
+                raise
+            self._on_error(exc)
+        return set(delivered)
+
+    # ---- the loop -------------------------------------------------------
+
+    def run(self, stop: Optional[threading.Event] = None) -> None:
+        """Tick until `stop` is set (or forever).
+
+        Primes only if the caller hasn't. Priming unconditionally here
+        would make the baseline moment depend on when this thread got
+        scheduled, so a change landing between `run_in_thread` returning
+        and this line would be absorbed into the baseline and never
+        reported. Callers that care — anything that starts the watch and
+        then does something observable — should `prime()` first.
+        """
+        stop = stop or threading.Event()
+        if not self._primed:
+            self.prime()
+        while not stop.is_set():
+            self.tick()
+            # Event.wait doubles as the sleep so a stop is instant rather
+            # than up to one poll interval late.
+            if stop.wait(self.poll_interval):
+                break
+
+    def run_in_thread(self, stop: threading.Event) -> threading.Thread:
+        """Start `run` on a daemon thread and return it."""
+        thread = threading.Thread(
+            target=self.run, args=(stop,), name="claude-code-log-watch", daemon=True
+        )
+        thread.start()
+        return thread

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1023,6 +1023,31 @@ cached rows are an exact prefix of its current rows, i.e. a pure append.
 output present, the session's growth makes it stale and the conversion
 falls to the streaming path instead.
 
+**What the tick then spends its time on** was, once §2.12 was reachable,
+no longer the render (12% of it) but the cache refresh. Profiled on the
+803MB / 217-file reference archive appending to its largest session file
+(39.7MB, 207 entries), a 1.03s tick materialised *the same entries three
+times*: §2.14's refresh parsed the file from source (488ms, of which
+307ms re-serialising and re-inserting every row), then the closure load
+rebuilt them from those rows (129ms), then the session-scoped render
+rebuilt them again (141ms). Two changes removed most of that:
+
+- **A per-conversion parsed-entry store** (`entry_store.py`, §2.16)
+  serves the refresh's list to the other two consumers: closure load
+  255ms → 7ms.
+- **The staleness sweep stopped scaling with the session count.**
+  `get_stale_sessions` ran two SQLite queries *per session* through
+  `is_transcript_stale`, and each of those called `get_library_version()`,
+  which re-parsed installed package metadata every time — 173 calls and
+  35ms a tick. The version lookup is now `lru_cache`d (it cannot change
+  inside a process) and the two tables are read once and joined in
+  Python: 85ms → 4.5ms.
+
+Tick: **1.03s → 0.717s**, with `load_transcript`'s full re-parse and
+full row rewrite of the modified file (483ms) now the remaining bulk —
+addressable only by parsing and writing the appended tail alone, which
+needs a stored prefix hash and is not built.
+
 **The served page updates itself** via
 `html/templates/components/live_update.js`, active only over `http(s)` —
 a `file://` page cannot fetch anything, not even its own URL, so the
@@ -1050,6 +1075,53 @@ the only foldable node.
 
 Measured: ~1s from append to visible; a 7.0MB session page costs 202ms to
 swap (31 fetch / 63 parse / 17 swap / 91 layout) and ~1ms per idle poll.
+
+
+### 2.16 Parsed-entry store
+
+`entry_store.py`. A conversion that refreshes the cache incrementally
+(§2.14) parses each modified file from source, and then loads those same
+entries back out of the rows it has just written — once for the closure
+load and once for the session-scoped render (§2.12). Each rebuild is a
+`zlib.decompress` + `json.loads` + Pydantic validation pass over the
+whole file, so a one-line append to a 39.7MB session paid it twice at
+~130ms each. The store holds the list the first pass produced and serves
+it to the other two.
+
+Four properties keep the invalidation surface at zero, and they are the
+reason it is a parameter rather than a memo:
+
+- **One store per conversion, threaded explicitly.** Never a global, and
+  never hung off `CacheManager` — the TUI keeps one of those across many
+  conversions.
+- **Only `_incremental_cache_refresh` fills it**, with the files it just
+  parsed, and `convert_jsonl_to` drops it after Phase 1b. A cold or full
+  conversion therefore stores nothing, and the streaming path (§2.13) is
+  deliberately never handed one: its bounded residency depends on
+  dropping each page's entries before the next page loads, which a store
+  spanning pages would defeat. What it holds is bounded by *what
+  changed*, not by the archive.
+- **Hits are verified against the file.** `get` re-stats and compares
+  `(size, mtime_ns)` against the stamp captured *before* the parse. A
+  stamp taken before the parse can only be older than the entries
+  describe, so a file that grew mid-parse declines to the cache rather
+  than serving a list its stamp misdescribes.
+- **Handouts are deep copies**, because the pipeline mutates entries in
+  place: `_integrate_agent_entries` appends `#agent-{id}` to `sessionId`
+  and is *not* idempotent, and dedup re-parents around dropped copies.
+  Today each consumer gets freshly deserialised objects; serving the same
+  objects twice would render `…#agent-X#agent-X`. The copy stays cheap
+  because the bulk of an entry is immutable strings, which `deepcopy`
+  shares rather than copies — 2.0ms and 0.83MB for the 207-entry, 39.7MB
+  session, against 123ms to rebuild it from the cache.
+
+Held to byte-identity with the store disabled, over repeated appends on a
+fixture whose 170 sidechain entries exercise the mutation above
+(`test/test_entry_store.py`), with the copy isolation pinned by a test
+that fails with exactly the doubled suffix when the copy is removed.
+`CLAUDE_CODE_LOG_ENTRY_STORE=0` is the kill switch; a per-file memory
+valve at `put` time declines to hold a file when available memory is
+under 6x its bytes, and `=1` overrides that valve.
 
 ---
 

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1043,10 +1043,13 @@ rebuilt them again (141ms). Two changes removed most of that:
   inside a process) and the two tables are read once and joined in
   Python: 85ms → 4.5ms.
 
-Tick: **1.03s → 0.717s**, with `load_transcript`'s full re-parse and
-full row rewrite of the modified file (483ms) now the remaining bulk —
-addressable only by parsing and writing the appended tail alone, which
-needs a stored prefix hash and is not built.
+Tick: **1.03s → 0.717s**. `load_transcript`'s full re-parse and full row
+rewrite of the modified file (483ms) was then the remaining bulk, and
+§2.16's cross-tick resumption takes it to ~35ms: **0.257s** steady state
+in a resident `watch`. What is left at that point is the cache queries
+around the refresh — `get_session_file_map` ×3 (50ms), `get_file_states`
+×2 (45ms, still fetching every row's blob to hash it, now redundant with
+the prefix digest), `get_uuid_owners` ×4 (37ms).
 
 **The served page updates itself** via
 `html/templates/components/live_update.js`, active only over `http(s)` —
@@ -1122,6 +1125,61 @@ that fails with exactly the doubled suffix when the copy is removed.
 `CLAUDE_CODE_LOG_ENTRY_STORE=0` is the kill switch; a per-file memory
 valve at `put` time declines to hold a file when available memory is
 under 6x its bytes, and `=1` overrides that valve.
+
+**Owned across ticks, a store does more.** `watch` keeps one for the life
+of the loop and passes it to every conversion (`convert_jsonl_to` takes
+an optional store; a caller-owned one outlives the call, an internally
+made one doesn't). That turns the store from a within-tick cache into a
+*resumption* point, via a second, prefix-pinned mode:
+
+- **The parse resumes.** `put_prefix` records the byte offset the parse
+  consumed plus a BLAKE2b digest of the bytes below it, and the next tick
+  hashes that prefix and reads only the tail. The digest is a *stronger*
+  check than the row-fingerprint prefix comparison it saves — identical
+  bytes imply identical rows — and it costs 32 ms over 39.7 MB against
+  143 ms to re-parse them. A mismatch (rewound session, replayed history)
+  drops the prefix and re-reads from the top. Byte reading replaces text
+  reading only when a store is present; every other caller keeps the
+  identical text path, and the held entries are the *pre*-post-processing
+  parse products, since the whole-file passes (sidecar linking,
+  prompt-hash linking, agent splicing — 0.1 ms together) must re-run over
+  the concatenated list.
+- **The cache write appends.** `CacheManager.extend_cached_entries`
+  inserts only the new rows instead of `save_cached_entries`' delete-and-
+  rewrite, which re-runs `json.dumps` + `zlib.compress` over every entry
+  (310 ms of a tick, for one added line).
+
+The write needs a proof the read doesn't, and it is the subtle part:
+
+> **A file being append-only does not make its rows append-only.** A
+> trunk's cached rows carry its subagents' transcripts, spliced in at
+> their anchors, so a subagent still running — the normal case under
+> `watch` — grows a block in the *middle* of the row sequence while the
+> trunk file only gained lines at the end.
+
+So `_appended_rows` offers rows only when the list is provably just the
+file's own parsed lines: resumed from a verified prefix, no agent
+references, no sidecars, nothing spliced, and no length change from the
+whole-file passes. That covers 136 of the reference archive's 185 trunk
+files; the 26% that reference subagents take the unchanged full rewrite.
+Beneath it, `extend_cached_entries` independently refuses when the table
+no longer holds the row count the caller thinks it wrote — the guard
+against another process having rewritten them. With the gates removed the
+caller offers a *wrong 96-entry slice* and that check catches it, so the
+tests assert on the offer rather than only on the write.
+
+Steady-state tick on the 803MB reference archive: **0.717s → 0.257s**
+(cumulatively 1.03s → 0.26s). Equivalence is held at three levels — parse
+output against the text path (162 fixture files whole-file, 90 resumed),
+**cache DB state** against a full-rewrite run over 6 ticks with 3 files
+growing, and rendered HTML throughout. DB state is the bar for the same
+reason as §2.14: the first bug of this kind is invisible in the rendered
+bytes.
+
+Resumption only helps a resident loop — a one-shot run, the TUI, and
+every tick-one still parse whole. Persisting `(prefix_len, prefix_hash)`
+in `cached_files` would extend it across processes; that migration was
+considered and not needed for the case that motivated it.
 
 ---
 

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -163,6 +163,32 @@ cache row, the session is reparsed. The schema-version row also
 invalidates the entire HTML cache when migrations bump the version,
 since rendered output may have changed even when source data hasn't.
 
+**Corruption is recovered by discarding, not repairing.** A damaged
+cache file is unusable and, left alone, permanently so: `apply_migration`
+records only a migration that completed, so a `CREATE INDEX` that hits a
+damaged page re-fails on every subsequent run. The writing
+`CacheManager.__init__` therefore catches SQLite's corruption errors
+(`is_corrupt_database_error` — narrowly matched on message text, since
+Python funnels "malformed", "not a database", "locked" and "disk full"
+into the same exception classes), deletes the `.db` with its `-wal`/`-shm`
+sidecars, and rebuilds. Everything in the cache is regenerable from the
+JSONL source, so the cost is one slow run.
+
+Two boundaries matter. A `read_only` manager — every spawned render
+worker (§ 2.10) — never deletes: several run concurrently against one
+file, and `_lookup_project_id` already degrades to "no cached data".
+And a zero-byte file is *not* corruption; SQLite adopts one as a new
+database, so an interrupted create heals without intervention.
+
+Note the cause is usually outside this tool. The case this was built
+for was a cache truncated to 2833 pages while its own header still
+claimed 14189 — traced to the virtiofs mount it lived on, not to
+anything the writer did. It had also been corrupt for some time
+*before* it was noticed: migration 012's index build is the first
+operation that full-scans `messages`, so earlier versions read around
+the damage and reported success. Assume corruption can recur on such
+filesystems, and that recovery, not prevention, is the tool's job.
+
 Paginated output carries an extra invalidation axis. `--page-size`
 assigns sessions to pages chronologically, and that assignment is
 recomputed from scratch on every run, so a page's *membership* can

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1085,11 +1085,20 @@ error against it.
 `html/templates/components/live_update.js`, active only over `http(s)` —
 a `file://` page cannot fetch anything, not even its own URL, so the
 poller notices and does nothing. It polls a HEAD of its own URL and
-compares `Last-Modified` **and `Content-Length`**: HTTP dates have
-one-second granularity, so two updates inside the same second are
-otherwise invisible (the same trap as the cache's mtime tolerance, which
-§2.3 solves the same way). On a change it re-fetches the page and either
-**patches** or **swaps**.
+compares `Last-Modified`, `Content-Length` **and `X-Content-Revision`**.
+Each covers the one before it: HTTP dates have one-second granularity, so
+two updates inside the same second are otherwise invisible (the same trap
+as the cache's mtime tolerance, which §2.3 solves the same way), and size
+is blind to a rewrite that keeps it — a counter or a status word changing
+width-for-width. `X-Content-Revision` is a digest of the served bytes,
+added by `server.py` to every file response; it is deliberately not an
+`ETag`, because the stock `send_head` skips its `If-Modified-Since` check
+whenever a request carries an `If-None-Match` and never evaluates one, so
+advertising an ETag would cost the 304s on multi-MB pages. Hashing is
+cached per `(path, mtime_ns, size)` but only once the file's mtime is a
+second old — a file being written right now is re-read, which is exactly
+the case the header exists for. On a change the page re-fetches and
+either **patches** or **swaps**.
 
 **Patching** applies when the new render's node-key sequence *extends*
 the one on screen: the nodes whose own markup changed are replaced, new

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -140,7 +140,13 @@ at `~/.claude/projects/claude-code-log-cache.db` (or
   per-role token totals, `team_name` (added in migration 005).
 - Per-message: a denormalised view used by archived-session
   restoration (the cache holds enough to re-render even after the
-  source JSONL is deleted).
+  source JSONL is deleted). Each row's `content` is the entry as
+  zlib-compressed JSON, written at `CONTENT_COMPRESSION_LEVEL` (3, not
+  zlib's default 6: levels only diverge on large payloads, so across a
+  real 18,288-row archive it costs 2.6% more bytes and makes a cold
+  conversion 11% faster — compressing rows is the largest item in a
+  watch tick). Reading is level-agnostic, so rows written at any level
+  still load.
 - Per-rendered-HTML: the HTML output itself, indexed by source file
   mtime + depth + compact flag (migrations 002–004) — so
   re-runs with unchanged inputs serve the cached HTML directly.

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -228,6 +228,18 @@ Current migrations:
   needs to recompute `projects.total_message_count` by delta (§ 2.14).
   Deliberately NULLable — a NULL means "unknown basis", and the
   refresh declines rather than compute a delta from it.
+- `011_cached_file_size.sql` — adds `source_size` to cached files, so
+  freshness no longer misses an append that lands inside the mtime
+  tolerance (§ 2.15). NULL on pre-011 rows falls back to mtime alone.
+- `012_message_lookup_indexes.sql` — composite indexes for the
+  refresh's per-tick lookups, each of which was walking every row in
+  the project (17–22 ms a call on a 38,706-row archive, 0.2–2.5 ms
+  after). Pure performance: no columns, nothing to backfill. One of
+  them, `(project_id, session_id, file_id)`, is double-edged — it also
+  lets the planner satisfy a bare `session_id IS NOT NULL` as a range
+  scan over every session-bearing row and *prefer* that to seeking the
+  uuids a query asked for, so three queries had to move that predicate
+  out of SQL and into Python to keep it from making them slower.
 
 Recreating-tables migrations toggle `PRAGMA foreign_keys = OFF/ON`
 around the rebuild to avoid losing rows to cascade-deletes during the
@@ -1051,11 +1063,16 @@ rebuilt them again (141ms). Two changes removed most of that:
 
 Tick: **1.03s → 0.717s**. `load_transcript`'s full re-parse and full row
 rewrite of the modified file (483ms) was then the remaining bulk, and
-§2.16's cross-tick resumption takes it to ~35ms: **0.257s** steady state
-in a resident `watch`. What is left at that point is the cache queries
-around the refresh — `get_session_file_map` ×3 (50ms), `get_file_states`
-×2 (45ms, still fetching every row's blob to hash it, now redundant with
-the prefix digest), `get_uuid_owners` ×4 (37ms).
+§2.16's cross-tick resumption takes it to ~35ms: 0.257s steady state in a
+resident `watch`. What remained after that was the refresh's own cache
+queries, every one of which was scanning the whole project — fixed by
+migration 012's indexes plus one query rewrite (`get_file_states` joined
+`cached_files` and filtered on `file_name`, which no index could serve;
+resolving names to `file_id` first made it 15.9ms → 0.0ms).
+
+**A steady-state watch tick on the 803MB reference archive is 0.145s**,
+from 1.03s — with rendering, which was where this began, now a rounding
+error against it.
 
 **The served page updates itself** via
 `html/templates/components/live_update.js`, active only over `http(s)` —

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -37,6 +37,7 @@ for user-facing operations docs see [`docs/`](../docs/).
 | Performance profiling | [`renderer_timings.py`](../claude_code_log/renderer_timings.py) | inlined below (§ 2.8) |
 | Intra-project render fan-out | [`render_pool.py`](../claude_code_log/render_pool.py) (mechanism) + [`render_dispatch.py`](../claude_code_log/render_dispatch.py) (policy) | inlined below (§ 2.10) |
 | Diagnosing hangs (SIGUSR1) | [`cli.py`](../claude_code_log/cli.py) `_install_stack_dump_signal` | inlined below (§ 2.11) |
+| Watch mode / live page updates | [`watch.py`](../claude_code_log/watch.py), `html/templates/components/live_update.js` | inlined below (§ 2.15); design in [`work/watch-mode.md`](../work/watch-mode.md); user-facing in [`docs/live-updates.md`](../docs/live-updates.md) |
 | Adding a new tool renderer | [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), `html/tool_formatters.py` | [implementing-a-tool-renderer.md](implementing-a-tool-renderer.md) (how-to) |
 | Which tools have a specialized renderer or provider adapter | `TOOL_INPUT_MODELS` / `TOOL_OUTPUT_PARSERS` in [`factories/tool_factory.py`](../claude_code_log/factories/tool_factory.py), plus provider adapters | [tools-coverage.md](tools-coverage.md) (Claude and Codex status vs. upstream references) |
 | Plugin system (third-party message transformers) | [`plugins.py`](../claude_code_log/plugins.py), [`factories/priorities.py`](../claude_code_log/factories/priorities.py), `Renderer._dispatch_format` | [plugins.md](plugins.md) |
@@ -984,6 +985,71 @@ render 901MB / 8.1s; incremental refresh + streamed render **582MB /
 peak — which is what this section removes, completing "no archive too
 big for the machine". `CLAUDE_CODE_LOG_INCREMENTAL_CACHE=0` is the
 kill switch.
+
+
+### 2.15 Watch mode and live page updates
+
+Two commands keep output current while a session is still being written:
+`claude-code-log watch` (a resident loop) and `claude-code-log serve
+--watch` (the same loop on a thread beside the HTTP server). See
+[`work/watch-mode.md`](../work/watch-mode.md) for the design and the
+measurements behind it.
+
+**The engine never renders.** `claude_code_log/watch.py` polls
+`(size, mtime_ns)` over `**/*.jsonl` and `**/agent-*.meta.json` under
+the watched roots, debounces, and calls a callback; the callback runs the
+ordinary conversion. The scan is a *trigger*, not a source of truth — a
+false positive costs one no-op conversion, while the conversion already
+knows precisely what is stale. Two file classes are excluded because both
+land in the watched tree and would make the loop feed itself: dot-prefixed
+atomic-write temp files, and generated output.
+
+Debounce is a quiet period (`--quiet-period`, 300ms) with a max-latency
+cap (`--max-latency`, 2s): a turn writes several entries in quick
+succession, so without the quiet period most of a turn is spent rendering
+states nobody sees; without the cap a long unbroken stream would never
+surface. `tick()` (poll once) is split from `run()` (wait) and the clock
+is injectable, so tests drive ticks by hand against a fake clock.
+
+**What makes a tick cheap** is §2.12's session-scoped path, which is
+reachable here only because `ensure_fresh_cache_detailed` reports *how*
+it refreshed (`CacheRefresh.NONE`/`INCREMENTAL`/`FULL`). Phase 1b's
+staleness test is per-session message counts, so it refuses a FULL
+refresh — which carries no guarantee that a session's content didn't
+change while its count stayed the same. An INCREMENTAL refresh does carry
+it: §2.14's ladder only succeeds after proving each modified file's
+cached rows are an exact prefix of its current rows, i.e. a pure append.
+`--combined` therefore defaults to `no` for `watch`: with a combined
+output present, the session's growth makes it stale and the conversion
+falls to the streaming path instead.
+
+**The served page updates itself** via
+`html/templates/components/live_update.js`, active only over `http(s)` —
+a `file://` page cannot fetch anything, not even its own URL, so the
+poller notices and does nothing. It polls a HEAD of its own URL and
+compares `Last-Modified` **and `Content-Length`**: HTTP dates have
+one-second granularity, so two updates inside the same second are
+otherwise invisible (the same trap as the cache's mtime tolerance, which
+§2.3 solves the same way). On a change it re-fetches the page and
+replaces `#transcript` wholesale rather than patching in messages —
+appends are not always in timestamp order, one entry can render as
+several cards, and `msg-d-N` anchors are positional, so inserting
+anywhere but the tail renumbers them.
+
+A swap destroys anything that decorated the old markup, so components
+register with `window.claudeLogOnRehydrate(fn)` (defined at the top of
+`<body>`, before every component include) and the poller calls
+`window.claudeLogRehydrate(root)` after swapping. Currently registered:
+timestamp localisation (scoped to a subtree) and the timeline rebuild.
+Delegated listeners and everything bound to the toolbar or floating
+buttons survive untouched and must **not** register. Fold state and
+`<details>` are captured and restored by the poller itself, keyed
+`data-uuid` → `data-session-id` → positional `id` — session headers and
+fork points carry no uuid, and on a single-session page the header is
+the only foldable node.
+
+Measured: ~1s from append to visible; a 7.0MB session page costs 202ms to
+swap (31 fetch / 63 parse / 17 swap / 91 layout) and ~1ms per idle poll.
 
 ---
 

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1088,26 +1088,66 @@ poller notices and does nothing. It polls a HEAD of its own URL and
 compares `Last-Modified` **and `Content-Length`**: HTTP dates have
 one-second granularity, so two updates inside the same second are
 otherwise invisible (the same trap as the cache's mtime tolerance, which
-§2.3 solves the same way). On a change it re-fetches the page and
-replaces `#transcript` wholesale rather than patching in messages —
-appends are not always in timestamp order, one entry can render as
-several cards, and `msg-d-N` anchors are positional, so inserting
-anywhere but the tail renumbers them.
+§2.3 solves the same way). On a change it re-fetches the page and either
+**patches** or **swaps**.
+
+**Patching** applies when the new render's node-key sequence *extends*
+the one on screen: the nodes whose own markup changed are replaced, new
+ones are inserted, and everything else is left alone — keeping its
+scroll, fold, `<details>` and localised timestamps because it is
+literally the same DOM. Change detection is a per-node hash of the
+node's own markup, taken from the **freshly parsed document, never from
+the live DOM**: decoration rewrites the live tree (timestamp
+localisation replaces `innerHTML`), so a hash taken from it never
+matches one taken from server bytes. Nothing is emitted server-side for
+this.
+
+A node's own markup is its `:scope > .message` *plus* every
+non-`.message-node` child of its `.children` — a fork point renders
+inside `.children` so folding hides it with the subtree, and on a
+fork-only slot it is the node's only content and carries its id.
+
+**Swapping** (replace `#transcript` wholesale) is the fallback for
+everything else: renumbered or reordered ids, deletions, a node with no
+key, more than 40 changed nodes, and the first update of a session,
+which is where the hashes are first taken. It is also what every update
+did before patching existed. Measured across three real sessions
+replayed through the renderer, 45 of 47 growth steps are pure
+extensions; the other 2 are out-of-order arrivals that renumber the
+positional `msg-d-N` ids and take the swap.
 
 A swap destroys anything that decorated the old markup, so components
 register with `window.claudeLogOnRehydrate(fn)` (defined at the top of
 `<body>`, before every component include) and the poller calls
-`window.claudeLogRehydrate(root)` after swapping. Currently registered:
-timestamp localisation (scoped to a subtree) and the timeline rebuild.
-Delegated listeners and everything bound to the toolbar or floating
-buttons survive untouched and must **not** register. Fold state and
-`<details>` are captured and restored by the poller itself, keyed
-`data-uuid` → `data-session-id` → positional `id` — session headers and
-fork points carry no uuid, and on a single-session page the header is
-the only foldable node.
+`window.claudeLogRehydrate(root)` — over the whole container after a
+swap, and over *only the elements it placed* after a patch. Passing the
+containing node instead is a live trap: the session header's fold bar
+counts its descendants, so it is replaced on every append, and its node
+is the entire page. Currently registered: timestamp localisation (scoped
+to a subtree) and the timeline rebuild. Delegated listeners and
+everything bound to the toolbar or floating buttons survive untouched
+and must **not** register. On the swap path only, fold state and
+`<details>` are captured and restored by the poller, keyed `data-uuid` →
+`data-session-id` → positional `id` — session headers and fork points
+carry no uuid, and on a single-session page the header is the only
+foldable node.
 
-Measured: ~1s from append to visible; a 7.0MB session page costs 202ms to
-swap (31 fetch / 63 parse / 17 swap / 91 layout) and ~1ms per idle poll.
+Measured: ~1s from append to visible. On a 2.4MB / 896-card page, a swap
+touches 897 cards, re-localises 896 timestamps and blocks the main
+thread 107ms; a patch of the same append touches **3 cards, 2
+timestamps, 61ms**. The remaining 61ms is fetch plus `DOMParser` of the
+whole page, which only a server-shipped delta would remove. Idle polls
+cost ~1ms.
+
+**Timestamp localisation drains against the idle deadline**, not in
+fixed batches. `timezone_converter.js` used 25 elements per
+`requestIdleCallback`, which made the *callback count* the cost: a 4MB
+page's 1,180 timestamps are 8ms of work but took 766ms of wall clock,
+and a 27MB page's 5,010 took 3.3s — in document order, so a live
+update's new cards were localised last and the fade-in played over a raw
+ISO string. Draining while `timeRemaining()` allows (checked per 32
+elements, `{timeout: 200}`, first slice on the current task under a 24ms
+budget) takes those to **13ms and 35ms**.
 
 
 ### 2.16 Parsed-entry store

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1242,7 +1242,18 @@ Beneath it, `extend_cached_entries` independently refuses when the table
 no longer holds the row count the caller thinks it wrote — the guard
 against another process having rewritten them. With the gates removed the
 caller offers a *wrong 96-entry slice* and that check catches it, so the
-tests assert on the offer rather than only on the write.
+tests assert on the offer rather than only on the write. That count and
+the insert run inside one `BEGIN IMMEDIATE`, because Python's sqlite3
+opens a transaction on the first write and not on a `SELECT`: without
+the explicit lock a second writer sharing the cache could append in
+between, and the check would let both appends land.
+
+Both cache writers are stamped with the source file's `(mtime, size)` as
+captured **before** the parse — the same discipline as the sidecar
+fingerprint beside it, and as the entry store's own stamp. A session
+appended to mid-read would otherwise be recorded at the size it reached
+while the rows are only what was parsed, marking an incomplete cache
+current; stamped with what was parsed, the growth invalidates instead.
 
 Steady-state tick on the 803MB reference archive: **0.717s → 0.257s**
 (cumulatively 1.03s → 0.26s). Equivalence is held at three levels — parse

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -234,12 +234,19 @@ Current migrations:
 - `012_message_lookup_indexes.sql` — composite indexes for the
   refresh's per-tick lookups, each of which was walking every row in
   the project (17–22 ms a call on a 38,706-row archive, 0.2–2.5 ms
-  after). Pure performance: no columns, nothing to backfill. One of
-  them, `(project_id, session_id, file_id)`, is double-edged — it also
-  lets the planner satisfy a bare `session_id IS NOT NULL` as a range
-  scan over every session-bearing row and *prefer* that to seeking the
-  uuids a query asked for, so three queries had to move that predicate
-  out of SQL and into Python to keep it from making them slower.
+  after). Pure performance: no columns, nothing to backfill. Two
+  things about it are worth knowing:
+  - `(project_id, session_id, timestamp, file_id)` carries `timestamp`
+    for a caller *outside* the refresh: `load_session_entries` (the TUI,
+    and rendering an archived session) filters on session but orders by
+    timestamp, and without that column the planner takes the timestamp
+    index and walks the whole project to load one session. With it, the
+    seek and the ordering come from one index and no sort is needed.
+  - That same index is double-edged — it also lets the planner satisfy
+    a bare `session_id IS NOT NULL` as a range scan over every
+    session-bearing row and *prefer* that to seeking the uuids a query
+    asked for, so three queries had to move that predicate out of SQL
+    and into Python to keep it from making them slower.
 
 Recreating-tables migrations toggle `PRAGMA foreign_keys = OFF/ON`
 around the rebuild to avoid losing rows to cascade-deletes during the

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1213,7 +1213,13 @@ made one doesn't). That turns the store from a within-tick cache into a
   identical text path, and the held entries are the *pre*-post-processing
   parse products, since the whole-file passes (sidecar linking,
   prompt-hash linking, agent splicing — 0.1 ms together) must re-run over
-  the concatenated list.
+  the concatenated list. The cut is on **entries as well as bytes**: a
+  final line whose newline hasn't landed — a torn append, or a file
+  simply stored without a trailing one — parses and is returned like any
+  other, but neither its bytes nor its entry is held, so the next tick
+  re-reads that line instead of handing its entry back a second time.
+  Prefixes are charged against the same budget as whole-file entries and
+  evicted alongside them, since a `watch` store never goes out of scope.
 - **The cache write appends.** `CacheManager.extend_cached_entries`
   inserts only the new rows instead of `save_cached_entries`' delete-and-
   rewrite, which re-runs `json.dumps` + `zlib.compress` over every entry

--- a/docs/live-updates.md
+++ b/docs/live-updates.md
@@ -74,6 +74,7 @@ project; lower `--interval` if you want changes noticed sooner.
 
 A tick re-converts only what changed. On a 319 MB, 217-file archive a
 tick is about a second; on a small project it is hundredths of a second.
-While nothing is changing, the browser's poll is a conditional request
-costing about a millisecond, and the watcher is a `stat` of the project
-directory.
+While nothing is changing, the browser's poll is a `HEAD` for the page's
+own metadata — about a millisecond, and no body — and the watcher is a
+`stat` of the project directory. The page is re-fetched in full only
+once that metadata says it moved.

--- a/docs/live-updates.md
+++ b/docs/live-updates.md
@@ -32,8 +32,12 @@ claude-code-log serve --watch
 
 Open a session page and it grows as messages arrive — roughly a second
 behind the CLI, without a reload. Your scroll position, folded sections
-and open disclosures all survive; new messages fade in, and a **follow**
-pill in the corner offers to keep the page pinned to the newest message.
+and open disclosures all survive, and new messages fade in.
+
+A **follow** button (⏬) joins the buttons down the right-hand edge once
+the page is being served. Click it to keep the page pinned to the newest
+message; while you are not following, it shows a count of how many have
+arrived since you last looked.
 
 This works only over the server. A page opened from `file://` cannot
 fetch anything at all — not even itself — so it stays static, exactly as

--- a/docs/live-updates.md
+++ b/docs/live-updates.md
@@ -1,0 +1,75 @@
+# Watching a session as it runs
+
+Two commands keep generated output current while Claude Code is still
+writing to a transcript.
+
+## Markdown (or HTML) on disk
+
+```bash
+claude-code-log watch
+```
+
+With no arguments this watches the project for the current directory —
+which is what you want when running it alongside a live session. It
+converts once up front, then re-converts whenever a transcript changes.
+Anything that reloads files picks the changes up: an editor, Obsidian, a
+browser refresh.
+
+For an Obsidian vault:
+
+```bash
+claude-code-log watch -f md -o ~/vault/claude
+```
+
+A tick regenerates only the session that changed, so a vault indexer sees
+one file move, not the whole projection.
+
+## The served page, updating itself
+
+```bash
+claude-code-log serve --watch
+```
+
+Open a session page and it grows as messages arrive — roughly a second
+behind the CLI, without a reload. Your scroll position, folded sections
+and open disclosures all survive; new messages fade in, and a **follow**
+pill in the corner offers to keep the page pinned to the newest message.
+
+This works only over the server. A page opened from `file://` cannot
+fetch anything at all — not even itself — so it stays static, exactly as
+before. Nothing about the generated HTML changes.
+
+## What "real-time" can and cannot mean here
+
+**It cannot show tokens arriving.** Claude Code writes a transcript entry
+exactly once, when the message is complete — it never rewrites a line, so
+there is no partial message on disk to display. The finest granularity
+available anywhere in this tool is *one whole message*, appearing
+promptly after it finishes. The fade-in is there to make that arrival
+legible, not to imitate streaming.
+
+Everything else follows from that. A message typically appears within a
+second or so of completing: the watcher waits briefly for the burst of
+entries in a turn to settle (a turn writes several), converts, and the
+page notices on its next poll.
+
+## Tuning
+
+| Flag | Default | What it does |
+|---|---|---|
+| `--interval` | `0.25` | Seconds between filesystem polls |
+| `--quiet-period` | `0.3` | Wait for changes to settle before converting |
+| `--max-latency` | `2.0` | Convert anyway after this long, so a long unbroken stream still surfaces |
+| `--all-projects` | off | Watch the whole archive instead of one project |
+| `--combined` | `no` | `no` keeps ticks cheap: only the changed session is regenerated |
+
+Raise `--quiet-period` if conversions feel too frequent on a large
+project; lower `--interval` if you want changes noticed sooner.
+
+## Cost
+
+A tick re-converts only what changed. On a 319 MB, 217-file archive a
+tick is about a second; on a small project it is hundredths of a second.
+While nothing is changing, the browser's poll is a conditional request
+costing about a millisecond, and the watcher is a `stat` of the project
+directory.

--- a/foldyard.toml
+++ b/foldyard.toml
@@ -119,11 +119,42 @@ or a clone of the project, which would describe a different version: the `foldya
 SKILL in .claude/skills/ (the model — posture, egress, why a change didn't take), and
 `fy docs` for the manual (`fy docs` lists topics; `fy docs modes`, `fy docs adr-0007`).
 """
+[claude.settings]
+showThinkingSummaries = true
 
 # OpenAI Codex CLI (`fy codex`). Declaring [codex] installs it on box-up + mounts ~/.codex.
 # Needs node in the box. Keyless like Claude — the proxy injects host-side.
 [codex]
 keyless = "chatgpt"  # your ChatGPT subscription: the minter refreshes ~/.codex/auth.json
+system_prompt = """
+You are root in this project's foldyard dev box, started by `fy codex` with permission
+prompts skipped. Orientation, so you don't have to re-derive it:
+
+`fy` works in here for the read and box verbs: `fy verify`, `fy box shell|ps|down`, and
+`fy mode` to SEE the credential posture — posture is SET from the host, not from in here,
+and so are egress grants. A second checkout beside this one is `fy worktree add <name>`,
+then `WORKTREE=<name> fy <verb>`.
+
+Git: read and commit locally, but you CANNOT push — no credential in here reaches the
+origin, by design. Push from the host.
+
+Egress that fails is the wall doing its job, not a bug to route around. Report the
+blocked hostname and ask the operator to `fy allow add <hostname>`; the grant store
+lives outside this box, out of your reach.
+
+You may not be alone: several sessions can attach to this one box and checkout. You run
+as root, so files you create land root-owned.
+
+Depth on demand, both version-matched to the foldyard running here — never a web search
+or a clone of the project, which would describe a different version: the `foldyard`
+SKILL in .claude/skills/ (the model — posture, egress, why a change didn't take), and
+`fy docs` for the manual (`fy docs` lists topics; `fy docs modes`, `fy docs adr-0007`).
+"""
+[codex.config]
+hide_agent_reasoning = false
+show_raw_agent_reasoning = true
+model_reasoning_summary = "auto"
+tui = { raw_output_mode = false }
 
 # ── The rest — uncomment as you grow (step 3) ────────────────────────────────────────────
 # Host-published ports, keyed by the env var your compose file reads. In-container ports

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - Example output: example.md
   - User Guide:
       - Searching the whole archive: archive-search.md
+      - Watching a session as it runs: live-updates.md
       - Restoring archived sessions: restoring-archived-sessions.md
   - Reference:
       - CLI: reference/cli.md

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -4828,10 +4828,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -5879,17 +5899,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -12652,10 +12697,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -13598,17 +13663,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -23006,10 +23096,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -24175,17 +24285,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -30948,10 +31083,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -32397,17 +32552,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -39170,10 +39350,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -40566,17 +40766,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -47339,10 +47564,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -48680,17 +48925,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -55453,10 +55723,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -56622,17 +56912,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -63395,10 +63710,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -64369,17 +64704,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });
@@ -71142,10 +71502,30 @@
               applySearchFilter();
           }
   
+          // The rehydrate contract passes a subtree, and calls the hooks once
+          // per changed element — which is what the other two hooks want,
+          // since they only touch what they are given. This one is the
+          // exception: it reads the whole document, so a patch touching a
+          // dozen cards would mean a dozen whole-page rebuilds, per poll, of
+          // exactly the work the patch path exists to avoid. Collapse a
+          // burst into one rebuild after the current task instead.
+          let rebuildScheduled = false;
+          function scheduleRebuild() {
+              if (!timeline || !itemsDataSet) return;  // never opened: nothing to do
+              if (rebuildScheduled) return;
+              rebuildScheduled = true;
+              const run = function () {
+                  rebuildScheduled = false;
+                  rebuildTimeline();
+              };
+              if (window.queueMicrotask) window.queueMicrotask(run);
+              else setTimeout(run, 0);
+          }
+  
           // Export functions to global scope
           window.rebuildTimeline = rebuildTimeline;
           if (window.claudeLogOnRehydrate) {
-              window.claudeLogOnRehydrate(rebuildTimeline);
+              window.claudeLogOnRehydrate(scheduleRebuild);
           }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
@@ -72065,17 +72445,42 @@
       // instead leaves the page wrong until something else changes.)
       let polling = false;
   
+      // How many bytes this document actually was, as the browser received
+      // it. The first poll cannot happen until the document has loaded, and
+      // that takes as long as it takes — tens of MB on the pages this
+      // feature is for. A conversion completing in that window would be
+      // adopted as the baseline and never applied, leaving the page
+      // permanently one update behind if the session then went quiet.
+      //
+      // The navigation timing entry is the one thing that knows what we were
+      // served, so the first poll compares against it rather than trusting
+      // whatever the server holds by then. Responses are not
+      // content-encoded, so this is directly comparable to `Content-Length`;
+      // anything that makes it unavailable (or zero) falls back to adopting
+      // the baseline, which is where this started.
+      function loadedLength() {
+          try {
+              const nav = performance.getEntriesByType('navigation')[0];
+              return (nav && nav.encodedBodySize) || null;
+          } catch (err) {
+              return null;
+          }
+      }
+  
       async function poll() {
           if (stopped || polling) return;
           polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const length = head.headers.get('Content-Length') || '';
               const stamp = [
                   head.headers.get('Last-Modified') || '',
-                  head.headers.get('Content-Length') || '',
+                  length,
                   head.headers.get('ETag') || '',
               ].join('|');
-              if (lastStamp === null) {
+              const served = lastStamp === null ? loadedLength() : null;
+              const missedOnLoad = !!served && !!length && Number(length) !== served;
+              if (lastStamp === null && !missedOnLoad) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
                   const res = await fetch(location.href, { cache: 'no-store' });

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -2240,6 +2240,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -4168,6 +4210,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Async Agents Fixture</h1>
   
       
@@ -4692,7 +4762,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -5101,8 +5195,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -5212,6 +5312,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -9311,6 +9652,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -11239,6 +11622,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Async Agents Fixture (LOW)</h1>
   
       
@@ -11763,7 +12174,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -12067,8 +12502,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -12178,6 +12619,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -16519,8 +17201,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -16630,6 +17318,14 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
   })();
           });
       </script>
@@ -18878,6 +19574,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -20806,6 +21544,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Test Session</h1>
   
       
@@ -21330,7 +22096,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -21857,8 +22647,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -21968,6 +22764,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -26067,6 +27104,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -27995,6 +29074,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Teammates Fixture</h1>
   
       
@@ -28519,7 +29626,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -29326,8 +30457,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -29437,6 +30574,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -33536,6 +34914,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -35464,6 +36884,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Edge Cases</h1>
   
       
@@ -35988,7 +37436,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -36742,8 +38214,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -36853,6 +38331,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -40952,6 +42671,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -42880,6 +44641,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Claude Transcripts - test_multi_session_html0</h1>
   
       
@@ -43404,7 +45193,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -44103,8 +45916,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -44214,6 +46033,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -48313,6 +50373,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -50241,6 +52343,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Test Transcript</h1>
   
       
@@ -50765,7 +52895,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -51292,8 +53446,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -51403,6 +53563,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -55502,6 +57903,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -57430,6 +59873,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">Claude Transcripts - test_steering_chronological_or0</h1>
   
       
@@ -57954,7 +60425,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -58286,8 +60781,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -58397,6 +60898,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle
@@ -62496,6 +65238,48 @@
       width: 1em;
       vertical-align: -0.125em;
   }
+  
+  /* Live update (serve --watch): a message that arrived since the last
+     poll. The fade is the whole "streaming" illusion — transcripts record
+     one complete message at a time, never partial tokens, so a card can
+     only ever appear whole. Announcing that arrival is the most honest
+     thing the page can do. */
+  @keyframes live-new-in {
+      from {
+          opacity: 0;
+          transform: translateY(6px);
+      }
+      to {
+          opacity: 1;
+          transform: none;
+      }
+  }
+  
+  .message.live-new {
+      animation: live-new-in 320ms ease-out;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+      .message.live-new {
+          animation: none;
+      }
+  }
+  
+  .live-update-pill {
+      bottom: 20px;
+      left: 20px;
+      width: auto;
+      min-width: 3em;
+      padding: 0 0.9em;
+      border-radius: 999px;
+      font-size: 0.85em;
+      white-space: nowrap;
+  }
+  
+  .live-update-pill[data-following="yes"] {
+      background-color: var(--highlight-light);
+      font-weight: 600;
+  }
   /* Session navigation styles */
   .navigation {
       background-color: var(--bg-neutral);
@@ -64424,6 +67208,34 @@
   </head>
   
   <body>
+      <script>
+          // ---- rehydrate contract -------------------------------------------
+          // A live update (see live_update.js) replaces #transcript wholesale.
+          // Anything that decorated the old markup after load has to run again
+          // over the new markup: timestamp localisation rewrites innerHTML,
+          // the timeline parses message types out of CSS classes, the filter
+          // toolbar hides message types, in-page search highlights matches.
+          //
+          // Delegated listeners (bound on `document`) and everything bound to
+          // the toolbar or the floating buttons survive a swap untouched and
+          // must NOT be registered here.
+          //
+          // Defined before any component script so registration never depends
+          // on include order.
+          (function () {
+              const hooks = [];
+              window.claudeLogOnRehydrate = function (fn) { hooks.push(fn); };
+              window.claudeLogRehydrate = function (root) {
+                  hooks.forEach(function (fn) {
+                      // One broken hook must not strand the rest — a page that
+                      // updated but lost its timeline is better than one that
+                      // silently stopped updating.
+                      try { fn(root); } catch (err) { console.error('rehydrate hook failed', err); }
+                  });
+              };
+          })();
+      </script>
+  
       <h1 id="title">System Reminders</h1>
   
       
@@ -64948,7 +67760,31 @@
               });
           }
   
+          // Rebuild from the current DOM after a live update swapped the
+          // transcript. The timeline reads message types out of CSS classes,
+          // so new cards are invisible to it until this runs.
+          //
+          // A timeline that was never opened needs nothing: it is built
+          // lazily, and will read the new DOM when it is.
+          function rebuildTimeline() {
+              if (!timeline || !itemsDataSet) return;
+              const { timelineItems, timelineGroups } = buildTimelineData();
+              items = timelineItems;
+              groups = timelineGroups;
+              // Replace the contents rather than the DataSet so the user's
+              // current zoom/pan window survives the update.
+              itemsDataSet.clear();
+              itemsDataSet.add(items);
+              timeline.setGroups(new vis.DataSet(groups));
+              applyFilters();
+              applySearchFilter();
+          }
+  
           // Export functions to global scope
+          window.rebuildTimeline = rebuildTimeline;
+          if (window.claudeLogOnRehydrate) {
+              window.claudeLogOnRehydrate(rebuildTimeline);
+          }
           window.toggleTimeline = toggleTimeline;
           window.applyTimelineFilters = applyFilters;
           window.applyTimelineSearchFilter = applySearchFilter;
@@ -65229,8 +68065,14 @@
               // Convert timestamps to user's timezone
   // This function can be called directly or will auto-run on DOMContentLoaded if included standalone
   (function() {
-      function convertTimestampsToLocalTimezone() {
-          const timestampElements = Array.from(document.querySelectorAll('.timestamp[data-timestamp]'));
+      // `root` scopes the work to a subtree. A live update replaces only the
+      // transcript container, and its new cards carry raw ISO timestamps;
+      // re-converting the whole document would redo every card that is
+      // already localised (and `innerHTML` has been rewritten on those, so
+      // they no longer match `[data-timestamp]`'s original text anyway).
+      function convertTimestampsToLocalTimezone(root) {
+          const scope = root || document;
+          const timestampElements = Array.from(scope.querySelectorAll('.timestamp[data-timestamp]'));
   
           if (timestampElements.length === 0) return;
   
@@ -65340,6 +68182,247 @@
   
       // Execute immediately - assumes this is included within a DOMContentLoaded handler
       convertTimestampsToLocalTimezone();
+  
+      // Exposed so a live update can re-run it over freshly swapped-in
+      // markup. Registered with the rehydrate contract when one is present
+      // (transcript pages); harmless on pages without it (the index).
+      window.claudeLogLocalizeTimestamps = convertTimestampsToLocalTimezone;
+      if (window.claudeLogOnRehydrate) {
+          window.claudeLogOnRehydrate(convertTimestampsToLocalTimezone);
+      }
+  })();
+  
+              // Live update (no-op unless served over http -- see the file)
+              // Keep this page current while the session it shows is still running.
+  //
+  // Only active over http(s): a page loaded from file:// cannot fetch
+  // anything at all — not itself, not a sibling, not even a HEAD (verified
+  // in Chromium; script tags are the only channel a file:// page has). So
+  // this is a `serve` feature, and the generated HTML stays exactly as
+  // useful from file:// as it was before.
+  //
+  // The shape, and why:
+  //
+  //   * The server never renders. `serve --watch` re-runs the ordinary
+  //     conversion and the files on disk stay canonical, so this page just
+  //     re-fetches its own URL. A conditional GET makes the idle case free
+  //     (304 in ~1ms) and needs no endpoint of its own.
+  //   * We swap #transcript rather than reloading. A reload loses fold
+  //     state and re-parses a document that can reach tens of MB; a swap
+  //     keeps scroll position for free, because everything above the
+  //     viewport is untouched.
+  //   * We do not patch in individual messages. New entries do not always
+  //     belong at the end (a transcript's appends are not in timestamp
+  //     order), one entry can render as several cards, and the `msg-d-N`
+  //     anchors are positional — inserting anywhere but the tail renumbers
+  //     them and breaks the fork/tool-pair links already on the page.
+  //     Replacing the whole container sidesteps all three.
+  (function () {
+      'use strict';
+  
+      if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+  
+      // A conditional GET costs ~1ms and 304s while nothing changes, so the
+      // interval is set by how fresh the page should feel, not by load.
+      const POLL_MS = 1000;
+      const container = () => document.getElementById('transcript');
+      if (!container()) return;
+  
+      // The page's identity as of the last poll. `Last-Modified` alone is
+      // not enough: HTTP dates have **one-second granularity**, so two
+      // conversions inside the same second produce an identical header and
+      // the second update is invisible. Observed directly — a third append
+      // never arrived until length was added to the comparison.
+      //
+      // (This is the same trap as the cache's mtime tolerance, one layer up,
+      // and it has the same fix: compare the size too. `Content-Length` is
+      // exact, free, and already on the HEAD response.)
+      let lastStamp = null;
+      let stopped = false;
+      let following = false;
+  
+      // ---- state that a swap would otherwise destroy -----------------------
+  
+      // A key that survives a re-render, for every card that can hold state.
+      //
+      // `data-uuid` is stable but is NOT unique per card (one entry can
+      // render as sibling text + tool_use cards), so it is paired with its
+      // ordinal among cards sharing it. Two kinds of card have no uuid at
+      // all and are exactly the ones that fold: **session headers** (keyed
+      // by `data-session-id`) and fork points. Missing the session header
+      // is not a corner case — on a single-session page it is the only
+      // foldable node there is.
+      //
+      // The `id` (`msg-d-N`) is unique but positional, so it is the last
+      // resort rather than the first choice: it is correct for appends at
+      // the tail and wrong the moment something lands earlier in the tree.
+      function stableKeys(root) {
+          const seen = new Map();
+          const keys = new Map();
+          root.querySelectorAll('.message, .fork-point').forEach(el => {
+              const uuid = el.getAttribute('data-uuid');
+              const session = el.getAttribute('data-session-id');
+              let base;
+              if (uuid) base = 'u:' + uuid;
+              else if (session) base = 's:' + session;
+              else base = 'p:' + (el.id || 'anon');
+              const n = seen.get(base) || 0;
+              seen.set(base, n + 1);
+              keys.set(el, base + '#' + n);
+          });
+          return keys;
+      }
+  
+      // The children container a card's fold bar controls: a *sibling* of
+      // the card inside the shared `.message-node`, not a descendant.
+      function childrenOf(el) {
+          const node = el.closest('.message-node');
+          return node ? node.querySelector(':scope > .children') : null;
+      }
+  
+      function captureState(root) {
+          const folds = new Map();
+          const keys = stableKeys(root);
+          keys.forEach((key, el) => {
+              const children = childrenOf(el);
+              if (children) folds.set(key, children.style.display);
+          });
+          const details = new Map();
+          root.querySelectorAll('details').forEach((d, i) => details.set(i, d.open));
+          return { folds, details, keys: new Set(keys.values()) };
+      }
+  
+      function restoreState(root, state) {
+          stableKeys(root).forEach((key, el) => {
+              if (!state.folds.has(key)) return;
+              const children = childrenOf(el);
+              if (!children) return;
+              children.style.display = state.folds.get(key);
+              // Keep the fold bar's arrows honest about what it is showing.
+              const bar = el.querySelector(':scope > .fold-bar');
+              if (!bar) return;
+              const folded = children.style.display === 'none';
+              bar.querySelectorAll('.fold-bar-section').forEach(section => {
+                  section.classList.toggle('folded', folded);
+              });
+          });
+          // `<details>` has no stable identity of its own; index order is the
+          // best available and is exact for the common case (appends at the
+          // tail leave every earlier disclosure at the same index).
+          const all = root.querySelectorAll('details');
+          state.details.forEach((open, i) => {
+              if (all[i]) all[i].open = open;
+          });
+      }
+  
+      function markNew(root, previousKeys) {
+          let count = 0;
+          stableKeys(root).forEach((key, el) => {
+              if (previousKeys.has(key) || !el.classList.contains('message')) return;
+              el.classList.add('live-new');
+              count += 1;
+          });
+          return count;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      function announce(added) {
+          let pill = document.getElementById('live-update-pill');
+          if (!pill) {
+              pill = document.createElement('button');
+              pill.id = 'live-update-pill';
+              pill.className = 'floating-btn live-update-pill';
+              pill.addEventListener('click', () => {
+                  following = !following;
+                  if (following) scrollToEnd();
+                  render();
+              });
+              document.body.appendChild(pill);
+          }
+          pill.dataset.following = following ? 'yes' : 'no';
+          pill.unseen = (pill.unseen || 0) + added;
+          render();
+  
+          function render() {
+              if (following) pill.unseen = 0;
+              pill.textContent = following
+                  ? '⏬ following'
+                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
+              pill.title = following
+                  ? 'Following new messages — click to stop'
+                  : 'Scroll to new messages as they arrive';
+          }
+      }
+  
+      function scrollToEnd() {
+          const c = container();
+          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+  
+      async function applyUpdate(html) {
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const next = doc.getElementById('transcript');
+          const current = container();
+          if (!next || !current) return;
+  
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+  
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+  
+          // The title carries the message/token counts, and the session nav
+          // its summaries; both go stale otherwise.
+          const nextTitle = doc.getElementById('title');
+          const title = document.getElementById('title');
+          if (nextTitle && title) title.innerHTML = nextTitle.innerHTML;
+  
+          if (added) announce(added);
+          if (following) scrollToEnd();
+      }
+  
+      async function poll() {
+          if (stopped) return;
+          try {
+              const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
+              const stamp = [
+                  head.headers.get('Last-Modified') || '',
+                  head.headers.get('Content-Length') || '',
+                  head.headers.get('ETag') || '',
+              ].join('|');
+              if (lastStamp === null) {
+                  lastStamp = stamp;
+              } else if (stamp !== lastStamp) {
+                  lastStamp = stamp;
+                  const res = await fetch(location.href, { cache: 'no-store' });
+                  if (res.ok) await applyUpdate(await res.text());
+              }
+          } catch (err) {
+              // A dropped server is the normal end of a watch session, not an
+              // error worth shouting about. Keep polling: `serve` may come back.
+              console.debug('live update poll failed', err);
+          }
+      }
+  
+      // Don't poll a page nobody is looking at.
+      function schedule() {
+          if (document.hidden) return;
+          poll();
+      }
+      setInterval(schedule, POLL_MS);
+      document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) poll();
+      });
+      poll();
+  
+      window.claudeLogLiveUpdate = {
+          poll,
+          stop() { stopped = true; },
+          setFollowing(v) { following = !!v; },
+      };
   })();
   
               // Debug UUID toggle

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -5473,6 +5473,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -5946,6 +5954,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -13252,6 +13261,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -13725,6 +13742,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -23904,6 +23922,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -24377,6 +24403,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -32186,6 +32213,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -32659,6 +32694,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -40415,6 +40451,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -40888,6 +40932,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -48589,6 +48634,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -49062,6 +49115,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -56591,6 +56645,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -57064,6 +57126,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -64398,6 +64461,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -64871,6 +64942,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;
@@ -72154,6 +72226,14 @@
       // (This is the same trap as the cache's mtime tolerance, one layer up,
       // and it has the same fix: compare the size too. `Content-Length` is
       // exact, free, and already on the HEAD response.)
+      //
+      // Size closes most of that gap but not all of it: a re-render can
+      // change content without changing length — a counter, a status word
+      // or a timestamp keeping its width — and inside one `Last-Modified`
+      // second such a rewrite is invisible to both headers. So `serve` also
+      // sends `X-Content-Revision`, a digest of the bytes themselves
+      // (server.py), and it joins the comparison. `ETag` stays in the list
+      // for any other server that sets one; ours deliberately does not.
       let lastStamp = null;
       let stopped = false;
       let following = false;
@@ -72627,6 +72707,7 @@
                   head.headers.get('Last-Modified') || '',
                   length,
                   head.headers.get('ETag') || '',
+                  head.headers.get('X-Content-Revision') || '',
               ].join('|');
               const served = lastStamp === null ? loadedLength() : null;
               const missedOnLoad = !!served && !!length && Number(length) !== served;

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -379,11 +379,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -2267,20 +2268,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -5172,6 +5216,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -5235,78 +5283,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -5337,16 +5404,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -5455,39 +5522,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -5496,13 +5840,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -5551,7 +5895,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -7791,11 +8135,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -9679,20 +10024,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -12479,6 +12867,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -12542,78 +12934,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -12644,16 +13055,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -12762,39 +13173,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -12803,13 +13491,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -12858,7 +13546,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -15098,11 +15786,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -17241,78 +17930,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -17713,11 +18421,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -19601,20 +20310,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -22624,6 +23376,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -22687,78 +23443,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -22789,16 +23564,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -22907,39 +23682,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -22948,13 +24000,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -23003,7 +24055,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -25243,11 +26295,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -27131,20 +28184,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -30434,6 +31530,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -30497,78 +31597,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -30599,16 +31718,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -30717,39 +31836,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -30758,13 +32154,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -30813,7 +32209,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -33053,11 +34449,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -34941,20 +36338,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -38191,6 +39631,10 @@
       </div>
   
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -38254,78 +39698,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -38356,16 +39819,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -38474,39 +39937,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -38515,13 +40255,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -38570,7 +40310,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -40810,11 +42550,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -42698,20 +44439,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -45893,6 +47677,10 @@
       </div>
   
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -45956,78 +47744,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -46058,16 +47865,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -46176,39 +47983,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -46217,13 +48301,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -46272,7 +48356,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -48512,11 +50596,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -50400,20 +52485,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -53423,6 +55551,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -53486,78 +55618,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -53588,16 +55739,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -53706,39 +55857,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -53747,13 +56175,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -53802,7 +56230,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -56042,11 +58470,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -57930,20 +60359,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -60758,6 +63230,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -60821,78 +63297,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -60923,16 +63418,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -61041,39 +63536,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -61082,13 +63854,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -61137,7 +63909,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   
@@ -63377,11 +66149,12 @@
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
-   * the transcript text underneath doesn't bleed through the message. */
+   * the transcript text underneath doesn't bleed through the message.
+   * Sits above the follow toggle (440px), which is the top of the stack. */
   .resume-toast {
       position: fixed;
       right: 20px;
-      bottom: 440px;
+      bottom: 500px;
       max-width: 320px;
       padding: 8px 12px;
       background-color: #e8f4fd;
@@ -65265,20 +68038,63 @@
       }
   }
   
-  .live-update-pill {
-      bottom: 20px;
-      left: 20px;
-      width: auto;
-      min-width: 3em;
-      padding: 0 0.9em;
-      border-radius: 999px;
-      font-size: 0.85em;
-      white-space: nowrap;
+  /* Follow toggle (`serve --watch`): a member of the floating stack, at the
+     top of it. It is rendered on every transcript page but stays hidden
+     until the poller actually starts — a `file://` page cannot poll at all
+     (see live_update.js), and a visible control there would promise
+     something it can never do.
+  
+     It was previously built in JS as a wide `.live-update-pill`, which set
+     `left: 20px` on top of `.floating-btn`'s `right: 20px`: with `width:
+     auto`, a fixed box with both insets stretches, and the "pill" was
+     measured at 1360px across a 1400px viewport. */
+  .follow-updates.floating-btn {
+      bottom: 440px;
+      display: none;
   }
   
-  .live-update-pill[data-following="yes"] {
-      background-color: var(--highlight-light);
+  .follow-updates.floating-btn.live-active {
+      display: flex;
+  }
+  
+  /* Opaque, as `.debug-toggle.active` is. The old pill signalled
+     "following" with `--highlight-light`, which computes to
+     rgba(227,242,253,0.333) against an idle `--session-bg-dimmed` of
+     rgba(232,244,253,0.4) — i.e. the engaged state rendered *fainter*
+     than the disengaged one. */
+  .follow-updates.floating-btn.following {
+      background-color: #d4e8f7;
+      color: #333;
+  }
+  
+  /* Unseen-message count, as a corner badge so the button keeps the round
+     50px footprint the rest of the stack has. */
+  .follow-updates[data-unseen]:not([data-unseen="0"])::after {
+      content: attr(data-unseen);
+      position: absolute;
+      top: 0;
+      right: 0;
+      box-sizing: border-box;
+      min-width: 17px;
+      height: 17px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background-color: #d64545;
+      color: #fff;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      font-size: 10px;
       font-weight: 600;
+      line-height: 17px;
+  }
+  
+  /* Room under the last card while following, so a newly-arrived message
+     lands clear of the viewport edge instead of flush against it.
+     Measured: with neither, the gap is 0px — the last card's bottom is
+     exactly the viewport bottom. The padding is what supplies the
+     scrollable space; `scrollToEnd` then scrolls the document to its end
+     rather than aligning the card, and the gap becomes this much. */
+  body.live-following {
+      padding-bottom: 120px;
   }
   /* Session navigation styles */
   .navigation {
@@ -68042,6 +70858,10 @@
           title="Resume session: copy the command that resumes this session in Claude Code"
           aria-label="Resume session">▶️</button>
       
+      
+      <button class="follow-updates floating-btn" id="followUpdates" data-unseen="0"
+          title="Follow new messages as they arrive" aria-label="Follow new messages"
+          aria-pressed="false">⏬</button>
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
       <button class="filter-messages floating-btn" id="filterMessages" title="Search & Filter (/)">🔍</button>
       <button class="toggle-details floating-btn" id="toggleDetails" title="Toggle all details">📋</button>
@@ -68105,78 +70925,97 @@
               timeZone: userTimezone
           });
   
-          // Process timestamps in batches to keep page responsive
-          const batchSize = 25;
-          const scheduleWork = window.requestIdleCallback || function(cb) { setTimeout(cb, 16); };
+          function localizeOne(element) {
+              const rawTimestamp = element.getAttribute('data-timestamp');
+              const rawTimestampEnd = element.getAttribute('data-timestamp-end');
+              const duration = element.getAttribute('data-duration');
   
-          function processBatch(startIndex) {
-              const endIndex = Math.min(startIndex + batchSize, timestampElements.length);
+              if (!rawTimestamp) return;
   
-              for (let i = startIndex; i < endIndex; i++) {
-                  const element = timestampElements[i];
-                  const rawTimestamp = element.getAttribute('data-timestamp');
-                  const rawTimestampEnd = element.getAttribute('data-timestamp-end');
-                  const duration = element.getAttribute('data-duration');
+              try {
+                  // Parse the ISO timestamp
+                  const date = new Date(rawTimestamp);
+                  if (isNaN(date.getTime())) return; // Invalid date
   
-                  if (!rawTimestamp) continue;
+                  const localTime = localFormatter.format(date).replace(/, /g, ' ');
+                  const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
   
-                  try {
-                      // Parse the ISO timestamp
-                      const date = new Date(rawTimestamp);
-                      if (isNaN(date.getTime())) continue; // Invalid date
+                  // Get timezone abbreviation (reuse formatter)
+                  const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
   
-                      const localTime = localFormatter.format(date).replace(/, /g, ' ');
-                      const utcTime = utcFormatter.format(date).replace(/, /g, ' ');
+                  // Handle time ranges (earliest to latest)
+                  if (rawTimestampEnd) {
+                      const dateEnd = new Date(rawTimestampEnd);
+                      if (!isNaN(dateEnd.getTime())) {
+                          const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
+                          const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
   
-                      // Get timezone abbreviation (reuse formatter)
-                      const timezoneName = tzNameFormatter.formatToParts(date).find(part => part.type === 'timeZoneName')?.value || userTimezone;
-  
-                      // Handle time ranges (earliest to latest)
-                      if (rawTimestampEnd) {
-                          const dateEnd = new Date(rawTimestampEnd);
-                          if (!isNaN(dateEnd.getTime())) {
-                              const localTimeEnd = localFormatter.format(dateEnd).replace(/, /g, ' ');
-                              const utcTimeEnd = utcFormatter.format(dateEnd).replace(/, /g, ' ');
-  
-                              // Update the element with range
-                              if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
-                                  element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              } else {
-                                  // If they're the same (user is in UTC), just show UTC
-                                  element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                                  element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
-                              }
-                          }
-                      } else {
-                          // Single timestamp
-                          if (localTime !== utcTime) {
-                              element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                          // Update the element with range
+                          if (localTime !== utcTime || localTimeEnd !== utcTimeEnd) {
+                              element.innerHTML = localTime + ' to ' + localTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           } else {
                               // If they're the same (user is in UTC), just show UTC
-                              element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
-                              element.title = duration ? duration : 'UTC: ' + utcTime;
+                              element.innerHTML = utcTime + ' to ' + utcTimeEnd + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                              element.title = 'UTC: ' + utcTime + ' to ' + utcTimeEnd;
                           }
                       }
-  
-                  } catch (error) {
-                      // If conversion fails, leave the original timestamp
-                      console.warn('Failed to convert timestamp:', rawTimestamp, error);
+                  } else {
+                      // Single timestamp
+                      if (localTime !== utcTime) {
+                          element.innerHTML = localTime + ' <span style="color: #888; font-size: 0.9em;">(' + timezoneName + ')</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      } else {
+                          // If they're the same (user is in UTC), just show UTC
+                          element.innerHTML = utcTime + ' <span style="color: #888; font-size: 0.9em;">(UTC)</span>';
+                          element.title = duration ? duration : 'UTC: ' + utcTime;
+                      }
                   }
-              }
   
-              // Schedule next batch if there are more timestamps
-              if (endIndex < timestampElements.length) {
-                  scheduleWork(function() {
-                      processBatch(endIndex);
-                  });
+              } catch (error) {
+                  // If conversion fails, leave the original timestamp
+                  console.warn('Failed to convert timestamp:', rawTimestamp, error);
               }
           }
   
-          // Start processing the first batch
-          scheduleWork(function() {
-              processBatch(0);
+          // Drain the queue against the idle deadline rather than a fixed batch
+          // size. The work itself is cheap — a whole 4MB page's 1,180 timestamps
+          // cost ~8ms of CPU — so a fixed 25-per-callback made the *callback
+          // count* the cost: 48 idle turns for that page, measured at 766ms of
+          // wall clock, and 3.3s for a 27MB one. Worse, the queue is in document
+          // order, so cards appended by a live update localise last and the
+          // fade-in plays over a raw ISO string.
+          //
+          // Draining on the deadline instead takes those to 13ms and 35ms —
+          // within a few ms of a straight synchronous pass, while still handing
+          // the main thread back whenever the browser wants it.
+          const scheduleWork = window.requestIdleCallback
+              ? function(cb) { window.requestIdleCallback(cb, { timeout: 200 }); }
+              // No requestIdleCallback (Safari < 16): a macrotask still yields
+              // between slices, and the synthetic deadline keeps them bounded.
+              : function(cb) { setTimeout(function() { cb({ timeRemaining: function() { return 8; }, didTimeout: false }); }, 0); };
+  
+          let cursor = 0;
+          function drain(deadline) {
+              // timeRemaining() is not free, so check it per chunk rather than
+              // per element; 32 conversions cost well under a millisecond.
+              const chunk = 32;
+              while (cursor < timestampElements.length) {
+                  if (!deadline.didTimeout && deadline.timeRemaining() <= 1) break;
+                  const end = Math.min(cursor + chunk, timestampElements.length);
+                  for (; cursor < end; cursor++) localizeOne(timestampElements[cursor]);
+              }
+              if (cursor < timestampElements.length) scheduleWork(drain);
+          }
+  
+          // The first slice runs on the current task, so a live update's new
+          // cards are localised before the browser paints them rather than an
+          // idle turn later. It gets a real budget rather than an unbounded
+          // one, so the largest pages yield instead of blocking on load.
+          const firstSliceEnds = performance.now() + 24;
+          drain({
+              timeRemaining: function() { return Math.max(0, firstSliceEnds - performance.now()); },
+              didTimeout: false
           });
       }
   
@@ -68207,16 +71046,16 @@
   //     conversion and the files on disk stay canonical, so this page just
   //     re-fetches its own URL. A conditional GET makes the idle case free
   //     (304 in ~1ms) and needs no endpoint of its own.
-  //   * We swap #transcript rather than reloading. A reload loses fold
-  //     state and re-parses a document that can reach tens of MB; a swap
-  //     keeps scroll position for free, because everything above the
-  //     viewport is untouched.
-  //   * We do not patch in individual messages. New entries do not always
-  //     belong at the end (a transcript's appends are not in timestamp
-  //     order), one entry can render as several cards, and the `msg-d-N`
-  //     anchors are positional — inserting anywhere but the tail renumbers
-  //     them and breaks the fork/tool-pair links already on the page.
-  //     Replacing the whole container sidesteps all three.
+  //   * We never reload. A reload loses fold state and re-parses a
+  //     document that can reach tens of MB.
+  //   * When the new render extends the one on screen, we patch the nodes
+  //     that changed and leave the rest alone (see "patching" below). When
+  //     it does not, we replace #transcript wholesale — which keeps scroll
+  //     position for free, because everything above the viewport is
+  //     untouched, and is the fallback for every shape the patch declines:
+  //     entries that do not belong at the end (a transcript's appends are
+  //     not in timestamp order) and the `msg-d-N` renumbering that follows,
+  //     which would break the fork/tool-pair links already on the page.
   (function () {
       'use strict';
   
@@ -68325,39 +71164,316 @@
           return count;
       }
   
-      // ---- the update ------------------------------------------------------
+      // ---- patching, for the case that is almost always the real one -------
+      //
+      // Replacing #transcript wholesale costs work proportional to the *page*
+      // for a change proportional to the *append*: on a 4MB session page,
+      // ~97ms of DOM work plus re-localising all 1,180 timestamps, to show two
+      // new cards. It also reconstructs fold and disclosure state from a
+      // heuristic key rather than keeping the nodes that already hold it.
+      //
+      // So when the new render is a pure *extension* of the one on screen —
+      // the same cards, in the same order, followed by new ones — we patch
+      // instead: replace the handful of cards whose own markup actually
+      // changed, insert the new ones, and leave every other node untouched.
+      // Measured on the same page: 2 cards inserted, 2 timestamps localised.
+      //
+      // Anything else falls back to the swap, which is unchanged and stays the
+      // definition of correct. Replaying three real sessions through the
+      // renderer, 45 of 47 growth steps were pure extensions; the other 2 were
+      // out-of-order arrivals that renumbered the positional `msg-d-N` ids, so
+      // they take the swap. That ratio is why the fallback is acceptable and
+      // why patching the general case is not worth its complexity yet.
   
-      function announce(added) {
-          let pill = document.getElementById('live-update-pill');
-          if (!pill) {
-              pill = document.createElement('button');
-              pill.id = 'live-update-pill';
-              pill.className = 'floating-btn live-update-pill';
-              pill.addEventListener('click', () => {
-                  following = !following;
-                  if (following) scrollToEnd();
-                  render();
-              });
-              document.body.appendChild(pill);
-          }
-          pill.dataset.following = following ? 'yes' : 'no';
-          pill.unseen = (pill.unseen || 0) + added;
-          render();
+      // The hashes the cards on screen were rendered from, keyed by card id.
+      // Taken from pristine parsed markup, never from the live DOM: by update
+      // time the live tree has been rewritten by decoration (timestamp
+      // localisation replaces innerHTML), so a hash taken from it would never
+      // match one taken from the server's bytes.
+      let cardHashes = null;
   
-          function render() {
-              if (following) pill.unseen = 0;
-              pill.textContent = following
-                  ? '⏬ following'
-                  : (pill.unseen ? `⏬ ${pill.unseen} new` : '⏬ follow');
-              pill.title = following
-                  ? 'Following new messages — click to stop'
-                  : 'Scroll to new messages as they arrive';
+      // FNV-1a. A collision would show one stale card, not break the page, and
+      // needs a *changed* card to land on its own previous value: 1 in 2^32.
+      function hashOf(s) {
+          let h = 0x811c9dc5;
+          for (let i = 0; i < s.length; i++) {
+              h ^= s.charCodeAt(i);
+              h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
           }
+          return h.toString(36);
       }
   
+      // What belongs to a node itself rather than to its descendants. That is
+      // the card — but not only the card: a fork point renders as a box inside
+      // `.children` so that folding hides it with the subtree, and on a
+      // fork-only slot that box is the node's *only* content and carries its
+      // id. Both kinds also hold positional `#msg-d-N` branch links, so
+      // treating them as part of the node is what keeps a changed fork point
+      // from being missed.
+      //
+      // The template always emits them after the child nodes, which is what
+      // lets `applyOwn` below put replacements back by appending.
+      function ownParts(node) {
+          const parts = [];
+          const card = node.querySelector(':scope > .message');
+          if (card) parts.push(card);
+          const kids = node.querySelector(':scope > .children');
+          if (kids) {
+              Array.from(kids.children).forEach(el => {
+                  if (!el.classList.contains('message-node')) parts.push(el);
+              });
+          }
+          return parts;
+      }
+  
+      // A node's identity: its card's id, or — for a fork-only slot, which has
+      // no card — the fork-point box's.
+      function nodeKey(node) {
+          const card = node.querySelector(':scope > .message');
+          if (card && card.id) return card.id;
+          const fork = node.querySelector(':scope > .children > .fork-point[id]');
+          return fork ? fork.id : null;
+      }
+  
+      // Node keys in document order, plus a hash of each node's own markup.
+      // A node with no key at all makes the whole update unpatchable, because
+      // the extension test below is only meaningful over a complete sequence.
+      // `withHashes` is off for the live tree: only its key sequence is
+      // wanted there, and hashing it would serialise the whole page — the
+      // very cost this is here to avoid. Its hashes would be meaningless
+      // anyway, having been taken after decoration rewrote the markup.
+      function scanTree(root, withHashes) {
+          const ids = [];
+          const hashes = new Map();
+          let ok = true;
+          root.querySelectorAll('.message-node').forEach(node => {
+              const key = nodeKey(node);
+              if (!key) { ok = false; return; }
+              ids.push(key);
+              if (withHashes) {
+                  hashes.set(key, hashOf(ownParts(node).map(el => el.outerHTML).join('')));
+              }
+          });
+          return { ids, hashes, ok };
+      }
+  
+      // Swap a node's own markup for the new render's, leaving its children
+      // alone. The card is replaced in place; the trailing parts are dropped
+      // and re-appended, which is correct because the template emits them
+      // after the child nodes.
+      //
+      // Returns the elements it actually put on the page, or null if the node
+      // is not a shape it can handle. Returning *those* rather than the node
+      // matters: the caller rehydrates what comes back, and a node's subtree
+      // is not what changed. The session header is the case that makes this
+      // sharp — its fold bar counts descendants, so it is replaced on every
+      // single append, and its node is the whole page.
+      function applyOwn(liveNode, newNode) {
+          const liveCard = liveNode.querySelector(':scope > .message');
+          const newCard = newNode.querySelector(':scope > .message');
+          if (!!liveCard !== !!newCard) return null;
+  
+          const placed = [];
+          if (liveCard && newCard) {
+              const imported = document.importNode(newCard, true);
+              liveCard.replaceWith(imported);
+              placed.push(imported);
+          }
+  
+          const newTrailing = ownParts(newNode).filter(el => !el.classList.contains('message'));
+          const liveKids = liveNode.querySelector(':scope > .children');
+          if (!liveKids) return newTrailing.length === 0 ? placed : null;
+          Array.from(liveKids.children).forEach(el => {
+              if (!el.classList.contains('message-node')) el.remove();
+          });
+          newTrailing.forEach(el => {
+              const imported = document.importNode(el, true);
+              liveKids.appendChild(imported);
+              placed.push(imported);
+          });
+          return placed;
+      }
+  
+      // Where a new node belongs in the live tree: inside its parent's
+      // `.children`, after the last card already there. Because the id
+      // sequence is an extension, every new card follows every existing one in
+      // document order, so appending after the last `.message-node` is the
+      // right place — and going through `.message-node` rather than the
+      // container's last child keeps any trailing junction-link markup last.
+      function liveNodeFor(key) {
+          const el = document.getElementById(key);
+          return el ? el.closest('.message-node') : null;
+      }
+  
+      function insertNode(newNode, imported) {
+          const parentNode = newNode.parentElement
+              && newNode.parentElement.closest('.message-node');
+          let liveKids;
+          if (!parentNode) {
+              liveKids = container();
+          } else {
+              const key = nodeKey(parentNode);
+              const holder = key && liveNodeFor(key);
+              if (!holder) return false;
+              liveKids = holder.querySelector(':scope > .children');
+              if (!liveKids) {
+                  // The parent had no children until now, so it has no
+                  // container to put them in; take the new one wholesale.
+                  const newKids = parentNode.querySelector(':scope > .children');
+                  if (!newKids) return false;
+                  holder.appendChild(document.importNode(newKids, true));
+                  return true;
+              }
+          }
+          if (!liveKids) return false;
+          const existing = liveKids.querySelectorAll(':scope > .message-node');
+          if (existing.length) existing[existing.length - 1].after(imported);
+          else liveKids.prepend(imported);
+          return true;
+      }
+  
+      // Returns the number of cards added, or null if this update is not a
+      // shape we patch — in which case the caller swaps.
+      function tryPatch(nextRoot, next) {
+          if (!cardHashes || !next.ok) return null;
+          const live = scanTree(container(), false);
+          if (!live.ok) return null;
+  
+          // A pure extension: every node on screen is still there, with the
+          // same key, in the same order. This is what fails when an
+          // out-of-order arrival renumbers the positional ids, and it is
+          // deliberately an all-or-nothing test — a single mismatch means the
+          // ids no longer mean what they meant, so nothing keyed on them is
+          // trustworthy.
+          if (next.ids.length < live.ids.length) return null;
+          for (let i = 0; i < live.ids.length; i++) {
+              if (next.ids[i] !== live.ids[i]) return null;
+          }
+  
+          const changed = [];
+          for (const key of live.ids) {
+              if (cardHashes.get(key) !== next.hashes.get(key)) changed.push(key);
+          }
+          // A broad edit is cheaper to apply wholesale than node by node. An
+          // append moves only the ancestors' descendant counts, so this stays
+          // in single digits in practice.
+          if (changed.length > 40) return null;
+  
+          // Resolve everything before touching the live DOM, so a shape we
+          // cannot handle leaves the page untouched for the swap to redo.
+          const edits = [];
+          for (const key of changed) {
+              const liveNode = liveNodeFor(key);
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!liveNode || !newNode) return null;
+              edits.push([liveNode, newNode]);
+          }
+  
+          const known = new Set(live.ids);
+          const additions = [];
+          for (const key of next.ids) {
+              if (known.has(key)) continue;
+              const newAnchor = nextRoot.querySelector('[id="' + CSS.escape(key) + '"]');
+              const newNode = newAnchor && newAnchor.closest('.message-node');
+              if (!newNode) return null;
+              // A new node nested inside another new node arrives with it;
+              // `next.ids` is in document order, so the outer one comes first.
+              if (additions.some(([, outer]) => outer.contains(newNode))) continue;
+              additions.push([key, newNode]);
+          }
+  
+          const fresh = [];
+          // Nodes already on screen whose own markup legitimately changed: an
+          // ancestor's descendant count, or a `pair_first` class arriving with
+          // the other half of a pair. The subtree underneath is kept, and with
+          // it every bit of state the card holds.
+          for (const [liveNode, newNode] of edits) {
+              const placed = applyOwn(liveNode, newNode);
+              if (!placed) return null;
+              placed.forEach(el => fresh.push(el));
+          }
+  
+          // New nodes. These carry the fade-in; the ones replaced above
+          // deliberately do not, since they were already on screen.
+          let added = 0;
+          for (const [key, newNode] of additions) {
+              const imported = document.importNode(newNode, true);
+              if (!insertNode(newNode, imported)) return null;
+              added += imported.querySelectorAll('.message').length;
+              imported.querySelectorAll('.message').forEach(el => el.classList.add('live-new'));
+              fresh.push(imported);
+          }
+  
+          // Rehydrate over what actually changed, not over the whole tree.
+          if (window.claudeLogRehydrate) {
+              fresh.forEach(el => window.claudeLogRehydrate(el));
+          }
+          return added;
+      }
+  
+      // ---- the update ------------------------------------------------------
+  
+      // The toggle is part of the page's floating-button stack rather than
+      // something this script builds, so it is styled with the rest of the
+      // toolbar and cannot drift from it. It is revealed only here, because
+      // reaching this point is the proof that polling is possible at all.
+      const followBtn = document.getElementById('followUpdates');
+      let unseen = 0;
+  
+      function renderFollowBtn() {
+          if (!followBtn) return;
+          if (following) unseen = 0;
+          followBtn.classList.toggle('following', following);
+          followBtn.setAttribute('aria-pressed', following ? 'true' : 'false');
+          followBtn.dataset.unseen = String(unseen);
+          followBtn.title = following
+              ? 'Following new messages — click to stop'
+              : (unseen
+                  ? `${unseen} new message${unseen === 1 ? '' : 's'} — click to follow`
+                  : 'Follow new messages as they arrive');
+          document.body.classList.toggle('live-following', following);
+      }
+  
+      function setFollowing(next) {
+          following = !!next;
+          renderFollowBtn();
+          if (following) scrollToEnd();
+      }
+  
+      if (followBtn) {
+          followBtn.classList.add('live-active');
+          followBtn.addEventListener('click', () => setFollowing(!following));
+          renderFollowBtn();
+      }
+  
+      function announce(added) {
+          unseen += added;
+          renderFollowBtn();
+      }
+  
+      // Scroll the document to its end rather than aligning the last card,
+      // which is what `scrollIntoView({block: 'end'})` did: that puts the
+      // card's bottom edge *exactly* on the viewport's, measured at a 0px
+      // gap. `body.live-following`'s padding supplies the space this then
+      // scrolls into. Both halves are needed — measured on a real page, the
+      // padding alone still gives 0px (the alignment ignores it) and a
+      // scroll-margin alone gives 25px (there is no room left to give).
       function scrollToEnd() {
-          const c = container();
-          if (c) c.lastElementChild?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+          window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: 'smooth',
+          });
+      }
+  
+      function swapIn(next, current) {
+          const before = captureState(current);
+          current.replaceWith(next);
+          restoreState(next, before);
+          const added = markNew(next, before.keys);
+          // Everything that decorated the old markup after load.
+          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          return added;
       }
   
       async function applyUpdate(html) {
@@ -68366,13 +71482,13 @@
           const current = container();
           if (!next || !current) return;
   
-          const before = captureState(current);
-          current.replaceWith(next);
-          restoreState(next, before);
-          const added = markNew(next, before.keys);
-  
-          // Everything that decorated the old markup after load.
-          if (window.claudeLogRehydrate) window.claudeLogRehydrate(next);
+          // Hashes come from the parsed bytes, before anything is put on the
+          // page, and are kept whichever route the update took — the swap is a
+          // valid starting point for the next patch.
+          const scan = scanTree(next, true);
+          let added = tryPatch(next, scan);
+          if (added === null) added = swapIn(next, current);
+          cardHashes = scan.hashes;
   
           // The title carries the message/token counts, and the session nav
           // its summaries; both go stale otherwise.
@@ -68421,7 +71537,7 @@
       window.claudeLogLiveUpdate = {
           poll,
           stop() { stopped = true; },
-          setFollowing(v) { following = !!v; },
+          setFollowing,
       };
   })();
   

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -34,6 +34,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -374,18 +379,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -7903,6 +7918,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -8243,18 +8263,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -15667,6 +15697,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -16007,18 +16042,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -18302,6 +18347,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -18642,18 +18692,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -26289,6 +26349,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -26629,18 +26694,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -34556,6 +34631,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -34896,18 +34976,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -42770,6 +42860,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -43110,18 +43205,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -50929,6 +51034,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -51269,18 +51379,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -58916,6 +59036,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -59256,18 +59381,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);
@@ -66708,6 +66843,11 @@
       --session-bg-dimmed: #e8f4fd66;
       --ide-notification-dimmed: #d2d6d966;
   
+      /* Where the resume-session button sits in the floating stack. Named
+       * because its toast is positioned beside it and must follow it when
+       * the stack is reordered. */
+      --resume-btn-bottom: 380px;
+  
       /* Fully transparent variants (88 = ~53% opacity) */
       --highlight-semi: #e3f2fd88;
       --error-semi: #ffebee88;
@@ -67048,18 +67188,28 @@
   /* Resume-session button (single-session pages only): copies the
    * `pushd … && claude -r <session-id>` command to the clipboard. */
   .resume-session.floating-btn {
-      bottom: 380px;
+      bottom: var(--resume-btn-bottom);
   }
   
   /* Transient confirmation shown after the resume command is copied.
    * Opaque background (not the `…-dimmed` variant the buttons use) so
    * the transcript text underneath doesn't bleed through the message.
-   * Sits above the follow toggle (440px), which is the top of the stack. */
+   *
+   * Sits to the *left* of its own button, centred on it: stacking it above
+   * the buttons meant every new one added to the stack pushed the toast up
+   * too, over buttons it has nothing to do with. Anchoring it beside the
+   * button it belongs to keeps that a one-number change
+   * (`--resume-btn-bottom`), and the column to the left is empty.
+   *
+   * The centring is height-agnostic — bottom edge at the button's middle,
+   * then shifted down by half the toast's own height — because the message
+   * wraps to one or two lines depending on the viewport. */
   .resume-toast {
       position: fixed;
-      right: 20px;
-      bottom: 500px;
-      max-width: 320px;
+      right: calc(20px + 50px + 12px);  /* button right + width + gap */
+      bottom: calc(var(--resume-btn-bottom) + 25px);
+      transform: translateY(50%);
+      max-width: min(320px, calc(100vw - 120px));
       padding: 8px 12px;
       background-color: #e8f4fd;
       color: var(--text-muted);

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -4821,6 +4821,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -5070,7 +5071,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/async-fixture &amp;&amp; claude -r eb000000-0000-4000-8000-000000000001"
@@ -11891,6 +11892,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -12035,7 +12037,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/async-fixture &amp;&amp; claude -r eb000000-0000-4000-8000-000000000001"
@@ -21457,6 +21459,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -21824,7 +21827,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp &amp;&amp; claude -r test_session"
@@ -28645,6 +28648,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -29292,7 +29296,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /home/synthetic/test-fixture &amp;&amp; claude -r ef000000-0000-4000-8000-000000000001"
@@ -36113,6 +36117,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -36711,7 +36716,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
@@ -43589,6 +43594,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -44071,7 +44077,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="timeline-toggle floating-btn" id="toggleTimeline" title="Show timeline">📆</button>
@@ -50888,6 +50894,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -51255,7 +51262,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp &amp;&amp; claude -r test_session"
@@ -58076,6 +58083,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -58248,7 +58256,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp/project &amp;&amp; claude -r 00000000-0295-4000-8000-000000000001"
@@ -65069,6 +65077,7 @@
       
   
       
+      <div id="transcript">
       
       <div class="session-divider"></div>
       
@@ -65190,7 +65199,7 @@
       
       </div>
       
-      
+      </div>
   
       
       <button class="resume-session floating-btn" id="resumeSession" data-command="cd /tmp/project &amp;&amp; claude -r system_reminder"

--- a/test/__snapshots__/test_snapshot_html.ambr
+++ b/test/__snapshots__/test_snapshot_html.ambr
@@ -2322,9 +2322,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -5402,8 +5404,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -5419,8 +5422,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -5858,8 +5862,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -5870,14 +5892,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -6483,24 +6509,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -6625,6 +6657,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -10078,9 +10146,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -13053,8 +13123,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -13070,8 +13141,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -13509,8 +13581,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -13521,14 +13611,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -14134,24 +14228,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -14276,6 +14376,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -20364,9 +20500,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -23562,8 +23700,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -23579,8 +23718,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -24018,8 +24158,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -24030,14 +24188,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -24643,24 +24805,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -24785,6 +24953,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -28238,9 +28442,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -31716,8 +31922,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -31733,8 +31940,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -32172,8 +32380,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -32184,14 +32410,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -32797,24 +33027,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -32939,6 +33175,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -36392,9 +36664,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -39817,8 +40091,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -39834,8 +40109,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -40273,8 +40549,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -40285,14 +40579,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -40898,24 +41196,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -41040,6 +41344,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -44493,9 +44833,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -47863,8 +48205,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -47880,8 +48223,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -48319,8 +48663,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -48331,14 +48693,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -48944,24 +49310,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -49086,6 +49458,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -52539,9 +52947,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -55737,8 +56147,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -55754,8 +56165,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -56193,8 +56605,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -56205,14 +56635,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -56818,24 +57252,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -56960,6 +57400,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -60413,9 +60889,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -63416,8 +63894,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -63433,8 +63912,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -63872,8 +64352,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -63884,14 +64382,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -64497,24 +64999,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -64639,6 +65147,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the
@@ -68092,9 +68636,11 @@
      Measured: with neither, the gap is 0px — the last card's bottom is
      exactly the viewport bottom. The padding is what supplies the
      scrollable space; `scrollToEnd` then scrolls the document to its end
-     rather than aligning the card, and the gap becomes this much. */
+     rather than aligning the card, and the gap becomes this much. Kept
+     small deliberately — enough to read as breathing room, not enough to
+     leave the newest message stranded above a band of empty page. */
   body.live-following {
-      padding-bottom: 120px;
+      padding-bottom: 20px;
   }
   /* Session navigation styles */
   .navigation {
@@ -71044,8 +71590,9 @@
   //
   //   * The server never renders. `serve --watch` re-runs the ordinary
   //     conversion and the files on disk stay canonical, so this page just
-  //     re-fetches its own URL. A conditional GET makes the idle case free
-  //     (304 in ~1ms) and needs no endpoint of its own.
+  //     re-fetches its own URL. A HEAD for the page's own metadata makes
+  //     the idle case free (~1ms, no body) and needs no endpoint of its
+  //     own; the full GET follows only when that metadata moved.
   //   * We never reload. A reload loses fold state and re-parses a
   //     document that can reach tens of MB.
   //   * When the new render extends the one on screen, we patch the nodes
@@ -71061,8 +71608,9 @@
   
       if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
   
-      // A conditional GET costs ~1ms and 304s while nothing changes, so the
-      // interval is set by how fresh the page should feel, not by load.
+      // A metadata HEAD costs ~1ms and carries no body while nothing
+      // changes, so the interval is set by how fresh the page should feel,
+      // not by load.
       const POLL_MS = 1000;
       const container = () => document.getElementById('transcript');
       if (!container()) return;
@@ -71500,8 +72048,26 @@
           if (following) scrollToEnd();
       }
   
+      // One poll at a time. The interval keeps firing while a full GET is in
+      // flight, and a page slow enough to fetch — which is exactly the large
+      // page all of this is for — would then have two updates racing:
+      // whichever *response* lands last wins, so an older render overwrites a
+      // newer one and the page loses messages it had already shown. Measured
+      // by holding one response for 3s: the newest message appeared at 2.0s,
+      // vanished at 4.0s when the stale body landed, and came back at 5.0s.
+      //
+      // Serialising is what stops it, and skipping a tick costs nothing:
+      // `lastStamp` only advances once an update has actually been applied,
+      // so the next tick still sees the change. (That ordering is also what
+      // bounds the damage above to one second rather than forever — the
+      // stale apply rewinds `lastStamp` to its own older value, so the next
+      // HEAD finds a difference again. Recording the stamp before the GET
+      // instead leaves the page wrong until something else changes.)
+      let polling = false;
+  
       async function poll() {
-          if (stopped) return;
+          if (stopped || polling) return;
+          polling = true;
           try {
               const head = await fetch(location.href, { method: 'HEAD', cache: 'no-store' });
               const stamp = [
@@ -71512,14 +72078,18 @@
               if (lastStamp === null) {
                   lastStamp = stamp;
               } else if (stamp !== lastStamp) {
-                  lastStamp = stamp;
                   const res = await fetch(location.href, { cache: 'no-store' });
-                  if (res.ok) await applyUpdate(await res.text());
+                  if (res.ok) {
+                      await applyUpdate(await res.text());
+                      lastStamp = stamp;
+                  }
               }
           } catch (err) {
               // A dropped server is the normal end of a watch session, not an
               // error worth shouting about. Keep polling: `serve` may come back.
               console.debug('live update poll failed', err);
+          } finally {
+              polling = false;
           }
       }
   
@@ -72125,24 +72695,30 @@
               // Apply all filters on page load
               applyFilter();
   
-              // Fold/unfold functionality with horizontal fold bars
-              const foldBarSections = document.querySelectorAll('.fold-bar-section');
+              // Fold/unfold functionality with horizontal fold bars.
+              //
+              // Delegated on `document` rather than bound per section, because
+              // a live update (`serve --watch`) replaces fold bars: a card's
+              // bar carries its descendant count, so every append re-renders
+              // the ancestors' bars, and the container swap replaces all of
+              // them. Bound directly, those listeners died with the elements
+              // and the fold controls silently stopped responding — measured:
+              // one update was enough to leave every bar on the page inert.
+              document.addEventListener('click', function (event) {
+                  const section = event.target.closest('.fold-bar-section');
+                  if (!section) return;
+                  event.stopPropagation();
+                  const action = section.getAttribute('data-action');
+                  const targetId = section.getAttribute('data-target');
+                  const isFolded = section.classList.contains('folded');
   
-              foldBarSections.forEach(section => {
-                  section.addEventListener('click', function(e) {
-                      e.stopPropagation();
-                      const action = this.getAttribute('data-action');
-                      const targetId = this.getAttribute('data-target');
-                      const isFolded = this.classList.contains('folded');
-  
-                      if (action === 'fold-one') {
-                          // Fold/unfold immediate children only
-                          handleFoldOne(targetId, isFolded, this);
-                      } else if (action === 'fold-all') {
-                          // Fold/unfold all descendants recursively
-                          handleFoldAll(targetId, isFolded, this);
-                      }
-                  });
+                  if (action === 'fold-one') {
+                      // Fold/unfold immediate children only
+                      handleFoldOne(targetId, isFolded, section);
+                  } else if (action === 'fold-all') {
+                      // Fold/unfold all descendants recursively
+                      handleFoldAll(targetId, isFolded, section);
+                  }
               });
   
               // Update tooltip based on fold state
@@ -72267,6 +72843,42 @@
   
               // Apply initial fold state
               setInitialFoldState();
+  
+              // Re-sync a fold bar to what its children container is actually
+              // doing. A live update re-renders a card whenever its descendant
+              // count changes — which is every ancestor of every append — and
+              // the replacement arrives with the server's default icons, not
+              // the state the user left it in. The children container is never
+              // replaced, so its own `display` is the truth; without this the
+              // bar claims "unfolded" over a hidden subtree, and the next
+              // click folds what is already folded and appears to do nothing.
+              function syncFoldBar(card) {
+                  const foldBar = card.querySelector(':scope > .fold-bar');
+                  if (!foldBar) return;
+                  const cc = getChildrenContainer(card);
+                  const oneSection = foldBar.querySelector('.fold-one-level');
+                  const allSection = foldBar.querySelector('.fold-all-levels');
+                  if (!cc || cc.style.display === 'none') {
+                      setSectionState(oneSection, true, '⏵');
+                      setSectionState(allSection, true, '⏵⏵');
+                      return;
+                  }
+                  // Immediate children are visible; `fold-all` reads as open
+                  // only when their own subtrees are open too.
+                  const kids = getImmediateChildMessages(card);
+                  const allOpen = kids.every(child => {
+                      const childCc = getChildrenContainer(child);
+                      return !childCc || childCc.style.display !== 'none';
+                  });
+                  setSectionState(oneSection, false, '⏷');
+                  setSectionState(allSection, !allOpen, allOpen ? '⏷⏷' : '⏵⏵');
+              }
+              if (window.claudeLogOnRehydrate) {
+                  window.claudeLogOnRehydrate(function (root) {
+                      if (root.matches && root.matches('.message')) syncFoldBar(root);
+                      root.querySelectorAll('.message').forEach(syncFoldBar);
+                  });
+              }
   
               // Unfold any folded ancestors so an anchor target (e.g. a tool_use
               // jumped to from the session index) is actually visible. In the

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -215,7 +215,32 @@ def _browser_user_data_dir(worker_id):
 
 
 @pytest.fixture(scope="session")
-def _persistent_context(playwright, browser_type_launch_args, _browser_user_data_dir):
+def _browser_expect_timeout():
+    """Give web-first assertions room for a starved CI machine.
+
+    Playwright's default is 5 s, which is a budget for *the page*, not for
+    the machine — and browser tests run under ``-n auto``, so a 4-core
+    Windows runner hosts four Chromiums at once. A confirmed failure there
+    (``test_search_unfolds_matches_in_folded_subtrees``, Windows/3.13,
+    green on 3.11 in the same matrix) had Playwright resolving its locator
+    only three times inside the five seconds — ~1.6 s per poll — so the
+    assertion expired while the page was still catching up rather than
+    because anything was wrong with it. Raising the ceiling costs nothing
+    on a passing run: an assertion that will pass still returns as soon as
+    it does.
+    """
+    from playwright.sync_api import expect
+
+    expect.set_options(timeout=20_000)
+
+
+@pytest.fixture(scope="session")
+def _persistent_context(
+    playwright,
+    browser_type_launch_args,
+    _browser_user_data_dir,
+    _browser_expect_timeout,
+):
     """Create a persistent browser context that shares HTTP cache across tests.
 
     This solves flaky CDN loading issues by caching resources like vis-timeline

--- a/test/test_atomic_write.py
+++ b/test/test_atomic_write.py
@@ -7,6 +7,7 @@ that `Path.write_text` opens stops being theoretical.
 """
 
 import os
+import sys
 import threading
 from pathlib import Path
 
@@ -47,6 +48,16 @@ def test_temp_file_is_removed_on_failure(tmp_path: Path, monkeypatch) -> None:
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Windows blocks the replace while a reader holds the target open "
+        "(Python's `open` does not grant FILE_SHARE_DELETE), so this "
+        "reader loop makes the writer fail rather than tear — a different "
+        "property from the one under test. The retry that covers it there "
+        "is `test_the_replace_is_retried_past_a_holding_reader`."
+    ),
+)
 def test_reader_never_sees_a_partial_file(tmp_path: Path) -> None:
     """The point of the helper, exercised against a concurrent reader.
 
@@ -81,6 +92,48 @@ def test_reader_never_sees_a_partial_file(tmp_path: Path) -> None:
     # Only the two complete sizes are ever observable — never a torn
     # prefix, never a missing file.
     assert observed <= {len(small), len(large)}, sorted(observed)
+
+
+def test_the_replace_is_retried_past_a_holding_reader(tmp_path, monkeypatch) -> None:
+    """What a reader costs on Windows: a refusal, not a torn file.
+
+    A reader with the target open makes `os.replace` raise
+    `PermissionError` there until it closes — so the write has to wait it
+    out rather than fail the conversion. Simulated, because the platform
+    that does this is not the one the suite runs on.
+    """
+    target = tmp_path / "out.html"
+    target.write_text("old")
+    real_replace = os.replace
+    attempts: list[int] = []
+
+    def busy(src, dst):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise PermissionError(5, "Access is denied")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", busy)
+    monkeypatch.setattr("claude_code_log.utils._REPLACE_BACKOFF_S", 0.001)
+
+    atomic_write_text(target, "new")
+    assert target.read_text() == "new"
+    assert len(attempts) == 3, "the replace was not retried"
+
+
+def test_a_reader_that_never_lets_go_still_reports(tmp_path, monkeypatch) -> None:
+    """Retrying forever would hang a watch; the error still surfaces."""
+    target = tmp_path / "out.html"
+
+    def always_busy(_src, _dst):
+        raise PermissionError(5, "Access is denied")
+
+    monkeypatch.setattr(os, "replace", always_busy)
+    monkeypatch.setattr("claude_code_log.utils._REPLACE_BACKOFF_S", 0.001)
+
+    with pytest.raises(PermissionError):
+        atomic_write_text(target, "x")
+    assert list(tmp_path.iterdir()) == [], "the temp file outlived the failure"
 
 
 def test_symlink_is_written_through_not_replaced(tmp_path: Path) -> None:

--- a/test/test_atomic_write.py
+++ b/test/test_atomic_write.py
@@ -1,0 +1,108 @@
+"""Tests for `utils.atomic_write_text`.
+
+The property that matters: a reader never observes a partial file. Watch
+mode rewrites the same output every few seconds while an editor, a vault
+indexer or a browser poll re-reads it, so the truncate-then-write window
+that `Path.write_text` opens stops being theoretical.
+"""
+
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.utils import atomic_write_text
+
+
+def test_writes_content(tmp_path: Path) -> None:
+    target = tmp_path / "out.html"
+    atomic_write_text(target, "hello")
+    assert target.read_text() == "hello"
+
+
+def test_overwrites_existing(tmp_path: Path) -> None:
+    target = tmp_path / "out.html"
+    target.write_text("old content that is longer")
+    atomic_write_text(target, "new")
+    assert target.read_text() == "new"
+
+
+def test_leaves_no_temp_file(tmp_path: Path) -> None:
+    atomic_write_text(tmp_path / "out.html", "x")
+    assert [p.name for p in tmp_path.iterdir()] == ["out.html"]
+
+
+def test_temp_file_is_removed_on_failure(tmp_path: Path, monkeypatch) -> None:
+    """A crash between write and replace must not litter the output dir."""
+    target = tmp_path / "out.html"
+
+    def boom(_src, _dst):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        atomic_write_text(target, "x")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_reader_never_sees_a_partial_file(tmp_path: Path) -> None:
+    """The point of the helper, exercised against a concurrent reader.
+
+    A 4 MB payload makes the truncate-then-write window wide enough that
+    a plain `write_text` is caught in it reliably; the assertion is that
+    the atomic path never is.
+    """
+    target = tmp_path / "page.html"
+    small = "a" * 4_000_000
+    large = "b" * 4_000_000
+    target.write_text(small)
+
+    observed: set[int] = set()
+    stop = threading.Event()
+
+    def reader() -> None:
+        while not stop.is_set():
+            try:
+                observed.add(len(target.read_text()))
+            except FileNotFoundError:
+                observed.add(-1)
+
+    th = threading.Thread(target=reader, daemon=True)
+    th.start()
+    try:
+        for i in range(40):
+            atomic_write_text(target, large if i % 2 else small)
+    finally:
+        stop.set()
+        th.join(timeout=5)
+
+    # Only the two complete sizes are ever observable — never a torn
+    # prefix, never a missing file.
+    assert observed <= {len(small), len(large)}, sorted(observed)
+
+
+def test_symlink_is_written_through_not_replaced(tmp_path: Path) -> None:
+    """`os.replace` would swap the link itself; users who linked meant it."""
+    real = tmp_path / "real.md"
+    real.write_text("old")
+    link = tmp_path / "link.md"
+    link.symlink_to(real)
+
+    atomic_write_text(link, "new")
+
+    assert link.is_symlink()
+    assert real.read_text() == "new"
+
+
+def test_concurrent_writers_do_not_clobber_each_others_temp(tmp_path: Path) -> None:
+    """The render fan-out can write the same path from several processes.
+
+    They write identical bytes, so the outcome is fine — but only because
+    the temp names differ. This pins that the pid is in the name.
+    """
+    target = tmp_path / "out.html"
+    atomic_write_text(target, "x")
+    # The helper's temp name for this process, reconstructed.
+    assert not (tmp_path / f".out.html.{os.getpid()}.tmp").exists()

--- a/test/test_cache_size_freshness.py
+++ b/test/test_cache_size_freshness.py
@@ -145,3 +145,38 @@ def test_pre_011_fallback_cannot_see_an_append_the_mtime_hides(
     assert cm.is_file_cached(jsonl), (
         "pre-011 rows fall back to mtime-only, which cannot see this"
     )
+
+
+def test_a_file_that_grows_mid_parse_does_not_look_cached(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stamp has to describe the parse, not the moment after it.
+
+    Watch mode reads files that are being appended to, so "the file grew
+    while we were reading it" is routine rather than theoretical. Stamped
+    at save time, the cache would claim the size and mtime the file
+    reached while holding only the rows we parsed — and if the session
+    then ends, that truncated view is what every later run trusts.
+    """
+    from claude_code_log import converter
+    from claude_code_log.converter import load_transcript
+
+    jsonl = project / "s1.jsonl"
+    cm = CacheManager(project, "test-version")
+    grew: list[int] = []
+    original = converter.create_transcript_entry
+
+    def _grow_during_parse(entry_dict):
+        if not grew:
+            grew.append(1)
+            with jsonl.open("a", encoding="utf-8") as f:
+                f.write(_entry("u2", "landed while we were reading"))
+        return original(entry_dict)
+
+    monkeypatch.setattr(converter, "create_transcript_entry", _grow_during_parse)
+    load_transcript(jsonl, cm, silent=True)
+    assert grew, "the fixture never exercised the growth"
+
+    assert not cm.is_file_cached(jsonl), (
+        "the cache is stamped with a size it does not hold the rows for"
+    )

--- a/test/test_cache_size_freshness.py
+++ b/test/test_cache_size_freshness.py
@@ -1,0 +1,147 @@
+"""The cached file-size check (migration 011).
+
+Freshness used to compare mtimes with a 1.0s tolerance and nothing else,
+so a write landing within a second of the mtime recorded at cache time
+was invisible. These tests pin the fix and its backward-compatible
+fallback.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.cache import CacheManager
+
+
+def _entry(uuid: str, text: str) -> str:
+    return (
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2025-07-03T16:15:00Z",
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "uuid": uuid,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "s1.jsonl").write_text(_entry("u1", "first"), encoding="utf-8")
+    return d
+
+
+def _cache(project: Path) -> CacheManager:
+    cm = CacheManager(project, "test-version")
+    cm.save_cached_entries(project / "s1.jsonl", [])
+    return cm
+
+
+def test_append_the_mtime_check_cannot_see_is_detected(project: Path) -> None:
+    """The case the tolerance used to hide, and the reason for 011.
+
+    The mtime is restored after the append so the mtime term provably
+    reports "fresh" — the detection can only be coming from the size.
+    (Left to real timing this would depend on whether the append landed
+    inside the 1.0s tolerance, which under parallel test execution goes
+    either way.)
+    """
+    import os
+
+    cm = _cache(project)
+    jsonl = project / "s1.jsonl"
+    assert cm.is_file_cached(jsonl), "sanity: freshly cached"
+    before = jsonl.stat()
+
+    with jsonl.open("a", encoding="utf-8") as f:
+        f.write(_entry("u2", "second"))
+    os.utime(jsonl, (before.st_atime, before.st_mtime))
+
+    assert not cm.is_file_cached(jsonl)
+    assert cm.get_modified_files([jsonl]) == [jsonl]
+
+
+def test_untouched_file_stays_cached(project: Path) -> None:
+    """The rule only tightens; it must not invalidate a stable file."""
+    cm = _cache(project)
+    jsonl = project / "s1.jsonl"
+    assert cm.is_file_cached(jsonl)
+    assert cm.get_modified_files([jsonl]) == []
+
+
+def test_pre_011_rows_fall_back_to_the_mtime_check(project: Path) -> None:
+    """A populated cache from before the migration must not mass-invalidate.
+
+    Rows written before 011 carry NULL, matching what the ALTER TABLE
+    gives existing rows.
+    """
+    cm = _cache(project)
+    jsonl = project / "s1.jsonl"
+
+    with sqlite3.connect(cm.db_path) as conn:
+        conn.execute("UPDATE cached_files SET source_size = NULL")
+        conn.commit()
+
+    # NULL size => mtime-only rule => an untouched file is still fresh.
+    assert cm.is_file_cached(jsonl)
+    assert cm.get_modified_files([jsonl]) == []
+
+
+def test_size_is_recorded_on_save(project: Path) -> None:
+    cm = _cache(project)
+    jsonl = project / "s1.jsonl"
+    with sqlite3.connect(cm.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT source_size FROM cached_files WHERE file_name = ?", ("s1.jsonl",)
+        ).fetchone()
+    assert row["source_size"] == jsonl.stat().st_size
+
+
+def test_pre_011_fallback_cannot_see_an_append_the_mtime_hides(
+    project: Path,
+) -> None:
+    """The negative control that proves 011 does something.
+
+    With the size NULLed out the rule is exactly what it was before the
+    migration, and it cannot see an append the mtime doesn't report.
+    Also an honest note on the fallback's limit: a cache populated before
+    011 keeps the old blind spot until its rows are rewritten.
+
+    The mtime is restored explicitly rather than relying on the append
+    landing inside the 1.0s tolerance — under parallel test execution
+    that race resolves either way, and a timing-dependent test is worth
+    less than the thing it pins.
+    """
+    import os
+
+    cm = _cache(project)
+    jsonl = project / "s1.jsonl"
+    before = jsonl.stat()
+
+    with sqlite3.connect(cm.db_path) as conn:
+        conn.execute("UPDATE cached_files SET source_size = NULL")
+        conn.commit()
+
+    with jsonl.open("a", encoding="utf-8") as f:
+        f.write(_entry("u2", "second"))
+    os.utime(jsonl, (before.st_atime, before.st_mtime))
+
+    assert cm.is_file_cached(jsonl), (
+        "pre-011 rows fall back to mtime-only, which cannot see this"
+    )

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -10,7 +10,13 @@ from pathlib import Path
 
 import pytest
 
-from claude_code_log.cache import CacheManager, SessionCacheData
+from claude_code_log.cache import (
+    CacheManager,
+    SessionCacheData,
+    _migrated_db_paths,
+    discard_database_files,
+    is_corrupt_database_error,
+)
 from claude_code_log.models import (
     AssistantMessageModel,
     AssistantTranscriptEntry,
@@ -1154,3 +1160,221 @@ class TestMigrationIntegrity:
             ).fetchone()[0]
 
         assert initial_count == final_count
+
+
+class TestCorruptDatabaseRecovery:
+    """A cache file damaged past reading is discarded and rebuilt.
+
+    Written against two real shapes. The first is the reported one: a cache
+    truncated to 11.6 MB while its header still claimed 58.1 MB, on which no
+    statement at all succeeded. The second is what made it *visible* —
+    migration 012's `CREATE INDEX` is the first operation to full-scan
+    `messages`, so damage confined to that table's leaf pages had been sitting
+    unnoticed under earlier versions, which never read those pages.
+    """
+
+    @staticmethod
+    def _populate(cache_dir: Path, db_path: Path, user_entry, assistant_entry) -> None:
+        """Build a real, healthy cache with enough rows to damage."""
+        cache_manager = CacheManager(cache_dir, "1.0.0", db_path=db_path)
+        jsonl_file = cache_dir / "test.jsonl"
+        jsonl_file.write_text(
+            json.dumps(user_entry.model_dump())
+            + "\n"
+            + json.dumps(assistant_entry.model_dump())
+            + "\n",
+            encoding="utf-8",
+        )
+        cache_manager.save_cached_entries(jsonl_file, [user_entry, assistant_entry])
+
+    def test_truncated_database_is_discarded_and_rebuilt(
+        self,
+        isolated_cache_dir,
+        isolated_db_path,
+        sample_user_entry,
+        sample_assistant_entry,
+        capsys,
+    ):
+        """The reported failure: header claims more pages than the file holds."""
+        self._populate(
+            isolated_cache_dir,
+            isolated_db_path,
+            sample_user_entry,
+            sample_assistant_entry,
+        )
+        original_size = isolated_db_path.stat().st_size
+        with open(isolated_db_path, "r+b") as f:
+            f.truncate(original_size // 4)
+
+        # Constructing over the damaged file must succeed, not raise.
+        cache_manager = CacheManager(
+            isolated_cache_dir, "1.0.0", db_path=isolated_db_path
+        )
+
+        assert "corrupt" in capsys.readouterr().out.lower()
+        with cache_manager._get_connection() as conn:
+            assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        # Rebuilt empty rather than carrying damaged rows forward: the project
+        # row exists again, but the messages the old file held are gone, so the
+        # next conversion re-ingests them from the JSONL source.
+        assert cache_manager._project_id is not None
+        with cache_manager._get_connection() as conn:
+            assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM cached_files").fetchone()[0] == 0
+
+    def test_corrupt_messages_pages_surface_and_heal_during_migration(
+        self,
+        isolated_cache_dir,
+        isolated_db_path,
+        sample_user_entry,
+        sample_assistant_entry,
+        capsys,
+    ):
+        """Damage only a full table scan reaches still heals.
+
+        Models the reported sequence exactly: a cache written by a version
+        that lacked migration 012, damaged in `messages`, then opened by one
+        that has it. The pending `CREATE INDEX` scans the damaged pages and
+        raises where nothing else would.
+        """
+        self._populate(
+            isolated_cache_dir,
+            isolated_db_path,
+            sample_user_entry,
+            sample_assistant_entry,
+        )
+        # Roll the schema back to pre-012 so the index build is pending again.
+        conn = sqlite3.connect(isolated_db_path)
+        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("DELETE FROM _schema_version WHERE version >= 12")
+        for name in (
+            "idx_messages_project_uuid",
+            "idx_messages_project_parent_uuid",
+            "idx_messages_project_request_id",
+            "idx_messages_project_metadata_type",
+            "idx_messages_project_session_ts",
+        ):
+            conn.execute(f"DROP INDEX IF EXISTS {name}")
+        conn.commit()
+        pages = [
+            r[0]
+            for r in conn.execute(
+                "SELECT pageno FROM dbstat WHERE name='messages' AND pagetype='leaf'"
+            )
+        ]
+        conn.close()
+        assert pages, "expected messages to occupy at least one leaf page"
+        # Overwrite the whole page, not a slice of it. A page holding two small
+        # rows is mostly free space, and cells are laid out from the *end*, so
+        # scribbling near the start damages nothing SQLite reads.
+        page_size = 4096
+        with open(isolated_db_path, "r+b") as f:
+            for pageno in pages:
+                f.seek((pageno - 1) * page_size)
+                f.write(b"\xff" * page_size)
+        # `_populate` left this path in the process-level "migrations already
+        # checked" memo, which would skip the pending migration. Real runs meet
+        # this across processes; drop the entry to stand in for a fresh one.
+        _migrated_db_paths.discard(str(isolated_db_path))
+
+        cache_manager = CacheManager(
+            isolated_cache_dir, "1.0.0", db_path=isolated_db_path
+        )
+
+        assert "corrupt" in capsys.readouterr().out.lower()
+        with cache_manager._get_connection() as conn2:
+            assert conn2.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            applied = [
+                r[0] for r in conn2.execute("SELECT version FROM _schema_version")
+            ]
+        # The migration that failed is applied on the rebuilt database, so the
+        # failure cannot repeat on every subsequent run.
+        assert 12 in applied
+
+    def test_garbage_file_is_replaced(
+        self, isolated_cache_dir, isolated_db_path, capsys
+    ):
+        """A non-database file at the cache path is replaced, not fatal."""
+        isolated_db_path.write_bytes(b"this is not a database" * 500)
+
+        cache_manager = CacheManager(
+            isolated_cache_dir, "1.0.0", db_path=isolated_db_path
+        )
+
+        assert "corrupt" in capsys.readouterr().out.lower()
+        assert cache_manager._project_id is not None
+
+    def test_wal_sidecars_are_removed_with_the_database(self, isolated_db_path):
+        """A stale -wal beside a fresh database is its own route to malformed."""
+        isolated_db_path.write_bytes(b"x")
+        wal = isolated_db_path.with_name(isolated_db_path.name + "-wal")
+        shm = isolated_db_path.with_name(isolated_db_path.name + "-shm")
+        wal.write_bytes(b"x")
+        shm.write_bytes(b"x")
+
+        assert discard_database_files(isolated_db_path) is True
+
+        assert not isolated_db_path.exists()
+        assert not wal.exists()
+        assert not shm.exists()
+
+    def test_empty_file_is_not_treated_as_corruption(
+        self, isolated_cache_dir, isolated_db_path, capsys
+    ):
+        """SQLite adopts a zero-byte file as a new database; don't panic."""
+        isolated_db_path.write_bytes(b"")
+
+        cache_manager = CacheManager(
+            isolated_cache_dir, "1.0.0", db_path=isolated_db_path
+        )
+
+        assert "corrupt" not in capsys.readouterr().out.lower()
+        assert cache_manager._project_id is not None
+
+    def test_read_only_manager_never_deletes_the_database(
+        self,
+        isolated_cache_dir,
+        isolated_db_path,
+        sample_user_entry,
+        sample_assistant_entry,
+    ):
+        """Render workers open read-only and must not delete a shared file.
+
+        Several run concurrently against one database; a worker that reacted
+        to corruption by unlinking it would pull the file out from under its
+        siblings. Degrading to "no cached data" is the contract.
+        """
+        self._populate(
+            isolated_cache_dir,
+            isolated_db_path,
+            sample_user_entry,
+            sample_assistant_entry,
+        )
+        with open(isolated_db_path, "r+b") as f:
+            f.truncate(isolated_db_path.stat().st_size // 4)
+        size_before = isolated_db_path.stat().st_size
+
+        cache_manager = CacheManager(
+            isolated_cache_dir, "1.0.0", db_path=isolated_db_path, read_only=True
+        )
+
+        assert cache_manager._project_id is None
+        assert isolated_db_path.exists()
+        assert isolated_db_path.stat().st_size == size_before
+
+    @pytest.mark.parametrize(
+        "exc,expected",
+        [
+            (sqlite3.DatabaseError("database disk image is malformed"), True),
+            (sqlite3.DatabaseError("file is not a database"), True),
+            (sqlite3.DatabaseError("malformed database schema (message_fts)"), True),
+            # Transient and environmental failures must never delete a cache
+            # that is merely busy, or on a disk that is merely full.
+            (sqlite3.OperationalError("database is locked"), False),
+            (sqlite3.OperationalError("database or disk is full"), False),
+            (sqlite3.OperationalError("no such table: messages"), False),
+            (OSError("permission denied"), False),
+        ],
+    )
+    def test_only_corruption_triggers_a_rebuild(self, exc, expected):
+        assert is_corrupt_database_error(exc) is expected

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -1262,12 +1262,14 @@ class TestCorruptDatabaseRecovery:
                 "SELECT pageno FROM dbstat WHERE name='messages' AND pagetype='leaf'"
             )
         ]
+        # `dbstat.pageno` counts pages of whatever size this database was
+        # built with, so read it rather than assuming SQLite's 4096 default.
+        page_size = conn.execute("PRAGMA page_size").fetchone()[0]
         conn.close()
         assert pages, "expected messages to occupy at least one leaf page"
         # Overwrite the whole page, not a slice of it. A page holding two small
         # rows is mostly free space, and cells are laid out from the *end*, so
         # scribbling near the start damages nothing SQLite reads.
-        page_size = 4096
         with open(isolated_db_path, "r+b") as f:
             for pageno in pages:
                 f.seek((pageno - 1) * page_size)

--- a/test/test_entry_store.py
+++ b/test/test_entry_store.py
@@ -6,7 +6,13 @@ closure load and the session-scoped render each rebuild them from the
 rows the refresh has just written. The store keeps the first pass's list
 and serves it to the other two (work/watch-mode.md, C14).
 
-Two layers of coverage, and the second is the one that matters:
+A store owned *across* ticks (which ``watch`` does) goes further: it pins
+its entries to a byte offset plus a hash of the bytes below it, so a tick
+can prove the file still starts with what it already parsed and read only
+what was appended — and, when the rows are provably just those lines,
+write only the new ones instead of rewriting every row.
+
+Three layers of coverage, and the last two are the ones that matter:
 
 - Unit tests for the store's own contract — stamp verification, copy
   isolation, budget, kill switch.
@@ -18,6 +24,12 @@ Two layers of coverage, and the second is the one that matters:
   objects; serving the same objects to two consumers would apply it
   twice. That is exactly what the copy isolation exists to prevent, so
   the equivalence test is its real proof.
+- Parse and write equivalence for the resumable path: the byte reader
+  against the text reader it replaces, a resumed parse against a fresh
+  one, and — the bar a write-path change has to clear — the **cache
+  rows** an append-only write leaves behind against the rows a full
+  rewrite leaves, since the first bug of that kind is invisible in the
+  rendered HTML.
 """
 
 import json
@@ -358,3 +370,309 @@ class TestWatchTick:
             assert _session_files(on_dir) == _session_files(off_dir), (
                 f"diverged on tick {tick}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Resumable parsing and append-only writes
+# ---------------------------------------------------------------------------
+
+
+def _dump(entries: list[Any]) -> list[dict[str, Any]]:
+    return [e.model_dump() for e in entries]
+
+
+def _synthetic_project(tmp_path: Path, sessions: int = 2, lines: int = 6) -> Path:
+    """A project with no subagents — the shape the append-only write covers."""
+    project = tmp_path / "-Users-dain-workspace-synthetic"
+    project.mkdir(parents=True)
+    for s in range(sessions):
+        sid = f"5eaf00d0-0000-4000-8000-00000000000{s}"
+        jsonl = project / f"{sid}.jsonl"
+        with jsonl.open("w", encoding="utf-8") as f:
+            parent = None
+            for i in range(lines):
+                uuid = f"{sid[:-2]}{s}{i}"
+                f.write(
+                    json.dumps(
+                        {
+                            "type": "user" if i % 2 == 0 else "assistant",
+                            "timestamp": f"2025-07-03T18:0{i}:00Z",
+                            "parentUuid": parent,
+                            "isSidechain": False,
+                            "userType": "human",
+                            "cwd": "/tmp",
+                            "sessionId": sid,
+                            "version": "1.0.0",
+                            "uuid": uuid,
+                            "message": (
+                                {
+                                    "role": "user",
+                                    "content": [{"type": "text", "text": f"q{i}"}],
+                                }
+                                if i % 2 == 0
+                                else {
+                                    "role": "assistant",
+                                    "model": "claude-opus-5",
+                                    "content": [{"type": "text", "text": f"a{i}"}],
+                                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                                }
+                            ),
+                        }
+                    )
+                    + "\n"
+                )
+                parent = uuid
+    return project
+
+
+def _message_rows(project: Path) -> list[tuple[Any, ...]]:
+    """Every cached message row, in table order, content included."""
+    import sqlite3
+
+    db = project.parent / "claude-code-log-cache.db"
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    try:
+        return [
+            tuple(r)
+            for r in con.execute(
+                """SELECT cf.file_name, m.type, m.timestamp, m.session_id,
+                          m._uuid, m._parent_uuid, m.content
+                   FROM messages m JOIN cached_files cf ON m.file_id = cf.id
+                   ORDER BY cf.file_name, m.id"""
+            )
+        ]
+    finally:
+        con.close()
+
+
+class TestByteParseEquivalence:
+    """The byte reader must produce exactly what the text reader produced."""
+
+    @pytest.mark.parametrize(
+        "fixture",
+        [p.name for p in sorted(AGENT_PROJECT.glob("*.jsonl")) if p.stat().st_size],
+    )
+    def test_whole_file(self, fixture: str) -> None:
+        path = AGENT_PROJECT / fixture
+        text_path = _dump(load_transcript(path, silent=True))
+        byte_path = _dump(
+            load_transcript(path, silent=True, entry_store=ParsedEntryStore())
+        )
+        assert text_path == byte_path
+
+    def test_resumed_parse_equals_a_fresh_one(self, tmp_path: Path) -> None:
+        source = _busiest_trunk(AGENT_PROJECT)
+        raw = source.read_bytes()
+        body = [ln for ln in raw.split(b"\n") if ln.strip()]
+        work = tmp_path / source.name
+
+        work.write_bytes(b"\n".join(body[:-3]) + b"\n")
+        store = ParsedEntryStore()
+        load_transcript(work, silent=True, entry_store=store)
+
+        work.write_bytes(b"\n".join(body) + b"\n")  # the append
+        resumed = _dump(load_transcript(work, silent=True, entry_store=store))
+        fresh = _dump(load_transcript(work, silent=True))
+
+        assert store.prefix_hits == 1
+        assert resumed == fresh
+
+    def test_rewritten_history_drops_the_prefix(self, tmp_path: Path) -> None:
+        """A rewound/replayed session must not be resumed onto."""
+        source = _busiest_trunk(AGENT_PROJECT)
+        body = [ln for ln in source.read_bytes().split(b"\n") if ln.strip()]
+        work = tmp_path / source.name
+
+        work.write_bytes(b"\n".join(body[:-3]) + b"\n")
+        store = ParsedEntryStore()
+        load_transcript(work, silent=True, entry_store=store)
+
+        # Same length, different history: the size/mtime check alone would
+        # miss this; the prefix hash is what catches it.
+        rewritten = list(body[:-3])
+        rewritten[1] = rewritten[-1]
+        work.write_bytes(b"\n".join(rewritten + body[-3:]) + b"\n")
+
+        resumed = _dump(load_transcript(work, silent=True, entry_store=store))
+        fresh = _dump(load_transcript(work, silent=True))
+        assert store.prefix_misses == 1
+        assert resumed == fresh
+
+    def test_a_torn_final_line_is_picked_up_next_time(self, tmp_path: Path) -> None:
+        """Mid-append bytes stay out of the prefix (C12)."""
+        work = tmp_path / "torn.jsonl"
+        entry = {
+            "type": "user",
+            "timestamp": "2025-07-03T18:00:00Z",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "human",
+            "cwd": "/tmp",
+            "sessionId": "torn",
+            "version": "1.0.0",
+            "uuid": "torn-1",
+            "message": {"role": "user", "content": [{"type": "text", "text": "one"}]},
+        }
+        complete = json.dumps(entry) + "\n"
+        second = json.dumps({**entry, "uuid": "torn-2"}) + "\n"
+
+        work.write_text(complete + second[:20], encoding="utf-8")  # torn tail
+        store = ParsedEntryStore()
+        first = load_transcript(work, silent=True, entry_store=store)
+        assert len(first) == 1
+
+        work.write_text(complete + second, encoding="utf-8")  # it lands
+        resumed = _dump(load_transcript(work, silent=True, entry_store=store))
+        assert _dump(load_transcript(work, silent=True)) == resumed
+        assert len(resumed) == 2
+
+
+def _count_append_proposals(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record every time the *caller's* gate offered rows for appending.
+
+    Separate from :func:`_count_append_only_writes` on purpose: the two
+    are different layers. This one is the parse-side proof ("the rows are
+    just this file's own new lines"); that one is the row-side check
+    ("the table still holds what we think we wrote"). Asserting only on
+    the write would let a broken gate hide behind the check.
+    """
+    proposals: list[int] = []
+    original = converter._appended_rows
+
+    def _spy(*args: Any, **kwargs: Any) -> Any:
+        out = original(*args, **kwargs)
+        if out is not None:
+            proposals.append(len(out))
+        return out
+
+    monkeypatch.setattr(converter, "_appended_rows", _spy)
+    return proposals
+
+
+def _count_append_only_writes(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record every append-only cache write that actually succeeded."""
+    from claude_code_log.cache import CacheManager
+
+    calls: list[int] = []
+    original = CacheManager.extend_cached_entries
+
+    def _spy(self: Any, jsonl_path: Path, all_entries: Any, appended: Any, **kw: Any):
+        result = original(self, jsonl_path, all_entries, appended, **kw)
+        if result:
+            calls.append(len(appended))
+        return result
+
+    monkeypatch.setattr(CacheManager, "extend_cached_entries", _spy)
+    return calls
+
+
+class TestAppendOnlyWrites:
+    """Only the new rows are written — and the table must not tell."""
+
+    def _tick(self, project: Path, store: Any) -> None:
+        convert_jsonl_to(
+            "html",
+            project,
+            silent=True,
+            write_combined=False,
+            generate_individual_sessions=True,
+            entry_store=store,
+        )
+
+    def test_rows_match_a_full_rewrite_over_repeated_appends(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bar for a write-path change: DB state, not just HTML."""
+        extended = _count_append_only_writes(monkeypatch)
+        appended = _synthetic_project(tmp_path / "appended")
+        rewritten = _synthetic_project(tmp_path / "rewritten")
+        store = ParsedEntryStore()
+        self._tick(appended, store)
+        self._tick(rewritten, None)
+
+        for tick in range(4):
+            for project in (appended, rewritten):
+                target = sorted(project.glob("*.jsonl"))[0]
+                _append_entry(target, f"grow-{tick}", f"message {tick}")
+            self._tick(appended, store)
+            self._tick(rewritten, None)
+
+            assert _message_rows(appended) == _message_rows(rewritten), (
+                f"cache rows diverged on tick {tick}"
+            )
+            assert _session_files(appended).keys() == _session_files(rewritten).keys()
+
+        assert store.prefix_hits > 0, "the resumable path never engaged"
+        assert extended, (
+            "no append-only write happened — this equivalence test would "
+            "have compared two full rewrites and proved nothing"
+        )
+
+    def test_a_growing_agent_file_inserts_rows_mid_sequence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Why the append-only write refuses agent-bearing transcripts.
+
+        A trunk's cached rows are not its lines: each referenced agent's
+        transcript is spliced in at its anchor. When a subagent is still
+        running — the normal case under ``watch`` — that block *grows*, so
+        rows land in the middle of the sequence even though the trunk file
+        itself only gained lines at the end. Treating that as an append
+        would leave the agent's new entries out of the cache.
+
+        Three ticks, because the hazard needs a resumable prefix to exist
+        first: cold, an append that establishes one, then an append that
+        lands alongside a growing agent file.
+        """
+        extended = _count_append_only_writes(monkeypatch)
+        proposed = _count_append_proposals(monkeypatch)
+        work_dir = _copy_project(tmp_path)
+        control = _copy_project(tmp_path / "control")
+
+        def advance(project: Path, store: Any, tick: int, grow_agent: bool) -> None:
+            _append_entry(
+                _busiest_trunk(project), f"trunk-{tick}", f"trunk message {tick}"
+            )
+            if grow_agent:
+                agent = project / "agent-668b5ac2.jsonl"
+                assert agent.exists(), "fixture lost its agent transcript"
+                _append_entry(agent, f"agent-{tick}", f"agent message {tick}")
+            self._tick(project, store)
+
+        store = ParsedEntryStore()
+        self._tick(work_dir, store)
+        self._tick(control, None)
+        advance(work_dir, store, 0, grow_agent=False)  # establishes a prefix
+        advance(control, None, 0, grow_agent=False)
+        advance(work_dir, store, 1, grow_agent=True)  # the hazard
+        advance(control, None, 1, grow_agent=True)
+
+        assert store.prefix_hits > 0, "no prefix was ever resumed from"
+        assert _message_rows(work_dir) == _message_rows(control)
+        # The gate must refuse to *offer* these rows. Asserting only on
+        # the write below would pass even with the gate gone, because the
+        # row-count check then catches the bad offer — measured: it
+        # proposes a wrong 96-entry slice and the check refuses it. Good
+        # defence in depth, useless as a test of the gate.
+        assert not proposed, (
+            f"the gate offered {proposed} rows for an agent-bearing file, "
+            "whose cached rows carry spliced agent blocks"
+        )
+        assert not extended, "an agent-bearing file took the append-only path"
+
+    def test_extend_refuses_when_the_rows_are_not_what_we_wrote(
+        self, tmp_path: Path
+    ) -> None:
+        """The cross-process guard: another writer changed the row count."""
+        from claude_code_log.cache import CacheManager, get_library_version
+
+        project = _synthetic_project(tmp_path)
+        cache = CacheManager(project, get_library_version())
+        target = sorted(project.glob("*.jsonl"))[0]
+        entries = load_transcript(target, cache, silent=True)
+
+        # Pretend the file has one more entry than the cache holds *and*
+        # that only that one is new — i.e. a count the table disagrees with.
+        assert not cache.extend_cached_entries(target, entries[:-2], entries[-1:])
+        # And the honest case still works.
+        assert cache.extend_cached_entries(target, entries + entries[-1:], entries[-1:])

--- a/test/test_entry_store.py
+++ b/test/test_entry_store.py
@@ -221,6 +221,29 @@ class TestStoreContract:
         assert store.get(second) is not None
         assert store.held_bytes <= 150
 
+    def test_held_prefixes_are_charged_and_evicted_too(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        """`watch` owns one store for hours — prefixes cannot grow forever."""
+        first = tmp_path / "first.jsonl"
+        second = tmp_path / "second.jsonl"
+
+        store = ParsedEntryStore(budget_bytes=150)
+        store.put_prefix(first, 100, b"d1", entries, set(), 1)
+        assert store.held_bytes == 100
+
+        store.put_prefix(second, 100, b"d2", entries, set(), 1)
+        assert store.get_prefix(first) is None, "oldest should have been evicted"
+        assert store.get_prefix(second) is not None
+        assert store.held_bytes <= 150
+
+        # Re-holding the same file replaces its charge rather than adding
+        # one: a watched file is re-held on every tick that touches it.
+        store.put_prefix(second, 100, b"d3", entries, set(), 1)
+        assert store.held_bytes == 100
+        store.drop_prefix(second)
+        assert store.held_bytes == 0
+
     def test_a_file_larger_than_the_budget_is_declined(
         self, tmp_path: Path, entries: list[Any]
     ) -> None:
@@ -526,6 +549,45 @@ class TestByteParseEquivalence:
         assert _dump(load_transcript(work, silent=True)) == resumed
         assert len(resumed) == 2
 
+    def test_an_unterminated_final_line_is_not_parsed_twice(
+        self, tmp_path: Path
+    ) -> None:
+        """A final line whose newline hasn't landed yet parses, but isn't held.
+
+        The other half of C12: the torn tail above fails to parse, so
+        holding it would be harmless. A *complete* record whose trailing
+        newline hasn't been flushed yet parses fine — and its bytes are
+        still below the prefix cut, so holding its entry would make the
+        next tick parse the same line a second time. Two of this repo's
+        own fixtures end without a trailing newline, so this is not only
+        a mid-append shape.
+        """
+        work = tmp_path / "unterminated.jsonl"
+        entry = {
+            "type": "user",
+            "timestamp": "2025-07-03T18:00:00Z",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "human",
+            "cwd": "/tmp",
+            "sessionId": "unterminated",
+            "version": "1.0.0",
+            "uuid": "u-1",
+            "message": {"role": "user", "content": [{"type": "text", "text": "one"}]},
+        }
+        lines = [json.dumps({**entry, "uuid": f"u-{n}"}) for n in (1, 2, 3)]
+        fourth = json.dumps({**entry, "uuid": "u-4"})
+
+        # Ends mid-line: the third record is whole, its newline is not there.
+        work.write_text("\n".join(lines), encoding="utf-8")
+        store = ParsedEntryStore()
+        first = load_transcript(work, silent=True, entry_store=store)
+        assert [e.uuid for e in first] == ["u-1", "u-2", "u-3"]  # type: ignore[union-attr]
+
+        work.write_text("\n".join(lines + [fourth]) + "\n", encoding="utf-8")
+        resumed = _dump(load_transcript(work, silent=True, entry_store=store))
+        assert _dump(load_transcript(work, silent=True)) == resumed
+
 
 def _count_append_proposals(monkeypatch: pytest.MonkeyPatch) -> list[int]:
     """Record every time the *caller's* gate offered rows for appending.
@@ -607,6 +669,44 @@ class TestAppendOnlyWrites:
             "no append-only write happened — this equivalence test would "
             "have compared two full rewrites and proved nothing"
         )
+
+    def test_rows_match_when_a_tick_lands_on_an_unterminated_line(
+        self, tmp_path: Path
+    ) -> None:
+        """A tick that sees a whole record without its newline yet.
+
+        The parse-side twin of this is in
+        ``TestByteParseEquivalence``; this is the half that would show up
+        in the cache, where a re-parsed line becomes a duplicate *row*
+        rather than a transient duplicate entry.
+        """
+        appended = _synthetic_project(tmp_path / "appended")
+        rewritten = _synthetic_project(tmp_path / "rewritten")
+        store = ParsedEntryStore()
+
+        def both(mutate: Any) -> None:
+            for project, held in ((appended, store), (rewritten, None)):
+                mutate(sorted(project.glob("*.jsonl"))[0])
+                self._tick(project, held)
+
+        both(lambda _target: None)  # cold: nothing is held yet
+        both(lambda target: _append_entry(target, "grow", "a first append"))
+
+        def torn(target: Path) -> None:  # a whole record, newline not yet
+            _append_entry(target, "whole", "flushed without its newline")
+            target.write_bytes(target.read_bytes().rstrip(b"\n"))
+
+        both(torn)
+
+        def lands(target: Path) -> None:
+            with target.open("a", encoding="utf-8") as f:
+                f.write("\n")
+            _append_entry(target, "after", "the write that follows it")
+
+        both(lands)
+
+        assert store.prefix_hits > 0, "the resumable path never engaged"
+        assert _message_rows(appended) == _message_rows(rewritten)
 
     def test_a_growing_agent_file_inserts_rows_mid_sequence(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/test/test_entry_store.py
+++ b/test/test_entry_store.py
@@ -1,0 +1,360 @@
+"""The per-conversion parsed-entry store (``entry_store.py``).
+
+A watch tick materialises the same entries up to three times: the
+incremental cache refresh parses each modified file from source, then the
+closure load and the session-scoped render each rebuild them from the
+rows the refresh has just written. The store keeps the first pass's list
+and serves it to the other two (work/watch-mode.md, C14).
+
+Two layers of coverage, and the second is the one that matters:
+
+- Unit tests for the store's own contract — stamp verification, copy
+  isolation, budget, kill switch.
+- An end-to-end equivalence test over a watch-shaped append, with the
+  store on and off, on a fixture whose 170 sidechain entries exercise
+  ``_integrate_agent_entries``. That transformation mutates entries **in
+  place and is not idempotent** (it appends ``#agent-{id}`` to
+  ``sessionId``), and today each consumer gets freshly deserialised
+  objects; serving the same objects to two consumers would apply it
+  twice. That is exactly what the copy isolation exists to prevent, so
+  the equivalence test is its real proof.
+"""
+
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from claude_code_log import converter
+from claude_code_log.converter import convert_jsonl_to, load_transcript
+from claude_code_log.entry_store import (
+    ParsedEntryStore,
+    entry_store_enabled,
+    entry_store_forced,
+    stamp_file,
+)
+
+FIXTURE_ROOT = Path(__file__).parent / "test_data" / "real_projects"
+# Multi-session, and the one fixture with a substantial population of
+# sidechain agent entries (170) — i.e. the mutation hazard above.
+AGENT_PROJECT = FIXTURE_ROOT / "-Users-dain-workspace-coderabbit-review-helper"
+
+
+def _copy_project(tmp_path: Path, source: Path = AGENT_PROJECT) -> Path:
+    """Copy a fixture project, keeping its directory name (titles derive from it)."""
+    work_dir = tmp_path / source.name
+    shutil.copytree(source, work_dir)
+    return work_dir
+
+
+def _session_files(work_dir: Path) -> dict[str, bytes]:
+    files = {p.name: p.read_bytes() for p in sorted(work_dir.glob("session-*.html"))}
+    assert files, "conversion produced no session files"
+    return files
+
+
+def _append_entry(jsonl: Path, uuid: str, text: str) -> None:
+    entry = {
+        "type": "user",
+        "timestamp": "2025-07-03T18:00:00Z",
+        "parentUuid": None,
+        "isSidechain": False,
+        "userType": "human",
+        "cwd": "/tmp",
+        "sessionId": jsonl.stem,
+        "version": "1.0.0",
+        "uuid": uuid,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+    with jsonl.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _spy_stores(monkeypatch: pytest.MonkeyPatch) -> list[ParsedEntryStore]:
+    """Collect the stores a conversion creates, without changing behaviour."""
+    created: list[ParsedEntryStore] = []
+    original = converter._make_entry_store
+
+    def _spy() -> Any:
+        store = original()
+        if store is not None:
+            created.append(store)
+        return store
+
+    monkeypatch.setattr(converter, "_make_entry_store", _spy)
+    return created
+
+
+def _busiest_trunk(project: Path) -> Path:
+    """The fixture's substantive trunk file (several others are empty)."""
+    trunk = [p for p in project.glob("*.jsonl") if not p.name.startswith("agent-")]
+    return max(trunk, key=lambda p: p.stat().st_size)
+
+
+@pytest.fixture
+def entries() -> list[Any]:
+    """A real parsed entry list to put in the store."""
+    parsed = load_transcript(_busiest_trunk(AGENT_PROJECT), silent=True)
+    assert parsed, "fixture produced no entries"
+    return parsed
+
+
+class TestStoreContract:
+    def test_round_trip_serves_the_held_entries(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        path = tmp_path / "a.jsonl"
+        path.write_text("x", encoding="utf-8")
+        store = ParsedEntryStore()
+        store.put(path, stamp_file(path), entries)
+
+        served = store.get(path)
+        assert served is not None
+        assert len(served) == len(entries)
+        assert store.hits == 1
+
+    def test_handouts_are_independent_copies(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        """The `_integrate_agent_entries` hazard, at the unit level.
+
+        One consumer's in-place mutation must not be visible to the next,
+        or a non-idempotent transformation would be applied twice.
+        """
+        path = tmp_path / "a.jsonl"
+        path.write_text("x", encoding="utf-8")
+        store = ParsedEntryStore()
+        store.put(path, stamp_file(path), entries)
+
+        first = store.get(path)
+        second = store.get(path)
+        assert first is not None and second is not None
+        assert first[0] is not second[0], "consumers share an object"
+
+        before = getattr(second[0], "sessionId", None)
+        first[0].sessionId = "mutated#agent-x"  # type: ignore[union-attr]
+        assert getattr(second[0], "sessionId", None) == before
+        assert getattr(entries[0], "sessionId", None) == before
+
+        third = store.get(path)
+        assert third is not None
+        assert getattr(third[0], "sessionId", None) == before
+
+    def test_declines_when_the_file_changed_since_the_parse(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        path = tmp_path / "a.jsonl"
+        path.write_text("x", encoding="utf-8")
+        store = ParsedEntryStore()
+        store.put(path, stamp_file(path), entries)
+
+        path.write_text("xy", encoding="utf-8")  # a size change is enough
+        assert store.get(path) is None
+        assert store.misses == 1
+
+    def test_declines_a_stale_stamp_taken_before_a_mid_parse_append(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        """A file that grew during the parse must not be served.
+
+        The stamp is captured *before* the parse precisely so this case
+        mismatches rather than serving a list its stamp misdescribes.
+        """
+        path = tmp_path / "a.jsonl"
+        path.write_text("x", encoding="utf-8")
+        stamp = stamp_file(path)
+        path.write_text("x-grown-during-the-parse", encoding="utf-8")
+
+        store = ParsedEntryStore()
+        store.put(path, stamp, entries)
+        assert store.get(path) is None
+
+    def test_put_declines_without_a_stamp_or_entries(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        path = tmp_path / "a.jsonl"
+        path.write_text("x", encoding="utf-8")
+        store = ParsedEntryStore()
+
+        store.put(path, None, entries)
+        assert store.get(path) is None
+
+        store.put(path, stamp_file(path), [])
+        assert store.get(path) is None
+        assert store.held_bytes == 0
+
+    def test_get_of_an_unknown_path_is_a_miss_not_an_error(
+        self, tmp_path: Path
+    ) -> None:
+        store = ParsedEntryStore()
+        assert store.get(tmp_path / "never-stored.jsonl") is None
+        assert store.misses == 1
+
+    def test_budget_evicts_in_insertion_order(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        first = tmp_path / "first.jsonl"
+        second = tmp_path / "second.jsonl"
+        first.write_text("a" * 100, encoding="utf-8")
+        second.write_text("b" * 100, encoding="utf-8")
+
+        store = ParsedEntryStore(budget_bytes=150)
+        store.put(first, stamp_file(first), entries)
+        store.put(second, stamp_file(second), entries)
+
+        assert store.get(first) is None, "oldest should have been evicted"
+        assert store.get(second) is not None
+        assert store.held_bytes <= 150
+
+    def test_a_file_larger_than_the_budget_is_declined(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        path = tmp_path / "big.jsonl"
+        path.write_text("a" * 500, encoding="utf-8")
+        store = ParsedEntryStore(budget_bytes=100)
+        store.put(path, stamp_file(path), entries)
+
+        assert store.get(path) is None
+        assert store.declines == 1
+
+
+class TestEnvironment:
+    @pytest.mark.parametrize("value", ["0", "off", "false", "OFF"])
+    def test_kill_switch(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", value)
+        assert not entry_store_enabled()
+        assert converter._make_entry_store() is None
+
+    @pytest.mark.parametrize("value", ["", "1", "on", "anything"])
+    def test_enabled_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", value)
+        assert entry_store_enabled()
+        assert converter._make_entry_store() is not None
+
+    def test_forced_only_on_an_explicit_yes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", "1")
+        assert entry_store_forced()
+        monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", "")
+        assert not entry_store_forced()
+
+
+class TestWatchTick:
+    """The shape the store exists for: a pure append over a warm cache."""
+
+    def _grown_project(self, tmp_path: Path) -> tuple[Path, Path]:
+        work_dir = _copy_project(tmp_path)
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+        return work_dir, _busiest_trunk(work_dir)
+
+    def test_the_store_is_used_on_an_append(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without this, the equivalence test below would pass vacuously."""
+        work_dir, jsonl = self._grown_project(tmp_path)
+        _append_entry(jsonl, "entry-store-append-1", "a new message arrives")
+
+        stores = _spy_stores(monkeypatch)
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+
+        assert stores, "no store was created"
+        assert sum(s.hits for s in stores) > 0, (
+            "the appended file was re-materialised from the cache instead of "
+            "being served from the store"
+        )
+
+    def test_a_cold_conversion_stores_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Residency is bounded by what changed, not by the project.
+
+        Only ``_incremental_cache_refresh`` fills the store, so a cold
+        run — and by the same token the streaming page loads, which are
+        never handed one — carries no extra memory.
+        """
+        work_dir = _copy_project(tmp_path)
+        stores = _spy_stores(monkeypatch)
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+
+        assert stores, "no store was created"
+        assert all(s.held_bytes == 0 for s in stores)
+        assert all(s.hits == 0 for s in stores)
+
+    def test_output_is_byte_identical_with_and_without_the_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two copies advance through the same append; bytes must match."""
+        on_dir, on_jsonl = self._grown_project(tmp_path / "on")
+        monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", "0")
+        off_dir, off_jsonl = self._grown_project(tmp_path / "off")
+
+        for jsonl in (on_jsonl, off_jsonl):
+            _append_entry(jsonl, "entry-store-append-1", "a new message arrives")
+
+        convert_jsonl_to("html", off_dir, silent=True, write_combined=False)
+        monkeypatch.delenv("CLAUDE_CODE_LOG_ENTRY_STORE")
+        convert_jsonl_to("html", on_dir, silent=True, write_combined=False)
+
+        assert _session_files(on_dir) == _session_files(off_dir)
+
+    def test_agent_session_ids_are_not_double_suffixed(
+        self, tmp_path: Path, entries: list[Any]
+    ) -> None:
+        """The concrete failure a shared (uncopied) list would produce.
+
+        ``_integrate_agent_entries`` appends ``#agent-{id}`` to
+        ``sessionId`` unconditionally, so one list handed to two
+        consumers — which is precisely what the closure load and the
+        session-scoped render are — comes out as ``…#agent-X#agent-X``
+        for the second. Asserted where the transformation happens rather
+        than in the rendered page, which does not surface the synthetic
+        id verbatim.
+        """
+        path = tmp_path / "a.jsonl"
+        path.write_text("x", encoding="utf-8")
+        store = ParsedEntryStore()
+        store.put(path, stamp_file(path), entries)
+
+        doubled = re.compile(r"#agent-.*#agent-")
+        suffixed = 0
+        for consumer in range(2):
+            served = store.get(path)
+            assert served is not None
+            converter._integrate_agent_entries(served)
+            ids = [getattr(e, "sessionId", None) for e in served]
+            suffixed = sum(1 for sid in ids if sid and "#agent-" in sid)
+            assert suffixed, (
+                "fixture yielded no agent-suffixed session ids — this test "
+                "would pass vacuously"
+            )
+            for sid in ids:
+                assert sid is None or not doubled.search(sid), (
+                    f"consumer {consumer} saw a doubly-suffixed id: {sid}"
+                )
+
+    def test_repeated_ticks_stay_identical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Several appends in a row, store on vs off, byte-for-byte."""
+        on_dir, on_jsonl = self._grown_project(tmp_path / "on")
+        monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", "0")
+        off_dir, off_jsonl = self._grown_project(tmp_path / "off")
+        monkeypatch.delenv("CLAUDE_CODE_LOG_ENTRY_STORE")
+
+        for tick in range(3):
+            for jsonl in (on_jsonl, off_jsonl):
+                _append_entry(jsonl, f"tick-{tick}", f"message {tick}")
+            monkeypatch.setenv("CLAUDE_CODE_LOG_ENTRY_STORE", "0")
+            convert_jsonl_to("html", off_dir, silent=True, write_combined=False)
+            monkeypatch.delenv("CLAUDE_CODE_LOG_ENTRY_STORE")
+            convert_jsonl_to("html", on_dir, silent=True, write_combined=False)
+
+            assert _session_files(on_dir) == _session_files(off_dir), (
+                f"diverged on tick {tick}"
+            )

--- a/test/test_entry_store.py
+++ b/test/test_entry_store.py
@@ -777,6 +777,49 @@ class TestAppendOnlyWrites:
         # And the honest case still works.
         assert cache.extend_cached_entries(target, entries + entries[-1:], entries[-1:])
 
+    def test_the_count_and_the_insert_hold_one_write_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Why that guard needs a transaction to be a guard at all.
+
+        Python's sqlite3 opens a transaction on the first write, not on a
+        SELECT, so between the row count and the insert another writer
+        sharing the cache — a second `watch`, a TUI beside one — could
+        append rows the count would have refused, and both appends would
+        land. Asserted by proving the lock is held *while* the append
+        runs: a second connection cannot write at that moment.
+        """
+        import sqlite3
+
+        from claude_code_log.cache import CacheManager, get_library_version
+
+        project = _synthetic_project(tmp_path)
+        cache = CacheManager(project, get_library_version())
+        target = sorted(project.glob("*.jsonl"))[0]
+        entries = load_transcript(target, cache, silent=True)
+
+        db = project.parent / "claude-code-log-cache.db"
+        outcome: list[str] = []
+        original = CacheManager._append_under_lock
+
+        def _spy(self: Any, *args: Any, **kwargs: Any) -> Any:
+            other = sqlite3.connect(db, timeout=0)
+            try:
+                other.execute("BEGIN IMMEDIATE")
+                outcome.append("wrote")
+                other.rollback()
+            except sqlite3.OperationalError as exc:
+                outcome.append(str(exc))
+            finally:
+                other.close()
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(CacheManager, "_append_under_lock", _spy)
+        assert cache.extend_cached_entries(target, entries + entries[-1:], entries[-1:])
+        assert outcome and "locked" in outcome[0], (
+            f"another writer got in during the checked append: {outcome}"
+        )
+
 
 class TestSessionLoadOrdering:
     """`load_session_entries` must not reorder when its index changes.

--- a/test/test_entry_store.py
+++ b/test/test_entry_store.py
@@ -676,3 +676,90 @@ class TestAppendOnlyWrites:
         assert not cache.extend_cached_entries(target, entries[:-2], entries[-1:])
         # And the honest case still works.
         assert cache.extend_cached_entries(target, entries + entries[-1:], entries[-1:])
+
+
+class TestSessionLoadOrdering:
+    """`load_session_entries` must not reorder when its index changes.
+
+    Migration 012's session index carries `timestamp` before `file_id`
+    specifically so the planner can satisfy this query's filter *and* its
+    `ORDER BY` from one index, instead of walking the whole project to
+    load a single session (84.5 ms -> 7.2 ms for the twelve busiest
+    sessions of a 19k-row archive).
+
+    An index that changes the returned order would be a silent rendering
+    change, and ties are not rare — real archives have tens of thousands
+    of rows sharing a timestamp with another row. This pins the property
+    against a fixture built to be hostile: duplicate timestamps, rows
+    split across two files within one session, and NULL timestamps.
+    """
+
+    @staticmethod
+    def _entry(sid: str, uuid: str, ts: Any, text: str) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "type": "user",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "human",
+            "cwd": "/tmp",
+            "sessionId": sid,
+            "version": "1.0.0",
+            "uuid": uuid,
+            "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+        }
+        if ts is not None:
+            entry["timestamp"] = ts
+        return entry
+
+    def test_order_matches_an_explicit_timestamp_sort(self, tmp_path: Path) -> None:
+        from claude_code_log.cache import CacheManager, get_library_version
+
+        project = tmp_path / "-Users-dain-workspace-ordering"
+        project.mkdir(parents=True)
+        sid = "5eaf00d0-0000-4000-8000-000000000099"
+
+        # One session, two files, interleaved and duplicated timestamps.
+        first = project / f"{sid}.jsonl"
+        second = project / "5eaf00d0-0000-4000-8000-000000000100.jsonl"
+        with first.open("w", encoding="utf-8") as f:
+            for i, ts in enumerate(
+                ["2025-07-03T18:00:00Z", "2025-07-03T18:00:00Z", "2025-07-03T18:02:00Z"]
+            ):
+                f.write(json.dumps(self._entry(sid, f"a{i}", ts, f"a{i}")) + "\n")
+        with second.open("w", encoding="utf-8") as f:
+            for i, ts in enumerate(
+                ["2025-07-03T18:00:00Z", "2025-07-03T18:01:00Z", "2025-07-03T18:02:00Z"]
+            ):
+                f.write(json.dumps(self._entry(sid, f"b{i}", ts, f"b{i}")) + "\n")
+
+        convert_jsonl_to("html", project, silent=True, write_combined=False)
+        cache = CacheManager(project, get_library_version())
+
+        entries = cache.load_session_entries(sid)
+        assert len(entries) == 6, "fixture did not land in one session"
+
+        stamps = [getattr(e, "timestamp", None) for e in entries]
+        non_null = [s for s in stamps if s]
+        assert non_null == sorted(non_null), (
+            f"session load came back out of timestamp order: {stamps}"
+        )
+        assert len({getattr(e, "uuid", None) for e in entries}) == 6
+
+        # The index must be the one serving it — otherwise this test would
+        # keep passing while the query silently went back to scanning.
+        with cache._get_connection() as conn:
+            plan = [
+                r[-1]
+                for r in conn.execute(
+                    "EXPLAIN QUERY PLAN SELECT content FROM messages "
+                    "WHERE project_id = ? AND session_id = ? "
+                    "ORDER BY timestamp NULLS LAST",
+                    (cache._project_id, sid),
+                )
+            ]
+        assert any("idx_messages_project_session_ts" in p for p in plan), (
+            f"session load is not using its index — plan was {plan}"
+        )
+        assert not any("TEMP B-TREE" in p.upper() for p in plan), (
+            f"the index no longer satisfies the ORDER BY — plan was {plan}"
+        )

--- a/test/test_html_regeneration.py
+++ b/test/test_html_regeneration.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+from claude_code_log import converter as converter_module
 from claude_code_log.converter import (
     convert_jsonl_to_html,
     process_projects_hierarchy,
@@ -184,11 +185,17 @@ class TestHtmlRegeneration:
         # no-op run produces byte-identical content, and an mtime
         # comparison can falsely fail (or pass) within the filesystem's
         # timestamp granularity.
-        real_write_text = Path.write_text
+        #
+        # The seam is `atomic_write_text`, not `Path.write_text`: output
+        # writes go to a uniquely-named temp file and are then renamed
+        # into place, so the destination path only appears at this call.
+        real_atomic_write = converter_module.atomic_write_text
         with (
             patch("builtins.print") as mock_print,
             patch.object(
-                Path, "write_text", autospec=True, side_effect=real_write_text
+                converter_module,
+                "atomic_write_text",
+                side_effect=real_atomic_write,
             ) as write_spy,
         ):
             process_projects_hierarchy(projects_dir, silent=False)

--- a/test/test_live_update.py
+++ b/test/test_live_update.py
@@ -199,6 +199,101 @@ class TestLiveUpdate:
         )
         assert still_folded == folded, "fold state was lost across the update"
 
+    # Toggle the first session header's fold bar, reporting the children
+    # container's `display` either side of the click. A working control
+    # changes it; a dead listener leaves it exactly as it was.
+    _CLICK_FOLD = (
+        "() => { const bar = document.querySelector('#transcript .message"
+        ".session-header > .fold-bar');"
+        " const section = bar && bar.querySelector('.fold-bar-section');"
+        " if (!section) return null;"
+        " const children = section.closest('.message-node')"
+        ".querySelector(':scope > .children');"
+        " const before = children.style.display;"
+        " section.click();"
+        " return { before, after: children.style.display,"
+        "   folded: section.classList.contains('folded') }; }"
+    )
+
+    def test_the_fold_control_still_works_after_an_update(
+        self, page, live_archive
+    ) -> None:
+        """The fold bars were bound per element at load, and a live update
+        replaces them: every append re-renders the bar of every ancestor
+        (it carries their descendant count), and the swap replaces all of
+        them at once. The listeners died with the elements, so one update
+        was enough to leave every fold control on the page inert — while
+        still *looking* exactly right, which is why nothing caught it.
+
+        Asserting that the state survives an update is not the same
+        assertion and passed throughout.
+        """
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        first = page.evaluate(self._CLICK_FOLD)
+        assert first is not None, "fixture has nothing foldable"
+        assert first["before"] != first["after"], "the control was dead on load"
+        page.evaluate(self._CLICK_FOLD)  # back to unfolded
+
+        # Update one: the swap.
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("fold-1", "FOLD-ONE"))
+        _wait_for(page, "() => !!document.querySelector('[data-uuid=\"fold-1\"]')")
+        after_swap = page.evaluate(self._CLICK_FOLD)
+        assert after_swap["before"] != after_swap["after"], (
+            "the fold control stopped responding after the container swap"
+        )
+        page.evaluate(self._CLICK_FOLD)
+
+        # Update two: the patch, which replaces the header card on its own
+        # rather than the whole container.
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("fold-2", "FOLD-TWO"))
+        _wait_for(page, "() => !!document.querySelector('[data-uuid=\"fold-2\"]')")
+        after_patch = page.evaluate(self._CLICK_FOLD)
+        assert after_patch["before"] != after_patch["after"], (
+            "the fold control stopped responding after the patch"
+        )
+
+    def test_a_replaced_fold_bar_still_describes_its_own_subtree(
+        self, page, live_archive
+    ) -> None:
+        """The card carries the fold bar; the children container carries the
+        fold *state*. An update replaces the first and not the second, so
+        the bar comes back with the server's default "unfolded" icons over
+        a subtree that is still hidden. The next click then folds what is
+        already folded and appears to do nothing at all.
+        """
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        folded = page.evaluate(self._CLICK_FOLD)
+        assert folded["after"] == "none", "the first click should fold"
+        assert folded["folded"], "the bar did not mark itself folded"
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("desync-1", "DESYNC-ONE"))
+        _wait_for(page, "() => !!document.querySelector('[data-uuid=\"desync-1\"]')")
+
+        state = page.evaluate(
+            "() => { const bar = document.querySelector('#transcript .message"
+            ".session-header > .fold-bar');"
+            " const section = bar.querySelector('.fold-bar-section');"
+            " const children = section.closest('.message-node')"
+            ".querySelector(':scope > .children');"
+            " return { hidden: children.style.display === 'none',"
+            "   folded: section.classList.contains('folded'),"
+            "   icon: section.querySelector('.fold-icon').textContent }; }"
+        )
+        assert state["hidden"], "the subtree unfolded itself across the update"
+        assert state["folded"], "the replaced bar forgot it was folded"
+        assert state["icon"] == "⏵", f"the icon disagrees with the subtree: {state}"
+
+        # And it is still a working toggle, not merely a correct label.
+        again = page.evaluate(self._CLICK_FOLD)
+        assert again["after"] != "none", "the next click did not unfold"
+
     # ---- patching ----------------------------------------------------
     #
     # The first update of a session always swaps: the hashes a patch
@@ -334,7 +429,8 @@ class TestLiveUpdate:
         """`scrollIntoView({block: 'end'})` aligns the card's bottom edge
         with the viewport's, which measures as a 0px gap and reads as the
         message being cut off. The padding under `body.live-following` is
-        what gives the scroll somewhere to go."""
+        what gives the scroll somewhere to go — 20px of it, which lands the
+        card 36px clear once the container's own margin is counted."""
         base, project, jsonl = live_archive
         self._open(page, base, project)
 
@@ -378,6 +474,79 @@ class TestLiveUpdate:
         with jsonl.open("a", encoding="utf-8") as f:
             f.write(_entry("rapid-2", "RAPID-TWO"))
         _wait_for(page, "() => document.body.innerText.includes('RAPID-TWO')")
+
+    def test_a_slow_response_cannot_overwrite_a_newer_one(
+        self, page, live_archive
+    ) -> None:
+        """The interval keeps firing while a full GET is in flight, so on a
+        page slow enough to fetch — the large page all of this is for — two
+        updates can be in the air at once and the *last response* wins.
+
+        Asserting on the *end* state is not enough and was measured to be
+        not enough: unserialised, the newest message appeared at 2.0s,
+        vanished at 4.0s when the held body landed, and was restored at
+        5.0s by the following poll. So this watches for the regression
+        itself — a message that was on screen and then was not.
+
+        Simulated at the only thing that matters — an older response
+        landing after a newer one — by holding the first full GET the page
+        makes and appending again while it is held.
+        """
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("race-seed", "RACE-SEED"))
+        _wait_for(page, "() => document.body.innerText.includes('RACE-SEED')")
+
+        # Hold the *next* full GET's response for 3s (well past POLL_MS)
+        # while letting its HEADs through, so the page keeps noticing
+        # changes while the older body is still in the air. Sample the
+        # rendered text throughout, so a message that comes and goes is
+        # caught rather than averaged away by a final check.
+        page.evaluate(
+            "() => { const orig = window.fetch;"
+            " window.__held = false;"
+            " window.__lost = [];"
+            " window.fetch = function (input, init) {"
+            "   const p = orig.apply(this, arguments);"
+            "   if (init && init.method === 'HEAD') return p;"
+            "   if (window.__held) return p;"
+            "   window.__held = true;"
+            "   return p.then(res => new Promise(r => setTimeout(() => r(res), 3000)));"
+            " };"
+            " const seen = new Set();"
+            " setInterval(() => { const t = document.body.innerText;"
+            "   for (const m of ['RACE-ONE', 'RACE-TWO']) {"
+            "     if (t.includes(m)) seen.add(m);"
+            "     else if (seen.has(m)) window.__lost.push(m);"
+            "   } }, 100); }"
+        )
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("race-one", "RACE-ONE"))
+        # The held GET has been issued: its body is the render carrying
+        # RACE-ONE but not RACE-TWO.
+        _wait_for(page, "() => window.__held === true")
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("race-two", "RACE-TWO"))
+
+        _wait_for(
+            page,
+            "() => document.body.innerText.includes('RACE-ONE')"
+            " && document.body.innerText.includes('RACE-TWO')",
+        )
+        # Both are on screen. Wait past the held response, and past the
+        # poll after it that would paper over the damage.
+        page.wait_for_timeout(4000)
+
+        text = page.evaluate("() => document.body.innerText")
+        assert "RACE-ONE" in text, "the newer render dropped an earlier message"
+        assert "RACE-TWO" in text, "a stale response overwrote the newer page"
+        assert page.evaluate("() => window.__lost") == [], (
+            "a message left the page after arriving: a stale response was applied"
+        )
 
     def test_the_poller_is_inert_over_file_urls(self, page, tmp_path: Path) -> None:
         """The generated HTML must stay exactly as useful from `file://`.

--- a/test/test_live_update.py
+++ b/test/test_live_update.py
@@ -9,6 +9,7 @@ not a sibling, not even itself. The rest of the browser suite runs from
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from pathlib import Path
@@ -543,6 +544,51 @@ class TestLiveUpdate:
         with jsonl.open("a", encoding="utf-8") as f:
             f.write(_entry("rapid-2", "RAPID-TWO"))
         _wait_for(page, "() => document.body.innerText.includes('RAPID-TWO')")
+
+    def test_a_same_size_rewrite_inside_one_second_is_seen(
+        self, page, tmp_path: Path
+    ) -> None:
+        """`Last-Modified` + `Content-Length` are both blind to a rewrite
+        that changes content without changing size — a re-render where a
+        counter, a status word or a timestamp keeps its width — and
+        inside one second neither header moves at all. The page must
+        still notice, via the server's content digest.
+
+        The page is rewritten directly rather than through a conversion:
+        the point is a specific pair of bytes on the wire, and the two
+        mtimes are set half a second apart inside one whole second so
+        this *is* the same-second case rather than usually being it.
+        """
+        projects = tmp_path / "projects"
+        project = projects / "-tmp-samesize"
+        project.mkdir(parents=True)
+        (project / f"{SESSION_ID}.jsonl").write_text(
+            _entry("only", "MARKER-AAAA"), encoding="utf-8"
+        )
+        process_projects_hierarchy(projects, silent=True)
+        rendered = project / f"session-{SESSION_ID}.html"
+
+        second_ns = 1_700_000_000_000_000_000
+        os.utime(rendered, ns=(second_ns, second_ns))
+        size_before = rendered.stat().st_size
+
+        from claude_code_log.server import ArchiveServer
+
+        with ArchiveServer(projects, port=0) as server:
+            self._open(page, server.url, project)
+            _wait_for(page, "() => document.body.innerText.includes('MARKER-AAAA')")
+
+            html = rendered.read_text(encoding="utf-8")
+            assert "MARKER-AAAA" in html
+            rendered.write_text(
+                html.replace("MARKER-AAAA", "MARKER-BBBB"), encoding="utf-8"
+            )
+            assert rendered.stat().st_size == size_before, (
+                "the rewrite has to keep the size for this to test anything"
+            )
+            os.utime(rendered, ns=(second_ns + 500_000_000, second_ns + 500_000_000))
+
+            _wait_for(page, "() => document.body.innerText.includes('MARKER-BBBB')")
 
     def test_a_slow_response_cannot_overwrite_a_newer_one(
         self, page, live_archive

--- a/test/test_live_update.py
+++ b/test/test_live_update.py
@@ -256,6 +256,75 @@ class TestLiveUpdate:
             "the fold control stopped responding after the patch"
         )
 
+    def test_an_update_during_page_load_is_not_absorbed(
+        self, page, live_archive
+    ) -> None:
+        """The first poll cannot adopt whatever the server holds by then.
+
+        It only runs once the document has loaded, and that is exactly the
+        window this feature's pages are slow in — tens of MB. A conversion
+        finishing in it would become the baseline, so the page would sit
+        one update behind until something *else* changed, which for a
+        session that has just gone quiet is forever.
+        """
+        base, project, jsonl = live_archive
+        url = f"{base}/{project.name}/session-{SESSION_ID}.html"
+        page_file = project / f"session-{SESSION_ID}.html"
+        served_stale: list[bool] = []
+
+        def hold(route):
+            # Only the navigation: the page's own HEAD and GET share this
+            # URL and must reach the server as usual.
+            if route.request.resource_type != "document" or served_stale:
+                route.continue_()
+                return
+            # Take the document as it is now, then let the session move on
+            # and the watch reconvert *before* handing it to the browser.
+            response = route.fetch()
+            body = response.body()
+            served_stale.append(b"LOAD-RACE-MARKER" not in body)
+            with jsonl.open("a", encoding="utf-8") as f:
+                f.write(_entry("load-race", "LOAD-RACE-MARKER"))
+            deadline = time.time() + 20
+            while time.time() < deadline:
+                if "LOAD-RACE-MARKER" in page_file.read_text(encoding="utf-8"):
+                    break
+                time.sleep(0.05)
+            route.fulfill(status=response.status, headers=response.headers, body=body)
+
+        page.route(url, hold)
+        self._open(page, base, project)
+        assert served_stale == [True], "the browser was served the new page after all"
+
+        _wait_for(page, "() => document.body.innerText.includes('LOAD-RACE-MARKER')")
+
+    def test_an_open_timeline_picks_up_new_cards(self, page, live_archive) -> None:
+        """The timeline is the one rehydrate hook that reads the whole page.
+
+        It is therefore called once per changed element and coalesced to a
+        single rebuild per update — so this asserts the rebuild still
+        happens at all, which the coalescing is the only thing standing
+        between the timeline and.
+        """
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+        page.locator("#toggleTimeline").click()
+        # The library is fetched from a CDN on first open.
+        page.wait_for_selector(".vis-item", timeout=30000)
+        before = page.locator(".vis-item").count()
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("timeline-1", "TIMELINE-MARKER"))
+        _wait_for(page, "() => document.body.innerText.includes('TIMELINE-MARKER')")
+
+        _wait_for(
+            page,
+            "() => [...document.querySelectorAll('.vis-item')]"
+            ".some(el => el.innerText.includes('TIMELINE-MARKER'))",
+            timeout=10000,
+        )
+        assert page.locator(".vis-item").count() > before
+
     def test_a_replaced_fold_bar_still_describes_its_own_subtree(
         self, page, live_archive
     ) -> None:

--- a/test/test_live_update.py
+++ b/test/test_live_update.py
@@ -1,0 +1,237 @@
+"""The served page updating itself while a session is still being written.
+
+These are live-server browser tests by necessity: the feature only
+activates over http, because a `file://` page cannot fetch anything —
+not a sibling, not even itself. The rest of the browser suite runs from
+`file://`, so it cannot cover this.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.converter import process_projects_hierarchy
+from claude_code_log.watch import WatchEngine
+
+SESSION_ID = "dddddddd-eeee-ffff-0000-111111111111"
+
+
+def _entry(uuid: str, text: str) -> str:
+    return (
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2026-08-30T21:00:00Z",
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp/live",
+                "sessionId": SESSION_ID,
+                "version": "1.0.0",
+                "uuid": uuid,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+@pytest.fixture
+def live_archive(tmp_path: Path):
+    """A served project with a watcher, and a handle to append to it."""
+    projects = tmp_path / "projects"
+    project = projects / "-tmp-live"
+    project.mkdir(parents=True)
+    jsonl = project / f"{SESSION_ID}.jsonl"
+    # Enough content that the page scrolls, so scroll preservation is
+    # actually being tested rather than trivially true.
+    jsonl.write_text(
+        "".join(
+            _entry(f"seed-{i}", f"seed message {i} " + ("padding " * 40))
+            for i in range(40)
+        ),
+        encoding="utf-8",
+    )
+    process_projects_hierarchy(projects, silent=True)
+
+    from claude_code_log.server import ArchiveServer
+
+    engine = WatchEngine(
+        [projects],
+        lambda _paths: process_projects_hierarchy(projects, silent=True),
+        quiet_period=0.1,
+        max_latency=0.5,
+        poll_interval=0.05,
+        on_error=lambda exc: pytest.fail(f"watch conversion failed: {exc!r}"),
+    )
+    engine.prime()
+    stop = threading.Event()
+    thread = engine.run_in_thread(stop)
+
+    server = ArchiveServer(projects, port=0)
+    server.start()
+    try:
+        yield server.url, project, jsonl
+    finally:
+        stop.set()
+        thread.join(timeout=10)
+        server.stop()
+
+
+def _wait_for(page, expression: str, timeout: int = 30000) -> None:
+    page.wait_for_function(expression, timeout=timeout)
+
+
+@pytest.mark.browser
+class TestLiveUpdate:
+    def _open(self, page, base: str, project: Path):
+        errors: list[str] = []
+        page.on(
+            "console", lambda m: errors.append(m.text) if m.type == "error" else None
+        )
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        page.goto(f"{base}/{project.name}/session-{SESSION_ID}.html")
+        page.wait_for_selector("#transcript")
+        return errors
+
+    def test_a_new_message_appears_without_navigating(self, page, live_archive) -> None:
+        """The whole point: the page updates in place, not by reloading."""
+        base, project, jsonl = live_archive
+        errors = self._open(page, base, project)
+
+        # A navigation would wipe this; a container swap must not.
+        page.evaluate("window.__stillHere = 'yes'")
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("live-1", "LIVE-MARKER-ONE"))
+
+        _wait_for(page, "() => document.body.innerText.includes('LIVE-MARKER-ONE')")
+        assert page.evaluate("window.__stillHere") == "yes", "the page navigated"
+        assert errors == []
+
+    def test_scroll_position_survives_an_update(self, page, live_archive) -> None:
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+        page.evaluate("window.scrollTo(0, 600)")
+        before = page.evaluate("window.scrollY")
+        assert before > 0, "fixture is not tall enough to test scrolling"
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("live-2", "LIVE-MARKER-TWO"))
+        _wait_for(page, "() => document.body.innerText.includes('LIVE-MARKER-TWO')")
+
+        assert page.evaluate("window.scrollY") == before
+
+    def test_new_cards_are_tagged_for_the_fade_in(self, page, live_archive) -> None:
+        """Transcripts record whole messages, never partial tokens, so a
+        card can only ever appear complete. Announcing that arrival is the
+        most honest 'streaming' the page can offer."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("live-3", "LIVE-MARKER-THREE"))
+        _wait_for(
+            page, "() => document.querySelectorAll('.message.live-new').length > 0"
+        )
+
+        assert page.locator("#live-update-pill").count() == 1
+
+    def test_timestamps_on_new_cards_are_localised(self, page, live_archive) -> None:
+        """The rehydrate contract, end to end: timestamp localisation
+        rewrites innerHTML after load, so swapped-in markup would keep raw
+        ISO strings unless the hook re-runs over it."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("live-4", "LIVE-MARKER-FOUR"))
+        _wait_for(page, "() => document.body.innerText.includes('LIVE-MARKER-FOUR')")
+
+        shown = page.evaluate(
+            "() => { const t = [...document.querySelectorAll('.timestamp[data-timestamp]')];"
+            " const last = t[t.length - 1];"
+            " return last && {text: last.textContent.trim(),"
+            "                 raw: last.getAttribute('data-timestamp')}; }"
+        )
+        assert shown, "no timestamp element found"
+        assert shown["text"] != shown["raw"], "the new card kept its raw ISO timestamp"
+
+    def test_fold_state_survives_an_update(self, page, live_archive) -> None:
+        """Session headers fold but carry no `data-uuid` — on a
+        single-session page the header is the *only* foldable node, so a
+        uuid-keyed capture would silently preserve nothing."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        bar = page.locator(".fold-bar-section.fold-one-level").first
+        assert bar.count() > 0, "fixture has nothing foldable"
+        bar.click()
+        page.wait_for_timeout(200)
+        folded = page.evaluate(
+            "() => [...document.querySelectorAll('.message-node > .children')]"
+            ".filter(c => c.style.display === 'none').length"
+        )
+        assert folded > 0, "clicking the fold bar did not fold anything"
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("live-5", "LIVE-MARKER-FIVE"))
+        # innerText cannot see inside a display:none container, so assert
+        # on DOM presence.
+        _wait_for(page, "() => !!document.querySelector('[data-uuid=\"live-5\"]')")
+
+        still_folded = page.evaluate(
+            "() => [...document.querySelectorAll('.message-node > .children')]"
+            ".filter(c => c.style.display === 'none').length"
+        )
+        assert still_folded == folded, "fold state was lost across the update"
+
+    def test_two_updates_inside_one_second_are_both_seen(
+        self, page, live_archive
+    ) -> None:
+        """HTTP dates have one-second granularity, so `Last-Modified`
+        alone makes the second of two rapid updates invisible. Observed
+        for real before `Content-Length` joined the comparison."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("rapid-1", "RAPID-ONE"))
+        _wait_for(page, "() => document.body.innerText.includes('RAPID-ONE')")
+        # Immediately, inside the same second as the update just applied.
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("rapid-2", "RAPID-TWO"))
+        _wait_for(page, "() => document.body.innerText.includes('RAPID-TWO')")
+
+    def test_the_poller_is_inert_over_file_urls(self, page, tmp_path: Path) -> None:
+        """The generated HTML must stay exactly as useful from `file://`.
+
+        A `file://` page cannot fetch anything at all, so the poller has
+        to notice and do nothing rather than throw on every interval.
+        """
+        projects = tmp_path / "projects"
+        project = projects / "-tmp-static"
+        project.mkdir(parents=True)
+        (project / f"{SESSION_ID}.jsonl").write_text(
+            _entry("only", "static page"), encoding="utf-8"
+        )
+        process_projects_hierarchy(projects, silent=True)
+
+        errors: list[str] = []
+        page.on(
+            "console", lambda m: errors.append(m.text) if m.type == "error" else None
+        )
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        page.goto((project / f"session-{SESSION_ID}.html").as_uri())
+        page.wait_for_selector("#transcript")
+        time.sleep(2)  # several poll intervals, had it been active
+
+        assert errors == []
+        assert page.locator("#live-update-pill").count() == 0

--- a/test/test_live_update.py
+++ b/test/test_live_update.py
@@ -142,7 +142,13 @@ class TestLiveUpdate:
             page, "() => document.querySelectorAll('.message.live-new').length > 0"
         )
 
-        assert page.locator("#live-update-pill").count() == 1
+        # The follow toggle belongs to the page's floating-button stack and
+        # is revealed once polling starts, so it carries the unseen count
+        # rather than being built from scratch on first arrival.
+        follow = page.locator("#followUpdates")
+        assert follow.count() == 1
+        assert "live-active" in (follow.get_attribute("class") or "")
+        assert follow.get_attribute("data-unseen") not in (None, "0")
 
     def test_timestamps_on_new_cards_are_localised(self, page, live_archive) -> None:
         """The rehydrate contract, end to end: timestamp localisation
@@ -193,6 +199,169 @@ class TestLiveUpdate:
         )
         assert still_folded == folded, "fold state was lost across the update"
 
+    # ---- patching ----------------------------------------------------
+    #
+    # The first update of a session always swaps: the hashes a patch
+    # compares against are taken from parsed markup, and the first update
+    # is where they are first taken. So every test below appends twice —
+    # once to seed, once to exercise the patch. Asserting only that the
+    # new message arrived would pass just as well with the patch disabled
+    # entirely, so these assert on *element identity*, which the swap
+    # necessarily destroys and the patch necessarily keeps.
+
+    _TAG_CARDS = (
+        "() => { let n = 0;"
+        " document.querySelectorAll('#transcript .message').forEach(el => {"
+        "   el.__probe = true; n++; });"
+        " return n; }"
+    )
+    _COUNT_TAGGED = (
+        "() => { const els = [...document.querySelectorAll('#transcript .message')];"
+        " return { total: els.length, kept: els.filter(e => e.__probe).length }; }"
+    )
+
+    def test_an_append_patches_rather_than_rebuilding_the_page(
+        self, page, live_archive
+    ) -> None:
+        """A swap replaces every node in the container, so no element on
+        screen survives it. A patch touches only what changed."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("patch-seed", "PATCH-SEED"))
+        _wait_for(page, "() => document.body.innerText.includes('PATCH-SEED')")
+
+        tagged = page.evaluate(self._TAG_CARDS)
+        assert tagged > 10, "fixture too small to distinguish patch from swap"
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("patch-two", "PATCH-TWO"))
+        _wait_for(page, "() => document.body.innerText.includes('PATCH-TWO')")
+
+        after = page.evaluate(self._COUNT_TAGGED)
+        assert after["total"] == tagged + 1, "the appended card did not arrive"
+        # A swap scores exactly 0. A patch keeps everything but the few
+        # cards whose own markup really changed — in practice the ancestors
+        # whose fold bar counts their descendants.
+        assert after["kept"] > 0, "every card was rebuilt: the patch did not run"
+        assert after["kept"] >= tagged - 5, (
+            f"patch replaced more than expected: {tagged - after['kept']} cards"
+        )
+
+    def test_a_patch_leaves_existing_timestamps_localised(
+        self, page, live_archive
+    ) -> None:
+        """Timestamp localisation rewrites innerHTML, so a rebuilt card
+        comes back with a raw ISO string and has to be converted again.
+        Across a growing session that is the whole page, every update."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("ts-seed", "TS-SEED"))
+        _wait_for(page, "() => document.body.innerText.includes('TS-SEED')")
+        _wait_for(
+            page,
+            "() => { const t = document.querySelector('#transcript .timestamp"
+            "[data-timestamp]'); return t && t.childElementCount > 0; }",
+        )
+        page.evaluate(
+            "() => { document.querySelector('#transcript .timestamp[data-timestamp]')"
+            ".__probe = true; }"
+        )
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("ts-two", "TS-TWO"))
+        _wait_for(page, "() => document.body.innerText.includes('TS-TWO')")
+
+        first = page.evaluate(
+            "() => { const t = document.querySelector('#transcript .timestamp"
+            "[data-timestamp]');"
+            " return t && { kept: !!t.__probe, localised: t.childElementCount > 0 }; }"
+        )
+        assert first["kept"], "the first timestamp's element was rebuilt"
+        assert first["localised"], "the first timestamp lost its localisation"
+
+    def test_the_swap_is_the_fallback_when_the_ids_move(
+        self, page, live_archive
+    ) -> None:
+        """The patch is only valid while the card ids still mean what they
+        meant. Out-of-order arrivals renumber the positional `msg-d-N`
+        ids — measured at 2 of 47 growth steps across three real sessions —
+        and the update must fall back rather than patch against stale
+        identities."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("fallback-seed", "FALLBACK-SEED"))
+        _wait_for(page, "() => document.body.innerText.includes('FALLBACK-SEED')")
+
+        # Control: with the ids intact, this same append patches. Without
+        # it, `kept == 0` below would prove only that *something* swapped —
+        # which is also what a permanently broken patch looks like.
+        page.evaluate(self._TAG_CARDS)
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("fallback-ctl", "FALLBACK-CTL"))
+        _wait_for(page, "() => document.body.innerText.includes('FALLBACK-CTL')")
+        assert page.evaluate(self._COUNT_TAGGED)["kept"] > 0, (
+            "control failed: the patch did not run even with the ids intact"
+        )
+
+        # Renumbering, simulated at its effect: the live tree's id sequence
+        # no longer matches the one the next render will carry.
+        page.evaluate(self._TAG_CARDS)
+        page.evaluate(
+            "() => { const els = [...document.querySelectorAll('#transcript .message')];"
+            " els[Math.floor(els.length / 2)].id = 'msg-d-999999'; }"
+        )
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("fallback-two", "FALLBACK-TWO"))
+        _wait_for(page, "() => document.body.innerText.includes('FALLBACK-TWO')")
+
+        after = page.evaluate(self._COUNT_TAGGED)
+        assert after["kept"] == 0, "the patch ran against a renumbered tree"
+        # And the fallback did the job properly, not just safely.
+        assert page.evaluate(
+            "() => !!document.querySelector('#transcript .message.live-new')"
+        ), "the swap did not tag the new card"
+
+    def test_following_leaves_the_newest_card_clear_of_the_viewport_edge(
+        self, page, live_archive
+    ) -> None:
+        """`scrollIntoView({block: 'end'})` aligns the card's bottom edge
+        with the viewport's, which measures as a 0px gap and reads as the
+        message being cut off. The padding under `body.live-following` is
+        what gives the scroll somewhere to go."""
+        base, project, jsonl = live_archive
+        self._open(page, base, project)
+
+        page.click("#followUpdates")
+        assert page.evaluate(
+            "() => document.body.classList.contains('live-following')"
+        ), "clicking the toggle did not engage follow mode"
+
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(_entry("follow-1", "FOLLOW-ONE"))
+        _wait_for(page, "() => document.body.innerText.includes('FOLLOW-ONE')")
+        # The scroll is smooth, so let it land.
+        page.wait_for_timeout(1200)
+
+        gap = page.evaluate(
+            "() => { const c = document.getElementById('transcript');"
+            " const r = c.lastElementChild.getBoundingClientRect();"
+            " return Math.round(window.innerHeight - r.bottom); }"
+        )
+        assert gap > 20, f"newest card sits {gap}px from the viewport bottom"
+
+        # And turning it off puts the page back the way it was.
+        page.click("#followUpdates")
+        assert not page.evaluate(
+            "() => document.body.classList.contains('live-following')"
+        )
+
     def test_two_updates_inside_one_second_are_both_seen(
         self, page, live_archive
     ) -> None:
@@ -234,4 +403,11 @@ class TestLiveUpdate:
         time.sleep(2)  # several poll intervals, had it been active
 
         assert errors == []
-        assert page.locator("#live-update-pill").count() == 0
+        # The follow toggle is in the markup of every transcript page, so
+        # that a served page and the same file on disk render identically.
+        # It must stay hidden here: `file://` can never poll, and a visible
+        # control would promise something it cannot do.
+        follow = page.locator("#followUpdates")
+        assert follow.count() == 1
+        assert "live-active" not in (follow.get_attribute("class") or "")
+        assert not follow.is_visible()

--- a/test/test_resume_session_browser.py
+++ b/test/test_resume_session_browser.py
@@ -121,6 +121,45 @@ class TestResumeSessionBrowser:
         expect(toast).to_contain_text("Paste into your terminal")
 
     @pytest.mark.browser
+    def test_the_toast_sits_beside_its_button_and_clears_the_stack(
+        self, page: Page
+    ) -> None:
+        """It used to stack *above* the floating buttons, which meant every
+        button added to the stack pushed the toast further up, over
+        controls it has nothing to do with. Beside its own button, the
+        column is empty and stays empty."""
+        html = self._render(
+            [_user_entry("u1", "hello", session_id="ab12cd34", cwd="/tmp/project")]
+        )
+        self._goto_with_clipboard_stub(page, html)
+        page.locator("#resumeSession").click()
+        page.wait_for_selector("#resumeToast.visible")
+
+        geometry = page.evaluate(
+            "() => {"
+            " const toast = document.getElementById('resumeToast')"
+            "   .getBoundingClientRect();"
+            " const btn = document.getElementById('resumeSession')"
+            "   .getBoundingClientRect();"
+            " const hits = [...document.querySelectorAll('.floating-btn')]"
+            "   .filter(el => { const r = el.getBoundingClientRect();"
+            "     return !(r.right < toast.left || r.left > toast.right"
+            "              || r.bottom < toast.top || r.top > toast.bottom); })"
+            "   .map(el => el.id);"
+            " return { leftOf: toast.right <= btn.left,"
+            "          onScreen: toast.left >= 0,"
+            "          centred: Math.abs((toast.top + toast.bottom) / 2"
+            "                            - (btn.top + btn.bottom) / 2) < 2,"
+            "          hits }; }"
+        )
+        assert geometry["leftOf"], "the toast is not to the left of its button"
+        assert geometry["centred"], "the toast is not centred on its button"
+        assert geometry["onScreen"], "the toast runs off the left edge"
+        assert geometry["hits"] == [], (
+            f"the toast covers other floating buttons: {geometry['hits']}"
+        )
+
+    @pytest.mark.browser
     def test_no_button_on_multi_session_page(self, page: Page) -> None:
         """Combined pages spanning several sessions render no button."""
         html = self._render(

--- a/test/test_search_browser.py
+++ b/test/test_search_browser.py
@@ -64,11 +64,25 @@ class TestSearchBrowser:
         return temp_file
 
     def _search_for(self, page: Page, query: str):
-        """Open the search toolbar via `/` and type a query."""
+        """Open the search toolbar via `/`, type a query, and let it run.
+
+        The input handler debounces by 300 ms, so filling returns before
+        anything has been searched. Without waiting here, every later
+        assertion spends part of its own budget on that debounce — and on
+        a CI box with four browsers on four cores, "part of" has been the
+        whole of it (a Windows run resolved the locator three times in
+        five seconds, i.e. ~1.6 s per poll, and never saw the filter
+        applied). The counter is the component's own "I have run" signal:
+        idle it reads "No results", and after a search it reads either
+        "N of M matches" or "No matches".
+        """
         page.keyboard.press("/")
         search_input = page.locator("#searchInput")
         expect(search_input).to_be_focused()
         search_input.fill(query)
+        expect(page.locator("#searchResultCount")).to_have_text(
+            re.compile(r"match", re.IGNORECASE)
+        )
 
     @pytest.mark.browser
     def test_slash_opens_search(self, page: Page):

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -7,6 +7,7 @@ path traversal, conditional GET, and not dying on a client disconnect.
 
 from __future__ import annotations
 
+import os
 import socket
 import urllib.error
 import urllib.request
@@ -15,7 +16,7 @@ from typing import Any, Optional
 
 import pytest
 
-from claude_code_log.server import ArchiveServer
+from claude_code_log.server import REVISION_HEADER, ArchiveServer
 
 
 @pytest.fixture
@@ -182,6 +183,68 @@ def test_conditional_get_returns_304(server: ArchiveServer) -> None:
     )
     assert status == 304
     assert body == b""
+
+
+def test_a_same_size_rewrite_in_the_same_second_changes_the_revision(
+    server: ArchiveServer,
+    archive: Path,
+) -> None:
+    """The header the live page polls on must follow the *bytes*.
+
+    `Last-Modified` is second-granular and `Content-Length` cannot see an
+    edit that keeps the size, so a re-render where a counter or a status
+    word keeps its width is invisible to both — and watch mode rewrites a
+    few hundred ms apart.
+
+    The two mtimes are set explicitly, half a second apart inside one
+    whole second, so this is exactly a same-second rewrite and not a
+    timing gamble. Dating them in the past also means the first digest is
+    genuinely cached (the cache only keeps a settled file's), so the
+    second response is pinned against reusing it.
+    """
+    page = archive / "-Users-someone-project" / "session-abc123.html"
+    url = f"{server.url}/-Users-someone-project/session-abc123.html"
+
+    second_ns = 1_700_000_000_000_000_000
+    os.utime(page, ns=(second_ns, second_ns))
+    original = os.stat(page)
+
+    status, _, before = _get(url)
+    assert status == 200
+    first = before[REVISION_HEADER]
+
+    page.write_text("<html><body>SESSION</body></html>")
+    assert page.stat().st_size == original.st_size
+    os.utime(page, ns=(second_ns + 500_000_000, second_ns + 500_000_000))
+
+    status, body, after = _get(url)
+    assert status == 200
+    assert b"SESSION" in body
+    assert after["Last-Modified"] == before["Last-Modified"]
+    assert after["Content-Length"] == before["Content-Length"]
+    assert after[REVISION_HEADER] != first
+
+
+def test_the_revision_is_stable_while_the_file_is(server: ArchiveServer) -> None:
+    """An unchanged file must not look changed, or every poll re-fetches."""
+    url = f"{server.url}/index.html"
+    _, _, first = _get(url)
+    _, _, second = _get(url)
+    assert first[REVISION_HEADER] == second[REVISION_HEADER]
+
+
+def test_head_carries_the_revision(server: ArchiveServer) -> None:
+    """The live page polls with HEAD; the header has to be on that reply."""
+    request = urllib.request.Request(f"{server.url}/index.html", method="HEAD")
+    with urllib.request.urlopen(request) as response:
+        assert response.status == 200
+        assert response.headers[REVISION_HEADER]
+
+
+def test_the_api_carries_no_revision(server: ArchiveServer) -> None:
+    """It describes a file response; a JSON payload has none."""
+    _, _, headers = _get(f"{server.url}/api/ping")
+    assert REVISION_HEADER not in headers
 
 
 def test_client_disconnect_does_not_kill_the_server(

--- a/test/test_session_scoped_render.py
+++ b/test/test_session_scoped_render.py
@@ -616,3 +616,100 @@ class TestBranchWinnerMechanics:
         _convert(branch_replay_project)
 
         assert _session_files(branch_replay_project) == baseline
+
+
+class TestSessionScopedAfterAppend:
+    """The watch-mode shape: the cache *was* updated, by a pure append.
+
+    Phase 1b used to refuse outright whenever `ensure_fresh_cache`
+    reported an update, which made it unreachable for the one case it
+    helps most — a live session gaining messages, where every run has new
+    bytes by definition. It now refuses only for a FULL refresh; an
+    INCREMENTAL one has already proven the change was a pure append
+    (`_incremental_cache_refresh` requires each modified file's cached
+    rows to be an exact prefix of its current rows), which is exactly the
+    premise the per-session message-count staleness check needs.
+    """
+
+    @staticmethod
+    def _append_entry(jsonl: Path, uuid: str, text: str) -> None:
+        entry = {
+            "type": "user",
+            "timestamp": "2025-07-03T18:00:00Z",
+            "parentUuid": None,
+            "isSidechain": False,
+            "userType": "human",
+            "cwd": "/tmp",
+            "sessionId": jsonl.stem,
+            "version": "1.0.0",
+            "uuid": uuid,
+            "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+        }
+        with jsonl.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def _grown_project(self, tmp_path: Path) -> tuple[Path, Path]:
+        work_dir = _copy_project(tmp_path, MULTI_SESSION_PROJECT)
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+        jsonl = sorted(work_dir.glob("*.jsonl"))[0]
+        return work_dir, jsonl
+
+    def test_append_reaches_the_partial_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression this whole change exists to prevent."""
+        work_dir, jsonl = self._grown_project(tmp_path)
+        self._append_entry(jsonl, "watch-append-1", "a new message arrives")
+
+        _forbid_full_load(monkeypatch)
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+
+    def test_append_output_is_byte_identical_to_the_full_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two copies advance through the same append; bytes must match."""
+        scoped_dir, scoped_jsonl = self._grown_project(tmp_path / "scoped")
+        full_dir, full_jsonl = self._grown_project(tmp_path / "full")
+
+        for jsonl in (scoped_jsonl, full_jsonl):
+            self._append_entry(jsonl, "watch-append-1", "a new message arrives")
+
+        convert_jsonl_to("html", scoped_dir, silent=True, write_combined=False)
+        monkeypatch.setenv("CLAUDE_CODE_LOG_SESSION_SCOPED", "0")
+        convert_jsonl_to("html", full_dir, silent=True, write_combined=False)
+
+        assert _session_files(scoped_dir) == _session_files(full_dir)
+
+    def test_the_appended_message_actually_lands_in_the_output(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards against the failure mode where nothing is regenerated.
+
+        A cheaper path that renders *nothing* would pass an equivalence
+        test against another path that also renders nothing.
+        """
+        work_dir, jsonl = self._grown_project(tmp_path)
+        before = _session_files(work_dir)
+
+        self._append_entry(jsonl, "watch-append-1", "UNIQUE-MARKER-9f3a")
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+        after = _session_files(work_dir)
+
+        assert before != after, "the append did not change any session file"
+        assert any(b"UNIQUE-MARKER-9f3a" in b for b in after.values())
+
+    def test_a_full_refresh_still_declines(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FULL carries no append-only proof, so the veto must survive.
+
+        The incremental refresh is disabled, forcing `ensure_fresh_cache`
+        down its full-load path; Phase 1b must then refuse.
+        """
+        work_dir, jsonl = self._grown_project(tmp_path)
+        self._append_entry(jsonl, "watch-append-1", "a new message arrives")
+
+        monkeypatch.setenv("CLAUDE_CODE_LOG_INCREMENTAL_CACHE", "0")
+        calls = _spy_full_load(monkeypatch)
+        convert_jsonl_to("html", work_dir, silent=True, write_combined=False)
+        assert calls, "a FULL cache refresh must not reach the session-scoped path"

--- a/test/test_template_rendering.py
+++ b/test/test_template_rendering.py
@@ -327,10 +327,20 @@ class TestTemplateRendering:
             assert "&lt;script&gt;" in html_content
             assert "&amp;" in html_content
             assert "&quot;" in html_content
-            # Should not contain unescaped HTML
-            assert (
-                "<script>" not in html_content or html_content.count("<script>") <= 2
-            )  # Allow for the markdown script and search script
+            # The user's payload must not survive as a live tag.
+            #
+            # This used to count `<script>` occurrences and allow up to
+            # two, which meant bumping the number every time the page grew
+            # a script block of its own — while saying nothing about
+            # whether the *content* was escaped. Assert the property
+            # itself: the payload's opening tag is escaped everywhere it
+            # appears, so it can never execute.
+            assert "<script>alert(" not in html_content
+            # Both renderings of the payload are escaped: the raw-text view
+            # keeps the apostrophe literal, the Markdown view entity-encodes
+            # it. Neither carries a live `<script>`.
+            assert "&lt;script&gt;alert('xss')&lt;/script&gt;" in html_content
+            assert "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;" in html_content
 
 
 class TestNestedDomSkipsEmptyLeaves:

--- a/test/test_watch_cli.py
+++ b/test/test_watch_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the `watch` subcommand's own logic.
+
+The loop is covered by `test_watch_engine.py`; what's specific here is
+which directory a bare `claude-code-log watch` decides to watch, and that
+the wiring actually converts.
+"""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from claude_code_log.cli import _resolve_watch_root, main
+
+
+def _entry(uuid: str, text: str, session_id: str) -> str:
+    return (
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2026-08-30T18:00:00Z",
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp/live/demo",
+                "sessionId": session_id,
+                "version": "1.0.0",
+                "uuid": uuid,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+class TestResolveWatchRoot:
+    def test_an_explicit_path_wins(self, tmp_path: Path) -> None:
+        explicit = tmp_path / "somewhere"
+        explicit.mkdir()
+        assert _resolve_watch_root(explicit, tmp_path / "projects", False) == explicit
+
+    def test_all_projects_selects_the_hierarchy(self, tmp_path: Path) -> None:
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        assert _resolve_watch_root(None, projects, True) == projects
+
+    def test_the_cwd_project_is_the_default(self, tmp_path: Path, monkeypatch) -> None:
+        """Running this beside a live session should just work."""
+        work = tmp_path / "myproject"
+        work.mkdir()
+        projects = tmp_path / "projects"
+        encoded = projects / str(work).replace("/", "-")
+        encoded.mkdir(parents=True)
+        monkeypatch.chdir(work)
+
+        assert _resolve_watch_root(None, projects, False) == encoded
+
+    def test_an_unknown_cwd_reports_rather_than_guessing(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        work = tmp_path / "not-a-claude-project"
+        work.mkdir()
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        monkeypatch.chdir(work)
+
+        assert _resolve_watch_root(None, projects, False) is None
+        err = capsys.readouterr().err
+        assert "No transcripts found" in err
+        assert "--all-projects" in err, "the error should say what to do instead"
+
+
+class TestWatchCommand:
+    def test_it_converts_once_before_watching(self, tmp_path: Path) -> None:
+        """A watch that only reacts leaves the output stale until the next
+        message; the up-front conversion is what makes it usable at once."""
+        projects = tmp_path / "projects"
+        proj = projects / "-tmp-demo"
+        proj.mkdir(parents=True)
+        sid = "11111111-2222-3333-4444-555555555555"
+        (proj / f"{sid}.jsonl").write_text(_entry("u0", "hello", sid), encoding="utf-8")
+        out = tmp_path / "vault"
+
+        # max_latency=0 with an immediate stop: run() ticks once, sees no
+        # change (the up-front conversion primed after writing), and exits.
+        import claude_code_log.watch as watch_mod
+
+        real_run = watch_mod.WatchEngine.run
+        calls: list[int] = []
+
+        def run_once(self, stop=None):  # noqa: ANN001
+            calls.append(1)
+            self.tick()
+
+        watch_mod.WatchEngine.run = run_once
+        try:
+            result = CliRunner().invoke(
+                main,
+                [
+                    "watch",
+                    str(proj),
+                    "--projects-dir",
+                    str(projects),
+                    "-f",
+                    "md",
+                    "-o",
+                    str(out),
+                ],
+            )
+        finally:
+            watch_mod.WatchEngine.run = real_run
+
+        assert result.exit_code == 0, result.output
+        assert calls, "the engine loop never ran"
+        produced = list(out.rglob(f"session-{sid}.md"))
+        assert produced, f"no session file was written: {result.output}"
+        assert "hello" in produced[0].read_text(encoding="utf-8")
+        assert "Watching" in result.output
+
+    def test_an_unresolvable_target_exits_nonzero(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        work = tmp_path / "elsewhere"
+        work.mkdir()
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        monkeypatch.chdir(work)
+
+        result = CliRunner().invoke(main, ["watch", "--projects-dir", str(projects)])
+        assert result.exit_code == 1

--- a/test/test_watch_cli.py
+++ b/test/test_watch_cli.py
@@ -130,6 +130,59 @@ class TestWatchCommand:
         result = CliRunner().invoke(main, ["watch", "--projects-dir", str(projects)])
         assert result.exit_code == 1
 
+    def test_a_project_dir_with_all_projects_fails_with_a_diagnosis(
+        self, tmp_path: Path
+    ) -> None:
+        """`INPUT_PATH --all-projects` means "this is the archive root" --
+        the same as it does for `convert`. Point it at a single project,
+        whose JSONL files sit directly inside it rather than one level
+        down, and there is nothing to convert.
+
+        That is the user's mistake, but it used to surface as a raw
+        traceback out of the up-front conversion, because only the
+        *per-tick* failures had a handler. Watching on regardless would be
+        worse: every tick would fail the same way, forever.
+        """
+        projects = tmp_path / "projects"
+        proj = projects / "-tmp-demo"
+        proj.mkdir(parents=True)
+        sid = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+        (proj / f"{sid}.jsonl").write_text(_entry("u0", "hello", sid), encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main,
+            ["watch", str(proj), "--projects-dir", str(projects), "--all-projects"],
+        )
+
+        assert result.exit_code == 1
+        assert "No project directories with JSONL files found" in result.output
+        assert "Traceback" not in result.output
+
+    def test_the_archive_root_with_all_projects_still_converts(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The other half of the pair: an explicit path *is* honoured under
+        `--all-projects` when it really is a hierarchy, so the guard above
+        must not have turned the combination into a blanket rejection."""
+        projects = tmp_path / "projects"
+        proj = projects / "-tmp-demo"
+        proj.mkdir(parents=True)
+        sid = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+        (proj / f"{sid}.jsonl").write_text(_entry("u0", "hello", sid), encoding="utf-8")
+
+        import claude_code_log.watch as watch_mod
+
+        monkeypatch.setattr(
+            watch_mod.WatchEngine, "run", lambda engine, stop=None: None
+        )
+        result = CliRunner().invoke(
+            main,
+            ["watch", str(projects), "--projects-dir", str(projects), "--all-projects"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (proj / f"session-{sid}.html").exists(), result.output
+
 
 class TestServeWatch:
     """`serve --watch` runs the same engine beside the HTTP server.

--- a/test/test_watch_cli.py
+++ b/test/test_watch_cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from claude_code_log.cli import _resolve_watch_root, main
+from claude_code_log.utils import real_path_to_project_dirname
 
 
 def _entry(uuid: str, text: str, session_id: str) -> str:
@@ -52,7 +53,10 @@ class TestResolveWatchRoot:
         work = tmp_path / "myproject"
         work.mkdir()
         projects = tmp_path / "projects"
-        encoded = projects / str(work).replace("/", "-")
+        # The same encoder the resolver uses — hand-rolling it here got the
+        # separator wrong on Windows, where the untouched `D:\...` joined
+        # back to an absolute path and the test tried to re-create `work`.
+        encoded = projects / real_path_to_project_dirname(work)
         encoded.mkdir(parents=True)
         monkeypatch.chdir(work)
 

--- a/test/test_watch_cli.py
+++ b/test/test_watch_cli.py
@@ -74,7 +74,9 @@ class TestResolveWatchRoot:
 
 
 class TestWatchCommand:
-    def test_it_converts_once_before_watching(self, tmp_path: Path) -> None:
+    def test_it_converts_once_before_watching(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         """A watch that only reacts leaves the output stale until the next
         message; the up-front conversion is what makes it usable at once."""
         projects = tmp_path / "projects"
@@ -88,30 +90,26 @@ class TestWatchCommand:
         # change (the up-front conversion primed after writing), and exits.
         import claude_code_log.watch as watch_mod
 
-        real_run = watch_mod.WatchEngine.run
         calls: list[int] = []
 
-        def run_once(self, stop=None):  # noqa: ANN001
+        def run_once(engine, stop=None):
             calls.append(1)
-            self.tick()
+            engine.tick()
 
-        watch_mod.WatchEngine.run = run_once
-        try:
-            result = CliRunner().invoke(
-                main,
-                [
-                    "watch",
-                    str(proj),
-                    "--projects-dir",
-                    str(projects),
-                    "-f",
-                    "md",
-                    "-o",
-                    str(out),
-                ],
-            )
-        finally:
-            watch_mod.WatchEngine.run = real_run
+        monkeypatch.setattr(watch_mod.WatchEngine, "run", run_once)
+        result = CliRunner().invoke(
+            main,
+            [
+                "watch",
+                str(proj),
+                "--projects-dir",
+                str(projects),
+                "-f",
+                "md",
+                "-o",
+                str(out),
+            ],
+        )
 
         assert result.exit_code == 0, result.output
         assert calls, "the engine loop never ran"
@@ -149,7 +147,7 @@ class TestServeWatch:
         (proj / f"{sid}.jsonl").write_text(_entry("u0", "hello", sid), encoding="utf-8")
         return projects, proj, sid
 
-    def _invoke(self, projects: Path, args: list[str]):
+    def _invoke(self, projects: Path, args: list[str], monkeypatch):
         """Run `serve`, returning as soon as the server would block.
 
         The stub calls `start()` rather than doing nothing:
@@ -159,35 +157,31 @@ class TestServeWatch:
         """
         import claude_code_log.server as server_mod
 
-        real = server_mod.ArchiveServer.serve_forever
-        server_mod.ArchiveServer.serve_forever = (
-            lambda self: server_mod.ArchiveServer.start(self)
-        )
-        try:
-            return CliRunner().invoke(
-                main,
-                ["serve", "--projects-dir", str(projects), "--port", "0", "--no-index"]
-                + args,
-            )
-        finally:
-            server_mod.ArchiveServer.serve_forever = real
+        def start_instead(server):
+            server_mod.ArchiveServer.start(server)
 
-    def test_watch_starts_and_stops_the_engine(self, tmp_path: Path) -> None:
+        monkeypatch.setattr(server_mod.ArchiveServer, "serve_forever", start_instead)
+        return CliRunner().invoke(
+            main,
+            ["serve", "--projects-dir", str(projects), "--port", "0", "--no-index"]
+            + args,
+        )
+
+    def test_watch_starts_and_stops_the_engine(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         projects, _proj, _sid = self._project(tmp_path)
         import claude_code_log.watch as watch_mod
 
         started: list[object] = []
         real_run_in_thread = watch_mod.WatchEngine.run_in_thread
 
-        def spy(self, stop):  # noqa: ANN001
-            started.append(self)
-            return real_run_in_thread(self, stop)
+        def spy(engine, stop):
+            started.append(engine)
+            return real_run_in_thread(engine, stop)
 
-        watch_mod.WatchEngine.run_in_thread = spy
-        try:
-            result = self._invoke(projects, ["--watch"])
-        finally:
-            watch_mod.WatchEngine.run_in_thread = real_run_in_thread
+        monkeypatch.setattr(watch_mod.WatchEngine, "run_in_thread", spy)
+        result = self._invoke(projects, ["--watch"], monkeypatch)
 
         assert result.exit_code == 0, result.output
         assert started, "the watch engine was never started"
@@ -201,17 +195,17 @@ class TestServeWatch:
             for t in threading.enumerate()
         )
 
-    def test_without_the_flag_no_engine_runs(self, tmp_path: Path) -> None:
+    def test_without_the_flag_no_engine_runs(self, tmp_path: Path, monkeypatch) -> None:
         projects, _proj, _sid = self._project(tmp_path)
         import claude_code_log.watch as watch_mod
 
         started: list[object] = []
-        real = watch_mod.WatchEngine.run_in_thread
-        watch_mod.WatchEngine.run_in_thread = lambda self, stop: started.append(self)
-        try:
-            result = self._invoke(projects, [])
-        finally:
-            watch_mod.WatchEngine.run_in_thread = real
+
+        def spy(engine, stop):
+            started.append(engine)
+
+        monkeypatch.setattr(watch_mod.WatchEngine, "run_in_thread", spy)
+        result = self._invoke(projects, [], monkeypatch)
 
         assert result.exit_code == 0, result.output
         assert not started

--- a/test/test_watch_cli.py
+++ b/test/test_watch_cli.py
@@ -131,3 +131,88 @@ class TestWatchCommand:
 
         result = CliRunner().invoke(main, ["watch", "--projects-dir", str(projects)])
         assert result.exit_code == 1
+
+
+class TestServeWatch:
+    """`serve --watch` runs the same engine beside the HTTP server.
+
+    The server never renders: it re-runs the ordinary conversion and lets
+    the files on disk stay canonical, so a page served over http and the
+    same file opened from file:// can never disagree.
+    """
+
+    def _project(self, tmp_path: Path) -> tuple[Path, Path, str]:
+        projects = tmp_path / "projects"
+        proj = projects / "-tmp-demo"
+        proj.mkdir(parents=True)
+        sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        (proj / f"{sid}.jsonl").write_text(_entry("u0", "hello", sid), encoding="utf-8")
+        return projects, proj, sid
+
+    def _invoke(self, projects: Path, args: list[str]):
+        """Run `serve`, returning as soon as the server would block.
+
+        The stub calls `start()` rather than doing nothing:
+        `BaseServer.shutdown()` waits on an event that only
+        `serve_forever` sets, so a no-op stub makes the command's own
+        `server.stop()` hang forever.
+        """
+        import claude_code_log.server as server_mod
+
+        real = server_mod.ArchiveServer.serve_forever
+        server_mod.ArchiveServer.serve_forever = (
+            lambda self: server_mod.ArchiveServer.start(self)
+        )
+        try:
+            return CliRunner().invoke(
+                main,
+                ["serve", "--projects-dir", str(projects), "--port", "0", "--no-index"]
+                + args,
+            )
+        finally:
+            server_mod.ArchiveServer.serve_forever = real
+
+    def test_watch_starts_and_stops_the_engine(self, tmp_path: Path) -> None:
+        projects, _proj, _sid = self._project(tmp_path)
+        import claude_code_log.watch as watch_mod
+
+        started: list[object] = []
+        real_run_in_thread = watch_mod.WatchEngine.run_in_thread
+
+        def spy(self, stop):  # noqa: ANN001
+            started.append(self)
+            return real_run_in_thread(self, stop)
+
+        watch_mod.WatchEngine.run_in_thread = spy
+        try:
+            result = self._invoke(projects, ["--watch"])
+        finally:
+            watch_mod.WatchEngine.run_in_thread = real_run_in_thread
+
+        assert result.exit_code == 0, result.output
+        assert started, "the watch engine was never started"
+        assert "watching for changes" in result.output
+        # The engine's thread is a daemon and was asked to stop in the
+        # finally block; nothing should still be running.
+        import threading
+
+        assert not any(
+            t.name == "claude-code-log-watch" and t.is_alive()
+            for t in threading.enumerate()
+        )
+
+    def test_without_the_flag_no_engine_runs(self, tmp_path: Path) -> None:
+        projects, _proj, _sid = self._project(tmp_path)
+        import claude_code_log.watch as watch_mod
+
+        started: list[object] = []
+        real = watch_mod.WatchEngine.run_in_thread
+        watch_mod.WatchEngine.run_in_thread = lambda self, stop: started.append(self)
+        try:
+            result = self._invoke(projects, [])
+        finally:
+            watch_mod.WatchEngine.run_in_thread = real
+
+        assert result.exit_code == 0, result.output
+        assert not started
+        assert "watching for changes" not in result.output

--- a/test/test_watch_engine.py
+++ b/test/test_watch_engine.py
@@ -224,6 +224,31 @@ class TestErrors:
         assert len(seen) == 2
         assert engine.stats.errors == 2
 
+    def test_an_interrupt_is_not_a_failed_conversion(self, project: Path) -> None:
+        """Ctrl+C must stop the watch, not be reported and slept off.
+
+        `claude-code-log watch` runs the loop on the main thread, so an
+        interrupt lands wherever the thread happens to be — and on an
+        active project that is usually inside the conversion, not the
+        sleep. Handing it to `on_error` would print "conversion failed"
+        and carry on, leaving the operator pressing Ctrl+C until one
+        happened to land in `stop.wait`.
+        """
+        clock = FakeClock()
+        seen: list[BaseException] = []
+
+        def interrupted(_paths: set[Path]) -> None:
+            raise KeyboardInterrupt
+
+        engine = WatchEngine([project], interrupted, clock=clock, on_error=seen.append)
+        engine.prime()
+        append(project / "s1.jsonl")
+        engine.tick()
+        clock.settle()
+        with pytest.raises(KeyboardInterrupt):
+            engine.tick()
+        assert not seen, "the interrupt was reported as a conversion failure"
+
     def test_without_a_handler_the_error_propagates(self, project: Path) -> None:
         """Silently swallowing by default would hide real breakage."""
         clock = FakeClock()

--- a/test/test_watch_engine.py
+++ b/test/test_watch_engine.py
@@ -1,0 +1,274 @@
+"""Tests for the watch engine's detection and debounce.
+
+All of it runs against a fake clock and a hand-driven `tick()`. Nothing
+sleeps: a watcher tested with real timing is a flaky-test generator, and
+these are the tests that have to stay trustworthy when the conversion
+behind them gets slower.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.watch import (
+    DEFAULT_MAX_LATENCY,
+    DEFAULT_QUIET_PERIOD,
+    WatchEngine,
+    scan,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+    def settle(self) -> None:
+        """Advance clear of the quiet period.
+
+        Deliberately not `advance(DEFAULT_QUIET_PERIOD)`: that lands the
+        comparison exactly on the threshold, where binary floating point
+        decides it (1000.0 + 0.3 - 1000.0 == 0.29999999999995453). Real
+        clocks never sit on the boundary; tests shouldn't either.
+        """
+        self.advance(DEFAULT_QUIET_PERIOD * 2)
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "s1.jsonl").write_text('{"type":"user"}\n', encoding="utf-8")
+    return d
+
+
+def build(project: Path, clock: FakeClock) -> tuple[WatchEngine, list[set[Path]]]:
+    fired: list[set[Path]] = []
+    engine = WatchEngine([project], fired.append, clock=clock)
+    engine.prime()
+    return engine, fired
+
+
+def append(path: Path, text: str = '{"type":"user"}\n') -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(text)
+
+
+class TestDetection:
+    def test_priming_does_not_fire_on_an_existing_archive(self, project: Path) -> None:
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+        clock.advance(10)
+        assert engine.tick() is None
+        assert fired == []
+
+    def test_an_append_is_detected(self, project: Path) -> None:
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+        append(project / "s1.jsonl")
+
+        assert engine.tick() is None, "first sighting starts the quiet period"
+        clock.settle()
+        assert engine.tick() == {project / "s1.jsonl"}
+        assert fired == [{project / "s1.jsonl"}]
+
+    def test_a_new_file_is_detected(self, project: Path) -> None:
+        clock = FakeClock()
+        engine, _fired = build(project, clock)
+        (project / "s2.jsonl").write_text('{"type":"user"}\n', encoding="utf-8")
+
+        engine.tick()
+        clock.settle()
+        assert engine.tick() == {project / "s2.jsonl"}
+
+    def test_a_deletion_is_detected(self, project: Path) -> None:
+        clock = FakeClock()
+        engine, _fired = build(project, clock)
+        (project / "s1.jsonl").unlink()
+
+        engine.tick()
+        clock.settle()
+        assert engine.tick() == {project / "s1.jsonl"}
+
+    def test_agent_sidecars_are_watched(self, project: Path) -> None:
+        """A sidecar can appear without the trunk transcript changing (#213)."""
+        clock = FakeClock()
+        engine, _fired = build(project, clock)
+        sub = project / "s1" / "subagents"
+        sub.mkdir(parents=True)
+        (sub / "agent-abc.meta.json").write_text("{}", encoding="utf-8")
+
+        engine.tick()
+        clock.settle()
+        assert engine.tick() == {sub / "agent-abc.meta.json"}
+
+    def test_our_own_temp_files_are_ignored(self, project: Path) -> None:
+        """Atomic writes leave a dot-prefixed temp beside the output.
+
+        Treating it as a change would make the loop feed itself: convert,
+        see the temp, convert again, forever.
+        """
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+        (project / ".session-x.html.999.tmp").write_text("x", encoding="utf-8")
+
+        clock.advance(DEFAULT_MAX_LATENCY * 2)
+        assert engine.tick() is None
+        assert fired == []
+
+    def test_generated_output_is_not_watched(self, project: Path) -> None:
+        """Output lands in the watched tree; only sources may trigger."""
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+        (project / "session-x.html").write_text("<html>", encoding="utf-8")
+        (project / "combined_transcripts.html").write_text("<html>", encoding="utf-8")
+
+        clock.advance(DEFAULT_MAX_LATENCY * 2)
+        assert engine.tick() is None
+        assert fired == []
+
+    def test_scan_skips_a_file_that_vanishes(self, tmp_path: Path) -> None:
+        assert scan([tmp_path / "does-not-exist"]) == {}
+
+
+class TestDebounce:
+    def test_a_burst_produces_one_conversion(self, project: Path) -> None:
+        """The turn shape: several entries land in quick succession."""
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+
+        for _ in range(5):
+            append(project / "s1.jsonl")
+            engine.tick()
+            clock.advance(DEFAULT_QUIET_PERIOD / 2)  # never quiet
+
+        assert fired == [], "still inside the burst"
+        clock.settle()
+        engine.tick()
+        assert len(fired) == 1
+        assert engine.stats.conversions == 1
+
+    def test_max_latency_forces_delivery_during_a_long_stream(
+        self, project: Path
+    ) -> None:
+        """An unbroken stream must still surface, not starve."""
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+
+        elapsed = 0.0
+        while elapsed < DEFAULT_MAX_LATENCY:
+            append(project / "s1.jsonl")
+            engine.tick()
+            step = DEFAULT_QUIET_PERIOD / 2
+            clock.advance(step)
+            elapsed += step
+
+        engine.tick()
+        assert fired, "max_latency did not force a delivery"
+
+    def test_all_changed_paths_in_a_burst_are_delivered_together(
+        self, project: Path
+    ) -> None:
+        clock = FakeClock()
+        engine, fired = build(project, clock)
+
+        append(project / "s1.jsonl")
+        engine.tick()
+        clock.advance(DEFAULT_QUIET_PERIOD / 2)
+        (project / "s2.jsonl").write_text("{}\n", encoding="utf-8")
+        engine.tick()
+        clock.settle()
+        delivered = engine.tick()
+
+        assert delivered == {project / "s1.jsonl", project / "s2.jsonl"}
+        assert len(fired) == 1
+
+    def test_pending_is_cleared_after_delivery(self, project: Path) -> None:
+        clock = FakeClock()
+        engine, _fired = build(project, clock)
+        append(project / "s1.jsonl")
+        engine.tick()
+        clock.settle()
+        engine.tick()
+
+        assert engine.pending_paths == frozenset()
+        clock.advance(DEFAULT_MAX_LATENCY * 2)
+        assert engine.tick() is None, "a delivered change must not re-fire"
+
+
+class TestErrors:
+    def test_a_failing_conversion_does_not_stop_the_watch(self, project: Path) -> None:
+        clock = FakeClock()
+        seen: list[BaseException] = []
+        calls: list[int] = []
+
+        def boom(_paths: set[Path]) -> None:
+            calls.append(1)
+            raise RuntimeError("render exploded")
+
+        engine = WatchEngine([project], boom, clock=clock, on_error=seen.append)
+        engine.prime()
+
+        for _ in range(2):
+            append(project / "s1.jsonl")
+            engine.tick()
+            clock.settle()
+            engine.tick()
+
+        assert len(calls) == 2, "the watch kept going after the first failure"
+        assert len(seen) == 2
+        assert engine.stats.errors == 2
+
+    def test_without_a_handler_the_error_propagates(self, project: Path) -> None:
+        """Silently swallowing by default would hide real breakage."""
+        clock = FakeClock()
+
+        def boom(_paths: set[Path]) -> None:
+            raise RuntimeError("render exploded")
+
+        engine = WatchEngine([project], boom, clock=clock)
+        engine.prime()
+        append(project / "s1.jsonl")
+        engine.tick()
+        clock.settle()
+        with pytest.raises(RuntimeError, match="render exploded"):
+            engine.tick()
+
+
+class TestLoop:
+    """`run`/`run_in_thread` are what `serve --watch` will use.
+
+    These are the only tests here that use a real clock — the loop's job
+    *is* to wait — so they keep the interval tiny and assert on an event
+    rather than on elapsed time.
+    """
+
+    def test_run_in_thread_delivers_and_stops(self, project: Path) -> None:
+        import threading
+
+        delivered = threading.Event()
+        engine = WatchEngine(
+            [project],
+            lambda _paths: delivered.set(),
+            poll_interval=0.01,
+            quiet_period=0.0,
+            max_latency=0.0,
+        )
+        # Prime before starting the thread: otherwise the baseline is
+        # taken at whatever moment the loop thread gets scheduled, and an
+        # append landing before that is absorbed into it and never seen.
+        engine.prime()
+        stop = threading.Event()
+        thread = engine.run_in_thread(stop)
+        try:
+            append(project / "s1.jsonl")
+            assert delivered.wait(timeout=10), "the loop never delivered the append"
+        finally:
+            stop.set()
+            thread.join(timeout=10)
+        assert not thread.is_alive(), "the loop did not stop when asked"

--- a/work/identifier-consolidation.md
+++ b/work/identifier-consolidation.md
@@ -120,8 +120,43 @@ Unpacking that:
    (watch the vacuous-guard trap). Use `f57deeb` as the reference for *what* to
    build (scheme + gate), not as the diff to merge.
 
+## Update: the consumer arrived, and did not need C2
+
+Recommendation 2 gated C2 on "the archive-search-server feature actually
+being built", on the grounds that the stable-anchor benefit had no runtime
+consumer. A different consumer appeared first — the live-update **patch
+protocol** in [`watch-mode.md`](watch-mode.md), which reconciles the DOM by
+card id instead of replacing the transcript container. That doc's C20
+argued C2 was its missing half. **Building the patch showed otherwise.**
+
+- **Addressing.** C20 expected C2 to replace an O(page) key-map rebuild with
+  one `getElementById`. It does not: the patch must fetch, parse and hash
+  the whole page regardless, because the comparison hash cannot be taken
+  from the live DOM (decoration has rewritten it — a prototype that tried
+  skipped 0 of 1,181 nodes). The O(page) pass is structural; only a
+  server-shipped delta removes it.
+- **Insertions.** C2's advantage is real and was measured — on an
+  out-of-order arrival, positional ids give 104 insertions + 103 deletions
+  where `m-{uuid}-{k}` gives 1 and 0. But replaying three real sessions
+  through the renderer, **45 of 47 growth steps were pure tail extensions**;
+  the id sequence broke in exactly the other 2. So C2 buys the difference
+  between a patch and a swap on **4% of ticks**, and the swap is correct,
+  already implemented, and cheap.
+
+Those two mid-tree arrivals also landed *near* the tail (index 306 of 311;
+308/310/312 of 312) — interleavings, not deep insertions. If 4% ever
+matters, widening the patch's extension test to tolerate a bounded
+reordering window near the tail is one function, against a migration
+through ~8 formatters, 4 modules and 9 coupled test files.
+
+**C2 stays deferred.** The gate is unchanged in form but should now read:
+take it when a consumer needs *stable anchors that outlive a render* —
+archive-search annotations and cross-session deep-links, as originally
+envisaged — not for patch addressing, which turned out not to need it.
+
 ## Status
 
 - C1: implemented on `improved-search` (commit above this one).
-- C2: prototype only, on `review/PR-273-monk` @ `f57deeb`; deferred pending a
-  consumer. This doc is the record.
+- C2: prototype only, on `review/PR-273-monk` @ `f57deeb`; still deferred.
+  Its first candidate consumer was built without it — see the update above.
+  This doc is the record.

--- a/work/obsidian-friendly-output.md
+++ b/work/obsidian-friendly-output.md
@@ -14,7 +14,30 @@ behaviour.
 
 ## Open follow-ups
 
-### Cache-freshness checks resolve against `project_path` (source), not the output destination
+### ~~Cache-freshness checks resolve against `project_path` (source), not the output destination~~ — FIXED
+
+**Resolved.** `is_transcript_stale` and `is_page_stale` both take an
+`output_dir` and resolve `actual_file` against it, and the conversion
+passes the destination. Re-measured on a 28-file Markdown projection:
+
+| run | wall | files rewritten |
+|---|---|---|
+| `-o A` (cold) | 4.1s | all |
+| `-o A` again | **0.0s** | `index.md` only |
+| `-o B` (fresh dest) | 4.0s | all |
+| `-o A` again, after B | **0.0s** | `index.md` only |
+| `-o A` after one appended message | 0.8s | **2 of 28** — the changed session + `index.md` |
+
+So repeated runs against the same destination are no-ops, alternating
+destinations no longer forces a re-render, and an incremental run
+rewrites only what changed. `index.md` is rewritten every run by the
+deliberate always-regenerate contract (so variant-flag changes refresh
+its links); since `9b20d77` that write is atomic, so a vault indexer sees one
+clean replacement rather than a truncated file.
+
+The original finding, kept for context:
+
+
 
 `cache.is_html_stale(html_path, ...)` and `cache.is_page_stale(...)` both compute their `actual_file` check as `self.project_path / html_path` — the **source** project dir under `~/.claude/projects/`, not the actual output destination (`dest_dir`). With the legacy in-place behaviour the two are identical, so the check works as intended. With `--output` projecting to a different tree, the source path never has a `combined_transcripts.html`, so `is_html_stale` returns "file_missing" / "stale" on every run.
 

--- a/work/render-format-once.md
+++ b/work/render-format-once.md
@@ -1,13 +1,36 @@
 # Render step 3: format once, assemble many
 
-**Status:** phase 1 (serial fragment store) landed on
-`perf/render-memo-and-intra-project-jobs`. Each entry-derived message is
-now formatted once per conversion and reused across the combined pages
-and session files — `fragment_store.py`, consumed by
+**Status: merged to `main`** in two squashes — `94134e8` (#313, steps 1–2
+plus the fragment store and worker feeding) and `9a0e29a` (#315,
+streaming stages 1–4, the sparse gate, and the §8 refactors). Each
+entry-derived message is formatted once per conversion and reused across
+the combined pages and session files — `fragment_store.py`, consumed by
 `_annotate_tree_for_render`, wired in `convert_jsonl_to`. Verified
 byte-identical on five real projects (including the 803MB / 187-file
 claude-code-log archive at a 50% hit rate) and by
 `test_render_cache_equivalence.py::test_fragment_store_render_is_byte_identical`.
+
+**What is still open:** the *architecture* §2 proposes — a distinct,
+parallel **format phase** — did not land. `RenderUnit.kind` is still only
+`"page"` or `"session"`; a message's fragment is computed the first time a
+tree containing it is rendered, and parallel formatting happens
+incidentally (page workers format and ship deltas back), not structurally.
+The flat pool (§2's third bullet, §7 item 4's tail) is likewise still
+open, as are the provider bypass (codex/agy) and the fragment-text spill.
+
+> ⚠️ **§1 below is stale** and is kept only for its problem statement and
+> measurements. Specifically: the commit shas it lists are pre-squash and
+> are not in `main`'s history; "each [worker] holds a full copy of the
+> transcript" is false since workers became fed (`RenderUnit.entries`);
+> the §7.5 conclusion about worker counts past ~8 was superseded by the
+> dispatch-gate finding (`render_dispatch._MIN_ENTRIES_FOR_RENDER_POOL`);
+> the "memory cap makes the fan-out inert on 16GB" claim was re-measured
+> and is not the binding constraint; the §3 seam table's line numbers are
+> all shifted and two rows moved module (`_dispatch_render_units` →
+> `render_dispatch.dispatch_render_units`, `_make_render_pool` →
+> `render_dispatch.build_render_pool`); and the as-built reference is now
+> `dev-docs/application_model.md` §§ 2.9, 2.10, **2.12, 2.13, 2.14**, not
+> just §§ 2.9–2.10.
 
 **Phase 2 progress (fed fragments):** three follow-up commits made the
 store process-portable and wired it through the fan-out — the

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -6,10 +6,11 @@ Status: **Stages 0–2 landed** on `feat/watch-mode`.
 session does. Stage 3 (the `file://` sidecar) remains speculative and is
 probably not worth building. Stage 4 was too — until the tick was
 profiled: see "Where a tick's time goes" and "Appending the HTML rather
-than replacing it" at the end. **Fixes A and C have landed** (tick
-1.03 s → 0.717 s on the 803 MB archive); Fix B, worth roughly another
-400 ms, has not. The HTML half found that patching does *not* need the
-per-message render seam C11 says is missing.
+than replacing it" at the end. **Fixes A, C and B have all landed**: a
+steady-state tick on the 803 MB archive went **1.03 s → 0.26 s**, and Fix
+B needed no migration in the end (the proof lives in the resident
+watcher's memory). The HTML half found that patching does *not* need the
+per-message render seam C11 says is missing; that is the open work.
 
 Decisions below are settled; the measurements that forced them are
 recorded so a later reader can tell which choices were reasoned and which
@@ -745,7 +746,13 @@ Two things the prototype got away with and the real one must not:
    undo. Plus a per-file valve (decline under 6× available memory) and
    `CLAUDE_CODE_LOG_ENTRY_STORE=0`.
 
-### Fix B — parse and write only the tail
+### Fix B — parse and write only the tail — ✅ LANDED, in memory rather than in the schema
+
+**Built, and the shape changed on contact.** What follows is the plan;
+"Fix B as built" below records what was actually true. Headline: the
+persisted columns turned out to be unnecessary — a resident watcher
+already knows what it parsed, so the proof lives in RAM and there is no
+migration. Steady-state tick **0.70 s → 0.26 s**.
 
 What remains after A is call ① — a full parse and a full row rewrite for
 one appended line. Both are avoidable, and the incremental refresh
@@ -767,6 +774,96 @@ those bytes; then a tick can
 Estimated ~450 ms off the remaining tick, i.e. **~1.1 s → ~0.3 s** with
 A and B together. Not prototyped — unlike A it needs a migration and a
 new decline path (hash mismatch → today's full parse).
+
+### Fix B as built — what the territory actually looked like
+
+The end number matched the estimate (**0.717 s → 0.257 s** steady state,
+measured on the 803 MB archive), but three things about the route were
+wrong in the plan above.
+
+**1. The migration was unnecessary.** The persisted `(prefix_len,
+prefix_hash)` columns exist to carry the append proof *across processes*.
+A resident watcher doesn't need that: it parsed the file last tick and
+can hold the offset and digest in RAM. So the store gained a
+prefix-pinned mode (`put_prefix`/`get_prefix`), `watch` owns one for the
+life of the loop, and `convert_jsonl_to` accepts a caller-owned store
+instead of always making its own. No schema change, no migration, and the
+proof is the same one either way — hash the prefix bytes (32 ms over
+39.7 MB, against 143 ms to re-parse them) and compare.
+
+The cost is scope: this only helps a resident loop. A one-shot run, the
+TUI, and every tick-one still parse whole. That is the right trade for
+the latency-sensitive case, but it is a narrower fix than the persisted
+version would have been, and it is why the columns may still be worth
+adding later.
+
+**2. The write half was the bigger prize *and* the harder proof.** The
+split, measured: of `load_transcript`'s 483 ms, the line loop is 143 ms
+and `save_cached_entries` is 310 ms; the whole-file post-processing
+(sidecar linking, prompt-hash linking, agent splicing) is **0.1 ms**, so
+re-running it over a concatenated list is free. But:
+
+> **A file being append-only does not make its *rows* append-only.** A
+> trunk's cached rows carry its subagents' transcripts, spliced in at
+> their anchors. A subagent still running — the normal case under
+> `watch` — grows a block in the *middle* of the row sequence while the
+> trunk file itself only gained lines at the end.
+
+That is why the write is gated on the row list being provably just the
+file's own parsed lines (no agent references, no sidecars, nothing
+spliced, no length change from the whole-file passes). On the reference
+archive that covers 136 of 185 trunk files; 26% reference subagents and
+take the unchanged full rewrite. Underneath it,
+`extend_cached_entries` independently refuses when the table no longer
+holds the row count we think we wrote — the guard against another process
+having rewritten the rows.
+
+**That third layer is not theoretical.** With the two gates removed, the
+caller offers a *wrong 96-entry slice* (splicing had shifted the
+positions the offset refers to) and the row-count check refuses it. Which
+also means the obvious test — "did an append-only write happen?" —
+passes with the gate gone, because the layer below rescues it. The test
+therefore asserts on the **offer**, not the write.
+
+**3. Two of my own probes lied before the code did**, both in the same
+way as the Stage 1 note above: a fixture that wasn't what it claimed.
+
+- Copying a *subset* of a project's trunk files breaks parent chains and
+  can make the session hierarchy cyclic — `renderer._depth` then blows
+  the stack. It reproduces with the store disabled, so it is a
+  pre-existing robustness edge (a truncated archive shouldn't recurse),
+  not a regression, but it cost a debugging cycle. Copy whole projects.
+- Copying the live source *twice* to compare two configurations captures
+  two different files when one of them is the session currently being
+  written. That showed up as a 3-row `messages` divergence and one
+  differing page. Clone one snapshot instead — the same trap that made
+  Fix A's first equivalence run report 27/28.
+
+**Equivalence, at three levels** (`test/test_entry_store.py`):
+
+| | |
+|---|---|
+| parse output, byte path vs text path | **162 fixture files, 0 mismatches** |
+| parse output, resumed vs fresh | **90 files, 0 mismatches** |
+| cache DB state vs a full-rewrite run | **6 ticks, 3 files growing, all tables match** |
+| rendered HTML | identical throughout |
+
+DB state is the bar rather than HTML for the same reason § 2.14 gives:
+the first bug a write-path change produces is invisible in the rendered
+bytes.
+
+**What is left in the tick.** At 0.26 s the remaining items are the cache
+queries around the refresh — `get_session_file_map` ×3 (50 ms),
+`get_file_states` ×2 (45 ms, still fetching every row's compressed blob
+to SHA it, now redundant with the prefix hash), `get_uuid_owners` ×4
+(37 ms). Those are the next 130 ms if anyone wants it.
+
+**One knob not taken.** `zlib` level 1 would cut the *full* rewrite from
+183 ms to 74 ms for 29% larger blobs (level 3: 81 ms, +18%) — measured,
+one line, backward compatible, since `decompress` doesn't care. It would
+help every path rather than just resumable ones, but it trades on-disk
+size for everyone to fix a watch-local problem, so it is a decision to
+take deliberately rather than fold into this.
 
 ### Fix C — the cheap ones — ✅ LANDED (the two that need no migration)
 
@@ -973,10 +1070,21 @@ So the DB does not grow either way; today's cost is write amplification
    | `get_library_version` (×173) | 35 ms | **0.0 ms** |
    | **tick** | **1.03 s** | **0.717 s** |
 
-2. **Fix B** if 0.72 s is still too slow — it is now two thirds of the
-   tick, all of it in re-parsing and rewriting a file that gained one
-   line. It is the one with a migration, and it must be designed
-   *against* A's store (C21), not dropped in beside it.
+2. ✅ **Fix B landed too**, as a cross-tick store rather than a
+   migration (see "Fix B as built"). Steady-state tick in a resident
+   `watch`:
+
+   | phase | after A+C | after B |
+   |---|---|---|
+   | `load_transcript` (modified file) | 483 ms | **~35 ms** |
+   | ↳ line loop | 143 ms | ~0 ms (tail only) |
+   | ↳ prefix hash (new) | — | 32 ms |
+   | ↳ `save_cached_entries` | 310 ms | ~5 ms (append-only) |
+   | **tick** | **0.717 s** | **0.257 s** |
+
+   C21 held exactly as written: B *does* break A's seeding, and the fix
+   was the cross-tick store it predicted. Cumulatively **1.03 s →
+   0.26 s**, a 4x tick.
 3. **Option 1** for the browser, which is where the user-visible cost
    actually is, and which no longer depends on `render-format-once.md`.
    Land the tail-append case first; take C2 (C20) when the fallback

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -1,8 +1,10 @@
 # Real-time watch mode — Design
 
-Status: **Stage 0 and Stage 1 landed** on `feat/watch-mode`;
-`claude-code-log watch` works for the Markdown-on-disk case. Stage 2
-(the served page updating itself) is designed but not built.
+Status: **Stages 0–2 landed** on `feat/watch-mode`.
+`claude-code-log watch` keeps Markdown (or HTML) on disk current, and
+`claude-code-log serve --watch` makes an open session page grow as the
+session does. Stages 3 (the `file://` sidecar) and 4 (SSE / fragment
+patching) remain speculative and are probably not worth building.
 
 Decisions below are settled; the measurements that forced them are
 recorded so a later reader can tell which choices were reasoned and which
@@ -578,17 +580,56 @@ Answers to Stage 1's other questions:
   clean conversion afterwards. Combined with D8's read-during-write
   numbers, the WAL setup handles this.
 
-**Stage 2 — use case 2 under `serve`.** `serve --watch` runs the Stage 1
-engine on a thread; the session page polls its own URL, swaps
-`#transcript`, rehydrates, fades in new cards, offers follow-tail.
+**Stage 2 — use case 2 under `serve`. ✅ Landed.**
 
-*Questions to answer first:*
-1. What does the `claudeLogRehydrate` contract look like, and how much of
-   the D5 table can be scoped to a subtree without restructuring?
-2. Is fold-state restore by `data-uuid` + sibling ordinal actually clean?
-   If it turns out ugly, that is the argument for reconsidering full
-   reload.
-3. What is the swap cost on a large session page (the 27 MB case)?
+- `serve --watch` (`6f7850d`) runs the Stage 1 engine on a daemon thread.
+- `#transcript` wrapper (`1ec29ed`) — verified layout-neutral by
+  pixel-comparing full-page screenshots, not by reading the CSS.
+- The in-page poller + rehydrate contract (`f48de95`).
+
+Measured in Chromium against a live-fed session: **~1 s from append to
+visible**, scroll position preserved exactly, no navigation (a `window`
+marker set before the update survives it), fold state kept, timestamps
+localised on new cards, zero console errors.
+
+Two bugs that only measurement found, both worth remembering:
+
+1. **Fold state was preserved for nothing.** Keying the capture on
+   `data-uuid` misses session headers and fork points — which carry no
+   uuid, and on a single-session page the header is the *only* foldable
+   node there is. The key now falls back `uuid → session-id →
+   positional id`.
+2. **⚠️ `Last-Modified` has one-second granularity**, so two updates
+   inside the same second were invisible and the third append in a row
+   simply never arrived. `Content-Length` now joins the comparison —
+   *the same trap as C7's mtime tolerance, one layer up, with the same
+   fix.* Its test fails 3/3 without it and passes 3/3 with it.
+
+**Q3 answered — the swap cost is fine.** On a real **7.0 MB** session
+page (523 messages):
+
+| | |
+|---|---|
+| fetch | 31 ms |
+| parse (`DOMParser`) | 63 ms |
+| swap (`replaceWith`) | 17 ms |
+| forced layout | 91 ms |
+| **total** | **202 ms** |
+| idle HEAD poll | **~1 ms** (5.6 ms first, then 0.9–2.2 ms) |
+
+Extrapolating linearly, the 27 MB worst case would be ~800 ms of
+main-thread work — but only *when that page changes*, and a 27 MB page is
+a finished session nobody is appending to. The pages that actually update
+are live ones, which start small. No size threshold needed.
+
+Design points that survived contact:
+
+- Only active over `http(s)` — a `file://` page still cannot fetch (C4),
+  so the poller notices and does nothing. Pinned by a test.
+- The server still never renders; the page re-fetches its own URL, so the
+  conditional GET is both the change signal and the content, and there is
+  no endpoint to keep in sync with the renderer.
+- Container swap, not fragment patching (C3, C10, C11).
 
 **Stage 3 — `file://` sidecar (optional).** A `session-<id>.live.js`
 sidecar carrying a revision counter; the page injects it on a timer and

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -10,8 +10,17 @@ than replacing it" at the end. **Fixes A, C and B have all landed**, plus
 a follow-up round on the refresh's own queries: a steady-state tick on
 the 803 MB archive went **1.03 s → 0.145 s, a 7x tick**, and Fix B needed
 no migration in the end — the proof lives in the resident watcher's
-memory. The HTML half found that patching does *not* need the
-per-message render seam C11 says is missing; that is the open work.
+memory.
+
+**The browser half has now landed too** (see "The browser half" at the
+end). Patching indeed did *not* need the per-message render seam C11 says
+is missing. A patched update on a 2.4 MB session page localises **2
+timestamps instead of 896** and blocks the main thread for 61 ms instead
+of 107 ms; separately, the timestamp localiser's scheduling turned out to
+be costing **766–3,348 ms of wall clock for 8–36 ms of work**, which was
+the actual source of the reported sluggishness. **C20's recommendation to
+take C2 is revised: the patch protocol arrived and did not need it** —
+see the measurements there.
 
 Decisions below are settled; the measurements that forced them are
 recorded so a later reader can tell which choices were reasoned and which
@@ -43,7 +52,7 @@ structural finding.
 | D2 | Add `source_size` to `cached_files` so the cache itself detects fast appends; the watcher then trusts `get_modified_files` rather than keeping parallel state. Detection is stat-polling. **Landed.** |
 | D3 | Default scope is one project; `--all-projects` is opt-in. **Landed.** |
 | D4 | Quiet-period debounce (~300 ms) with a max-latency cap (~2 s), both flags. **Landed.** |
-| D5 | Container swap (option B) with uuid-set diffing, not full reload and not fragment patching. |
+| D5 | Container swap (option B) with uuid-set diffing, not full reload. Fragment patching was rejected here and **later built anyway** — the reasons turned out not to hold; see C26. |
 | D6 | Polling. SSE only if measurement later justifies it. |
 | D7 | Route every output write through temp-file + `os.replace`. **Landed.** |
 | D8 | Measured: the write + FTS update is fast enough. No lock-avoidance machinery needed. |
@@ -344,6 +353,12 @@ document. Fragment patching was rejected on C11 (no isolation seam,
 (out-of-order arrivals) and C10 (positional ids, non-unique uuids). B gets
 most of the perceived benefit for a fraction of the risk.
 
+**That rejection was later overturned — see C26.** C11 does not apply,
+because a patch takes the delta between two whole renders rather than
+rendering one message in isolation; C3 and C10 turned out to be a 4%
+fallback rate (revised C20) rather than a correctness hazard. The swap
+remains, as that fallback.
+
 The inventory is favourable. **Survives a swap for free:** listeners
 delegated on `document` (`transcript.html:395, 538, 575`), everything
 bound to the toolbar and floating buttons (outside the container), and
@@ -636,21 +651,19 @@ Design points that survived contact:
 - The server still never renders; the page re-fetches its own URL, so the
   conditional GET is both the change signal and the content, and there is
   no endpoint to keep in sync with the renderer.
-- Container swap, not fragment patching (C3, C10, C11).
+- Container swap, not fragment patching (C3, C10, C11) — *superseded:
+  patching landed later, with this swap as its fallback (C26).*
 
 **Stage 3 — `file://` sidecar (optional).** A `session-<id>.live.js`
 sidecar carrying a revision counter; the page injects it on a timer and
 reloads on change (C4). Honest and cheap, but strictly worse than Stage 2,
 so build it only if the no-server case proves to matter.
 
-**Stage 4 — SSE and/or fragment patching (speculative).** Only after
-Stage 2 has been lived with, and only if the poll interval or swap cost
-demonstrably hurts. Fragment patching additionally needs the *architecture*
-half of `render-format-once.md` step 3 — a real format phase and a
-per-message render seam — which has not landed (C11). **See C19 below:
-a patch protocol does not actually need that seam, because the delta can
-be taken between two whole renders rather than produced by rendering one
-message in isolation.**
+**Stage 4 — patching. ✅ Landed** (see "The browser half"), and it needed
+neither the *architecture* half of `render-format-once.md` step 3 nor a
+per-message render seam: C19 was right that the delta can be taken
+between two whole renders. SSE remains unbuilt and unjustified — D6's
+argument still holds, and the poll is not what costs anything.
 
 ---
 
@@ -1088,6 +1101,61 @@ from that draft (resolver plumbing through ~8 formatters / 4 modules,
 9 coupled test files, full `.ambr` regeneration, and the vacuous-guard
 trap).
 
+#### ⚠️ Revised, after building the patch: **do not take C2**
+
+The above was written before the protocol existed. Building it (see "The
+browser half") contradicted both bullets, and the recommendation with
+them.
+
+**The addressing argument was wrong about where the O(page) work is.**
+The patch does not do "one `getElementById`" instead of a whole-tree
+pass, whatever the id scheme: it has to fetch the page, `DOMParser` it,
+and hash every card in it, because *the hash cannot come from the live
+DOM*. By update time the live tree has been rewritten by decoration —
+timestamp localisation replaces `innerHTML` — so a hash taken from it can
+never match one taken from server bytes. This was found by measurement,
+not by reasoning: the first prototype computed hashes client-side from
+the live tree and skipped **0 of 1,181 nodes**. So an O(page) pass over
+pristine bytes is structural, C2 removes none of it, and only a
+server-shipped delta would.
+
+**The insertion argument was right about the mechanism and wrong about
+the stakes.** Measured directly, keying the same reconcile both ways on
+a real 4 MB page:
+
+| fixture | id scheme | subtrees skipped | ins | del | re-localise |
+|---|---|---|---|---|---|
+| tail append | `msg-d-N` | 186 | 1 | 0 | 2 |
+| tail append | `m-{uuid}-{k}` | 186 | 1 | 0 | 2 |
+| mid-tree | `msg-d-N` | 29 | **104** | **103** | **593** |
+| mid-tree | `m-{uuid}-{k}` | 186 | **1** | **0** | **2** |
+
+Identical for tail appends; positional ids degenerate into a ~100-node
+teardown on an out-of-order arrival, exactly as predicted. But **how
+often that happens** was never measured, and it decides everything.
+Replaying three real sessions line by line through the renderer at stride
+7 (a debounced tick's worth), checking whether each render's card
+sequence extends the last:
+
+> **47 growth steps: 45 tail-only, 2 mid-tree — and the `msg-d-N` prefix
+> broke in exactly those 2.**
+
+So C2 buys the difference between a patch and a swap on **4% of ticks**.
+On those two the page pays today's swap, which is correct, already
+implemented, and the thing every other tick used to do.
+
+And the two mid-tree cases landed *near* the tail — new cards at index
+306 of 311, and 308/310/312 of 312. They are interleavings, not deep-tree
+insertions. If that 4% ever becomes annoying, letting the extension test
+tolerate a bounded reordering window near the tail is a change to one
+function, against a migration through ~8 formatters, 4 modules and 9
+coupled test files.
+
+**Recommendation: leave C2 deferred, and update
+`identifier-consolidation.md` to say the consumer arrived and did not
+need it.** Take it if a *different* consumer appears — archive-search
+annotations are still the plausible one — not for this.
+
 It does **not** help the cache. `msg-d-N` and `data-uuid` are
 render-only and never enter it; cache identity is the transcript uuid /
 `sessionId` / `parentUuid` / `requestId` family, plus the DAG *line* ids
@@ -1147,6 +1215,197 @@ Measured on the 46 MB archive, appending one line to a 626-row file:
 So the DB does not grow either way; today's cost is write amplification
 (~600x), not size.
 
+---
+
+## The browser half — ✅ LANDED
+
+Three items, prompted by living with Stage 2: the follow control was in
+the wrong place (and, it turned out, broken), following scrolled to a
+position that felt wrong, and timestamps visibly lagged the fade-in on
+large sessions. Only the third was expected to be interesting. All three
+turned out to have a measurable cause, and two of them were bugs rather
+than preferences.
+
+### C23. The sluggish fade-in was the *scheduler*, not the work
+
+The reported symptom — "timestamps are all reconverted on every change,
+which makes the fade-in look sluggish past 100–200 K tokens" — pointed
+at the reconversion. The reconversion is nearly free. The scheduling was
+not.
+
+`timezone_converter.js` processed **25 elements per
+`requestIdleCallback`**, so the cost was set by the *number of
+callbacks*, not by the work:
+
+| page | timestamps | CPU, one pass | wall clock, as scheduled |
+|---|---|---|---|
+| 4 MB | 1,180 | 8 ms | **766–1,500 ms** |
+| 12 MB | 2,471 | 15 ms | **1,624 ms** |
+| 27 MB | 5,010 | 36 ms | **3,348 ms** |
+
+And the queue is in *document order*, so cards appended by a live update
+are localised **last** — the fade-in plays over a raw ISO string and the
+timestamp flips in a second later. That is the whole reported feel.
+
+**Fixed** by draining against the idle deadline (`timeRemaining()`,
+checked every 32 elements, `{timeout: 200}`) instead of a fixed batch,
+with the first slice on the current task under a 24 ms budget so a live
+update's new cards are localised before the browser paints them:
+
+| page | before | after |
+|---|---|---|
+| 4 MB / 1,180 ts | 766 ms | **13 ms** |
+| 12 MB / 2,471 ts | 1,624 ms | **19 ms** |
+| 27 MB / 5,010 ts | 3,348 ms | **35 ms** |
+
+— within a few ms of a straight synchronous pass, while still yielding.
+Verified on regenerated pages by recording, in-page, when each
+`.timestamp` was rewritten: the span from first conversion to last went
+**778 ms → 0 ms**, i.e. a single burst. Instrumenting
+`requestIdleCallback` showed **0 idle slices** on a 2.4 MB page — the
+drain now finishes in the first one.
+
+*A probe artefact worth remembering:* the first measurement of this put
+the span at 165–219 ms even after the fix, which looked like the fix
+half-working. It was the probe. A `MutationObserver` watching
+`.timestamp` for `childList` also sees **HTML parsing** insert each
+element's original text node, spread across the page's parse. Filtering
+to mutations whose `addedNodes` contain an *element* separates
+conversions (which insert a `<span>`) from parsing (which never does).
+
+### C24. The follow pill was 1,360 px wide, and "following" rendered fainter than "not following"
+
+Both found by measuring the thing rather than reading the CSS, and both
+were bugs, not placement preferences:
+
+- `.floating-btn` sets `right: 20px`; `.live-update-pill` added
+  `left: 20px` with `width: auto`. A fixed-position box with both insets
+  and auto width **stretches**: measured at **1360 px across a 1400 px
+  viewport**.
+- `data-following="yes"` used `--highlight-light`, which computes to
+  `rgba(227,242,253,0.333)` against an idle `--session-bg-dimmed` of
+  `rgba(232,244,253,0.4)`. The engaged state was **fainter than the
+  disengaged one**; only the text label distinguished them.
+
+**Fixed** by making the toggle a real member of the floating stack —
+`#followUpdates`, in `transcript.html` with the others, at `bottom:
+440px` (`.resume-toast` moved 440 → 500 to stay above it). It keeps the
+stack's round 50 px footprint and carries the unseen count as a corner
+badge; "following" uses the opaque `#d4e8f7` that `.debug-toggle.active`
+already established.
+
+It is rendered on *every* transcript page and revealed by
+`live_update.js` adding `.live-active`, so a served page and the same
+file on disk carry identical markup, and a `file://` page — which can
+never poll (C4) — never shows a control that would promise something it
+cannot do.
+
+### C25. The follow scroll needed both halves, and neither alone works
+
+`scrollIntoView({block: 'end'})` aligns the last card's bottom edge with
+the viewport's: measured gap **0 px**, which reads as the message being
+cut off. The obvious fixes fail individually:
+
+| | resulting gap |
+|---|---|
+| today | 0 px |
+| `scroll-margin-bottom: 120px` alone | 25 px — the document has no room left to give |
+| `padding-bottom: 120px` alone | 0 px — `block: 'end'` aligns to the edge regardless |
+| **padding + scrolling to the document end** | **120 px** ✓ |
+
+So: `body.live-following { padding-bottom: 120px }` supplies the space,
+and `scrollToEnd` scrolls the *document* to its end rather than aligning
+the card. Scoping the padding to the following state keeps every ordinary
+page layout-identical. Measured on a real page: **134 px**.
+
+### C26. Patching, as built
+
+The shape C19 described, with one change forced by measurement and one
+simplification justified by it.
+
+**Forced: the hash cannot come from the live DOM.** Both sides of the
+comparison have to be pristine server bytes, because decoration rewrites
+the live tree (C23's localiser replaces `innerHTML`). A first prototype
+hashed the live tree and skipped **0 of 1,181 nodes**. So the client
+hashes each node's own markup out of the freshly parsed document and
+keeps the map for next time — which also means **no server change at
+all**: no `data-h` attribute, no renderer work, and no risk of a
+server-side hash silently missing a field and showing a stale card.
+
+**Simplified: patch the extension case, swap for everything else.** Per
+the revised C20, 45 of 47 real growth steps are pure extensions. So the
+update tests whether the new render's node-key sequence *extends* the
+one on screen; if it does, it replaces the few nodes whose own markup
+changed and inserts the new ones. Anything else — renumbering,
+reordering, deletions, a node with no key, more than 40 changed nodes —
+returns to the unchanged swap, which stays the definition of correct.
+
+Two structural details that are easy to get wrong:
+
+- **A node's "own markup" is not just its card.** A fork point renders
+  as a box *inside* `.children` so folding hides it with the subtree,
+  and on a fork-only slot that box is the node's only content and
+  carries its id. Both kinds hold positional `#msg-d-N` branch links, so
+  a model that only looked at `:scope > .message` would silently miss a
+  changed fork point. `ownParts` takes the card plus every non-
+  `.message-node` child of `.children`; the template always emits those
+  last, which is what lets a replacement be re-appended.
+- **Rehydrate what you placed, not the node you placed it in.** The
+  first working version pushed the whole `.message-node` to the
+  rehydrate list. The session header's fold bar counts its descendants,
+  so it is replaced on *every* append — and its node is the entire page.
+  Measured: an update that changed 3 cards re-localised **1,186**
+  timestamps. Fixed by having `applyOwn` return the elements it actually
+  inserted. This was invisible to every test that asserted on the
+  outcome; it took the end-to-end measurement to see it.
+
+**Reachability, checked rather than assumed.** The patch requires *every*
+`.message-node` to have a key, and bails to the swap if one does not — a
+decline that would be completely silent. Across **29 real session pages
+(11,140 nodes)**: **0 unkeyed**. So the fallback is not quietly the only
+path. Those pages also contained exactly **one** fork point between them,
+so the `ownParts` generalisation above is defensive rather than hot — but
+it is the difference between a rare stale fork point and a correct one.
+
+**Measured end to end**, driving the real pipeline (a real session file
+with its tail held back, re-rendered per append, the shipped
+`live_update.js` polling a real server) on a 2.4 MB / 896-card page:
+
+| | first update (swap) | second update (patch) |
+|---|---|---|
+| cards inserted or replaced | 897 | **3** |
+| timestamps localised | 896 | **2** |
+| main thread blocked | 107 ms | **61 ms** |
+
+The first update of a session always swaps — it is where the hashes are
+first taken — and the swap is a valid starting point for the next patch.
+What remains in the 61 ms is the floor a client-side diff cannot avoid:
+fetching the page and parsing it. Only a server-shipped delta removes
+that, and it is not worth building for this.
+
+Also gone, in the patched case: the `uuid → session-id → positional-id`
+capture-and-restore of fold and `<details>` state. Untouched nodes keep
+their state because they *are* the same nodes.
+
+### C27. Testing this needs identity assertions, not outcome assertions
+
+The obvious tests — "the new message appeared", "the timestamp is
+localised" — pass with the patch disabled entirely, because the swap
+does those things too. The same trap as Fix B's "did an append-only
+write happen?", which passed with the gate removed because the layer
+below rescued it.
+
+So the tests tag every card on screen with a JS property and assert on
+**element identity** afterwards: a swap necessarily scores 0, a patch
+necessarily keeps almost everything. Verified by sabotage — forcing
+`tryPatch` to return `null` fails exactly the two patch tests and no
+others. The fallback test carries its own within-test control (the same
+append patches with the ids intact, then does not once they move),
+because `kept == 0` alone would also be what a permanently broken patch
+looks like.
+
+Every test here appends **twice**: the first update seeds the hashes.
+
 ### Suggested order
 
 1. ✅ **Fix C and Fix A landed.** Tick **1.03 s → 0.717 s** on the 803 MB
@@ -1179,7 +1438,20 @@ So the DB does not grow either way; today's cost is write amplification
 3. ✅ **The refresh's own queries** (migration 012 + one query rewrite),
    taking the tick to **0.145 s** — cumulatively **1.03 s → 0.145 s, a
    7x tick**. See "What was left in the tick" above.
-3. **Option 1** for the browser, which is where the user-visible cost
-   actually is, and which no longer depends on `render-format-once.md`.
-   Land the tail-append case first; take C2 (C20) when the fallback
-   rate on out-of-order arrivals proves it is worth the migration.
+4. ✅ **Option 1 for the browser** — landed as described in "The browser
+   half", and it did not need `render-format-once.md` or C2. On a 2.4 MB
+   page an update went from 897 cards / 896 timestamps / 107 ms to
+   **3 / 2 / 61 ms**, and the timestamp localiser's own scheduling —
+   which was the actual reported symptom, and was never about the
+   update path at all — went from **766–3,348 ms to 13–35 ms**.
+
+   The fallback rate C20 said to wait for was then measured at **4%**,
+   which is what argues *against* the migration rather than for it.
+
+**What is left, if anything.** The 61 ms floor is fetch + `DOMParser` of
+the whole page, which only a server-shipped delta removes; that is a real
+project (an endpoint or sidecar, and the server holding the previous
+render) for a benefit that is invisible below ~10 MB pages. Nothing here
+needs doing. The next thing that would justify reopening the browser side
+is a *user-visible* complaint on a very large live page, not a number in
+this document.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -103,7 +103,7 @@ container swap.
 page's own URL is both the change-detection channel and the content
 channel, in one request.
 
-### C6. ⚠️ The session-scoped fast path is unreachable in watch mode
+### C6. ~~⚠️~~ ✅ The session-scoped fast path was unreachable in watch mode
 
 **This is the finding that most shapes the work.** Phase 1b
 (`_try_current_or_session_scoped`, `converter.py:3027`) — the 0.6 s
@@ -130,6 +130,43 @@ touched. With `--combined no` the combined-staleness veto is already
 skipped, so `cache_was_updated` is genuinely the only blocker. This is a
 converter change, not a watcher change, and it is the prerequisite that
 makes watch mode cheap rather than merely possible.
+
+#### ✅ Resolved
+
+The veto's real concern was narrower than "the cache changed": Phase 1b's
+staleness test is per-session **message counts**, so a session whose
+content changed without its count changing would be missed. An
+**incremental** refresh rules that out — `_incremental_cache_refresh`
+only succeeds after proving every modified file's cached rows are an
+exact *prefix* of its current rows (`converter.py:3866`), i.e. a pure
+append, and with append-only sources a changed session always changes its
+count. It also keeps the sidecar current via `merge_session_sidecar`,
+which is the partial load's other requirement.
+
+So `ensure_fresh_cache` now reports *how* it refreshed
+(`CacheRefresh.NONE` / `INCREMENTAL` / `FULL`, via
+`ensure_fresh_cache_detailed`; the old bool function remains as a
+wrapper), and Phase 1b refuses only for `FULL`.
+
+Measured on the same 64 MB / 32-session archive, a watch tick with
+`--combined no`:
+
+| | before | after |
+|---|---|---|
+| path taken | full project load | **`_load_stale_session_transcripts`** |
+| tick (in-process, incl. hierarchy overhead) | 0.78 s | **0.31 s** |
+| render alone | — | **0.09 s** |
+
+Equivalence: two independent copies of the archive advanced through the
+same appends, one with the session-scoped path and one with
+`CLAUDE_CODE_LOG_SESSION_SCOPED=0`. **8 ticks, both formats, 28–29 output
+files each, byte-identical every time.**
+
+Pinned in `test/test_session_scoped_render.py::TestSessionScopedAfterAppend`
+— including that a FULL refresh still declines, and that the appended
+message actually reaches the output (an equivalence test alone would pass
+if *both* paths rendered nothing, which is precisely how the first draft
+of this measurement fooled itself).
 
 ### C7. ~~⚠️~~ ✅ The cache's 1-second mtime tolerance silently swallows fast appends
 

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -1,0 +1,476 @@
+# Real-time watch mode — Design
+
+Status: **designed, not implemented.** Decisions below are settled; the
+measurements that forced them are recorded so a later reader can tell
+which choices were reasoned and which were measured.
+
+## Motivation
+
+Two use cases, deliberately different in their tolerance for latency and
+complexity:
+
+1. **Markdown on disk.** Someone has `session-<id>.md` open in an IDE or
+   Obsidian and wants it to keep up with the running session. The "client"
+   is the editor's own file watcher; all we owe it is a fresh, non-torn
+   file. Latency budget: a second or two, easily.
+2. **Session page in the browser.** Someone has the generated HTML open
+   under `serve` and wants the page to grow as the session does, "like the
+   CLI". Latency budget: sub-second would be nice; loss of scroll position
+   or fold state would not be.
+
+Both reduce to the same engine (*detect change → re-render → notify*), and
+differ only in how the client learns about it. That symmetry is the main
+structural finding.
+
+## Decisions
+
+| # | decision |
+|---|---|
+| D1 | A `watch` subcommand owns the loop; `serve --watch` runs the same engine on a thread. |
+| D2 | Add `source_size` to `cached_files` so the cache itself detects fast appends; the watcher then trusts `get_modified_files` rather than keeping parallel state. Detection is stat-polling. |
+| D3 | Default scope is one project; `--all-projects` is opt-in. |
+| D4 | Quiet-period debounce (~300 ms) with a max-latency cap (~2 s), both flags. |
+| D5 | Container swap (option B) with uuid-set diffing, not full reload and not fragment patching. |
+| D6 | Polling. SSE only if measurement later justifies it. |
+| D7 | Route every output write through temp-file + `os.replace`. |
+| D8 | Measured: the write + FTS update is fast enough. No lock-avoidance machinery needed. |
+| D9 | Fix `--output` destination-aware freshness; it pairs with D7. |
+| D10 | Injectable clock and file-event source; unit tests drive ticks by hand. |
+| D11 | The `stream-json` piping request (#43 follow-up) is **subsumed** by watch mode. No stream-json parser. |
+
+---
+
+## Constraints, measured
+
+Measured on this box, not assumed. The live transcript is this session's
+own JSONL; the timing corpus is a copy of the `claude-code-log` project
+archive (64 MB, 32 session files, 8 cores, warm cache).
+
+### C1. The source is append-only, and never rewritten in place
+
+168 entries, **110 distinct UUIDs, zero duplicates** — no entry is ever
+rewritten. A 4.5 KB append left the first 50 KB byte-identical.
+
+**Consequence:** everything before the last known offset is stable. There
+is nothing to diff — only a tail to consider.
+
+### C2. The granularity floor is one complete message. Token streaming is impossible.
+
+Follows from C1: an entry is written exactly once, so only when complete.
+Confirmed by shape — the newest assistant entry was a whole 704-byte
+`tool_use` block, on disk within the same second the message finished, not
+batched to end-of-turn.
+
+**Consequence, and the expectation to set with users:** we can never show
+tokens arriving. The best achievable is *a whole message appearing
+promptly*. "Smooth" must come from presentation (a fade-in on new cards),
+not from streaming.
+
+### C3. Appends are not in timestamp order
+
+The last two lines of the live file were `attachment` entries stamped
+`15:42:17.930` and `15:42:26.973`, appended *after* a `user` entry stamped
+`15:42:26.971`.
+
+**Consequence:** "append new lines to the bottom of the page" is wrong. A
+newly-arrived line can belong earlier in the tree.
+
+### C4. `file://` cannot fetch anything. `<script src>` is the only channel.
+
+Probed in Chromium via Playwright — one page attempting each access,
+loaded first from `file://`, then from a real `ArchiveServer` on loopback:
+
+| | `file://` | `http://` (`ArchiveServer`) |
+|---|---|---|
+| `fetch('sibling.json')` | **BLOCKED** | OK |
+| `fetch(location.href)` (self) | **BLOCKED** | OK |
+| `XMLHttpRequest` HEAD | **BLOCKED** | OK |
+| `<script src="sibling.js">` | OK | OK |
+| `localStorage` | OK | OK |
+| `history.scrollRestoration` | `auto` | `auto` |
+
+**Consequence:** "polling works even without the server" is half right. A
+`file://` page can poll only by injecting a `<script>` sidecar, and cannot
+fetch page content — so its ceiling is a revision counter plus
+`location.reload()`. Under `http://`, `fetch(location.href)` unlocks the
+container swap.
+
+### C5. Under `serve`, polling needs no new server code
+
+`fetch(location.href)` already works against the stock
+`SimpleHTTPRequestHandler`, which already does `Last-Modified`/304
+(0.5–1.6 ms, per `archive-search-server.md`). A conditional GET on the
+page's own URL is both the change-detection channel and the content
+channel, in one request.
+
+### C6. ⚠️ The session-scoped fast path is unreachable in watch mode
+
+**This is the finding that most shapes the work.** Phase 1b
+(`_try_current_or_session_scoped`, `converter.py:3027`) — the 0.6 s
+session-scoped path from #315 — is vetoed outright when
+`cache_was_updated` is true (`converter.py:3067-3073`). A watch tick
+*always* has new bytes, so it is *always* vetoed.
+
+Measured by spying on the conversion internals across simulated watch
+ticks (append one line, clear the mtime tolerance, convert):
+
+| mode | `try_session_scoped` | what actually ran | steady tick |
+|---|---|---|---|
+| `--combined yes` | `None` (vetoed) | Phase 1c streaming | **0.46 s** |
+| `--combined no` | `None` (vetoed) | **full project load** (0.51 s of it) | **0.82 s** |
+
+So today: streaming rescues the combined case, but `--combined no` — the
+Obsidian mode, i.e. exactly use case 1 — **full-loads the whole project on
+every tick**. `_incremental_cache_refresh` does fire (0.19 s) and is the
+fixed floor of every tick.
+
+**Consequence:** the enabling change for watch mode is to let Phase 1b run
+when the cache *was* updated, restricted to the sessions the update
+touched. With `--combined no` the combined-staleness veto is already
+skipped, so `cache_was_updated` is genuinely the only blocker. This is a
+converter change, not a watcher change, and it is the prerequisite that
+makes watch mode cheap rather than merely possible.
+
+### C7. ⚠️ The cache's 1-second mtime tolerance silently swallows fast appends
+
+`cache.py:349` — `if abs(source_mtime - row["source_mtime"]) >= 1.0`. A
+change landing within 1.0 s of the recorded mtime is **invisible**.
+Reproduced: appending and converting immediately alternated 0.74 s (change
+seen) / 0.29 s (change missed), run after run.
+
+It fails in the worst shape: the *last* message of a turn, landing within
+a second of the previous tick and then followed by silence, is stranded
+until something else touches the file. See D2.
+
+### C8. Every output write is non-atomic
+
+Eight `write_text` sites in `converter.py` plus `render_pool.py:570`; only
+image export uses temp-file + `os.replace` (`image_export.py:79`). Today a
+narrow race; under a watch loop rewriting the same file every few seconds
+while Obsidian re-reads it, routine. The 27 MB-page case is a wide window.
+
+### C9. There is no wrapping container around the message tree
+
+`transcript.html:252` emits
+`{% for root in roots %}{{ render_message(root) }}{% endfor %}` directly
+into `<body>`, between the filter toolbar and the floating buttons. A
+container swap needs a `<div id="transcript">` added first — small and
+safe, but it moves every HTML snapshot, so it wants its own commit.
+
+### C10. Two identifiers, only one of them stable
+
+- `id="msg-d-{N}"` (`renderer.py:403`) is **positional per-render**.
+  Inserting anywhere but the tail renumbers every subsequent slot and
+  breaks the existing `#msg-d-N` fork/tool-pair links on the page.
+- `data-uuid` is **stable across re-renders** but **not unique per card** —
+  one entry can render as sibling text + tool_use cards.
+
+### C11. Fragment-level patching is still blocked, and the code says so
+
+`work/render-format-once.md`'s step 3 landed as a *result* (format once,
+reuse across trees) but not as an architecture: there is no seam that
+renders one message in isolation. `RenderUnit.kind` is only `"page"` or
+`"session"`; a fragment is produced by the inline `visit()` closure inside
+`_annotate_tree_for_render` (`html/renderer.py:1550-1616`) and needs a
+fully built `TemplateMessage`, a renderer whose `_ctx` came from *that*
+tree, and the SHA-link `ContextVar`.
+
+Decisively: **any fragment containing `msg-d-` is deliberately never
+cached** (`html/renderer.py:1608-1609`), precisely because those links are
+cross-tree positional. That is the same reason it cannot be patched into a
+live page in isolation.
+
+### C12. A torn last line is already tolerated
+
+`json.JSONDecodeError` is caught per line in the load loop
+(`converter.py:~434`), so reading mid-append skips the partial line and
+picks it up next tick. Sampling the live file at 5 ms across a
+473,810-byte append never caught a torn tail (0/3964 samples) — but only
+one growth event was observed, so that is weak evidence and the existing
+tolerance is what we should keep relying on. The skip prints a warning; a
+watch loop needs it silenced.
+
+### C13. Nothing watch-shaped exists yet
+
+No `watchdog`, `inotify`, `watchfiles`, `asyncio`, no `--watch`, no push
+channel. The only long-running loop in the package is
+`ArchiveServer.serve_forever` (`server.py:194`).
+
+---
+
+## The shape
+
+> **One watch engine. The server never renders — it re-runs the ordinary
+> incremental conversion and tells the client the file on disk changed.**
+
+Worth stating as a principle because it protects an invariant the project
+leans on: *the generated HTML on disk is canonical and works from
+`file://`*. If the server rendered fragments on demand there would be two
+rendering paths that could disagree, and `serve` would need the fragment
+store, the render memo and the cache write lock in-process.
+
+- Use case 1's client is the editor's file watcher; use case 2's is the
+  browser. Same engine, two notification adapters.
+- Zero new rendering code.
+- Latency is bounded by C6 — which is why C6's fix is a prerequisite, not
+  an optimisation.
+
+---
+
+## Decision detail
+
+### D1. `watch` subcommand
+
+A resident process saves the ~0.25 s interpreter + import startup on every
+tick (a bare `--help` costs that much), and serves use case 1 with no
+server at all. `serve --watch` starts the same `WatchEngine` on a thread.
+A `--watch` flag on `convert` was rejected: `convert` is a one-shot verb
+and a flag that makes it never return is a surprising overload.
+
+### D2. Put the size in the cache
+
+`get_modified_files` already calls `jsonl_file.stat()` per file
+(`cache.py:1544`), so `st_size` is **free** — no extra syscall. Add
+`source_size` to `cached_files` (migration 011) and make the rule:
+
+```
+stale  if  size != cached_size  OR  |mtime delta| >= 1.0
+```
+
+This is **strictly tightening** — it can only mark more files stale, never
+fewer — so it cannot break existing correctness. Pre-011 rows carry NULL
+and fall back to mtime-only, following the pre-007 `subagents_fingerprint`
+precedent already in `_cache_row_is_fresh`.
+
+Why this is better than the watcher keeping its own state, as first
+proposed: it fixes C7 for *every* caller, not just the watcher; it makes
+the cache directly usable as the watcher's oracle (no parallel
+bookkeeping); and it removes the sleep-based timing workarounds tests
+currently need, since a rewritten fixture is detected immediately rather
+than after a 1 s wait.
+
+Residual hole: a same-size modification within the 1 s window. Impossible
+for an append-only source (C1); acceptable elsewhere.
+
+**Detection mechanism: stat-polling at ~250 ms.** Dependency-free,
+portable, works on network filesystems, and at watch scope (one project,
+~32 files) costs one `scandir`. `watchdog`/`watchfiles` would cut idle CPU
+but adds a dependency and, on macOS, FSEvents coalescing latency of its
+own. Revisit only if idle CPU is ever a real complaint.
+
+### D3. Scope
+
+Default is the project for `$PWD`; `watch <path>` and `--session-id`
+narrow further; `--all-projects` is explicit opt-in. Re-converting a
+665-project hierarchy per tick is the obvious wrong default, and it keeps
+C6's per-project numbers honest.
+
+### D4. Debounce
+
+Claude Code appends several entries per turn, each within a second or so
+of the last. Per-event re-rendering would thrash and spend most of a turn
+rendering intermediate states. Quiet-period ~300 ms with a max-latency cap
+~2 s, so an unbroken stream of appends still surfaces regularly. Both
+flags — the right numbers differ between a small live project and a large
+one.
+
+### D5. Container swap, with a re-init contract
+
+`fetch(location.href)` → parse → replace `#transcript` → diff the uuid set
+→ rehydrate. Scroll is preserved naturally (appends are below the fold);
+fold state is the real casualty and must be snapshotted and reapplied.
+
+Full reload was rejected: it loses fold state *and* re-parses the whole
+document. Fragment patching was rejected on C11 (no isolation seam,
+`msg-d-` fragments deliberately uncacheable) compounded by C3
+(out-of-order arrivals) and C10 (positional ids, non-unique uuids). B gets
+most of the perceived benefit for a fraction of the risk.
+
+The inventory is favourable. **Survives a swap for free:** listeners
+delegated on `document` (`transcript.html:395, 538, 575`), everything
+bound to the toolbar and floating buttons (outside the container), and
+`localStorage`-backed prefs (raw/md user view, search state).
+
+**Must be re-run, and none of it is currently re-runnable:**
+
+| what | where | note |
+|---|---|---|
+| timestamp localisation | `components/timezone_converter.js` | an IIFE that rewrites `innerHTML` for every `[data-timestamp]`, batched via `requestIdleCallback`; **not exposed on `window`** |
+| timeline rebuild | `components/timeline.html:46` `buildTimelineData()` | parses message types from DOM CSS classes; `window.timeline` and `applyTimelineFilters` exist, a rebuild entry point does not |
+| filter re-application | `transcript.html` filter toolbar | current selection must apply to new cards |
+| in-page search state | `components/search.html:1077` `initSearch` | |
+| fold state | — | key by `data-uuid` + ordinal-among-siblings sharing it (C10) |
+| new-card tagging | — | diff uuid sets before/after; class drives the CSS fade-in |
+
+So the concrete deliverable of this stage is a **`window.claudeLogRehydrate(rootEl)`
+contract** that each component registers into, plus scoping each of the
+above to a subtree instead of the document. That refactor is most of the
+work; the poller itself is small.
+
+Also: tail-follow should be an explicit toggle with an "N new messages"
+affordance — auto-scrolling someone who is reading is worse than not
+updating. And **watch mode targets session pages**; a growing session can
+push the paginated combined view across a page boundary, so that view gets
+reload-or-nothing for now.
+
+### D6. Polling
+
+Note the asymmetry that cuts against the intuition that SSE is the proper
+answer:
+
+> With polling the server needs **no background machinery at all** — the
+> check happens inside a request. SSE needs a watcher thread, a client
+> registry, heartbeats and stream teardown regardless. SSE is *more*
+> infrastructure, not less.
+
+At a 1 s interval a 304 costs ~1 ms (C5); the efficiency argument for SSE
+is worth about a millisecond a second per tab. WebSocket is not worth
+discussing — traffic is one-directional and it means hand-rolling framing
+on `http.server` or taking a dependency.
+
+If SSE is ever built it must sit behind the same `Host` check
+(`server.py:53`), send heartbeats, cap concurrent streams, and be closable
+from `ArchiveServer.stop()`.
+
+### D7. Atomic writes
+
+Route every output write through a temp-file + `os.replace` helper — the
+pattern `image_export.py:79` already uses. Its own commit; a small
+correctness improvement that watch mode makes urgent rather than creates.
+
+### D8. Contention — measured, and fine
+
+Tick cost and search-read latency, measured with an FTS index present and
+a reader thread hammering `search()` during ticks:
+
+| | |
+|---|---|
+| tick, no FTS index | 0.46 s |
+| tick, FTS index present | **0.52 s** (so the index update costs ~55 ms) |
+| tick under concurrent read load | 0.52 s (unchanged) |
+| search reads during ticks (n=103) | **p50 5.0 ms, p95 17.9 ms, max 113 ms, 0 errors** |
+
+No `SQLITE_BUSY`, no measurable slowdown of either side. WAL plus
+read-only thread-local connections (`api.py:63-71`) do their job.
+
+**Consequence:** no lock-avoidance machinery is needed. A pleasant side
+effect: because `save_cached_entries` also maintains the FTS index
+(`cache.py:928-938`), a watch loop keeps **archive search live** for free,
+for ~55 ms a tick.
+
+Still open: a single-instance advisory guard per projects dir, so two
+watchers (or a watcher plus a manual run) don't fight. Cheap insurance,
+annoying to retrofit — decide during Stage 1.
+
+### D9. `--output` destination-aware freshness
+
+`work/obsidian-friendly-output.md` records it: `is_html_stale` /
+`is_page_stale` resolve against the *source* project dir, not `dest_dir`,
+so under `--output` every run re-renders everything. Under a watch loop
+pointed at an Obsidian vault — exactly use case 1 — that means every tick
+re-renders every session and (with C8) rewrites every file, thrashing the
+vault's own indexer. Prerequisite, not a nice-to-have. Pairs naturally
+with D7 since both touch the write path.
+
+### D10. Testing
+
+A watcher tested with `sleep()` is a flaky-test generator. The engine
+takes its clock and file-event source as injectable collaborators, so unit
+tests drive it by hand (`engine.tick()` after writing a fixture) and only
+one or two Playwright tests cover the real path. D2 helps here directly —
+with size in the cache, a rewritten fixture is detected without waiting
+out the mtime tolerance. The polling tests must be live-server; the
+existing browser suite is `file://`-based and C4 means it cannot cover
+them.
+
+---
+
+## D11. The `stream-json` piping request
+
+The feature request asks for `claude -p --output-format stream-json |
+claude-code-log --stream-json`, on the premise that stream-json is missing
+`parentUuid`, `isSidechain`, `userType`, `cwd`, `version` and `timestamp`.
+
+**Verified: `claude -p` writes a normal, full-fidelity transcript JSONL**
+to `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` — `parentUuid`,
+`isSidechain`, `uuid`, `timestamp`, `queue-operation` entries, everything,
+identical in shape to an interactive session. (Confirmed on 2.1.251 by
+running a headless prompt: the run failed at auth, and the full transcript
+was written anyway.)
+
+So the piped schema never needs to be parsed:
+
+- **Live case** → `watch`, pointed at the project. Full renderer, every
+  depth and format, all fidelity — strictly more than stream-json carries.
+- **CI case** → run to completion, then a one-shot
+  `claude-code-log --session-id <id> -o - -f md`. `-o -` already streams a
+  rendered document to stdout with status on stderr. The session id is in
+  the stream's own `result` event (`session_id`).
+
+The premise is also stale: stream-json on 2.1.251 *does* carry `uuid`,
+`timestamp`, `session_id` and `parent_tool_use_id`. What still differs is
+naming (`session_id` vs `sessionId`, `parent_tool_use_id` vs
+`parentUuid`), the absent `cwd`/`version`/`isSidechain`/`userType`, and
+extra `system`/`init` and `result` event types.
+
+**Recommendation: close as subsumed; do not build a stream-json parser.**
+The cost being avoided is a second, divergent schema to track forever, for
+strictly less information than the file we already have. If the pipe
+ergonomics turn out to matter for CI, the cheap answer is a `--follow`
+mode that tails the *session's own JSONL* and streams rendered output to
+stdout — same engine, no new schema.
+
+---
+
+## Phasing
+
+Each stage answers its own open questions before it starts; each is
+independently shippable.
+
+**Stage 0 — prerequisites.** All four are independently justified and all
+move snapshots, so they land before, not during:
+
+- D7 atomic writes.
+- D2 `source_size` column (migration 011).
+- D9 destination-aware freshness.
+- C9 `<div id="transcript">` wrapper.
+
+*Question to answer first:* none — these are all self-contained.
+
+**Stage 1 — the engine + use case 1.** `claude-code-log watch [path]`:
+stat-poll, debounce, call the existing conversion, one line per
+regeneration. Serves the Markdown/Obsidian case completely.
+
+*Questions to answer first:*
+1. **Can Phase 1b be made reachable when the cache was updated, restricted
+   to the touched sessions (C6)?** Without this, Stage 1 full-loads the
+   project every tick. This is the stage's real work.
+2. Tick cost on the 803 MB reference archive, not the 64 MB one — C6's
+   numbers are the optimistic end.
+3. Does a resident watcher's warm render memo beat the cold-memo figure?
+   (In-process steady ticks were 0.46–0.82 s; the memo's contribution is
+   unmeasured.)
+4. Single-instance guard: needed, or overkill (D8)?
+
+**Stage 2 — use case 2 under `serve`.** `serve --watch` runs the Stage 1
+engine on a thread; the session page polls its own URL, swaps
+`#transcript`, rehydrates, fades in new cards, offers follow-tail.
+
+*Questions to answer first:*
+1. What does the `claudeLogRehydrate` contract look like, and how much of
+   the D5 table can be scoped to a subtree without restructuring?
+2. Is fold-state restore by `data-uuid` + sibling ordinal actually clean?
+   If it turns out ugly, that is the argument for reconsidering full
+   reload.
+3. What is the swap cost on a large session page (the 27 MB case)?
+
+**Stage 3 — `file://` sidecar (optional).** A `session-<id>.live.js`
+sidecar carrying a revision counter; the page injects it on a timer and
+reloads on change (C4). Honest and cheap, but strictly worse than Stage 2,
+so build it only if the no-server case proves to matter.
+
+**Stage 4 — SSE and/or fragment patching (speculative).** Only after
+Stage 2 has been lived with, and only if the poll interval or swap cost
+demonstrably hurts. Fragment patching additionally needs the *architecture*
+half of `render-format-once.md` step 3 — a real format phase and a
+per-message render seam — which has not landed (C11).

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -540,6 +540,44 @@ exactly like a regression in the atomic-write change, and a
 `if __name__ == "__main__":` guard. Any probe that drives a conversion
 needs one.
 
+### Stage 1, measured on real archives
+
+The synthetic "large archive" built for this — one project duplicated
+four times into 128 files / 180 MB — turned out to be a **worst case,
+not a large case**. Every uuid appeared four times, which is exactly what
+makes `_incremental_cache_refresh` decline; it fell back to the full
+refresh, `CacheRefresh.FULL` vetoed Phase 1b, and every tick full-loaded
+(4.1 s). The decline ladder was working as designed; the fixture was
+lying. Real archives are what these numbers have to come from.
+
+On `downloads/projects/-Users-dain-workspace-claude-code-log`
+(**217 trunk files, 319 MB**), appending to the *largest* session file
+(40 MB — the pessimistic pick):
+
+| | |
+|---|---|
+| cold conversion | 15.2 s |
+| **steady tick** | **1.12 s** |
+| ↳ `_incremental_cache_refresh` | 0.75 s (**67% of the tick**) |
+| ↳ `_load_stale_session_transcripts` | 0.14 s |
+
+So the session-scoped path *does* engage on real data, and **the
+bottleneck has moved**: rendering is now 12% of a tick and the cache
+refresh is two thirds of it. That is the next thing to attack if 1.1 s
+proves too slow; the render work is done.
+
+Answers to Stage 1's other questions:
+
+- **Q3 — does a resident watcher's warm memo help?** Barely. In-process
+  ticks 4.11 s vs a fresh subprocess per tick 4.62 s (on the synthetic
+  archive, where both paths were identical work). The ~0.5 s gap is
+  interpreter startup; the render memo contributes essentially nothing
+  across ticks, because the render is not where the time goes.
+- **Q4 — single-instance guard?** Not needed. Three concurrent
+  conversions against one cache: **0 failures**, no `SQLITE_BUSY`, and a
+  clean conversion afterwards. Combined with D8's read-during-write
+  numbers, the WAL setup handles this.
+
 **Stage 2 — use case 2 under `serve`.** `serve --watch` runs the Stage 1
 engine on a thread; the session page polls its own URL, swaps
 `#transcript`, rehydrates, fades in new cards, offers follow-tail.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -896,6 +896,38 @@ Cost: cache DB **+8.4%** (39.5 → 42.8 MB on a 49 MB archive) and no write
 regression — a cold conversion went 5.85 s → 5.79 s, five more indexes on
 an INSERT being small next to compressing the row's content blob.
 
+**Do these indexes help anything outside watch?** Checked every query the
+codebase runs against `messages`, with the indexes present and dropped.
+Mostly no — `load_cached_entries` and the FTS indexer already seek by
+`file_id` (0.00 ms either way), and archiving's session DELETE is 0.4 ms
+to begin with. Two things did come out of it:
+
+- The refresh queries aren't watch-specific: `_incremental_cache_refresh`
+  runs on *any* invocation with changed files over a warm cache, i.e. the
+  ordinary daily run.
+- **`load_session_entries` was scanning the whole project to load one
+  session** — the TUI (`tui.py:1843`) and archived-session rendering
+  (`converter.py:5153`). Same trap as the `session_id IS NOT NULL` one:
+  `ORDER BY timestamp NULLS LAST` lets the planner take the *timestamp*
+  index to get the sort free, then filter session by session. 84.5 ms for
+  a 19 k-row archive's twelve busiest sessions.
+
+  The fix that looked obvious — `ANALYZE` — is the *worse* of the two
+  candidates, and measuring saved shipping it: it gets to 15.8 ms,
+  `PRAGMA optimize` writes partial statistics that **don't change the
+  plan at all** (verified: stats present, plan unchanged), and either way
+  the plan then depends on when statistics were last gathered. Putting
+  `timestamp` into the session index instead makes one index serve both
+  the seek and the ordering: **84.5 ms → 7.2 ms**, no sort, no
+  statistics, deterministic. End to end (the method also decompresses and
+  validates) a caller sees 21.7 ms → 15.0 ms per session, for 0.4 MB.
+
+  Ordering is the risk with any such change, so it is pinned: 234
+  sessions, **29,605 tied-timestamp rows**, 1,237 NULL timestamps, zero
+  ordering differences — plus a test that asserts the plan still uses the
+  index and still needs no temp B-tree, which fails on exactly that
+  message if the column is dropped.
+
 **Steady-state tick: 0.257 s → 0.145 s.** Cumulatively **1.03 s →
 0.145 s, a 7x tick**, and the render — where this investigation started —
 is now a rounding error against it.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -1313,10 +1313,16 @@ cut off. The obvious fixes fail individually:
 | `padding-bottom: 120px` alone | 0 px — `block: 'end'` aligns to the edge regardless |
 | **padding + scrolling to the document end** | **120 px** ✓ |
 
-So: `body.live-following { padding-bottom: 120px }` supplies the space,
-and `scrollToEnd` scrolls the *document* to its end rather than aligning
-the card. Scoping the padding to the following state keeps every ordinary
-page layout-identical. Measured on a real page: **134 px**.
+So: `body.live-following { padding-bottom: … }` supplies the space, and
+`scrollToEnd` scrolls the *document* to its end rather than aligning the
+card. Scoping the padding to the following state keeps every ordinary
+page layout-identical.
+
+**The 120 px above was then cut to 20 px on use** — it read as the newest
+message being stranded above a band of empty page, which is the opposite
+failure to the one it was fixing. The container's own bottom margin adds
+to it, so 20 px of padding measures as a **36 px** gap: clear of the edge,
+still in view. The mechanism is unchanged; only the constant moved.
 
 ### C26. Patching, as built
 
@@ -1405,6 +1411,56 @@ because `kept == 0` alone would also be what a permanently broken patch
 looks like.
 
 Every test here appends **twice**: the first update seeds the hashes.
+
+### C28. What replacing DOM breaks that no test was looking at
+
+Three defects, all found by *using* the thing rather than by any
+assertion, and all the same shape: a test that checks the outcome an
+update produces will not notice that the page stopped **working**.
+
+**The fold bars went inert after one update.** `transcript.html` bound a
+click listener to each `.fold-bar-section` at load. A live update
+replaces those elements — the swap replaces all of them, and a patch
+replaces the bar of every ancestor of an append, since the bar carries
+their descendant count — so the listeners died with the elements. One
+update was enough to leave every fold control on the page unresponsive,
+while still rendering exactly right. Fixed by delegating on `document`,
+as the rest of the page's post-load listeners already are; the rehydrate
+contract at the top of `transcript.html` says as much, and this was the
+one that had not followed it.
+
+`test_fold_state_survives_an_update` passed throughout — because "the
+state survived" and "the control still works" are different assertions,
+and only the first was ever made.
+
+**The bar and its subtree could disagree.** The card carries the fold
+bar; the `.children` container carries the fold *state*, as inline
+`display`. `applyOwn` replaces the first and deliberately keeps the
+second, so a replaced bar came back with the server's default "unfolded"
+icons over a subtree that was still hidden — and the next click folded
+what was already folded and appeared to do nothing. Fixed by a rehydrate
+hook that re-derives the bar from the container's own `display`, which
+the update never touches and is therefore the truth. It fixes the swap
+path too, where `restoreState` synced the `folded` class but not the
+icon.
+
+**Overlapping polls could apply an older render.** `setInterval` fired
+regardless of whether a full GET was still in flight, so on a page slow
+enough to fetch — the large page this is all for — two updates raced and
+the last *response* won. Measured by holding one response for 3 s: the
+newest message appeared at 2.0 s, vanished at 4.0 s when the stale body
+landed, and returned at 5.0 s. Fixed by serialising the poll. Two details
+worth keeping:
+
+- Advancing `lastStamp` only *after* an update is applied is what bounds
+  the damage to one second instead of forever — the stale apply rewinds
+  the stamp to its own older value, so the next HEAD finds a difference
+  again. Recorded before the GET, as it originally was, nothing would
+  ever refetch the newer render.
+- That self-healing is also why the first version of the regression test
+  passed against the broken code: it asserted on the *end* state, by
+  which time the page had recovered. It has to watch for the regression
+  itself — a message that was on screen and then was not.
 
 ### Suggested order
 

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -6,10 +6,11 @@ Status: **Stages 0–2 landed** on `feat/watch-mode`.
 session does. Stage 3 (the `file://` sidecar) remains speculative and is
 probably not worth building. Stage 4 was too — until the tick was
 profiled: see "Where a tick's time goes" and "Appending the HTML rather
-than replacing it" at the end. **Fixes A, C and B have all landed**: a
-steady-state tick on the 803 MB archive went **1.03 s → 0.26 s**, and Fix
-B needed no migration in the end (the proof lives in the resident
-watcher's memory). The HTML half found that patching does *not* need the
+than replacing it" at the end. **Fixes A, C and B have all landed**, plus
+a follow-up round on the refresh's own queries: a steady-state tick on
+the 803 MB archive went **1.03 s → 0.145 s, a 7x tick**, and Fix B needed
+no migration in the end — the proof lives in the resident watcher's
+memory. The HTML half found that patching does *not* need the
 per-message render seam C11 says is missing; that is the open work.
 
 Decisions below are settled; the measurements that forced them are
@@ -852,11 +853,52 @@ DB state is the bar rather than HTML for the same reason § 2.14 gives:
 the first bug a write-path change produces is invisible in the rendered
 bytes.
 
-**What is left in the tick.** At 0.26 s the remaining items are the cache
-queries around the refresh — `get_session_file_map` ×3 (50 ms),
-`get_file_states` ×2 (45 ms, still fetching every row's compressed blob
-to SHA it, now redundant with the prefix hash), `get_uuid_owners` ×4
-(37 ms). Those are the next 130 ms if anyone wants it.
+**What was left in the tick — ✅ also done.** At 0.26 s the remaining
+items were the refresh's own cache queries, and they turned out to be
+much cheaper to fix than "restructure the refresh". Every one of them was
+scanning the entire project, which `EXPLAIN QUERY PLAN` says plainly:
+
+    SEARCH m USING INDEX idx_messages_project_timestamp (project_id=?)
+
+Measured per call on a 38,706-row archive:
+
+| | before | after | how |
+|---|---|---|---|
+| `get_uuid_owners` | 17.2 ms | **0.9 ms** | index `(project_id, _uuid)` |
+| `get_parent_uuid_dependents` | 21.5 ms | **0.6 ms** | index `(project_id, _parent_uuid)` |
+| `get_request_id_entries` | 17.0 ms | **0.3 ms** | index `(project_id, _request_id)` |
+| `get_metadata_target_files` | 14.5 ms | **0.2 ms** | *partial* index on `type` |
+| `get_session_file_map` | 16.8 ms | **2.5 ms** | index `(project_id, session_id, file_id)` |
+| `get_file_states` | 15.9 ms | **0.0 ms** | **query rewrite, no index** |
+
+Three things worth keeping:
+
+1. **`get_file_states` needed no migration at all.** It joined
+   `cached_files` and filtered on `cf.file_name IN (...)`, which gives
+   SQLite no indexed way in — resolving the names to `file_id` first and
+   filtering on that uses the `idx_messages_file` index that has existed
+   since 001.
+2. **`get_uuid_owners` already had an index it wasn't using.**
+   `idx_messages_uuid(_uuid)` has been there since 001, but the query
+   filters `project_id = ? AND _uuid IN (...)`, and SQLite uses one index
+   per table reference — so it took the `project_id` one and scanned.
+3. **⚠️ The session index made three queries *slower* before it made
+   them faster.** `(project_id, session_id, file_id)` lets the planner
+   satisfy a bare `session_id IS NOT NULL` as a range scan over every
+   session-bearing row, and it *prefers* that to seeking the handful of
+   uuids the query asked for. `get_uuid_owners` went from 37 ms to
+   **45 ms** on first measurement. Moving that predicate out of SQL and
+   into Python — a one-line `if row["session_id"] is not None` — took it
+   to 1.4 ms. Adding an index is not automatically safe for queries that
+   don't want it.
+
+Cost: cache DB **+8.4%** (39.5 → 42.8 MB on a 49 MB archive) and no write
+regression — a cold conversion went 5.85 s → 5.79 s, five more indexes on
+an INSERT being small next to compressing the row's content blob.
+
+**Steady-state tick: 0.257 s → 0.145 s.** Cumulatively **1.03 s →
+0.145 s, a 7x tick**, and the render — where this investigation started —
+is now a rounding error against it.
 
 **The zlib knob — taken, at level 3, and I had the cost wrong.** Level 3
 cuts the *full* row rewrite from 183 ms to 81 ms; `decompress` is
@@ -1100,8 +1142,11 @@ So the DB does not grow either way; today's cost is write amplification
    | **tick** | **0.717 s** | **0.257 s** |
 
    C21 held exactly as written: B *does* break A's seeding, and the fix
-   was the cross-tick store it predicted. Cumulatively **1.03 s →
-   0.26 s**, a 4x tick.
+   was the cross-tick store it predicted.
+
+3. ✅ **The refresh's own queries** (migration 012 + one query rewrite),
+   taking the tick to **0.145 s** — cumulatively **1.03 s → 0.145 s, a
+   7x tick**. See "What was left in the tick" above.
 3. **Option 1** for the browser, which is where the user-visible cost
    actually is, and which no longer depends on `render-format-once.md`.
    Land the tail-append case first; take C2 (C20) when the fallback

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -871,7 +871,9 @@ items were the refresh's own cache queries, and they turned out to be
 much cheaper to fix than "restructure the refresh". Every one of them was
 scanning the entire project, which `EXPLAIN QUERY PLAN` says plainly:
 
-    SEARCH m USING INDEX idx_messages_project_timestamp (project_id=?)
+```text
+SEARCH m USING INDEX idx_messages_project_timestamp (project_id=?)
+```
 
 Measured per call on a 38,706-row archive:
 
@@ -1200,6 +1202,11 @@ in-memory transcript at ~3x its bytes on disk, so a 39.7 MB session is
 ~100 MB resident while the tick runs, bounded by the sessions in play
 rather than by the archive. That is the argument for a valve like the
 fragment store's, and for evicting on session change.
+
+B — *as costed here, before it was built.* What shipped holds the
+prefix in memory instead, so none of the storage below applies to the
+code today; it stands as the costing of the persisted variant, which
+"Fix B as built" explains was not needed. Read on with that caveat.
 
 B adds two small columns to `cached_files` (`prefix_len`,
 `prefix_hash`) — tens of bytes per file row, ~8 KB across a 217-file
@@ -1572,3 +1579,56 @@ mechanical rather than design-level — the shapes above held.
    adopting the baseline. Reproduced with a Playwright route that serves
    the pre-append body and lets the watch reconvert before the browser
    sees it: without the fix the marker never arrives.
+
+## C30. A second round: Windows CI, and the review comments C29 didn't cover
+
+**Two Windows CI failures, both real, neither a Windows-only test bug.**
+
+- `atomic_write_text` is not atomic on Windows while a reader holds the
+  target open: Python's `open` doesn't grant `FILE_SHARE_DELETE`, so
+  `os.replace` fails with `PermissionError` (WinError 5) rather than the
+  write tearing. That is the *good* failure mode, but it fails the
+  conversion, and watch mode's whole premise is a page being re-read
+  while it is rewritten. The replace is now retried for ~180 ms, which
+  outlasts a read of even a 27 MB page. The concurrent-reader test can't
+  run there — its reader loop holds the file essentially continuously, so
+  it tests the writer's patience rather than the reader's safety — and is
+  skipped on win32 with the retry covered by its own test instead.
+- `test_the_cwd_project_is_the_default` hand-rolled the project-dir
+  encoding as `str(path).replace("/", "-")`. On Windows that leaves
+  `D:\...` untouched, so joining it produced an absolute path and the
+  test tried to re-create its own `tmp_path`. It now calls
+  `real_path_to_project_dirname`, which is what the resolver uses and
+  handles both separators.
+
+**Review comments, verified against the code.** Three were still live:
+
+- *The append's count and insert aren't atomic.* Correct, and the reason
+  is subtle: Python's sqlite3 begins a transaction on the first write,
+  not on a `SELECT`, so the row-count guard held no lock at all. Two
+  writers sharing a cache — a second `watch`, or a TUI beside one — could
+  both pass the count and both append. Now `BEGIN IMMEDIATE` before the
+  count, with the rollback scoped so it never unwinds a `batch()`
+  caller's transaction. Pinned by asserting a second connection *cannot*
+  write while the checked append runs.
+- *The cache stamp is taken after the parse.* Correct, and it was true of
+  `save_cached_entries` all along, not just the new append path — so both
+  now take the stamp `load_transcript` captured before parsing, beside
+  the sidecar fingerprint that already worked that way. A file appended
+  to mid-read used to be stamped at the size it reached while holding
+  only the rows we parsed; if the session then ended, that truncated view
+  stayed "fresh" forever.
+- *Held prefixes escape the byte budget.* Already fixed in C29.
+
+Two were declined:
+
+- *Bound the timestamp drain even when `didTimeout` is true.* That drain
+  is the fix for the reported symptom (C23): the callback count, not the
+  work, was the cost, and draining on the deadline took 766 ms → 13 ms
+  and 3.3 s → 35 ms. The unbounded slice is bounded in practice by the
+  page's own timestamp count — ~8 ms per 1,180 — and only runs when the
+  browser was too busy to offer idle time for 200 ms. Re-slicing there
+  reintroduces the storm to save tens of milliseconds.
+- *Drop the quotes around `'SFMono-Regular'`.* Valid CSS either way, and
+  six of the seven declarations across the templates are quoted; changing
+  one desynchronises them and rewrites ten snapshots for nothing.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -1511,3 +1511,64 @@ render) for a benefit that is invisible below ~10 MB pages. Nothing here
 needs doing. The next thing that would justify reopening the browser side
 is a *user-visible* complaint on a very large live page, not a number in
 this document.
+
+---
+
+## C29. What a review round turned up, after all of the above landed
+
+Five findings against the branch; four were real, and all four are
+mechanical rather than design-level — the shapes above held.
+
+1. **An unterminated final line was parsed twice** (`converter.py`).
+   `_ByteParse.commit` cut the held *bytes* at the last `\n` but handed
+   the store the whole entry list. C12 reasoned about the torn line that
+   *fails* to parse, where holding it is harmless; a final line whose
+   newline simply hasn't landed can be a whole valid record, and that
+   entry was held while its bytes were not — so the next tick re-read the
+   line and appended the entry again. Reproduced as
+   `['1','2','3'] → ['1','2','3','3','4']`, and it reached the cache: the
+   gates in `_appended_rows` both still agreed. Two of this repo's own
+   145 fixtures end without a trailing newline, so it is not only a
+   mid-append shape. The cut is now on entries as well as bytes; the row
+   count check in `extend_cached_entries` catches the tick after and
+   takes the full rewrite, which is the one thing that would have made
+   this visible in the DB.
+
+2. **Ctrl+C during a conversion didn't stop `watch`** (`watch.py`). The
+   `except BaseException` that keeps one bad conversion from ending the
+   loop also swallowed `KeyboardInterrupt`. `watch` runs `run()` on the
+   main thread, so an interrupt lands inside `convert()` — most of a tick
+   on an active project — and was reported as `conversion failed:
+   KeyboardInterrupt()` while the loop carried on. Now re-raised.
+
+3. **Held prefixes were never evicted** (`entry_store.py`). `put_prefix`
+   never charged `self._bytes` and nothing trimmed `_prefixes`, so in a
+   store owned for the life of a `watch` every trunk file touched pinned
+   a deep copy of its parsed entries forever — invisible to the per-file
+   valve, which only ever sees one file. Charged and evicted like `put`
+   now, whole-file entries first (the cache can rebuild those; a prefix
+   is the only thing standing between the next tick and a whole-history
+   re-parse).
+
+4. **The timeline rebuilt once per changed element** (`timeline.html`).
+   The rehydrate contract passes a subtree and the patch path calls it
+   per changed element, which is what the other two hooks want.
+   `rebuildTimeline` ignores its root and scans the whole document, so an
+   open timeline paid N whole-page rebuilds per poll — measured at 2 per
+   update on the test fixture (1 edit + 1 addition), and it scales with
+   the changed set, up to the patch path's cap of 40. Coalesced to one
+   rebuild per update.
+
+5. **The first poll adopted the server's current stamp**
+   (`live_update.js`). `if (lastStamp === null) lastStamp = stamp` runs
+   after the document has loaded — tens of MB, which is the whole reason
+   this feature exists — so a conversion completing in that window became
+   the baseline and was never applied, leaving the page one update behind
+   until something *else* changed. For a session that has just gone
+   quiet, that is forever. The navigation timing entry knows how many
+   bytes we were actually served, and responses are not content-encoded,
+   so the first poll compares that against `Content-Length` and fetches
+   on a disagreement; anything that makes it unavailable falls back to
+   adopting the baseline. Reproduced with a Playwright route that serves
+   the pre-append body and lets the watch reconvert before the browser
+   sees it: without the fix the marker never arrives.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -858,12 +858,29 @@ queries around the refresh — `get_session_file_map` ×3 (50 ms),
 to SHA it, now redundant with the prefix hash), `get_uuid_owners` ×4
 (37 ms). Those are the next 130 ms if anyone wants it.
 
-**One knob not taken.** `zlib` level 1 would cut the *full* rewrite from
-183 ms to 74 ms for 29% larger blobs (level 3: 81 ms, +18%) — measured,
-one line, backward compatible, since `decompress` doesn't care. It would
-help every path rather than just resumable ones, but it trades on-disk
-size for everyone to fix a watch-local problem, so it is a decision to
-take deliberately rather than fold into this.
+**The zlib knob — taken, at level 3, and I had the cost wrong.** Level 3
+cuts the *full* row rewrite from 183 ms to 81 ms; `decompress` is
+level-agnostic, so it is backward compatible and one line.
+
+I first priced the size at **+18%**, from that same atypical 40 MB
+session (207 entries, ~190 KB each). That number does not survive
+contact with an archive: zlib's levels only diverge on large payloads,
+and real transcripts are mostly small entries. Measured across a 49 MB
+archive's **18,288 rows**, blobs grow 26.37 MB → 27.05 MB — **2.6%**,
+with the DB file up 2.1%:
+
+| | level 6 | level 3 |
+|---|---|---|
+| cold conversion | 6.15 s | **5.49 s** |
+| cache DB | 38.3 MB | 39.1 MB |
+| tick (full rewrite path) | 0.377 s | **0.329 s** |
+| tick (resumed) | 0.352 s | **0.269 s** |
+
+So it is not the watch-local trade I described — it makes cold
+conversions 11% faster for 2% more disk, everywhere. One transition
+artifact: re-serialising an entry changes its blob and therefore its row
+fingerprint, so the first incremental refresh over a level-6 cache
+declines to a full refresh once.
 
 ### Fix C — the cheap ones — ✅ LANDED (the two that need no migration)
 

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -1632,3 +1632,64 @@ Two were declined:
 - *Drop the quotes around `'SFMono-Regular'`.* Valid CSS either way, and
   six of the seven declarations across the templates are quoted; changing
   one desynchronises them and rewrites ten snapshots for nothing.
+
+## C31. A third round: the stamp's remaining blind spot, and a search flake
+
+**The poll stamp could still miss an update.** C29/5 and the original
+`Content-Length` fix left one gap open: size is blind to a rewrite that
+*keeps* the size — a counter, a status word or a timestamp changing
+width-for-width — and inside one `Last-Modified` second such a rewrite
+moves neither header. Watch converts a few hundred ms apart, so the
+window is reachable rather than theoretical.
+
+The server now sends `X-Content-Revision`, a blake2b digest of the bytes
+it is about to serve, and the poll compares it alongside the other two.
+Three notes on the shape:
+
+- **Not an `ETag`.** `SimpleHTTPRequestHandler.send_head` skips its
+  `If-Modified-Since` check whenever the request carries an
+  `If-None-Match`, and it never evaluates one — so advertising an ETag
+  would make browsers stop getting 304s on exactly the multi-MB pages
+  that make 304s worth having. A custom header has no such side effect;
+  `ETag` stays in the JS comparison for any other server that sets one.
+- **Hashing is cached per `(path, mtime_ns, size)`, but only once the
+  mtime is a second old.** A later write can only land on a cached key if
+  the filesystem's timestamp resolution is coarse enough to give it the
+  same mtime — so a settled entry is safe whatever that resolution is,
+  and a file being written *right now* is re-read every poll. That is the
+  case the header exists for, and it costs one 27 MB read per second at
+  the very worst (~25 ms), only while a session is actively appending.
+- **The test doesn't gamble on timing.** Both regression tests set the
+  two mtimes explicitly, half a second apart inside one whole second, so
+  the rewrite *is* the same-second case rather than usually being it;
+  dating them in the past also means the first digest is genuinely
+  cached, so the second response is pinned against reusing it. The
+  browser test rewrites the rendered page directly (not through a
+  conversion) because the point is a specific pair of bytes on the wire,
+  and it fails — times out waiting for the new marker — with the header
+  removed from the JS comparison.
+
+**A Windows CI flake in the search suite, and why it isn't a search bug.**
+`test_search_unfolds_matches_in_folded_subtrees` failed on
+windows-latest/3.13 while 3.11 passed in the same matrix. The element it
+waited on carried *no* `search-*` class at all — not `search-match`, not
+`search-hidden` — which rules out "the search ran and got it wrong":
+`applyTranscriptSearchFilter` toggles all three on every indexed card, so
+an applied filter always leaves a mark. The search simply had not run
+inside the assertion's five seconds. Playwright's own log says why: it
+resolved the locator **three times in 5,000 ms**, ~1.6 s per poll, on a
+4-core runner hosting four Chromiums under `-n auto`. The page was
+starved, not wrong.
+
+Two test-side fixes, no product change:
+
+- `_search_for` now waits for the component's own "I have run" signal
+  (`#searchResultCount` leaves its idle "No results" for either
+  "N of M matches" or "No matches") instead of returning while the 300 ms
+  input debounce is still pending. Every later assertion in the test then
+  starts from a searched page rather than spending its own budget on the
+  debounce.
+- Web-first assertions get a 20 s ceiling for browser tests
+  (`_browser_expect_timeout` in `test/conftest.py`). Playwright's 5 s
+  default is a budget for the page, not for a machine running four
+  browsers at once, and raising it costs nothing on a passing run.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -1,8 +1,12 @@
 # Real-time watch mode — Design
 
-Status: **designed, not implemented.** Decisions below are settled; the
-measurements that forced them are recorded so a later reader can tell
-which choices were reasoned and which were measured.
+Status: **Stage 0 and Stage 1 landed** on `feat/watch-mode`;
+`claude-code-log watch` works for the Markdown-on-disk case. Stage 2
+(the served page updating itself) is designed but not built.
+
+Decisions below are settled; the measurements that forced them are
+recorded so a later reader can tell which choices were reasoned and which
+were measured — and which turned out to be wrong.
 
 ## Motivation
 
@@ -26,16 +30,16 @@ structural finding.
 
 | # | decision |
 |---|---|
-| D1 | A `watch` subcommand owns the loop; `serve --watch` runs the same engine on a thread. |
+| D1 | A `watch` subcommand owns the loop; `serve --watch` runs the same engine on a thread. **Subcommand landed; `serve --watch` is Stage 2.** |
 | D2 | Add `source_size` to `cached_files` so the cache itself detects fast appends; the watcher then trusts `get_modified_files` rather than keeping parallel state. Detection is stat-polling. **Landed.** |
-| D3 | Default scope is one project; `--all-projects` is opt-in. |
-| D4 | Quiet-period debounce (~300 ms) with a max-latency cap (~2 s), both flags. |
+| D3 | Default scope is one project; `--all-projects` is opt-in. **Landed.** |
+| D4 | Quiet-period debounce (~300 ms) with a max-latency cap (~2 s), both flags. **Landed.** |
 | D5 | Container swap (option B) with uuid-set diffing, not full reload and not fragment patching. |
 | D6 | Polling. SSE only if measurement later justifies it. |
 | D7 | Route every output write through temp-file + `os.replace`. **Landed.** |
 | D8 | Measured: the write + FTS update is fast enough. No lock-avoidance machinery needed. |
 | D9 | ~~Fix `--output` destination-aware freshness~~ — already fixed; the doc that reported it was stale. **No work needed.** |
-| D10 | Injectable clock and file-event source; unit tests drive ticks by hand. |
+| D10 | Injectable clock; unit tests drive `tick()` by hand. **Landed** — the sleep injection turned out unnecessary once `run` used `Event.wait`. |
 | D11 | The `stream-json` piping request (#43 follow-up) is **subsumed** by watch mode. No stream-json parser. |
 
 ---
@@ -506,20 +510,35 @@ independently shippable.
   which is the first thing that needs it — landing it now would carry a
   large snapshot delta through two unrelated stages.
 
-**Stage 1 — the engine + use case 1.** `claude-code-log watch [path]`:
-stat-poll, debounce, call the existing conversion, one line per
-regeneration. Serves the Markdown/Obsidian case completely.
+**Stage 1 — the engine + use case 1. ✅ Landed.**
 
-*Questions to answer first:*
-1. **Can Phase 1b be made reachable when the cache was updated, restricted
-   to the touched sessions (C6)?** Without this, Stage 1 full-loads the
-   project every tick. This is the stage's real work.
-2. Tick cost on the 803 MB reference archive, not the 64 MB one — C6's
-   numbers are the optimistic end.
-3. Does a resident watcher's warm render memo beat the cold-memo figure?
-   (In-process steady ticks were 0.46–0.82 s; the memo's contribution is
-   unmeasured.)
-4. Single-instance guard: needed, or overkill (D8)?
+- `claude_code_log/watch.py` — `WatchEngine`: stat-poll, debounce, deliver
+  changed paths to a callback. No CLI or HTTP awareness. The scan is a
+  cheap *trigger*, not a source of truth; the conversion already knows
+  precisely what is stale, and since 011 the cache is the thing that gets
+  freshness right. Two classes of file must never be seen as a change —
+  dot-prefixed atomic-write temps and generated output, both of which
+  land in the watched tree — or the loop feeds itself forever. Pinned by
+  tests.
+- `claude-code-log watch [path]` — scoped to one project by default,
+  resolving the current directory's project; `--combined` defaults to
+  `no`, which is what keeps a tick on the session-scoped path.
+- Phase 1b reachability (`1ffc41b`) — the stage's real work; see C6.
+
+End-to-end against a live-fed session: an appended message is visible in
+the `.md` **0.26–0.36 s** later, dominated by the 0.3 s quiet period,
+with the conversion itself at 0.01–0.02 s.
+
+*A note on how the measurements went wrong first, since it cost real
+time:* the render pool **spawns**, so a worker re-imports the probe
+module. Two probe scripts did their fixture setup (`rmtree` + `copytree`
++ truncate) at module scope, so every worker re-ran it against the tree
+the parent was writing into. That produced a `FileNotFoundError` on an
+atomic-write temp and an `OSError: Directory not empty` that both looked
+exactly like a regression in the atomic-write change, and a
+`message_count` that appeared not to advance. All three were the missing
+`if __name__ == "__main__":` guard. Any probe that drives a conversion
+needs one.
 
 **Stage 2 — use case 2 under `serve`.** `serve --watch` runs the Stage 1
 engine on a thread; the session page polls its own URL, swaps

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -3,8 +3,13 @@
 Status: **Stages 0–2 landed** on `feat/watch-mode`.
 `claude-code-log watch` keeps Markdown (or HTML) on disk current, and
 `claude-code-log serve --watch` makes an open session page grow as the
-session does. Stages 3 (the `file://` sidecar) and 4 (SSE / fragment
-patching) remain speculative and are probably not worth building.
+session does. Stage 3 (the `file://` sidecar) remains speculative and is
+probably not worth building. Stage 4 was too — until the tick was
+profiled: see "Where a tick's time goes" and "Appending the HTML rather
+than replacing it" at the end. **Fixes A and C have landed** (tick
+1.03 s → 0.717 s on the 803 MB archive); Fix B, worth roughly another
+400 ms, has not. The HTML half found that patching does *not* need the
+per-message render seam C11 says is missing.
 
 Decisions below are settled; the measurements that forced them are
 recorded so a later reader can tell which choices were reasoned and which
@@ -640,4 +645,339 @@ so build it only if the no-server case proves to matter.
 Stage 2 has been lived with, and only if the poll interval or swap cost
 demonstrably hurts. Fragment patching additionally needs the *architecture*
 half of `render-format-once.md` step 3 — a real format phase and a
-per-message render seam — which has not landed (C11).
+per-message render seam — which has not landed (C11). **See C19 below:
+a patch protocol does not actually need that seam, because the delta can
+be taken between two whole renders rather than produced by rendering one
+message in isolation.**
+
+---
+
+## Where a tick's time goes — Stage 1's open question, measured
+
+Stage 1 ended with "the bottleneck has moved: `_incremental_cache_refresh`
+is 0.75 s of a 1.12 s tick; that is the next thing to attack". This
+section answers *why* it costs that, and what appending rather than
+replacing would and would not buy.
+
+Measured on the same real archive as Stage 1 —
+`downloads/projects/-Users-dain-workspace-claude-code-log`, **217 trunk
+files, 319 MB**, appending held-back real lines to the largest session
+file (**39.7 MB, 214 lines, 207 entries**), 8 cores, warm cache. The
+corroborating small-archive runs use the live `~/.claude/projects` copy
+(33 trunk files, 46 MB). Reproduced across three independent probes;
+ticks are steady to ±0.1 s.
+
+### C14. One appended line materialises the same 207 entries three times
+
+Per-call trace of a steady tick (1.10–1.24 s):
+
+| # | call site | what it does | cost |
+|---|---|---|---|
+| 1 | `_incremental_cache_refresh` → `load_transcript` | re-reads and re-parses the whole 39.7 MB file, then `save_cached_entries` **deletes every row for the file and re-inserts all 207** (re-`json.dumps` + `zlib.compress` each) | **488 ms** (307 ms of it the rewrite) |
+| 2 | `_load_sessions_partial` → `load_cached_entries` | rebuilds the same entries from the rows just written (`zlib.decompress` + `json.loads` + pydantic) | **129 ms** |
+| 3 | `_load_stale_session_transcripts` → `load_cached_entries` | rebuilds them a third time, for the render | **141 ms** |
+
+That is ~760 ms of a 1.1 s tick spent producing three copies of one
+list, and every one of the three costs is proportional to the *file*,
+not to the append. Phase totals for the rest of the tick:
+`get_stale_sessions` 85 ms, `get_session_file_map` ×3 53 ms,
+`get_file_states` ×2 47 ms, `get_uuid_owners` ×4 35 ms,
+`get_parent_uuid_dependents` / `get_request_id_entries` /
+`get_metadata_target_files` ~45 ms combined.
+
+Floors on the same file, for scale: `json.loads` over all 208 lines is
+**154 ms**, `blake2b` over the whole 39.7 MB is **33 ms**, and a
+`seek` + read of the last 200 KB is **0.13 ms**.
+
+### C15. `get_library_version()` runs 173 times a tick
+
+`is_transcript_stale` → `is_html_outdated` → `get_library_version()`, once
+per session, and each call re-parses installed package metadata through
+`importlib.metadata`: **35 ms a tick**, and it scales with the number of
+sessions in the project rather than with anything that changed. Memoising
+it took `get_stale_sessions` from 85 ms to 44 ms. The version cannot
+change inside a process; this is a one-line `lru_cache`.
+
+### Fix A — a parsed-entry store, measured — ✅ LANDED
+
+The same shape as the existing `fragment_store`, one layer down: hold the
+entries a conversion has already materialised, keyed on
+`(path, size, mtime_ns)`, populated by `save_cached_entries` and read by
+`load_cached_entries`. Prototyped by monkeypatch:
+
+| | |
+|---|---|
+| tick, baseline | **1.079 s** (mean of 3) |
+| tick, with the store | **0.750 s** (mean of 3) — **30% faster** |
+| store traffic per tick | 2 hits, 1 miss — exactly ①→②③ above |
+
+Equivalence: two copies of the 46 MB archive advanced through the same 8
+appends, store on and off. **27 of 28 pages byte-identical every tick.**
+The 28th is this session's own live transcript, whose *source* differed
+by one line between the two `copytree`s (205 vs 206) — a fixture
+artifact, not a divergence.
+
+**As built** (`claude_code_log/entry_store.py`, dev-docs § 2.16): the
+landed version reproduces the prototype — **0.997s → 0.702s (30%)**,
+2 hits / 0 misses per tick — and the phase table confirms where it went:
+the closure load fell from 255 ms to **7.1 ms**.
+
+Two things the prototype got away with and the real one must not:
+
+1. **The pipeline mutates entries in place.** `_integrate_agent_entries`
+   appends `#agent-{id}` to `sessionId` and is *not* idempotent, and
+   dedup re-parents around dropped copies. Today each consumer gets
+   freshly deserialised objects; handing both the same list renders
+   `…#agent-X#agent-X`. The prototype's fixture happened not to have
+   sidechain agents in the modified session, so its byte-identity result
+   was luck. `get` therefore returns a `deepcopy` — **2.0 ms and 0.83 MB**
+   for the 207-entry, 39.7 MB session, because the bulk of an entry is
+   immutable strings that `deepcopy` shares rather than copies. Pinned by
+   a test that fails with exactly the doubled suffix when the copy is
+   removed (verified by sabotage, not by assumption).
+2. **Scope, so it cannot cost RAM anywhere else.** Threaded as a
+   parameter like the fragment store, never a global and never on
+   `CacheManager` (the TUI holds one across conversions); filled only by
+   `_incremental_cache_refresh`, with the files it parsed; dropped after
+   Phase 1b. A cold conversion stores nothing, and the streaming path is
+   deliberately never handed one — its bounded residency depends on
+   dropping each page's entries, which a store spanning pages would
+   undo. Plus a per-file valve (decline under 6× available memory) and
+   `CLAUDE_CODE_LOG_ENTRY_STORE=0`.
+
+### Fix B — parse and write only the tail
+
+What remains after A is call ① — a full parse and a full row rewrite for
+one appended line. Both are avoidable, and the incremental refresh
+already proves the precondition: it only proceeds after showing the
+cached rows are an exact *prefix* of the current rows. Today that proof
+is a *consequence* of the full parse (`get_file_states` fingerprints
+every row, fetching each row's compressed blob just to SHA it). Store
+instead, per file, the byte length the cached rows cover plus a hash of
+those bytes; then a tick can
+
+1. hash the file's first `prefix_len` bytes (33 ms on 39.7 MB — and a
+   strictly *stronger* proof than the row-fingerprint prefix, since
+   identical bytes imply identical rows),
+2. parse only what follows (~1 ms for one line),
+3. `INSERT` only the new rows instead of `DELETE` + re-insert all
+   (`messages.id` order is already the ordering the readers rely on, and
+   appends preserve it).
+
+Estimated ~450 ms off the remaining tick, i.e. **~1.1 s → ~0.3 s** with
+A and B together. Not prototyped — unlike A it needs a migration and a
+new decline path (hash mismatch → today's full parse).
+
+### Fix C — the cheap ones — ✅ LANDED (the two that need no migration)
+
+`lru_cache` on `get_library_version` (C15, 35 ms) and reading the
+`sessions` / `html_cache` tables once each in `get_stale_sessions`
+instead of two queries per session through `is_transcript_stale`.
+Together: **85 ms → 4.5 ms**, better than the 44 ms the version memo
+alone predicted, because the per-session round-trips were most of the
+rest. The per-session logic is inlined faithfully — same check order,
+same reason strings; `is_transcript_stale` stays as it was for its other
+callers.
+
+Still open, because it needs a migration and belongs with Fix B: give
+`get_file_states` a stored fingerprint column so it stops fetching every
+row's compressed blob just to SHA it (47 ms).
+
+---
+
+## Appending the HTML rather than replacing it
+
+### C16. The file is the wrong thing to append
+
+Writing the whole page costs **5–6 ms for 3.9 MB** — about 1% of a tick.
+Appending in place would save that 1% and would give back the torn-read
+class D7/C8 just closed: `os.replace` is what makes a reader (Obsidian, a
+browser mid-fetch) safe, and `r+b` + seek + write + truncate is not
+atomic. **Recommendation: keep rewriting the file.** The cost worth
+attacking is the *browser's*, not the disk's — Stage 2 measured 202 ms of
+main-thread work per update on a 7 MB page (fetch 31 / `DOMParser` 63 /
+swap 17 / forced layout 91), and that number scales with the page while
+the change that caused it does not.
+
+### C17. The page's shape is delta-friendly
+
+Session pages split cleanly: **~140 KB of head** (styles, nav, toolbar)
+before `<div id="transcript">`, **~98% body**, then a **9,157-byte tail**
+— identical to the byte across the three largest pages sampled. Across 14
+page updates the head and the tail were **byte-identical every time**.
+
+### C18. But the body is *not* byte-append-only, for two nameable reasons
+
+Over 14 updates: **0 were exact byte appends.** Six preserved ≥99.9% of
+the old body, diverging only within the last ~1 KB; the other eight
+diverged at **byte 598**. The causes, read off the diffs:
+
+1. **Ancestor descendant counts.** `data-title-unfolded='Fold (all
+   levels) all 227 descendants'` → `…228 descendants` on the root's fold
+   bar. Any message added anywhere updates every ancestor's count, and
+   the root's is 598 bytes into the container.
+2. **Retroactive classes on existing cards.** `class='message thinking'`
+   → `class='message thinking pair_first'` when the other half of a pair
+   arrives — an already-rendered card legitimately changing.
+
+Both are small and both are client-derivable, which matters for the
+option below.
+
+### C19. What actually changes between two renders is ~0.1–0.3% of the body
+
+A line-level diff of the same updates, i.e. what a patch would have to
+ship rather than what a byte-prefix comparison can prove:
+
+| tick | body | change blocks | shipped | share of body | shape |
+|---|---|---|---|---|---|
+| 0 | 19,315 → 19,591 lines | 2 | +11.6 KB / −0.1 KB | 0.32% | tail-only |
+| 6 | 19,591 → 19,615 | 9 | +2.1 KB / −1.3 KB | 0.09% | tail + earlier edits |
+| 7 | 19,615 → 19,683 | 3 | +5.4 KB / −0.1 KB | 0.15% | tail-only |
+| 9 | 19,683 → 19,706 | 9 | +2.3 KB / −1.3 KB | 0.10% | tail + earlier edits |
+
+Even the "diverged at byte 598" ticks change **7 lines / 1.3 KB** away
+from the tail. A 3.6 MB body is re-shipped to move 2–12 KB.
+
+**The C11 blocker does not apply.** C11 says there is no seam that renders
+*one message in isolation* — true, and it stays true. A patch protocol
+does not need one: the server renders the whole page exactly as it does
+today, diffs that output against the previous render of the same page,
+and ships the difference. Renumbered `msg-d-N` ids (C10) and
+out-of-order arrivals (C3) stop being correctness hazards and become
+merely a *bigger diff*, with today's full container swap as the automatic
+fallback when the diff exceeds some fraction of the body.
+
+### Two ways to get there
+
+**Option 1 — structural delta (no markup change).** Diff by card, keyed
+on the `uuid → session-id → positional-id` + ordinal key `live_update.js`
+already computes for fold state, and ship
+`{replace: {key: html, …}, append: [html, …]}`. Handles C18's retro-edits
+and C3's out-of-order arrivals natively. Needs a place to put the patch:
+either a small `/api/` endpoint (the server would then need the previous
+render, which it has — it is the file on disk) or a sidecar file the
+poller `GET`s.
+
+**Option 2 — make the body append-stable, then range-fetch it.** Remove
+C18's two mutations from the server-rendered markup: compute descendant
+counts in JS at rehydrate (the subtree is right there), and apply
+`pair_first` client-side. The body then becomes byte-append-only for the
+common case, a `Range: bytes=N-` on the page itself is the whole
+protocol, and `SimpleHTTPRequestHandler` already serves ranges. Cheaper
+protocol, but it moves rendering responsibility into JS and weakens the
+`file://` page, so Option 1 is the safer first move.
+
+Either way the client work goes from "202 ms and growing with the page"
+to "a few ms, constant" and, unlike today, `claudeLogRehydrate` runs over
+the new cards rather than the whole tree.
+
+### C20. C2 from `identifier-consolidation.md` is the patch protocol's missing half
+
+That draft deferred C2 — the content-derived card id `m-{uuid}-{k}` —
+explicitly "pending a consumer", since "the stable-anchor benefit has no
+runtime consumer today". **A patch protocol is that consumer**, and it
+needs C2 for two things beyond tidiness:
+
+- **Addressing.** A patch says `replace m-<uuid>-0`, and the client does
+  one `getElementById`. Without it the client must rebuild the
+  `uuid → ordinal` map over the *whole* tree to locate anything —
+  `live_update.js` does exactly that today, three full-tree
+  `querySelectorAll` passes per update (capture, restore, mark-new).
+  That is O(page) work inside the update we are trying to make
+  O(delta), and it is a real part of the 202 ms.
+- **Insertions.** Every measured update here landed at the tail. C3 says
+  arrivals are *not* always in timestamp order, and with positional
+  `msg-d-N` one message landing mid-tree renumbers every later card and
+  every `#msg-d-N` anchor aimed at them — the diff goes from ~2 KB to
+  the whole body and the protocol falls back to a full swap. With
+  `m-{uuid}-{k}` an insertion changes nothing about its neighbours, so
+  the out-of-order case stays a small patch instead of a fallback.
+
+So the sequencing is: C2 is not a prerequisite for a *tail-append*
+patch, but it is what makes the patch robust rather than best-effort,
+and it turns C10 from a hazard into a non-issue. Its cost is unchanged
+from that draft (resolver plumbing through ~8 formatters / 4 modules,
+9 coupled test files, full `.ambr` regeneration, and the vacuous-guard
+trap).
+
+It does **not** help the cache. `msg-d-N` and `data-uuid` are
+render-only and never enter it; cache identity is the transcript uuid /
+`sessionId` / `parentUuid` / `requestId` family, plus the DAG *line* ids
+(`{trunk}@{uuid12}`, `{trunk}#agent-{id}`) that
+`_incremental_cache_refresh` keeps normalising back to a trunk id with
+its local `_trunk()`. Consolidating *that* family would simplify the
+refresh, but it is a different consolidation from C2 and a clarity win,
+not a speed one — the refresh's time is in parsing and serialising, not
+in identifier handling.
+
+### C21. B breaks A's seeding unless the store is cross-tick
+
+A and B attack disjoint costs — B kills call ① (488 ms), A kills ② and
+③ (270 ms) — so neither subsumes the other. But they interact, in a
+direction that is easy to get wrong:
+
+**A works today only because ① parses the whole file** and hands the
+list to `save_cached_entries`, which is what populates the store; ② and
+③ then hit it (measured: 2 hits, 1 miss per tick). Under B, ① parses
+only the appended tail, so there is no full list to seed with, and ②
+and ③ fall back to a full `load_cached_entries` each. **Implemented
+naively, B gives back most of what A won.**
+
+The fix makes them reinforce instead: keep the store **across ticks**,
+holding `(prefix_len, entries)` per file, and on a proven append
+*extend* the stored list with the tail entries B just parsed. A
+resident `watch` process then builds the full entry list once and never
+again — ① is a ~1 ms tail parse, ② and ③ are hits.
+
+Note this revises Stage 1's Q3 ("a resident watcher's warm memo helps
+barely — the ~0.5 s gap is interpreter startup"). That was measured on
+the *render* memo, which was never where the time went. An entry store
+is the thing that makes residency pay; a one-shot `convert` still
+rebuilds the list once per run, where A alone still earns its 30%.
+
+### C22. Neither fix grows the cache DB — B shrinks what it writes
+
+A is purely in-process: already-parsed `TranscriptEntry` objects held
+for the duration of a conversion. No schema, no rows, no bytes on disk.
+What it costs is **memory** — CONTRIBUTING already puts a project's
+in-memory transcript at ~3x its bytes on disk, so a 39.7 MB session is
+~100 MB resident while the tick runs, bounded by the sessions in play
+rather than by the archive. That is the argument for a valve like the
+fragment store's, and for evicting on session change.
+
+B adds two small columns to `cached_files` (`prefix_len`,
+`prefix_hash`) — tens of bytes per file row, ~8 KB across a 217-file
+project. Against that, it removes a large amount of *write* traffic.
+Measured on the 46 MB archive, appending one line to a 626-row file:
+
+| | |
+|---|---|
+| blobs rewritten per tick, today | **4.08 MB** (all 626 rows deleted and re-inserted) |
+| same, under B | ~7 KB (one row) |
+| cache DB file growth over 6 ticks | **0 KB** — SQLite reuses the freed pages, WAL checkpoints back |
+
+So the DB does not grow either way; today's cost is write amplification
+(~600x), not size.
+
+### Suggested order
+
+1. ✅ **Fix C and Fix A landed.** Tick **1.03 s → 0.717 s** on the 803 MB
+   archive. The phase table afterwards:
+
+   | phase | before | after |
+   |---|---|---|
+   | `load_transcript` (modified file) | 483 ms | 483 ms — *Fix B's target* |
+   | ↳ `save_cached_entries` | 310 ms | 310 ms |
+   | `_load_sessions_partial` (closure) | 255 ms | **7.1 ms** |
+   | `get_stale_sessions` | 85 ms | **4.5 ms** |
+   | `get_library_version` (×173) | 35 ms | **0.0 ms** |
+   | **tick** | **1.03 s** | **0.717 s** |
+
+2. **Fix B** if 0.72 s is still too slow — it is now two thirds of the
+   tick, all of it in re-parsing and rewriting a file that gained one
+   line. It is the one with a migration, and it must be designed
+   *against* A's store (C21), not dropped in beside it.
+3. **Option 1** for the browser, which is where the user-visible cost
+   actually is, and which no longer depends on `render-format-once.md`.
+   Land the tail-append case first; take C2 (C20) when the fallback
+   rate on out-of-order arrivals proves it is worth the migration.

--- a/work/watch-mode.md
+++ b/work/watch-mode.md
@@ -27,14 +27,14 @@ structural finding.
 | # | decision |
 |---|---|
 | D1 | A `watch` subcommand owns the loop; `serve --watch` runs the same engine on a thread. |
-| D2 | Add `source_size` to `cached_files` so the cache itself detects fast appends; the watcher then trusts `get_modified_files` rather than keeping parallel state. Detection is stat-polling. |
+| D2 | Add `source_size` to `cached_files` so the cache itself detects fast appends; the watcher then trusts `get_modified_files` rather than keeping parallel state. Detection is stat-polling. **Landed.** |
 | D3 | Default scope is one project; `--all-projects` is opt-in. |
 | D4 | Quiet-period debounce (~300 ms) with a max-latency cap (~2 s), both flags. |
 | D5 | Container swap (option B) with uuid-set diffing, not full reload and not fragment patching. |
 | D6 | Polling. SSE only if measurement later justifies it. |
-| D7 | Route every output write through temp-file + `os.replace`. |
+| D7 | Route every output write through temp-file + `os.replace`. **Landed.** |
 | D8 | Measured: the write + FTS update is fast enough. No lock-avoidance machinery needed. |
-| D9 | Fix `--output` destination-aware freshness; it pairs with D7. |
+| D9 | ~~Fix `--output` destination-aware freshness~~ — already fixed; the doc that reported it was stale. **No work needed.** |
 | D10 | Injectable clock and file-event source; unit tests drive ticks by hand. |
 | D11 | The `stream-json` piping request (#43 follow-up) is **subsumed** by watch mode. No stream-json parser. |
 
@@ -131,7 +131,7 @@ skipped, so `cache_was_updated` is genuinely the only blocker. This is a
 converter change, not a watcher change, and it is the prerequisite that
 makes watch mode cheap rather than merely possible.
 
-### C7. ⚠️ The cache's 1-second mtime tolerance silently swallows fast appends
+### C7. ~~⚠️~~ ✅ The cache's 1-second mtime tolerance silently swallows fast appends
 
 `cache.py:349` — `if abs(source_mtime - row["source_mtime"]) >= 1.0`. A
 change landing within 1.0 s of the recorded mtime is **invisible**.
@@ -140,14 +140,22 @@ seen) / 0.29 s (change missed), run after run.
 
 It fails in the worst shape: the *last* message of a turn, landing within
 a second of the previous tick and then followed by silence, is stranded
-until something else touches the file. See D2.
+until something else touches the file.
 
-### C8. Every output write is non-atomic
+**Fixed** by migration 011 (D2). End-to-end re-measurement of the same
+failure mode — append one line, convert immediately, no sleep — went
+from alternating SEEN/MISSED to six appends seen out of six.
+
+### C8. ✅ Every output write is non-atomic
 
 Eight `write_text` sites in `converter.py` plus `render_pool.py:570`; only
 image export uses temp-file + `os.replace` (`image_export.py:79`). Today a
 narrow race; under a watch loop rewriting the same file every few seconds
 while Obsidian re-reads it, routine. The 27 MB-page case is a wide window.
+
+Quantified against a concurrent reader over a 4 MB payload: 40 plain
+rewrites produced **142 torn reads**, including a fully-truncated 0-byte
+read. **Fixed** in `9b20d77` (D7) — the same run produces none.
 
 ### C9. There is no wrapping container around the message tree
 
@@ -362,15 +370,34 @@ Still open: a single-instance advisory guard per projects dir, so two
 watchers (or a watcher plus a manual run) don't fight. Cheap insurance,
 annoying to retrofit — decide during Stage 1.
 
-### D9. `--output` destination-aware freshness
+### D9. `--output` destination-aware freshness — ✅ already fixed, no work needed
 
-`work/obsidian-friendly-output.md` records it: `is_html_stale` /
-`is_page_stale` resolve against the *source* project dir, not `dest_dir`,
-so under `--output` every run re-renders everything. Under a watch loop
-pointed at an Obsidian vault — exactly use case 1 — that means every tick
-re-renders every session and (with C8) rewrites every file, thrashing the
-vault's own indexer. Prerequisite, not a nice-to-have. Pairs naturally
-with D7 since both touch the write path.
+`work/obsidian-friendly-output.md` recorded this as an open follow-up:
+freshness resolving against the *source* project dir, so `--output` runs
+re-render everything every time. **That doc was stale.**
+`is_transcript_stale` and `is_page_stale` both take an `output_dir` and
+resolve against it. Re-measured on a 28-file Markdown projection:
+
+| run | wall | files rewritten |
+|---|---|---|
+| `-o A` (cold) | 4.1 s | all |
+| `-o A` again | **0.0 s** | `index.md` only |
+| `-o B` (fresh dest) | 4.0 s | all |
+| `-o A` again, after B | **0.0 s** | `index.md` only |
+| `-o A` after one appended message | 0.8 s | **2 of 28** — the changed session + `index.md` |
+
+So a watch loop pointed at a vault rewrites the changed session and the
+index, not the whole projection. `obsidian-friendly-output.md` has been
+corrected.
+
+`index.md` is rewritten on every run by the deliberate always-regenerate
+contract (so variant-flag changes refresh its links) — including on a
+true no-op. That is not a problem under watch mode, which only converts
+when it has already seen a change, but it does mean *any* tick touches
+the index and wakes a vault indexer once. Acceptable; with D7 the write
+is an atomic rename rather than a truncation.
+
+**Stage 0 therefore has three items, not four.**
 
 ### D10. Testing
 
@@ -427,15 +454,20 @@ stdout — same engine, no new schema.
 Each stage answers its own open questions before it starts; each is
 independently shippable.
 
-**Stage 0 — prerequisites.** All four are independently justified and all
-move snapshots, so they land before, not during:
+**Stage 0 — prerequisites.**
 
-- D7 atomic writes.
-- D2 `source_size` column (migration 011).
-- D9 destination-aware freshness.
-- C9 `<div id="transcript">` wrapper.
-
-*Question to answer first:* none — these are all self-contained.
+- ✅ **D7 atomic writes** (`9b20d77`). Every output write goes through
+  `utils.atomic_write_text`. Pinned by a concurrent-reader test: 40
+  plain rewrites of a 4 MB payload produced 142 torn reads including a
+  0-byte one; the atomic path produces none.
+- ✅ **D2 `source_size` column** (migration 011). The end-to-end C7
+  failure mode — append, convert immediately, repeat — went from
+  alternating SEEN/MISSED to six-for-six SEEN.
+- ✅ **D9** — nothing to do; see above.
+- ⬜ **C9 `<div id="transcript">` wrapper.** The only remaining item, and
+  the only one that moves snapshots. Deferred to just before Stage 2,
+  which is the first thing that needs it — landing it now would carry a
+  large snapshot delta through two unrelated stages.
 
 **Stage 1 — the engine + use case 1.** `claude-code-log watch [path]`:
 stat-poll, debounce, call the existing conversion, one line per


### PR DESCRIPTION
First pass of the feature is in, using a relatively crude method of replacing the whole inner transcript in the HTML, but I think this is already a version worth testing to see how it feels. ~1s end-to-end on a multi-hundred session project is a pretty decent start!

Here's a little video of it in following mode:

https://github.com/user-attachments/assets/6d58f2df-0b02-461a-81a6-c0932303fb34

UI-wise I'm wondering if the follow toggle should be another round button in the right toolbar instead?

Claude's summary:

> Watch mode is working end to end on feat/watch-mode — 14 commits, just ci green (3098 unit + 68 TUI + 97 browser + snapshots, pyright and ty clean).
> 
> What you can do now:
> 
> claude-code-log watch                      # this project, HTML
> claude-code-log watch -f md -o ~/vault     # Obsidian stays current
> claude-code-log serve --watch              # open page grows as messages arrive
> 
> The served page updates in place — measured ~1s from append to visible, scroll position preserved exactly, folds and open disclosures intact, new messages fading in, with a follow pill. No navigation: a window marker set before an update survives it.
> 
> Three findings that changed the work:
> 
> Phase 1b was unreachable, and the fix was narrower than expected. The veto's real concern was that its staleness test is per-session message counts — a session whose content changed at an unchanged count would be missed. An incremental refresh already rules that out: it only succeeds after proving each modified file's cached rows are an exact prefix of its current rows. So ensure_fresh_cache now reports how it refreshed and Phase 1b refuses only FULL. Tick went 0.78s → 0.31s, byte-identical across 8 ticks in both formats.
> 
> The same bug bit twice, at two layers. Your source_size idea fixed the cache's 1-second mtime tolerance. Then the browser poller silently dropped every third append — Last-Modified also has one-second granularity. Content-Length joins the comparison; that test fails 3/3 without it, passes 3/3 with it.
> 
> D9 was already fixed — obsidian-friendly-output.md was stale. Re-measured: repeat runs to the same --output are 0.0s, and an incremental run rewrites 2 of 28 files. Stage 0 shrank from four prerequisites to three, and I corrected that doc.
> 
> A correction to something I said mid-way: I reported a regression in the atomic-write change. There wasn't one. The render pool spawns, so workers re-import the probe module — and two of my probe scripts did fixture setup (rmtree/copytree/truncate) at module scope, which then ran again inside each worker against the tree the parent was writing to. That produced a FileNotFoundError, an OSError: Directory not empty, and a message_count that appeared frozen. All three were a missing if __name__ == "__main__": guard. I've noted it in the doc, since any future probe that drives a conversion needs one.
> 
> Answers to the open questions: tick on a real 319 MB / 217-file archive is 1.12s — and the bottleneck has moved: _incremental_cache_refresh is 0.75s of it, the render 0.14s. The render work is done; the cache refresh is the next target if that's too slow. A resident watcher's warm memo saves only interpreter startup (~0.5s). No single-instance guard needed — three concurrent conversions, zero failures. Swap cost on a real 7 MB page is 202ms, idle poll ~1ms.
> 
> I also fixed test_html_escaping, which counted <script> tags and allowed two, so it needed bumping whenever the page grew a script block — while saying nothing about whether content was escaped. It now asserts the property directly.
> 
> Stages 3 (file:// sidecar) and 4 (SSE / fragment patching) are documented as probably not worth building — Stage 2 covers the real case, and fragment patching still needs the architecture half of render-format-once.md step 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `watch` mode to automatically reconvert transcripts as they change.
  - Added `serve --watch` for live session pages that update without reloads while preserving scroll position and folded sections.
  - Added a follow-updates control for tracking new messages.

- **Bug Fixes**
  - Improved detection of rapid, append-only, and same-size file changes.
  - Prevented partially written output files from being read.
  - Improved cache recovery when corruption is detected.

- **Documentation**
  - Added user guidance for watch mode and live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->