### PR TITLE
Make watch ticks cheap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,13 +171,19 @@ uv run pytest test/test_snapshot_html.py -n0
 # all pass → the committed .ambr matches the render (not a raced file)
 ```
 
-When you do intend to regenerate, run `--snapshot-update` serially; a purely
-additive result (`+N/-0`, e.g. "8 snapshots passed. 1 snapshot generated.")
-is the healthy signature:
+When you do intend to regenerate, use the recipe — it purges stale
+bytecode, regenerates serially, and then re-runs read-only to prove the
+file it just wrote is what the code renders:
 
 ```bash
-uv run pytest test/test_snapshot_html.py -n0 --snapshot-update
+just update-snapshot
 ```
+
+A purely additive result (`+N/-0`, e.g. "8 snapshots passed. 1 snapshot
+generated.") is the healthy signature. The recipe exists because doing
+only part of this by hand is what produced both incidents above; reach
+for a bare `pytest --snapshot-update` only if you have a reason to, and
+keep the `-n0`.
 
 When snapshot tests fail:
 1. Review the diff to verify changes are intentional

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -119,6 +119,10 @@ class HtmlCacheEntry(BaseModel):
     )
     message_count: int = 0  # for sanity checking
     library_version: str  # which version generated it
+    # Whether the page carries the combined-transcript back-link, so a run
+    # that changes the answer can mark it stale (migration 013). None for
+    # rows written before that migration, and for outputs with no link.
+    combined_linked: Optional[int] = None
 
 
 class PageCacheData(BaseModel):
@@ -262,6 +266,26 @@ CONTENT_COMPRESSION_LEVEL = 3
 
 
 @functools.lru_cache(maxsize=1)
+def _combined_link_stale(cached: Optional[int], desired: Optional[bool]) -> bool:
+    """Whether a page's combined back-link state no longer matches reality.
+
+    ``cached`` is the ``html_cache.combined_linked`` column: 1/0 for pages
+    written since migration 013, NULL for anything older. NULL is treated
+    as matching — the page's link state is simply unknown, and marking
+    every pre-013 page stale would re-render every session in every
+    project on upgrade for a cosmetic affordance (the 007/011 precedent).
+
+    ``desired`` is None for callers that aren't rendering session pages.
+
+    Shared by ``is_transcript_stale`` and ``get_stale_sessions``, which
+    are otherwise parallel implementations of the same checks — this is
+    the one place the rule lives, so they cannot drift apart on it.
+    """
+    if cached is None or desired is None:
+        return False
+    return bool(cached) != desired
+
+
 def get_library_version() -> str:
     """Get the current library version from package metadata or pyproject.toml.
 
@@ -2073,7 +2097,8 @@ class CacheManager:
 
         with self._get_connection() as conn:
             row = conn.execute(
-                """SELECT html_path, generated_at, source_session_id, message_count, library_version
+                """SELECT html_path, generated_at, source_session_id, message_count,
+                          library_version, combined_linked
                    FROM html_cache
                    WHERE project_id = ? AND html_path = ?""",
                 (self._project_id, html_path),
@@ -2088,6 +2113,7 @@ class CacheManager:
             source_session_id=row["source_session_id"],
             message_count=row["message_count"] or 0,
             library_version=row["library_version"],
+            combined_linked=row["combined_linked"],
         )
 
     def update_html_cache(
@@ -2095,22 +2121,31 @@ class CacheManager:
         html_path: str,
         session_id: Optional[str],
         message_count: int,
+        combined_linked: Optional[bool] = None,
     ) -> None:
-        """Update or insert HTML cache entry."""
+        """Update or insert HTML cache entry.
+
+        ``combined_linked`` records whether the page was rendered with the
+        combined-transcript back-link, so that a later run which changes
+        that answer can mark the page stale (migration 013). None leaves
+        the column NULL — the pre-013 state, read back as "already
+        matching" — and is right for outputs that have no such link.
+        """
         if self._project_id is None:
             return
 
         with self._get_connection() as conn:
             conn.execute(
                 """INSERT INTO html_cache
-                   (project_id, html_path, generated_at, source_session_id, message_count, library_version)
-                   VALUES (?, ?, ?, ?, ?, ?)
+                   (project_id, html_path, generated_at, source_session_id, message_count, library_version, combined_linked)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(project_id, html_path)
                    DO UPDATE SET
                        generated_at = excluded.generated_at,
                        source_session_id = excluded.source_session_id,
                        message_count = excluded.message_count,
-                       library_version = excluded.library_version""",
+                       library_version = excluded.library_version,
+                       combined_linked = excluded.combined_linked""",
                 (
                     self._project_id,
                     html_path,
@@ -2118,6 +2153,7 @@ class CacheManager:
                     session_id,
                     message_count,
                     self.library_version,
+                    None if combined_linked is None else int(combined_linked),
                 ),
             )
             conn.commit()
@@ -2127,6 +2163,7 @@ class CacheManager:
         html_path: str,
         session_id: Optional[str] = None,
         output_dir: Optional[Path] = None,
+        combined_linked: Optional[bool] = None,
     ) -> tuple[bool, str]:
         """Check if a rendered output file needs regeneration.
 
@@ -2143,6 +2180,10 @@ class CacheManager:
                 the source project directory (legacy in-place layout);
                 ``--output`` runs must pass their destination or the file
                 check reports ``file_missing`` forever.
+            combined_linked: Whether a session page rendered now would
+                carry the combined back-link (see
+                ``converter.combined_link_available``). A page rendered
+                with the other answer is stale. None skips the check.
 
         Returns:
             Tuple of (is_stale: bool, reason: str)
@@ -2160,6 +2201,9 @@ class CacheManager:
         # Check library version in cache
         if html_cache.library_version != self.library_version:
             return True, "version_mismatch"
+
+        if _combined_link_stale(html_cache.combined_linked, combined_linked):
+            return True, "combined_link_changed"
 
         # Check if file exists and has correct version
         actual_file = (output_dir or self.project_path) / html_path
@@ -2204,6 +2248,7 @@ class CacheManager:
         variant: str = "",
         ext: str = "html",
         output_dir: Optional[Path] = None,
+        combined_linked: Optional[bool] = None,
     ) -> List[tuple[str, str]]:
         """Get list of sessions whose rendered file needs regeneration.
 
@@ -2218,6 +2263,11 @@ class CacheManager:
                 every run and the project re-renders forever.
             output_dir: Where the rendered files live (``--output`` runs);
                 defaults to the source project directory.
+            combined_linked: Whether a session page rendered now would
+                carry the combined back-link (see
+                ``converter.combined_link_available``). A page rendered
+                with the other answer is stale. None skips the check, for
+                callers that don't render session pages.
 
         Returns:
             List of (session_id, reason) tuples for sessions needing regeneration
@@ -2244,12 +2294,16 @@ class CacheManager:
                 (self._project_id,),
             ).fetchall()
             html_rows = conn.execute(
-                """SELECT html_path, message_count, library_version
+                """SELECT html_path, message_count, library_version, combined_linked
                    FROM html_cache WHERE project_id = ?""",
                 (self._project_id,),
             ).fetchall()
             html_cache = {
-                r["html_path"]: (r["message_count"] or 0, r["library_version"])
+                r["html_path"]: (
+                    r["message_count"] or 0,
+                    r["library_version"],
+                    r["combined_linked"],
+                )
                 for r in html_rows
             }
 
@@ -2268,9 +2322,12 @@ class CacheManager:
                 if cached is None:
                     stale_sessions.append((session_id, "not_cached"))
                     continue
-                cached_count, cached_version = cached
+                cached_count, cached_version, cached_linked = cached
                 if cached_version != self.library_version:
                     stale_sessions.append((session_id, "version_mismatch"))
+                    continue
+                if _combined_link_stale(cached_linked, combined_linked):
+                    stale_sessions.append((session_id, "combined_link_changed"))
                     continue
                 actual_file = base_dir / html_path
                 if not actual_file.exists():

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import sqlite3
+import threading
 import zlib
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -285,8 +286,8 @@ def _combined_link_stale(cached: Optional[int], desired: Optional[bool]) -> bool
     return bool(cached) != desired
 
 
-def get_library_version() -> str:
 @functools.lru_cache(maxsize=1)
+def get_library_version() -> str:
     """Get the current library version from package metadata or pyproject.toml.
 
     Memoised because it is called *per rendered file* on the staleness
@@ -297,12 +298,12 @@ def get_library_version() -> str:
     with anything that changed. An installed version cannot change inside
     a process, so a one-slot cache is exact; tests that need a different
     value patch this name on the module, which is unaffected.
-    """
 
     The decorator has to sit directly above this ``def``: a helper once
     got inserted between the two, which silently moved the memo onto the
     helper and put the 675-call, 3.3 s re-parse back into every archive
     pass. ``test_cache.py`` pins the wrapper to this function.
+    """
     # First try to get version from installed package metadata
     try:
         from importlib.metadata import version as get_version
@@ -524,6 +525,143 @@ def discard_database_files(db_path: Path) -> bool:
 _migrated_db_paths: set[str] = set()
 
 
+# ========== Connection lifecycle ==========
+#
+# By default every `CacheManager._get_connection()` opens a connection and
+# closes it on exit, so no handle lingers on the .db/.db-wal/.db-shm files
+# (Windows refuses to delete an open file, and tests tear temp dirs down).
+# That is the right default for a single call and the wrong one for a
+# loop: in WAL mode, closing the *last* connection checkpoints the database
+# and deletes the -wal/-shm files, and the next `connect` + `PRAGMA
+# journal_mode=WAL` creates them again. A hierarchy pass on a 332-project
+# archive did that 3,658 times — 11 opens per project, each the only
+# connection alive — and on Windows against an 890 MB cache the churn was
+# ~90 s of a 96 s pass (41 s in `close` alone). Measured per cycle on that
+# file: 29 ms with nothing else open, 6.7 ms with one idle connection held.
+#
+# `batch()` already fixes this *within* a project build by sharing one
+# connection per instance. A lease is the same idea one level up: one
+# connection for the scope, shared by every instance addressing that
+# database on this thread, closed on scope exit. Same steady pass: 96 s →
+# 5.3 s. Per thread because sqlite3 connections are thread-bound, and the
+# server thread answers requests while the watch thread converts.
+
+
+def _configure_connection(conn: sqlite3.Connection, *, read_only: bool) -> None:
+    """Apply the standard pragmas/row factory to a fresh connection."""
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    if read_only:
+        # A mode=ro connection cannot switch journal modes, and a
+        # reader needs neither pragma: the writing parent already
+        # keeps the database in WAL.
+        return
+    conn.execute("PRAGMA journal_mode = WAL")
+    # synchronous=NORMAL is the recommended pairing for WAL: it keeps
+    # durability across application crashes (only a power/OS crash can lose
+    # the last committed transaction) while skipping an fsync on every
+    # commit. The cache is fully regenerable from the JSONL source, so that
+    # residual risk is acceptable.
+    conn.execute("PRAGMA synchronous = NORMAL")
+
+
+def _open_connection(
+    db_path: Path,
+    *,
+    read_only: bool,
+    configure: Callable[[sqlite3.Connection], None],
+) -> sqlite3.Connection:
+    """Open a connection and run ``configure`` on it, closing it if that fails.
+
+    If a PRAGMA in ``configure`` raises, the just-opened handle is closed
+    before re-raising so it can't leak and lock the .db/.db-wal/.db-shm
+    files — the exact failure mode the connection lifecycle elsewhere is
+    careful to avoid (Windows WinError 32). ``configure`` is a parameter
+    rather than a fixed call so an instance can route through its own
+    (patchable) ``_configure_connection`` hook.
+    """
+    if read_only:
+        # as_uri() percent-encodes the (absolute) path, so URI mode is
+        # safe for paths with spaces or query-ish characters.
+        conn = sqlite3.connect(
+            db_path.resolve().as_uri() + "?mode=ro", uri=True, timeout=30.0
+        )
+    else:
+        conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        configure(conn)
+    except BaseException:
+        conn.close()
+        raise
+    return conn
+
+
+_LeaseKey = Tuple[str, bool]
+_leases = threading.local()
+
+
+def _thread_leases() -> Dict[_LeaseKey, sqlite3.Connection]:
+    """This thread's active leases, keyed by (database path, read_only)."""
+    conns: Optional[Dict[_LeaseKey, sqlite3.Connection]] = getattr(
+        _leases, "conns", None
+    )
+    if conns is None:
+        conns = {}
+        _leases.conns = conns
+    return conns
+
+
+def _drop_leases(db_path: Path) -> None:
+    """Close and forget any lease this thread holds on ``db_path``.
+
+    For the corruption-rebuild path, which must delete the file: the
+    enclosing ``connection_lease`` scope then simply has nothing to close.
+    """
+    leases = _thread_leases()
+    for key in [k for k in leases if k[0] == str(db_path)]:
+        leases.pop(key).close()
+
+
+@contextmanager
+def connection_lease(
+    db_path: Path, *, read_only: bool = False
+) -> Generator[None, None, None]:
+    """Hold one connection to ``db_path`` open for the scope, on this thread.
+
+    Every ``CacheManager`` addressing that database from this thread
+    reuses it — ``_get_connection`` and ``batch()`` both yield it and leave
+    the closing to the lease — so a loop over many projects opens one
+    connection instead of one per query. Nesting reuses the outer lease.
+
+    The connection is closed on scope exit, including on exception, so the
+    Windows file-lock guarantee holds at the scope boundary rather than
+    per call. A database that cannot be opened here (typically corrupt)
+    is not the lease's problem: the scope runs without one, and the first
+    ``CacheManager`` inside it reports and rebuilds the file as before.
+    """
+    key: _LeaseKey = (str(db_path), read_only)
+    leases = _thread_leases()
+    if key in leases:
+        yield
+        return
+    try:
+        conn = _open_connection(
+            db_path,
+            read_only=read_only,
+            configure=functools.partial(_configure_connection, read_only=read_only),
+        )
+    except sqlite3.DatabaseError:
+        yield
+        return
+    leases[key] = conn
+    try:
+        yield
+    finally:
+        # `_drop_leases` may already have removed and closed it.
+        if leases.pop(key, None) is not None:
+            conn.close()
+
+
 class CacheManager:
     """SQLite-based cache manager for Claude Code Log."""
 
@@ -586,55 +724,39 @@ class CacheManager:
 
     def _configure_connection(self, conn: sqlite3.Connection) -> None:
         """Apply the standard pragmas/row factory to a fresh connection."""
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON")
-        if self._read_only:
-            # A mode=ro connection cannot switch journal modes, and a
-            # reader needs neither pragma: the writing parent already
-            # keeps the database in WAL.
-            return
-        conn.execute("PRAGMA journal_mode = WAL")
-        # synchronous=NORMAL is the recommended pairing for WAL: it keeps
-        # durability across application crashes (only a power/OS crash can lose
-        # the last committed transaction) while skipping an fsync on every
-        # commit. The cache is fully regenerable from the JSONL source, so that
-        # residual risk is acceptable.
-        conn.execute("PRAGMA synchronous = NORMAL")
+        _configure_connection(conn, read_only=self._read_only)
 
     def _open_configured_connection(self) -> sqlite3.Connection:
-        """Open a connection and apply pragmas, closing it if setup fails.
+        """Open a connection and apply pragmas, closing it if setup fails."""
+        return _open_connection(
+            self.db_path,
+            read_only=self._read_only,
+            configure=self._configure_connection,
+        )
 
-        If a PRAGMA in ``_configure_connection`` raises, the just-opened
-        handle is closed before re-raising so it can't leak and lock the
-        .db/.db-wal/.db-shm files — the exact failure mode the connection
-        lifecycle elsewhere is careful to avoid (Windows WinError 32).
-        """
-        if self._read_only:
-            # as_uri() percent-encodes the (absolute) path, so URI mode is
-            # safe for paths with spaces or query-ish characters.
-            conn = sqlite3.connect(
-                self.db_path.resolve().as_uri() + "?mode=ro", uri=True, timeout=30.0
-            )
-        else:
-            conn = sqlite3.connect(self.db_path, timeout=30.0)
-        try:
-            self._configure_connection(conn)
-        except BaseException:
-            conn.close()
-            raise
-        return conn
+    def _leased_connection(self) -> Optional[sqlite3.Connection]:
+        """The connection a `connection_lease` holds for this database on
+        this thread, if any."""
+        return _thread_leases().get((str(self.db_path), self._read_only))
 
     @contextmanager
     def _get_connection(self) -> Generator[sqlite3.Connection, None, None]:
         """Get a database connection with proper settings.
 
         Inside a ``batch()`` scope this yields the shared connection without
-        closing it (the batch owns its lifecycle). Otherwise it opens a fresh
-        connection and closes it on exit — the default, Windows-safe behaviour
-        (no lingering file handle on the .db/.db-wal/.db-shm files).
+        closing it (the batch owns its lifecycle). Under a
+        ``connection_lease`` for this database it yields the leased one,
+        likewise without closing it. Otherwise it opens a fresh connection
+        and closes it on exit — the default, Windows-safe behaviour (no
+        lingering file handle on the .db/.db-wal/.db-shm files).
         """
         if self._shared_conn is not None:
             yield self._shared_conn
+            return
+
+        leased = self._leased_connection()
+        if leased is not None:
+            yield leased
             return
 
         conn = self._open_configured_connection()
@@ -667,6 +789,17 @@ class CacheManager:
             # Already batching — reuse the existing shared connection and leave
             # its lifecycle to the outermost batch().
             yield
+            return
+
+        leased = self._leased_connection()
+        if leased is not None:
+            # A lease is an outermost batch that spans instances: reuse
+            # its connection and leave the closing to the lease.
+            self._shared_conn = leased
+            try:
+                yield
+            finally:
+                self._shared_conn = None
             return
 
         # Open+configure first; only publish to _shared_conn once setup has
@@ -710,6 +843,11 @@ class CacheManager:
         `_lookup_project_id` already degrades to "no cached data".
         """
         print(f"Cache database is corrupt ({exc}): {self.db_path}")
+        # A lease on this thread holds the file open, and Windows refuses
+        # to delete an open file. Drop it first; the rest of the enclosing
+        # scope falls back to a connection per call, which is correct and
+        # merely slower.
+        _drop_leases(self.db_path)
         if not discard_database_files(self.db_path):
             # Couldn't remove it, so a retry would just fail the same way.
             # Re-raise and let the caller degrade to running cacheless.

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -597,6 +597,10 @@ def _open_connection(
 
 
 _LeaseKey = Tuple[str, bool]
+# Thread-local, and safe across the render pools only because both use
+# `multiprocessing.get_context("spawn")`: a forked child would inherit
+# this dict and its sqlite3 handles, which is undefined behaviour. Keep
+# the pools on spawn.
 _leases = threading.local()
 
 

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -265,7 +265,6 @@ def scrub_surrogates(s: Optional[str]) -> Optional[str]:
 CONTENT_COMPRESSION_LEVEL = 3
 
 
-@functools.lru_cache(maxsize=1)
 def _combined_link_stale(cached: Optional[int], desired: Optional[bool]) -> bool:
     """Whether a page's combined back-link state no longer matches reality.
 
@@ -287,6 +286,7 @@ def _combined_link_stale(cached: Optional[int], desired: Optional[bool]) -> bool
 
 
 def get_library_version() -> str:
+@functools.lru_cache(maxsize=1)
     """Get the current library version from package metadata or pyproject.toml.
 
     Memoised because it is called *per rendered file* on the staleness
@@ -298,6 +298,11 @@ def get_library_version() -> str:
     a process, so a one-slot cache is exact; tests that need a different
     value patch this name on the module, which is unaffected.
     """
+
+    The decorator has to sit directly above this ``def``: a helper once
+    got inserted between the two, which silently moved the memo onto the
+    helper and put the 675-call, 3.3 s re-parse back into every archive
+    pass. ``test_cache.py`` pins the wrapper to this function.
     # First try to get version from installed package metadata
     try:
         from importlib.metadata import version as get_version

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -2192,6 +2192,15 @@ def serve(
     watch_thread: Optional[threading.Thread] = None
     if watch_sources:
         from .watch import WatchEngine
+        from .entry_store import ParsedEntryStore, entry_store_enabled
+
+        # One store for the whole serve, not one per tick, for the same
+        # reason `watch` owns one: it lets a tick resume its parse from
+        # the bytes the previous tick already read. Only the *inline*
+        # conversion path takes it (see `_convert_plan_inline`), which is
+        # the steady state here -- one live project stale per tick means
+        # `resolved_jobs == 1` and no pool.
+        serve_store = ParsedEntryStore() if entry_store_enabled() else None
 
         def reconvert(_changed: set[Path]) -> None:
             # The server never renders. It re-runs the ordinary conversion
@@ -2208,7 +2217,12 @@ def serve(
             # startup conversion below stay on disk and keep serving --
             # they just stop tracking the live session until the next
             # restart, which is the trade `watch` already makes.
-            process_projects_hierarchy(projects_path, silent=True, write_combined=False)
+            process_projects_hierarchy(
+                projects_path,
+                silent=True,
+                write_combined=False,
+                entry_store=serve_store,
+            )
 
         def report(exc: BaseException) -> None:
             click.echo(f"  watch: conversion failed: {exc!r}", err=True)

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -2198,7 +2198,17 @@ def serve(
             # and lets the pages on disk stay canonical, so a page served
             # over http and the same file opened from file:// can never
             # disagree.
-            process_projects_hierarchy(projects_path, silent=True)
+            #
+            # `write_combined=False` for the same reason the `watch`
+            # command defaults to it: regenerating the combined pages is
+            # what forces a tick to reload the project rather than just
+            # the session that grew. Measured on a 302-session/373MB
+            # archive, one appended line cost 7.6s with the combined
+            # pages and 0.7s without. The combined pages written by the
+            # startup conversion below stay on disk and keep serving --
+            # they just stop tracking the live session until the next
+            # restart, which is the trade `watch` already makes.
+            process_projects_hierarchy(projects_path, silent=True, write_combined=False)
 
         def report(exc: BaseException) -> None:
             click.echo(f"  watch: conversion failed: {exc!r}", err=True)
@@ -2209,7 +2219,10 @@ def serve(
         engine.prime()
         watch_stop = threading.Event()
         watch_thread = engine.run_in_thread(watch_stop)
-        click.echo("  watching for changes (reload a page to see new messages)")
+        click.echo(
+            "  watching for changes (reload a session page to see new messages;"
+            " combined pages refresh on restart)"
+        )
 
     try:
         server.serve_forever()

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2080,6 +2080,21 @@ _NEXT_LINK_PATTERN = re.compile(
     re.DOTALL,
 )
 
+# Closing delimiter of the block above, as a plain string. Finding it in a
+# prefix of the file proves the whole nav block is in that prefix, which is
+# what lets `_enable_next_link_on_previous_page` answer from a bounded read.
+_NEXT_LINK_END_MARKER = "<!-- PAGINATION_NEXT_LINK_END -->"
+
+# How much of a page to read before deciding whether it needs the edit.
+#
+# `transcript.html` emits the nav block exactly once, in the page header
+# directly after the inlined stylesheet, so its offset is bounded by the
+# template's own preamble rather than by the transcript: across a 22-page
+# 253MB archive it never ended past 110KB. 512KB is a wide margin on that,
+# and being wrong is not a correctness problem — a page whose block falls
+# outside the prefix takes the full read below, exactly as before.
+_NAV_BLOCK_PREFIX_CHARS = 512 * 1024
+
 
 def _enable_next_link_on_previous_page(
     output_dir: Path, page_number: int, variant_suffix: str = ""
@@ -2105,16 +2120,31 @@ def _enable_next_link_on_previous_page(
     if not page_path.exists():
         return False
 
+    # Decide from a bounded prefix whether this page needs the edit at all.
+    #
+    # The obvious guard -- `if "last-page" not in content` -- cannot ever
+    # fire: every page inlines the rule that hides the link,
+    # `.page-nav-link.next.last-page { display: none }`, so the bare
+    # substring is always present. The result was that each call read the
+    # whole page back and ran a DOTALL backtracking `subn` over it, on
+    # every page, on every conversion. On a watched project that is the
+    # dominant per-tick cost -- 253MB re-read and ~5.2s of regex per tick
+    # over a 22-page archive, to change nothing on 21 of the 22.
+    #
+    # The delimiters are what distinguish the real nav block both from
+    # that CSS rule and from transcript content quoting the class name, so
+    # a prefix containing the closing delimiter can answer for the file.
     # ``errors="replace"`` guards against lone surrogates that may have
     # been written here previously (issue #139): pre-fix runs encoded
     # JSON-decoded surrogates straight into the HTML, and a strict
     # read-back would crash on revisit. Replacing them here lets older
     # corrupt pages still rewrite cleanly.
-    content = page_path.read_text(encoding="utf-8", errors="replace")
-
-    # Check if there's a last-page class to remove
-    if "last-page" not in content:
+    with page_path.open(encoding="utf-8", errors="replace") as handle:
+        prefix = handle.read(_NAV_BLOCK_PREFIX_CHARS)
+    if _NEXT_LINK_END_MARKER in prefix and not _NEXT_LINK_PATTERN.search(prefix):
         return False
+
+    content = page_path.read_text(encoding="utf-8", errors="replace")
 
     # Replace the pattern to remove last-page class
     new_content, count = _NEXT_LINK_PATTERN.subn(r"\1\2", content)

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -6226,6 +6226,7 @@ def process_projects_hierarchy(
     no_timestamps: bool = False,
     no_recaps: bool = False,
     jobs: Optional[int] = None,
+    entry_store: "Optional[ParsedEntryStore]" = None,
 ) -> Path:
     """Process the entire ~/.claude/projects/ hierarchy and create linked output files.
 
@@ -6550,8 +6551,16 @@ def process_projects_hierarchy(
         project_start_time = time.monotonic()
         try:
             # Generate output for this project (handles cache updates internally)
+            #
+            # A caller-owned store is handed only to the *inline* path. It
+            # holds parsed entries, so it is neither picklable at sensible
+            # cost nor useful across a `spawn`: shipping one to a pool
+            # worker would cost more than the re-parse it saves, and the
+            # worker's copy would die with the task. Deliberately absent
+            # from `_conversion_kwargs` for that reason.
             convert_jsonl_to(
-                **_conversion_kwargs(plan, silent=silent, render_jobs=render_jobs)
+                **_conversion_kwargs(plan, silent=silent, render_jobs=render_jobs),
+                entry_store=entry_store,
             )
         except Exception:
             _print_project_failed(plan, traceback.format_exc())

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -2024,6 +2024,33 @@ def _get_page_html_path(page_number: int, variant_suffix: str = "") -> str:
     return f"{base}_{page_number}.html"
 
 
+def combined_link_available(
+    output_dir: Path, variant_suffix: str, ext: str, write_combined: bool
+) -> bool:
+    """Whether a session page should carry the combined-transcript back-link.
+
+    It should iff the file it points at will be there to receive the click:
+    this run's combined output when we're writing one, and otherwise
+    whatever a previous run left on disk.
+
+    Deliberately not just ``write_combined``. Keying the *rendered page* on
+    the run's mode made its content depend on something the freshness check
+    knows nothing about, so the state stuck: a page rendered by a
+    ``--combined no`` run (every watch tick) kept no link for good, and
+    later full runs saw a current file and skipped it. An archive ended up
+    with some session pages linking and some not, decided by which run
+    happened to render each. Under `serve --watch` the combined page is not
+    rewritten but is still on disk and still served, so the link stays good
+    and the divergence never arises.
+
+    Paginated projects name page 1 ``combined_transcripts{suffix}.{ext}``
+    too (see ``_get_page_html_path``), so one check covers both layouts.
+    """
+    if write_combined:
+        return True
+    return (output_dir / f"combined_transcripts{variant_suffix}.{ext}").exists()
+
+
 def _variant_label_from_suffix(suffix: str) -> str:
     """Human-readable label for a filename suffix (e.g. '.agent.compact')."""
     if not suffix:
@@ -3170,6 +3197,9 @@ def _stream_paginated_conversion(
                     variant=session_suffix,
                     ext="html",
                     output_dir=effective_output_dir,
+                    combined_linked=combined_link_available(
+                        effective_output_dir, session_suffix, "html", write_combined
+                    ),
                 )
             }
 
@@ -3441,7 +3471,12 @@ def _try_current_or_session_scoped(
 
     # Check if any session file of this variant is stale
     stale_sessions = cache_manager.get_stale_sessions(
-        variant=suffix, ext=ext, output_dir=effective_output_dir
+        variant=suffix,
+        ext=ext,
+        output_dir=effective_output_dir,
+        combined_linked=combined_link_available(
+            effective_output_dir, suffix, ext, write_combined
+        ),
     )
     if not stale_sessions or not generate_individual_sessions:
         # Nothing needs regeneration - skip loading
@@ -4923,6 +4958,9 @@ def _generate_individual_session_files(
 
     ext = get_file_extension(format)
     suffix = _variant_suffix(depth, compact, format, no_timestamps, no_recaps)
+    combined_available = combined_link_available(
+        output_dir, suffix, ext, write_combined
+    )
     # Find all unique session IDs, excluding warmup sessions and
     # coalescing agent sessionIds to their trunk — same rule as
     # compute_session_data() when it writes the sessions table.
@@ -5012,7 +5050,10 @@ def _generate_individual_session_files(
             # reads its own `version` field (see `_tracks_version_marker`).
             if cache_manager is not None and _tracks_version_marker(format):
                 is_stale, _reason = cache_manager.is_transcript_stale(
-                    session_file_name, session_id, output_dir=output_dir
+                    session_file_name,
+                    session_id,
+                    output_dir=output_dir,
+                    combined_linked=combined_available,
                 )
                 should_regenerate_session = (
                     is_stale
@@ -5043,9 +5084,11 @@ def _generate_individual_session_files(
                         key=session_id,
                         file_name=session_file_name,
                         title=session_title,
-                        # Under `--combined no` the combined file is never
-                        # written, so the per-session back-link would 404.
-                        suppress_combined_link=not write_combined,
+                        # No combined file to point at — the back-link
+                        # would 404, so leave it out. See
+                        # `combined_available` above for why this is not
+                        # simply `not write_combined`.
+                        suppress_combined_link=not combined_available,
                     )
                 )
             elif not silent:
@@ -5087,7 +5130,10 @@ def _generate_individual_session_files(
                     if hasattr(m, "sessionId") and getattr(m, "sessionId") == unit.key
                 )
             cache_manager.update_html_cache(
-                unit.file_name, unit.key, session_message_count
+                unit.file_name,
+                unit.key,
+                session_message_count,
+                combined_linked=not unit.suppress_combined_link,
             )
 
         # Feed each pooled session unit everything its worker renders from:
@@ -5695,6 +5741,10 @@ def render_provider_wholesale(
 
         # Phase 3 — build index cards and render per-session pages (skipping
         # unchanged ones).
+        #
+        combined_available = combined_link_available(
+            dest_dir, suffix, ext, write_combined
+        )
         session_dicts: list[dict[str, Any]] = []
         last_modified = 0.0
         for info, messages in loaded:
@@ -5720,13 +5770,14 @@ def render_provider_wholesale(
                         compact,
                         no_timestamps,
                         no_recaps,
-                        suppress_combined_link=not write_combined,
+                        suppress_combined_link=not combined_available,
                     )
                     if cache is not None:
                         cache.update_html_cache(
                             output_name,
                             session_key,
                             session_counts.get(session_key, len(messages)),
+                            combined_linked=combined_available,
                         )
 
             first_ts, last_ts = _entry_timestamp_range(messages)
@@ -6102,6 +6153,9 @@ def _plan_project(
             variant=variant,
             ext=combined_ext,
             output_dir=dest_dir,
+            combined_linked=combined_link_available(
+                dest_dir, variant, combined_ext, write_combined
+            ),
         )
         if cache_manager
         else []

--- a/claude_code_log/converter.py
+++ b/claude_code_log/converter.py
@@ -52,6 +52,7 @@ from .render_dispatch import build_render_pool, dispatch_render_units
 from .cache import (
     CacheManager,
     SessionCacheData,
+    connection_lease,
     get_all_cached_projects,
     get_cache_db_path,
     get_library_version,
@@ -6262,6 +6263,66 @@ def _convert_project_worker(
 
 
 def process_projects_hierarchy(
+    projects_path: Path,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    use_cache: bool = True,
+    generate_individual_sessions: bool = True,
+    output_format: str = "html",
+    image_export_mode: Optional[str] = None,
+    silent: bool = True,
+    page_size: int = 2000,
+    depth: RenderingDepth = DEFAULT_DEPTH,
+    compact: bool = False,
+    output_dir: Optional[Path] = None,
+    expand_paths: bool = False,
+    filter_path: Optional[str] = None,
+    write_combined: bool = True,
+    no_timestamps: bool = False,
+    no_recaps: bool = False,
+    jobs: Optional[int] = None,
+    entry_store: "Optional[ParsedEntryStore]" = None,
+) -> Path:
+    """Process the entire ~/.claude/projects/ hierarchy and create linked output files.
+
+    Holds one cache connection for the whole pass (``connection_lease``):
+    the pass plans every project before converting any, and each plan is
+    ~11 short queries — on a 332-project archive that used to be 3,658
+    connection open/close cycles, ~90 s of a 96 s no-change pass on
+    Windows. See the lease's module comment in ``cache.py`` for the
+    mechanism. The lease is released when this returns, so no handle
+    outlives the pass. Everything else is documented on the body.
+    """
+    lease = (
+        connection_lease(get_cache_db_path(projects_path))
+        if use_cache
+        else contextlib.nullcontext()
+    )
+    with lease:
+        return _process_projects_hierarchy(
+            projects_path=projects_path,
+            from_date=from_date,
+            to_date=to_date,
+            use_cache=use_cache,
+            generate_individual_sessions=generate_individual_sessions,
+            output_format=output_format,
+            image_export_mode=image_export_mode,
+            silent=silent,
+            page_size=page_size,
+            depth=depth,
+            compact=compact,
+            output_dir=output_dir,
+            expand_paths=expand_paths,
+            filter_path=filter_path,
+            write_combined=write_combined,
+            no_timestamps=no_timestamps,
+            no_recaps=no_recaps,
+            jobs=jobs,
+            entry_store=entry_store,
+        )
+
+
+def _process_projects_hierarchy(
     projects_path: Path,
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,

--- a/claude_code_log/migrations/013_html_cache_combined_link.sql
+++ b/claude_code_log/migrations/013_html_cache_combined_link.sql
@@ -1,0 +1,40 @@
+-- Record whether a rendered session page carries the combined back-link
+-- Migration: 013
+-- Description: Add a `combined_linked` column to `html_cache`.
+--
+-- A session page's "View All Sessions (Combined Transcript)" back-link
+-- was emitted or omitted according to the *run's* `--combined` setting,
+-- but nothing about that setting reaches the freshness check, which
+-- compares only message_count and library_version. So the link state was
+-- sticky: a page rendered by a `--combined no` run (which is every watch
+-- tick) kept no link for good, and later full conversions did not put it
+-- back -- they saw a current page and skipped it. An archive ended up
+-- with some session pages linking and some not, depending only on which
+-- run happened to render each one.
+--
+-- Two changes fix that, and this column is the second half. First, the
+-- link now follows whether the combined file *exists* rather than
+-- whether this run writes it: under `serve --watch` the startup
+-- conversion has written it and it is still served, so the link stays
+-- valid and the mixed state stops arising. Second, this column records
+-- what each page was rendered with, so a genuine transition -- a
+-- project that had no combined page until a full run wrote one, or one
+-- whose combined page was deleted -- marks the affected session pages
+-- stale and regenerates them.
+--
+-- The check costs nothing: `get_stale_sessions` already reads the whole
+-- html_cache table in one query and already stats every session file, so
+-- this rides along as one more in-memory comparison (measured at 0.05%
+-- of the call). Deriving the same fact by reading the rendered page
+-- would not be free -- the link sits past the inlined stylesheet, tens
+-- of KB in -- which is the mistake `_enable_next_link_on_previous_page`
+-- used to make.
+--
+-- Backward-compatible in the shape of 007 and 011: existing rows get
+-- NULL and are treated as already matching, so a populated cache does
+-- not mass-invalidate on upgrade. Pages that a past `--combined no` run
+-- left link-less stay that way until something else regenerates them --
+-- exactly today's behaviour, not a regression -- while every page
+-- written from here on carries its state and self-corrects.
+
+ALTER TABLE html_cache ADD COLUMN combined_linked INTEGER;

--- a/claude_code_log/watch.py
+++ b/claude_code_log/watch.py
@@ -26,6 +26,8 @@ flaky-test generator.
 
 from __future__ import annotations
 
+import fnmatch
+import os
 import threading
 import time
 from dataclasses import dataclass, field
@@ -62,24 +64,51 @@ FileStamp = tuple[int, int]
 """(size, mtime_ns) — the pair a change has to preserve to go unnoticed."""
 
 
+_WATCHED_NAMES = tuple(pattern.rsplit("/", 1)[-1] for pattern in WATCHED_GLOBS)
+
+
+def _is_watched_name(name: str) -> bool:
+    return not name.startswith(IGNORED_PREFIXES) and any(
+        fnmatch.fnmatchcase(name, pattern) for pattern in _WATCHED_NAMES
+    )
+
+
 def scan(roots: Iterable[Path]) -> dict[Path, FileStamp]:
     """Stamp every watched file under `roots`.
 
     Missing files are simply absent from the result, which makes deletion
     a change like any other. A file that vanishes mid-scan is skipped
     rather than raising: the next tick will see the settled state.
+
+    One ``os.scandir`` walk rather than a ``glob`` per pattern plus a
+    ``stat`` per hit: the directory listing already carries size and
+    mtime on Windows, so ``DirEntry.stat`` costs nothing there, whereas
+    ``Path.stat`` is a syscall per file. On a 332-project / 1,896-file
+    archive the glob form took 0.4–0.9 s per poll — polled four times a
+    second, the watch thread never slept — and this form returned the
+    identical dict 4–7× faster. Symlinked directories are not followed,
+    which is the one place this differs from ``glob("**")``; nothing in
+    a transcript tree is a symlink, and not following rules out a loop.
     """
     stamps: dict[Path, FileStamp] = {}
-    for root in roots:
-        for pattern in WATCHED_GLOBS:
-            for path in root.glob(pattern):
-                if path.name.startswith(IGNORED_PREFIXES):
-                    continue
-                try:
-                    st = path.stat()
-                except OSError:
-                    continue
-                stamps[path] = (st.st_size, st.st_mtime_ns)
+    pending = [os.fspath(root) for root in roots]
+    while pending:
+        directory = pending.pop()
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            pending.append(entry.path)
+                            continue
+                        if not _is_watched_name(entry.name):
+                            continue
+                        st = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    stamps[Path(entry.path)] = (st.st_size, st.st_mtime_ns)
+        except OSError:
+            continue
     return stamps
 
 

--- a/claude_code_log/watch.py
+++ b/claude_code_log/watch.py
@@ -68,8 +68,13 @@ _WATCHED_NAMES = tuple(pattern.rsplit("/", 1)[-1] for pattern in WATCHED_GLOBS)
 
 
 def _is_watched_name(name: str) -> bool:
+    # `fnmatch.fnmatch`, not `fnmatchcase`: it normalises case the way the
+    # platform does (insensitive on Windows, sensitive on POSIX), which is
+    # also `Path.glob`'s rule -- and the converter discovers sessions with
+    # `Path.glob("*.jsonl")`, so a session it renders must also wake the
+    # watcher. Verified: `UP.JSONL` was rendered and never watched.
     return not name.startswith(IGNORED_PREFIXES) and any(
-        fnmatch.fnmatchcase(name, pattern) for pattern in _WATCHED_NAMES
+        fnmatch.fnmatch(name, pattern) for pattern in _WATCHED_NAMES
     )
 
 
@@ -103,7 +108,11 @@ def scan(roots: Iterable[Path]) -> dict[Path, FileStamp]:
                             continue
                         if not _is_watched_name(entry.name):
                             continue
-                        st = entry.stat(follow_symlinks=False)
+                        # Follow a symlinked file, as `Path.stat` did: the
+                        # stamp has to be the target's, or appends to it go
+                        # unnoticed. Still free on Windows for anything
+                        # that is not a reparse point.
+                        st = entry.stat()
                     except OSError:
                         continue
                     stamps[Path(entry.path)] = (st.st_size, st.st_mtime_ns)

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1068,7 +1068,11 @@ measurements behind it.
 **The engine never renders.** `claude_code_log/watch.py` polls
 `(size, mtime_ns)` over `**/*.jsonl` and `**/agent-*.meta.json` under
 the watched roots, debounces, and calls a callback; the callback runs the
-ordinary conversion. The scan is a *trigger*, not a source of truth — a
+ordinary conversion. The poll is one `os.scandir` walk taking size and
+mtime from the directory entries, not a `glob` per pattern plus a `stat`
+per hit: over a whole archive (1,896 files) the glob form cost 0.4–0.9 s
+per poll, more than the poll interval, and the walk returns the same
+dict 4–7× faster. The scan is a *trigger*, not a source of truth — a
 false positive costs one no-op conversion, while the conversion already
 knows precisely what is stale. Two file classes are excluded because both
 land in the watched tree and would make the loop feed itself: dot-prefixed

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -1072,7 +1072,9 @@ ordinary conversion. The poll is one `os.scandir` walk taking size and
 mtime from the directory entries, not a `glob` per pattern plus a `stat`
 per hit: over a whole archive (1,896 files) the glob form cost 0.4–0.9 s
 per poll, more than the poll interval, and the walk returns the same
-dict 4–7× faster. The scan is a *trigger*, not a source of truth — a
+dict 4–7× faster. Name matching follows the platform's case rule, as
+`Path.glob` does (insensitive on Windows), so a session the converter
+discovers is also one the watcher wakes for. The scan is a *trigger*, not a source of truth — a
 false positive costs one no-op conversion, while the conversion already
 knows precisely what is stale. Two file classes are excluded because both
 land in the watched tree and would make the loop feed itself: dot-prefixed

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -212,6 +212,25 @@ per-file load loop, per-session generation) in `CacheManager.batch()`:
 one shared connection reused for the scope and closed on exit (including
 on exception). `batch()` nesting is a no-op reuse, so the wraps compose.
 
+`batch()` is per instance, and an instance is per project, so a loop over
+projects still closes the last connection between every two of them. In
+WAL mode that is the expensive close: the last connection out checkpoints
+and deletes the `-wal`/`-shm` files, and the next `connect` +
+`PRAGMA journal_mode=WAL` recreates them. `process_projects_hierarchy`
+plans every project (11 short queries each) before converting any, which
+on a 332-project archive was 3,658 open/close cycles — ~90 s of a 96 s
+no-change pass on Windows against an 890 MB cache (29 ms per cycle with
+nothing else open, 6.7 ms with one idle connection held). So the pass
+holds a `connection_lease(db_path)` for its whole run: one connection
+per thread and database, which `_get_connection()` and `batch()` both
+yield instead of opening (a lease is an outermost batch that spans
+instances). Closed on scope exit like a batch, so the Windows guarantee
+holds at the pass boundary; per thread because `sqlite3` connections
+are thread-bound and `serve` answers requests on other threads while
+the watch thread converts. A corrupt database drops the lease before
+the rebuild deletes the file, and the rest of that pass runs
+connection-per-call. Same pass with the lease: 5.3 s.
+
 Freshness checks are batched too (issue #12): `get_modified_files()`
 fetches every cached row for the project in one query (one connection
 open, or zero extra inside a `batch()` scope) and rules out

--- a/docs/live-updates.md
+++ b/docs/live-updates.md
@@ -49,7 +49,9 @@ the combined pages alone, for the same reason `watch` defaults to
 `--combined no`: regenerating them is what forces a tick to reload the
 whole project rather than just the session that grew. The combined pages
 written at startup stay on disk and keep serving — they simply stop
-tracking the live session until you restart.
+tracking the live session until you restart. Their "View All Sessions"
+back-link keeps working throughout — it points at a page that exists and
+is still served, just one that stopped growing.
 
 This works only over the server. A page opened from `file://` cannot
 fetch anything at all — not even itself — so it stays static, exactly as

--- a/docs/live-updates.md
+++ b/docs/live-updates.md
@@ -44,6 +44,13 @@ the page is being served. Click it to keep the page pinned to the newest
 message; while you are not following, it shows a count of how many have
 arrived since you last looked.
 
+It is the *session* pages that track a live session. Watch ticks leave
+the combined pages alone, for the same reason `watch` defaults to
+`--combined no`: regenerating them is what forces a tick to reload the
+whole project rather than just the session that grew. The combined pages
+written at startup stay on disk and keep serving — they simply stop
+tracking the live session until you restart.
+
 This works only over the server. A page opened from `file://` cannot
 fetch anything at all — not even itself — so it stays static, exactly as
 before. Nothing about the generated HTML changes.

--- a/foldyard.toml
+++ b/foldyard.toml
@@ -95,6 +95,7 @@ recommend = [
 # below it. Same progressive opt-in as the rest of this file.
 [claude]
 keyless = "oauth"      # Bearer on api.anthropic.com ← `claude setup-token` on the host
+transcript_sync_seconds = 10
 system_prompt = """
 You are root in this project's foldyard dev box, started by `fy claude` with permission
 prompts skipped. Orientation, so you don't have to re-derive it:
@@ -126,6 +127,7 @@ showThinkingSummaries = true
 # Needs node in the box. Keyless like Claude — the proxy injects host-side.
 [codex]
 keyless = "chatgpt"  # your ChatGPT subscription: the minter refreshes ~/.codex/auth.json
+transcript_sync_seconds = 10
 system_prompt = """
 You are root in this project's foldyard dev box, started by `fy codex` with permission
 prompts skipped. Orientation, so you don't have to re-derive it:

--- a/justfile
+++ b/justfile
@@ -16,9 +16,17 @@ test:
 test-benchmark:
     CLAUDE_CODE_LOG_DEBUG_TIMING=1 uv run pytest -n0 -m benchmark -q
 
-# Update snapshot tests (runs serially for deterministic file ordering)
+# Update snapshot tests. Encodes the whole procedure from CONTRIBUTING
+# ("Snapshot Testing"), because doing only part of it has twice produced a
+# damaged .ambr: purge stale bytecode, regenerate SERIALLY (-n0; a parallel
+# --snapshot-update once silently truncated ~6000 lines), then re-run
+# read-only to prove the committed file matches what the code renders.
+# A healthy result is purely additive -- "+N/-0".
 update-snapshot:
+    find . -name __pycache__ -type d -prune -exec rm -rf {} +
     uv run pytest -n0 -m snapshot --snapshot-update -q
+    @echo "--- verifying the regenerated snapshots read back clean ---"
+    uv run pytest -n0 -m snapshot -q
 
 # Run TUI tests (requires isolated event loop)
 test-tui:

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -976,3 +976,30 @@ class TestCachePathEnvVar:
         # get_all_cached_projects without explicit path uses env var (empty db)
         projects_env = get_all_cached_projects(projects_dir)
         assert len(projects_env) == 0  # env_db doesn't have any projects
+
+
+class TestLibraryVersionMemo:
+    """`get_library_version` must stay memoised, and on the right function.
+
+    The `@functools.lru_cache` sits directly above the `def`; a helper once
+    got inserted between the two, which silently moved the memo onto the
+    helper and put a per-session package-metadata re-parse back into every
+    archive pass (675 calls, 3.3 s on a 332-project archive).
+    """
+
+    def test_get_library_version_is_memoised(self):
+        from claude_code_log import cache as cachemod
+
+        assert hasattr(cachemod.get_library_version, "cache_info"), (
+            "get_library_version lost its lru_cache: check the decorator is "
+            "directly above its def"
+        )
+        cachemod.get_library_version.cache_clear()
+        cachemod.get_library_version()
+        cachemod.get_library_version()
+        assert cachemod.get_library_version.cache_info().hits == 1
+
+    def test_the_memo_did_not_land_on_a_neighbour(self):
+        from claude_code_log import cache as cachemod
+
+        assert not hasattr(cachemod._combined_link_stale, "cache_info")

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -1380,3 +1380,181 @@ class TestCorruptDatabaseRecovery:
     )
     def test_only_corruption_triggers_a_rebuild(self, exc, expected):
         assert is_corrupt_database_error(exc) is expected
+
+
+class TestConnectionLease:
+    """`connection_lease`: one connection for a scope, shared across instances.
+
+    The lifecycle guarantees matter more than the speed-up: the leased
+    connection must be closed at scope exit (Windows refuses to delete an
+    open .db/-wal/-shm file, and callers tear temp dirs down right after),
+    must not escape to other threads (sqlite3 connections are thread-bound),
+    and must get out of the way of the corruption rebuild, which deletes
+    the file.
+    """
+
+    @pytest.fixture
+    def two_managers(self, tmp_path):
+        db = tmp_path / "cache.db"
+        dirs = []
+        for name in ("p1", "p2"):
+            d = tmp_path / name
+            d.mkdir()
+            dirs.append(d)
+        return db, [CacheManager(d, "1.0.0", db_path=db) for d in dirs]
+
+    def test_calls_under_a_lease_share_one_connection_across_instances(
+        self, two_managers
+    ):
+        from claude_code_log.cache import connection_lease
+
+        db, (a, b) = two_managers
+        with connection_lease(db):
+            with a._get_connection() as c1, a._get_connection() as c2:
+                assert c1 is c2
+            with b._get_connection() as c3:
+                assert c3 is c1
+            # batch() under a lease reuses it and must not close it on exit.
+            with b.batch():
+                with b._get_connection() as c4:
+                    assert c4 is c1
+            assert c1.execute("SELECT 1").fetchone()[0] == 1
+
+    def test_the_lease_is_closed_on_exit_and_the_files_can_go(self, two_managers):
+        from claude_code_log.cache import connection_lease
+
+        db, (a, _b) = two_managers
+        with connection_lease(db):
+            with a._get_connection() as leased:
+                pass
+        with pytest.raises(sqlite3.ProgrammingError):
+            leased.execute("SELECT 1")
+        # Outside the lease we are back to a connection per call, and it is
+        # a different one.
+        with a._get_connection() as fresh:
+            assert fresh is not leased
+        # The Windows guarantee: nothing holds the files after the scope.
+        shutil.rmtree(db.parent)
+
+    def test_the_lease_is_closed_when_the_scope_raises(self, two_managers):
+        from claude_code_log.cache import connection_lease
+
+        db, (a, _b) = two_managers
+        with pytest.raises(RuntimeError):
+            with connection_lease(db):
+                with a._get_connection() as leased:
+                    pass
+                raise RuntimeError("body failed")
+        with pytest.raises(sqlite3.ProgrammingError):
+            leased.execute("SELECT 1")
+
+    def test_nested_leases_reuse_the_outer_one(self, two_managers):
+        from claude_code_log.cache import connection_lease
+
+        db, (a, _b) = two_managers
+        with connection_lease(db):
+            with a._get_connection() as outer:
+                pass
+            with connection_lease(db):
+                with a._get_connection() as inner:
+                    assert inner is outer
+            # The inner scope must not have closed the outer connection.
+            assert outer.execute("SELECT 1").fetchone()[0] == 1
+
+    def test_a_lease_is_per_thread(self, two_managers):
+        from claude_code_log.cache import connection_lease
+
+        db, (a, _b) = two_managers
+        seen: list = []
+        with connection_lease(db):
+            with a._get_connection() as leased:
+                pass
+
+            def other_thread():
+                with a._get_connection() as conn:
+                    seen.append(conn is leased)
+                    conn.execute("SELECT 1")
+
+            t = threading.Thread(target=other_thread)
+            t.start()
+            t.join()
+        assert seen == [False]
+
+    def test_a_corrupt_database_is_still_rebuilt_under_a_lease(
+        self, tmp_path, sample_user_entry, capsys
+    ):
+        """The lease opens nothing on a corrupt file and the first manager
+        inside the scope deletes and rebuilds it as it always did."""
+        from claude_code_log.cache import connection_lease
+
+        db = tmp_path / "cache.db"
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        # A real database first, so the corruption is a truncation rather
+        # than a file that never was one.
+        cm = CacheManager(proj, "1.0.0", db_path=db)
+        jsonl = proj / "s.jsonl"
+        jsonl.write_text(json.dumps(sample_user_entry.model_dump()), encoding="utf-8")
+        cm.save_cached_entries(jsonl, [sample_user_entry])
+        _migrated_db_paths.discard(str(db))
+        size = db.stat().st_size
+        with open(db, "r+b") as f:
+            f.truncate(size // 4)
+
+        with connection_lease(db):
+            rebuilt = CacheManager(proj, "1.0.0", db_path=db)
+            assert "corrupt" in capsys.readouterr().out.lower()
+            with rebuilt._get_connection() as conn:
+                assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            assert rebuilt._project_id is not None
+        shutil.rmtree(tmp_path / "proj")
+
+    def test_a_lease_survives_a_rebuild_of_another_database(self, two_managers):
+        """`_drop_leases` is keyed by path: dropping one database's lease
+        leaves a lease on a different file untouched."""
+        from claude_code_log.cache import _drop_leases, connection_lease
+
+        db, (a, _b) = two_managers
+        with connection_lease(db):
+            with a._get_connection() as leased:
+                pass
+            _drop_leases(db.parent / "other.db")
+            assert leased.execute("SELECT 1").fetchone()[0] == 1
+
+
+class TestHierarchyPassHoldsOneLease:
+    def test_a_hierarchy_pass_opens_no_per_call_connections(
+        self, tmp_path, monkeypatch, sample_user_entry
+    ):
+        """`process_projects_hierarchy` plans every project under one lease.
+
+        Counting per-instance opens rather than timing: on a 332-project
+        archive the connection-per-call pattern was 3,658 open/close
+        cycles and ~90 s of a 96 s no-change pass on Windows.
+        """
+        from claude_code_log.converter import process_projects_hierarchy
+
+        projects = tmp_path / "projects"
+        for name in ("p1", "p2"):
+            d = projects / name
+            d.mkdir(parents=True)
+            (d / "session-1.jsonl").write_text(
+                json.dumps(sample_user_entry.model_dump()) + "\n", encoding="utf-8"
+            )
+        monkeypatch.setenv("CLAUDE_CODE_LOG_CACHE_PATH", str(tmp_path / "cache.db"))
+
+        opens: list[int] = []
+        real_open = CacheManager._open_configured_connection
+
+        def counting_open(self):
+            opens.append(1)
+            return real_open(self)
+
+        monkeypatch.setattr(CacheManager, "_open_configured_connection", counting_open)
+
+        process_projects_hierarchy(projects, use_cache=True)  # populates
+        opens.clear()
+        process_projects_hierarchy(projects, use_cache=True)  # the steady pass
+        assert opens == [], f"{len(opens)} per-call connections in a leased pass"
+        # And the lease let go: the tree can be deleted (Windows-meaningful).
+        shutil.rmtree(tmp_path / "projects")

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -1509,6 +1509,56 @@ class TestConnectionLease:
             assert rebuilt._project_id is not None
         shutil.rmtree(tmp_path / "proj")
 
+    def test_a_corrupt_table_page_drops_a_held_lease_before_the_rebuild(
+        self, tmp_path, sample_user_entry, capsys
+    ):
+        """The path `_drop_leases` exists for.
+
+        A truncated file fails at the lease's own open, so that case never
+        holds a lease. Garbling only the `projects` table's root page keeps
+        the header intact: the lease opens fine, then the first manager's
+        `_ensure_project_exists` raises on the leased connection, and the
+        rebuild has to close that handle before Windows will let it delete
+        the file. Afterwards the scope's exit must not close it twice.
+        """
+        from claude_code_log.cache import _thread_leases, connection_lease
+
+        db = tmp_path / "cache.db"
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        cm = CacheManager(proj, "1.0.0", db_path=db)
+        jsonl = proj / "s.jsonl"
+        jsonl.write_text(json.dumps(sample_user_entry.model_dump()), encoding="utf-8")
+        cm.save_cached_entries(jsonl, [sample_user_entry])
+        _migrated_db_paths.discard(str(db))
+
+        raw = sqlite3.connect(db)
+        raw.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        page_size = raw.execute("PRAGMA page_size").fetchone()[0]
+        rootpage = raw.execute(
+            "SELECT rootpage FROM sqlite_master WHERE name = 'projects'"
+        ).fetchone()[0]
+        raw.close()
+        with open(db, "r+b") as f:
+            f.seek((rootpage - 1) * page_size)
+            f.write(b"\xff" * page_size)
+
+        with connection_lease(db):
+            assert _thread_leases(), "the lease should open on an intact header"
+            leased = _thread_leases()[(str(db), False)]
+            rebuilt = CacheManager(proj, "1.0.0", db_path=db)
+            assert "corrupt" in capsys.readouterr().out.lower()
+            # The rebuild dropped the lease; the old handle is closed.
+            assert not _thread_leases()
+            with pytest.raises(sqlite3.ProgrammingError):
+                leased.execute("SELECT 1")
+            with rebuilt._get_connection() as conn:
+                assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            assert rebuilt._project_id is not None
+        # Scope exit found nothing to close, and nothing holds the files.
+        shutil.rmtree(tmp_path / "proj")
+        db.unlink()
+
     def test_a_lease_survives_a_rebuild_of_another_database(self, two_managers):
         """`_drop_leases` is keyed by path: dropping one database's lease
         leaves a lease on a different file untouched."""

--- a/test/test_combined_transcript_link.py
+++ b/test/test_combined_transcript_link.py
@@ -124,3 +124,100 @@ class TestCombinedTranscriptLink:
             # Verify link is present and title is used
             assert "← View All Sessions (Combined Transcript)" in html
             assert f"<title>{custom_title}</title>" in html
+
+
+class TestCombinedLinkFollowsTheFileNotTheFlag:
+    """The back-link tracks whether the combined page exists on disk.
+
+    It used to track ``--combined`` instead, which made a rendered page
+    depend on the *run's* mode -- something the freshness check knows
+    nothing about. So the state stuck: a page rendered by a
+    ``--combined no`` run (every watch tick) kept no link for good, and a
+    later full conversion saw a current file and skipped it. An archive
+    ended up with some session pages linking and some not, decided only
+    by which run happened to render each.
+
+    Migration 013 records the state per page so a genuine transition
+    regenerates; these tests pin both halves.
+    """
+
+    FIXTURE = (
+        Path(__file__).parent / "test_data" / "real_projects" / "-experiments-ideas"
+    )
+    LINK = "← View All Sessions (Combined Transcript)"
+
+    def _project(self, tmp_path: Path) -> Path:
+        import shutil
+
+        work = tmp_path / self.FIXTURE.name
+        shutil.copytree(self.FIXTURE, work)
+        return work
+
+    def _pages(self, work: Path) -> list[Path]:
+        pages = sorted(work.glob("session-*.html"))
+        assert pages, "conversion produced no session files"
+        return pages
+
+    def _linked(self, work: Path) -> bool:
+        return all(
+            self.LINK in p.read_text(encoding="utf-8") for p in self._pages(work)
+        )
+
+    def _convert(self, work: Path, write_combined: bool) -> None:
+        from claude_code_log.converter import convert_jsonl_to
+
+        convert_jsonl_to("html", work, silent=True, write_combined=write_combined)
+
+    def test_no_link_when_no_combined_page_has_ever_been_written(
+        self, tmp_path: Path
+    ) -> None:
+        work = self._project(tmp_path)
+        self._convert(work, write_combined=False)
+
+        assert not (work / "combined_transcripts.html").exists()
+        assert not self._linked(work)
+
+    def test_link_appears_once_a_combined_page_exists(self, tmp_path: Path) -> None:
+        """The regression: a full run after a `--combined no` run must fix it."""
+        work = self._project(tmp_path)
+        self._convert(work, write_combined=False)
+        assert not self._linked(work)
+
+        self._convert(work, write_combined=True)
+
+        assert (work / "combined_transcripts.html").exists()
+        assert self._linked(work), (
+            "session pages kept their link-less state after a full conversion "
+            "wrote the combined page they should link to"
+        )
+
+    def test_link_survives_a_watch_style_run_without_rewriting(
+        self, tmp_path: Path
+    ) -> None:
+        """`--combined no` over an existing combined page changes nothing.
+
+        The page it points at is still there and still served, so the link
+        stays valid -- and the pages must not be rewritten for it.
+        """
+        work = self._project(tmp_path)
+        self._convert(work, write_combined=True)
+        before = {p: p.stat().st_mtime_ns for p in self._pages(work)}
+
+        self._convert(work, write_combined=False)
+
+        assert self._linked(work)
+        assert {p: p.stat().st_mtime_ns for p in self._pages(work)} == before
+
+    def test_link_is_dropped_when_the_combined_page_goes_away(
+        self, tmp_path: Path
+    ) -> None:
+        work = self._project(tmp_path)
+        self._convert(work, write_combined=True)
+        assert self._linked(work)
+
+        (work / "combined_transcripts.html").unlink()
+        self._convert(work, write_combined=False)
+
+        assert not self._linked(work), (
+            "session pages still link to a combined page that no longer exists"
+        )

--- a/test/test_entry_store.py
+++ b/test/test_entry_store.py
@@ -906,3 +906,84 @@ class TestSessionLoadOrdering:
         assert not any("TEMP B-TREE" in p.upper() for p in plan), (
             f"the index no longer satisfies the ORDER BY — plan was {plan}"
         )
+
+
+class TestHierarchyCallerOwnedStore:
+    """A caller may own the store across `process_projects_hierarchy` calls.
+
+    `watch` already does this for the single-project path, which is what
+    lets a tick resume its parse from the bytes the previous tick read.
+    `serve --watch` converts the *hierarchy* instead, so without a
+    caller-owned store every tick built a fresh one and re-parsed each
+    changed file whole.
+
+    The hierarchy fans stale projects out over a process pool, and a
+    store holding parsed entries is no use across a `spawn` — so it
+    reaches only the inline conversion. That is the watch steady state:
+    one live project stale per tick means `resolved_jobs == 1` and no
+    pool.
+    """
+
+    def _archive(self, tmp_path: Path) -> tuple[Path, Path]:
+        projects = tmp_path / "projects"
+        projects.mkdir(parents=True)
+        work_dir = _copy_project(projects)
+        return projects, _busiest_trunk(work_dir)
+
+    def _tick(self, projects: Path, store: Any = None) -> None:
+        converter.process_projects_hierarchy(
+            projects, silent=True, write_combined=False, entry_store=store
+        )
+
+    def test_a_caller_owned_store_resumes_across_ticks(self, tmp_path: Path) -> None:
+        """Three ticks: cold, one that holds a prefix, one that resumes it."""
+        projects, jsonl = self._archive(tmp_path)
+        store = ParsedEntryStore()
+
+        self._tick(projects, store)
+        _append_entry(jsonl, "hierarchy-store-1", "a new message arrives")
+        self._tick(projects, store)
+        _append_entry(jsonl, "hierarchy-store-2", "and another")
+        self._tick(projects, store)
+
+        assert store.prefix_hits > 0, (
+            "the third tick re-read the whole file instead of resuming from "
+            "the prefix the second tick held"
+        )
+
+    def test_per_conversion_stores_cannot_resume(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The contrast that gives the test above its meaning.
+
+        Without a caller-owned store each tick builds its own, which dies
+        with the call — so no tick can ever resume from another's prefix.
+        """
+        projects, jsonl = self._archive(tmp_path)
+        stores = _spy_stores(monkeypatch)
+
+        self._tick(projects)
+        _append_entry(jsonl, "hierarchy-store-1", "a new message arrives")
+        self._tick(projects)
+        _append_entry(jsonl, "hierarchy-store-2", "and another")
+        self._tick(projects)
+
+        assert stores, "no store was created"
+        assert all(s.prefix_hits == 0 for s in stores)
+
+    def test_output_is_byte_identical_with_a_caller_owned_store(
+        self, tmp_path: Path
+    ) -> None:
+        """The bar any store change has to clear: the bytes must not move."""
+        on_projects, on_jsonl = self._archive(tmp_path / "on")
+        off_projects, off_jsonl = self._archive(tmp_path / "off")
+        store = ParsedEntryStore()
+
+        self._tick(on_projects, store)
+        self._tick(off_projects)
+        for jsonl in (on_jsonl, off_jsonl):
+            _append_entry(jsonl, "hierarchy-store-1", "a new message arrives")
+        self._tick(on_projects, store)
+        self._tick(off_projects)
+
+        assert _session_files(on_jsonl.parent) == _session_files(off_jsonl.parent)

--- a/test/test_pagination.py
+++ b/test/test_pagination.py
@@ -964,6 +964,65 @@ class TestNextLinkInPlaceUpdate:
         result = _enable_next_link_on_previous_page(temp_project_dir, -1)
         assert result is False
 
+    def test_enable_next_link_does_not_read_whole_page_for_css_match(
+        self, temp_project_dir, monkeypatch
+    ):
+        """The inlined CSS rule must not drag the whole page into memory.
+
+        Every page inlines `.page-nav-link.next.last-page { display: none }`,
+        so a guard on the bare substring can never fire. That made each call
+        read the entire page back and run a DOTALL regex over it -- the
+        dominant per-tick cost under `watch`, for pages needing no edit.
+        """
+        from claude_code_log.converter import (
+            _enable_next_link_on_previous_page,
+            _get_page_html_path,
+        )
+
+        page_path = temp_project_dir / _get_page_html_path(1)
+        page_path.write_text(
+            "<style>.page-nav-link.next.last-page { display: none; }</style>\n"
+            "<!-- PAGINATION_NEXT_LINK_START -->\n"
+            '<a href="combined_transcripts_2.html" class="page-nav-link next">Next</a>\n'
+            "<!-- PAGINATION_NEXT_LINK_END -->\n" + "<div>body</div>\n" * 20000,
+            encoding="utf-8",
+        )
+
+        def fail_read_text(*args, **kwargs):
+            raise AssertionError("read the whole page for a CSS-only match")
+
+        monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+        assert _enable_next_link_on_previous_page(temp_project_dir, 1) is False
+
+    def test_enable_next_link_falls_back_when_block_past_prefix(
+        self, temp_project_dir, monkeypatch
+    ):
+        """A nav block beyond the bounded prefix still gets updated.
+
+        The prefix is a fast path, not a new precondition: if the block
+        isn't wholly inside it, the full read still has to happen.
+        """
+        from claude_code_log import converter
+        from claude_code_log.converter import (
+            _enable_next_link_on_previous_page,
+            _get_page_html_path,
+        )
+
+        monkeypatch.setattr(converter, "_NAV_BLOCK_PREFIX_CHARS", 64)
+
+        page_path = temp_project_dir / _get_page_html_path(1)
+        page_path.write_text(
+            "<div>padding</div>\n" * 50 + "<!-- PAGINATION_NEXT_LINK_START -->\n"
+            '<a href="combined_transcripts_2.html"'
+            ' class="page-nav-link next last-page">Next</a>\n'
+            "<!-- PAGINATION_NEXT_LINK_END -->\n",
+            encoding="utf-8",
+        )
+
+        assert _enable_next_link_on_previous_page(temp_project_dir, 1) is True
+        assert "last-page" not in page_path.read_text(encoding="utf-8")
+
 
 class TestPaginationNextLinkVisibility:
     """Integration tests for next link visibility across pages."""

--- a/test/test_watch_engine.py
+++ b/test/test_watch_engine.py
@@ -6,6 +6,7 @@ these are the tests that have to stay trustworthy when the conversion
 behind them gets slower.
 """
 
+import fnmatch
 from pathlib import Path
 
 import pytest
@@ -340,10 +341,14 @@ class TestScanParity:
         (root / "top.jsonl").write_text("{}\n", encoding="utf-8")
         (root / ".hidden").mkdir()
         (root / ".hidden" / "h.jsonl").write_text("{}\n", encoding="utf-8")
+        # Case follows the platform, as it does for `Path.glob` and for the
+        # converter's own `*.jsonl` discovery: watched on Windows, not on
+        # POSIX. The parity assertion below is what checks it either way.
+        (p2 / "UP.JSONL").write_text("{}\n", encoding="utf-8")
 
         got = scan([root])
         assert got == self._glob_scan([root])
-        assert {p.name for p in got} == {
+        expected = {
             "s1.jsonl",
             "s2.jsonl",
             "agent-abc.jsonl",
@@ -352,6 +357,9 @@ class TestScanParity:
             "top.jsonl",
             "h.jsonl",
         }
+        if fnmatch.fnmatch("UP.JSONL", "*.jsonl"):
+            expected.add("UP.JSONL")
+        assert {p.name for p in got} == expected
 
     def test_scan_over_several_roots(self, tmp_path: Path) -> None:
         a = tmp_path / "a"

--- a/test/test_watch_engine.py
+++ b/test/test_watch_engine.py
@@ -297,3 +297,68 @@ class TestLoop:
             stop.set()
             thread.join(timeout=10)
         assert not thread.is_alive(), "the loop did not stop when asked"
+
+
+class TestScanParity:
+    """The scandir walk must return exactly what the glob form returned.
+
+    The glob form is kept here as the reference so a divergence names the
+    path that differs, rather than showing up later as a session that
+    stopped updating.
+    """
+
+    @staticmethod
+    def _glob_scan(roots: list[Path]) -> dict[Path, tuple[int, int]]:
+        from claude_code_log.watch import IGNORED_PREFIXES, WATCHED_GLOBS
+
+        stamps: dict[Path, tuple[int, int]] = {}
+        for root in roots:
+            for pattern in WATCHED_GLOBS:
+                for path in root.glob(pattern):
+                    if path.name.startswith(IGNORED_PREFIXES):
+                        continue
+                    st = path.stat()
+                    stamps[path] = (st.st_size, st.st_mtime_ns)
+        return stamps
+
+    def test_scandir_scan_matches_the_glob_scan(self, tmp_path: Path) -> None:
+        root = tmp_path / "projects"
+        p1 = root / "p1"
+        p2 = root / "p2"
+        deep = p1 / "s1" / "subagents"
+        deep.mkdir(parents=True)
+        p2.mkdir()
+        (p1 / "s1.jsonl").write_text("{}\n", encoding="utf-8")
+        (p1 / "s2.jsonl").write_text("{}{}\n", encoding="utf-8")
+        (deep / "agent-abc.jsonl").write_text("{}\n", encoding="utf-8")
+        (deep / "agent-abc.meta.json").write_text("{}", encoding="utf-8")
+        (deep / "agent-abc.other.json").write_text("{}", encoding="utf-8")
+        (deep / "notes.meta.json").write_text("{}", encoding="utf-8")
+        (p1 / ".s1.html.123.tmp").write_text("x", encoding="utf-8")
+        (p1 / "session-s1.html").write_text("<html>", encoding="utf-8")
+        (p2 / "solo.jsonl").write_text("{}\n", encoding="utf-8")
+        (root / "top.jsonl").write_text("{}\n", encoding="utf-8")
+        (root / ".hidden").mkdir()
+        (root / ".hidden" / "h.jsonl").write_text("{}\n", encoding="utf-8")
+
+        got = scan([root])
+        assert got == self._glob_scan([root])
+        assert {p.name for p in got} == {
+            "s1.jsonl",
+            "s2.jsonl",
+            "agent-abc.jsonl",
+            "agent-abc.meta.json",
+            "solo.jsonl",
+            "top.jsonl",
+            "h.jsonl",
+        }
+
+    def test_scan_over_several_roots(self, tmp_path: Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "x.jsonl").write_text("{}\n", encoding="utf-8")
+        (b / "y.jsonl").write_text("{}\n", encoding="utf-8")
+        assert set(scan([a, b])) == {a / "x.jsonl", b / "y.jsonl"}
+        assert scan([a, b]) == self._glob_scan([a, b])

--- a/work/watch-live-sessions.md
+++ b/work/watch-live-sessions.md
@@ -1,0 +1,278 @@
+# `serve --watch` latency on a large archive — findings and plan
+
+Status: investigation done, nothing implemented. Follows PR #321
+("Make watch ticks cheap"), whose measurements were taken on a 217-file
+archive with a few hundred entries per file. This note re-measures on
+cboos's Windows archive, which has a different shape, and finds two
+costs the earlier measurements could not see. Everything below was
+measured on 2026-09-06 on this branch (`perf/watch-tick-latency`, tip
+`1c38ba0`), Windows 11, 4 logical cores, cache DB 890 MB.
+
+## The archive
+
+| | |
+|---|---|
+| projects | 332 |
+| trunk JSONL files | 1,607 (1.2 GB); 1,896 watched files with agent sidecars |
+| largest project | `C--Users-cboos-SAM-main`: 10 files, 109 MB, live file 53 MB / **28,421 lines** |
+| this repo's project | 7 files, 20 MB, live file 9 MB / 2,363 lines |
+
+The reference archive PR #321 was tuned on had a 39.7 MB live file with
+**207 entries**. Here the live files carry 100× the entry count at the
+same byte size. Everything that costs per entry rather than per byte is
+100× more expensive, and that turns out to be most of a tick.
+
+## What `serve --watch` does per tick today
+
+`WatchEngine([projects_path])` globs the whole archive every 0.25 s, and
+on any change calls `process_projects_hierarchy(projects_path,
+write_combined=False)` — a full plan pass over every project, then a
+conversion of the ones that changed, then the index and search page.
+
+## Measured
+
+### 1. The no-change hierarchy pass: 95 s, of which ~90 s is SQLite connection churn
+
+Three consecutive passes with nothing changed: 94.5 s and 97.4 s wall
+(the first, a catch-up, 171 s). Per-project plan cost has a median of
+0.2 s, ×332 = 67 s; the rest is the same cost outside the loop.
+
+cProfile of one steady pass (104.9 s under the profiler):
+
+| | calls | cumulative |
+|---|---|---|
+| `CacheManager._get_connection` | 7,354 | 89.5 s |
+| ↳ `sqlite3.Connection.close` | 3,658 | **41.4 s** |
+| ↳ `sqlite3.Connection.execute` (the three PRAGMAs dominate) | 16,724 | 37.2 s |
+| ↳ `sqlite3.connect` | 3,658 | 11.1 s |
+| `get_library_version` via `importlib.metadata` | 675 | 3.3 s |
+| `pathlib.glob` | 7,348 | 4.3 s |
+| `check_html_version` (opens each session page) | 670 | 1.6 s |
+
+`_plan_project` opens **eleven** connections per project, each a fresh
+`connect` + `PRAGMA journal_mode=WAL` + close. Every close is the *last*
+connection on the database, so SQLite checkpoints and deletes the
+`-wal`/`-shm` files each time, which on Windows against an 890 MB file is
+where the 41 s goes. Micro-benchmark on the real DB:
+
+| connect + 3 PRAGMAs + close | per cycle |
+|---|---|
+| no other connection open | 29.0 ms |
+| one idle connection held open | **6.7 ms** |
+
+Patched into the pass without touching the repo:
+
+| strategy | steady pass |
+|---|---|
+| baseline, a connection per call | 95.9 s |
+| one idle connection held for the pass, still a connection per call | **17.9 s** |
+| one connection shared by every `_get_connection` in the process | **5.3 s** |
+
+The 5.3 s remainder is the version lookup (3.3 s, see next), globbing
+and file opens.
+
+### 2. Regression on this branch: `get_library_version` lost its memo
+
+`1c38ba0` inserted `_combined_link_stale` between
+`@functools.lru_cache(maxsize=1)` and `def get_library_version`, so the
+decorator now memoises the wrong (pure, two-argument) function and the
+version lookup re-parses package metadata on every call again: 675 calls,
+3.3 s per pass. §2.15 of the application model still describes it as
+memoised. One-line fix: move the decorator back.
+
+### 3. The watch scan itself: 0.4–0.9 s per poll, polled every 0.25 s
+
+`watch.scan` runs two `**` globs over the archive and then `stat`s each of
+the 1,896 hits. On Windows the stat is a separate syscall per file, while
+`os.scandir` already returns size and mtime with the listing. Measured
+idle: 0.43–0.91 s per scan; a `scandir` walk using `DirEntry.stat()`
+returned the identical dict 4–7× faster. At the current poll interval the
+watch thread never sleeps, and it shares the GIL with the server thread
+answering the page's HEADs. (Under the design in §Plan B the roots shrink
+to a handful of directories and this stops mattering for `serve`; it still
+matters for `watch --all-projects`.)
+
+### 4. A real one-line append tick on a big session: 15–27 s
+
+The hierarchy pass hid this. Scratch copies of two projects, the live
+file's last five lines held back and appended one per tick, entry store
+held across ticks as `serve` does:
+
+| project | cold | no-change tick | append ticks (one line each) |
+|---|---|---|---|
+| this repo (live file 9 MB, 2,363 lines) | 25.6 s | 0.06 s | 2.15, 1.32, 6.70, 1.37, 1.44 s |
+| SAM-main (live file 53 MB, 28,421 lines) | 54.4 s | 0.07 s | 26.9, 15.5, 16.6, 17.8, 16.1 s |
+
+Against a documented target of 0.26 s. cProfile of one SAM-main append
+tick (25.4 s):
+
+| | cumulative | what |
+|---|---|---|
+| `copy.deepcopy` | **16.0 s** | 4.6 M recursive calls copying pydantic entries: `entry_store.get_prefix` 4.5 s, `entry_store.get` 3.9 s (×2), `put_prefix` 3.3 s |
+| `save_cached_entries` | 5.5 s | re-`json.dumps` + `zlib.compress` + insert of all 22,551 rows |
+| `get_file_states` ×2 | 5.8 s | reads every row's `content` blob and `sha256`s it, both calls |
+| `_load_sessions_partial` | 4.5 s | mostly the `get` deepcopy above |
+
+Three separate costs, each O(entries in the file), none O(append):
+
+- **The store copies on every read and write.** `entry_store.py`'s
+  docstring argues `deepcopy` "is cheap and stays cheap because the bulk
+  of an entry is immutable strings". That is true per byte and false per
+  entry: it is ~0.2 ms per entry, three times a tick. The consumers that
+  mutate are the reason for the copy; either they stop mutating (and the
+  store hands out the same list, guarded by a test that mutation raises),
+  or the copy becomes lazy — copy the slice a consumer touches, not the
+  file.
+- **The full row rewrite** is the "not in scope" item from PR #321: a
+  trunk whose rows carry spliced subagent transcripts cannot append rows,
+  so it deletes and re-inserts all of them. SAM-main has subagents; so
+  does anything that uses the Agent tool, i.e. the sessions one actually
+  watches.
+- **`get_file_states` fingerprints from content.** Hashing 22 k blobs
+  twice per tick to compare prefixes is 5.8 s here. A stored fingerprint
+  column (one migration) makes the query index-only.
+
+Without the deepcopy alone the tick is ~9 s; with all three addressed it
+should land near the 0.26 s the note promises, since the remaining work is
+proportional to the append.
+
+## The proposal, evaluated
+
+cboos's proposal: build the index at server start; when a session page is
+opened, mark it *live* and watch only live sessions; a page that stops
+asking is no longer live; regenerate the index every few minutes or on
+explicit reload.
+
+**It is the right shape, and the fixes above do not replace it.** Even at
+5.3 s the no-change hierarchy pass is not something a 1 s-poll loop can
+run per tick, and it will always be O(archive): every project is planned
+so that the *index* can be rewritten, on a tick whose only purpose is one
+session page. A tick has to cost O(what is live). Two further things the
+proposal buys that the fixes do not:
+
+- The hierarchy pass reads the whole cache DB on the watch thread while
+  the server thread is answering HEADs a second apart; both share the GIL
+  and the disk. Under the proposal the watch thread touches one project.
+- The engine's roots collapse from the archive to the live projects'
+  directories, which makes the scan cost (§3) irrelevant for `serve`.
+
+The browser side needs nothing new to signal liveness: `live_update.js`
+already HEADs its own URL every second and stops when the tab is hidden.
+That HEAD *is* the heartbeat. A page whose tab is hidden or closed stops
+polling, drops out of the live set after a timeout, and stops being
+watched — exactly the semantics asked for, with no registration call.
+
+What the proposal does not fix: the per-tick cost of the live session
+itself (§4). A watched SAM-main session would still take 16 s per append
+until §4 is addressed. Both are needed; they are independent.
+
+## Plan
+
+### A. Cheap fixes, in this order — they help every command, not just watch
+
+✅ **Landed (2026-09-06), all three.** Steady no-change hierarchy pass on
+this archive: **95 s → 2.1–2.8 s** (three consecutive runs: 65 s
+catch-up, then 2.8 s, 2.1 s). The lease is `cache.connection_lease`,
+taken by `process_projects_hierarchy` for its whole run;
+`get_library_version` has its memo back with a test pinning the wrapper
+to the function; `watch.scan` is a `scandir` walk with a parity test
+against the glob form. Track C is what the live-session tick still
+needs on big files; track B is unchanged.
+
+1. **Restore the memo** on `get_library_version` (§2). One line, plus a
+   test that asserts the function object is an `lru_cache` wrapper so a
+   later insertion cannot move it silently again.
+2. **Connection lease for the hierarchy pass** (§1). A module-level,
+   per-thread lease in `cache.py`: `with CacheManager.lease(db_path):`
+   opens one configured connection and `_get_connection` yields it when
+   no `batch()` is active. `process_projects_hierarchy` takes the lease
+   for its whole run, and `serve --watch` holds one for the process
+   lifetime. Per-thread because `sqlite3` connections are thread-bound
+   and the server thread has its own. Measured 96 s → 5.3 s. Keep the
+   existing Windows-safety property: the lease closes on scope exit, so
+   nothing holds the `-wal`/`-shm` files past the pass. Fallback if the
+   shared connection turns out to interact badly with `batch()` or the
+   pool workers: the sentinel alone (a held idle connection, no sharing)
+   is three lines and gives 96 s → 18 s.
+3. **`scandir`-based `watch.scan`** (§3). Same result dict, same
+   filtering; `DirEntry.stat(follow_symlinks=False)`. Pinned by a test
+   that both scans agree on a fixture tree with a dotfile, a sidecar and
+   a nested agent directory.
+
+### B. Live sessions under `serve --watch`
+
+4. **Live registry** in `server.py`: `LiveSessions` with
+   `touch(project_dir_name, session_id)` and `live(ttl) -> {project:
+   {session,...}}`. `send_head` calls `touch` when the translated path
+   matches `<projects>/<project>/session-<id>.html` (session pages only;
+   combined and index pages are explicitly not live, matching the
+   existing "combined pages stop tracking" decision). TTL 10 s: the page
+   polls every 1 s and stops when hidden, so the set follows what is
+   actually on screen. Thread-safe (requests arrive on server threads,
+   reads on the watch thread).
+5. **Roots as a provider.** `WatchEngine(roots=...)` accepts a callable
+   evaluated per tick; `serve` passes `lambda: [projects_path / p for p
+   in live.projects()]`. A project entering the live set is primed on
+   entry so its history is not reported as one change. `watch
+   --all-projects` and the `watch` command are unchanged.
+6. **Tick converts live projects only.** `reconvert` calls
+   `convert_jsonl_to(project_dir, write_combined=False,
+   entry_store=store)` per live project, never
+   `process_projects_hierarchy`. The session-scoped path then renders
+   only the stale session(s) in that project. The index is not touched
+   by a tick.
+7. **Index on a timer and on demand.** `--index-interval` (default 5 min,
+   0 to disable) runs the hierarchy plan pass on the watch thread between
+   ticks, skipped whenever a live tick is pending so it never delays one.
+   `/api/refresh-index` triggers the same pass and returns when done; a
+   small "refresh" control on the index page calls it and reloads. With
+   A2 the pass is ~5 s here and ~1 s on Linux.
+8. **Lazy first render** (`--lazy`, later the default under `--watch`).
+   Startup today converts the whole archive (171 s catch-up here, minutes
+   cold). Instead: startup runs the plan pass and writes the index only;
+   a GET of a session page whose project is stale converts that project
+   inline before serving (one blocking request, seconds on a big project,
+   once). Projects never cached still need one full load, which this
+   defers to first click rather than start. This is the most invasive
+   step and can ship after 4–7.
+
+### C. The per-tick O(entries) costs (§4), each its own PR
+
+9. **Stop copying the file to read a line.** Decide the store's mutation
+   contract: find the consumers that mutate (`git grep` for in-place
+   changes on `TranscriptEntry` after `load_transcript`), make them copy
+   what they change, and have the store return its list. A test that
+   freezes returned entries (or checks identity across two `get`s) pins
+   it. Expected ~16 s off the SAM-main tick.
+10. **Stored row fingerprints** (migration 014): a `fingerprint` column
+    written by `save_cached_entries`, read by `get_file_states` instead of
+    hashing `content`. ~5 s off.
+11. **Append-only rows for spliced trunks** — the "not in scope" item in
+    PR #321: stop splicing agent rows into trunk rows so an appended file
+    is an appended row set. ~5 s off, and the change that lets §2.16's
+    resume path apply to the sessions people actually watch.
+
+### Verification
+
+- Re-run this note's benchmarks after each step; the scripts are
+  `hier_bench.py`, `hier_prof.py`, `hier_fix.py`, `append_bench.py`,
+  `append_prof.py` (session scratchpad; worth moving under `scripts/`
+  as a `bench_watch.py` with the held-back-lines method, so the numbers
+  are reproducible on a copy of any real project).
+- Targets on this archive: steady hierarchy pass ≤ 6 s (A), a
+  `serve --watch` tick with one live session ≤ 1 s on the 9 MB session
+  (B), ≤ 1 s on the 53 MB session (C).
+- Browser tests for B: a live page receives an append; a page that has
+  stopped polling causes no conversion (assert the engine's
+  `conversions` counter); index refresh route works and the index page's
+  control uses it.
+- Docs: `docs/live-updates.md` (what "live" means, the index cadence,
+  `--index-interval`, `--lazy`), `dev-docs/application_model.md` §2.15
+  (the registry, the roots provider, and correct the memo claim).
+
+### Side finding, unrelated
+
+`claude-code-log convert --help` crashes with `UnicodeEncodeError` when
+stdout is cp1252 (a Git Bash pipe on Windows): a `※` in the help text.
+`PYTHONUTF8=1` works around it; the fix is to drop the character or set
+`click.echo` up to degrade.


### PR DESCRIPTION
Watch re-converts on every change, so a tick's cost is latency you feel. On a
302-session / 373MB archive, one appended line per tick: **7.6–8.3s → 1.26s**.

**1. Stop re-reading whole pages to fix pagination links.**
`_enable_next_link_on_previous_page` guarded on `if "last-page" not in content`,
which can never fire — every page inlines the CSS rule containing
that string. So each call read the whole page back and ran a backtracking
regex over it, every page, every conversion, to change nothing on 21 of 22.
The nav block sits in the header just after the inlined stylesheet, so a
512KB prefix answers for the whole file; anything past it takes the full read
exactly as before. **5.22s → 0.23s.**

**2. Don't reload the project on `serve --watch` ticks.** It now passes
`--combined no`, as `watch` already defaults to — regenerating the combined
pages is what forces a tick to reload the whole project rather than the
session that grew. Those pages stay on disk and keep serving, but stop
tracking the live session until restart; the index still regenerates every
tick, so new sessions stay discoverable. `serve --watch` also now keeps its
parsed entries between ticks, as `watch` already did: **0.21s → 0.13s** on a
6.8MB project, with byte-identical output.

**3. Fix: the combined back-link was sticky.** Found while checking (2). The
link was emitted per the run's `--combined` setting, so rendered content
depended on something the freshness check doesn't track. A page rendered by a
`--combined no` run kept no link permanently — later full runs saw a current
file and skipped it — leaving archives where some session pages link and some
don't, decided only by which run rendered each. The link now follows whether
the combined file *exists*, and migration 013 records each page's state so
real transitions regenerate. Costs one in-memory comparison (0.05% of the
staleness call) plus one stat per run; existing rows are NULL and read as
matching, so no mass invalidation on upgrade.

Also: `just update-snapshot` now runs the whole procedure CONTRIBUTING
documents — purge bytecode, regenerate serially, verify read-only. Partial
runs caused both `.ambr` corruption incidents recorded there.

**Testing.** `just ci` green: 3194 unit, 68 TUI, 108 browser, 78 integration;
ruff, pyright, ty. Regression tests for each fix, each verified to fail
against unpatched code.

**Notes.** Combined pages not tracking the live session under `serve --watch`
is deliberate, and documented in `docs/live-updates.md`. A long-running
`serve --watch` now holds parsed entries it used to discard, bounded by the
store's existing 268MB budget. Migration 013 is a plain in-place `ALTER TABLE`,
independent of the `library_version` breaking-changes map — merges
cleanly with `dev/agent-spawn-linking`.

**Not in scope.** Subagent sessions still rewrite every cache row per tick
(~63ms for 537 rows vs ~2.7ms to append 12). Not fixable in isolation: a
trunk's rows include its spliced subagent transcripts, so an appended file
doesn't mean appended rows, and rows read back in timestamp order with no
positional key. The fix is to stop splicing agent rows into trunk rows —
a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added periodic transcript synchronization for Claude and Codex sessions.
  - Improved `serve --watch` updates by preserving conversion state between refreshes.
  - Combined transcript pages remain available while session pages continue updating; refresh combined pages on restart.

- **Bug Fixes**
  - Session links now accurately reflect whether combined transcripts exist.
  - Improved watch scanning performance and resilience across platforms, including handling files removed during scans.

- **Documentation**
  - Clarified live-update behavior and snapshot regeneration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->