### PR TITLE
Re-parse cached entries when the shape of what we cache changes (#320)

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -13,7 +13,7 @@ import zlib
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, get_args
 
 from packaging import version
 from pydantic import BaseModel
@@ -391,6 +391,43 @@ def subagents_fingerprint(jsonl_path: Path) -> str:
     return f"{len(metas)}:{newest}"
 
 
+# Manual salt for content-shape changes the field names cannot see: a
+# field whose *meaning* or serialized representation changed while keeping
+# its name. Bump it and every cached blob is re-parsed once. Leave it alone
+# for field additions/removals/renames — those move the digest by
+# themselves, which is the point.
+_CONTENT_SCHEMA_SALT = "1"
+
+
+@functools.lru_cache(maxsize=1)
+def content_schema_version() -> str:
+    """Digest of the shape of what we store in ``messages.content``.
+
+    Cached entries are ``zlib(json(entry.model_dump()))``, so a blob is only
+    as complete as the model that produced it. File freshness keys on mtime,
+    size and the sidecar fingerprint — all properties of the *source* — so
+    before this existed, adding a field to a transcript model left every
+    unchanged file serving a blob written without it. The field then read as
+    absent for data that plainly had it (issue #320: ``imagePasteIds``
+    rehydrated as ``None`` on transcripts untouched since before it shipped).
+
+    Deriving the version from the declared field names rather than asking a
+    developer to bump a constant is deliberate: the failure it replaces was
+    exactly a remembered step nobody remembered. Add a field and the digest
+    moves on its own.
+
+    Field *names* only — not types or ordering — so the digest is stable
+    across Python and Pydantic versions and cannot mass-invalidate a 3 GB
+    cache on a dependency upgrade. Semantic changes that keep every name are
+    invisible here and are what ``_CONTENT_SCHEMA_SALT`` is for.
+    """
+    parts = [_CONTENT_SCHEMA_SALT]
+    for model in get_args(TranscriptEntry):
+        parts.append(model.__name__ + ":" + ",".join(sorted(model.model_fields)))
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return digest[:12]
+
+
 def _cache_row_is_fresh(
     row: sqlite3.Row,
     source_mtime: float,
@@ -423,6 +460,13 @@ def _cache_row_is_fresh(
     files stale, never fewer. Pre-011 rows carry NULL and fall back to
     the mtime-only check so a populated cache doesn't mass-invalidate.
     """
+    # Unlike the size and fingerprint columns above, a NULL here is NOT
+    # accepted. Those describe inputs we might have missed; this describes
+    # the completeness of what we wrote, and a NULL means the row was
+    # written before we tracked it -- the issue #320 state exactly. Treat
+    # unknown as stale so it re-parses once.
+    if row["content_version"] != content_schema_version():
+        return False
     if source_size is not None:
         cached_size = row["source_size"]
         if cached_size is not None and cached_size != source_size:
@@ -1071,7 +1115,8 @@ class CacheManager:
 
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT source_mtime, source_size, subagents_fingerprint"
+                "SELECT source_mtime, source_size, subagents_fingerprint,"
+                " content_version"
                 " FROM cached_files"
                 " WHERE project_id = ? AND file_name = ?",
                 (self._project_id, jsonl_path.name),
@@ -1208,15 +1253,17 @@ class CacheManager:
                 """
                 INSERT INTO cached_files
                 (project_id, file_name, file_path, source_mtime, source_size,
-                 cached_mtime, message_count, subagents_fingerprint)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                 cached_mtime, message_count, subagents_fingerprint,
+                 content_version)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(project_id, file_name) DO UPDATE SET
                     file_path = excluded.file_path,
                     source_mtime = excluded.source_mtime,
                     source_size = excluded.source_size,
                     cached_mtime = excluded.cached_mtime,
                     message_count = excluded.message_count,
-                    subagents_fingerprint = excluded.subagents_fingerprint
+                    subagents_fingerprint = excluded.subagents_fingerprint,
+                    content_version = excluded.content_version
                 """,
                 (
                     self._project_id,
@@ -1227,6 +1274,7 @@ class CacheManager:
                     cached_mtime,
                     len(entries),
                     subagents_fp,
+                    content_schema_version(),
                 ),
             )
 
@@ -1375,7 +1423,8 @@ class CacheManager:
         conn.execute(
             """UPDATE cached_files
                SET file_path = ?, source_mtime = ?, source_size = ?,
-                   cached_mtime = ?, message_count = ?, subagents_fingerprint = ?
+                   cached_mtime = ?, message_count = ?, subagents_fingerprint = ?,
+                   content_version = ?
                WHERE id = ?""",
             (
                 str(jsonl_path),
@@ -1384,6 +1433,7 @@ class CacheManager:
                 datetime.now().timestamp(),
                 len(all_entries),
                 subagents_fp,
+                content_schema_version(),
                 file_id,
             ),
         )
@@ -2026,7 +2076,7 @@ class CacheManager:
         with self._get_connection() as conn:
             rows = conn.execute(
                 "SELECT file_name, source_mtime, source_size,"
-                " subagents_fingerprint"
+                " subagents_fingerprint, content_version"
                 " FROM cached_files WHERE project_id = ?",
                 (self._project_id,),
             ).fetchall()

--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -399,6 +399,45 @@ def subagents_fingerprint(jsonl_path: Path) -> str:
 _CONTENT_SCHEMA_SALT = "1"
 
 
+def _nested_models(annotation: object) -> Generator[type[BaseModel], None, None]:
+    """Every Pydantic model reachable through a type annotation.
+
+    Unwraps whatever containers the annotation is wrapped in -- ``Optional``,
+    unions, ``List``, ``Dict`` -- because what matters is which models can end
+    up serialized, not how they are addressed.
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        yield annotation
+        return
+    for arg in get_args(annotation):
+        yield from _nested_models(arg)
+
+
+def _content_models() -> List[type[BaseModel]]:
+    """Every model whose fields can land in a stored content blob.
+
+    ``model_dump()`` serializes the whole tree, not just the entry's own
+    fields, so a digest over the top-level union members alone leaves the
+    #320 hazard live one level down -- and the content-item models are
+    exactly where new fields actually appear. Measured before this walk
+    existed: adding a field to ``TextContent`` left the digest unmoved.
+
+    Sorted by name so the digest does not depend on traversal order.
+    """
+    seen: Dict[str, type[BaseModel]] = {}
+    queue: List[type[BaseModel]] = list(get_args(TranscriptEntry))
+    while queue:
+        model = queue.pop()
+        key = model.__module__ + "." + model.__qualname__
+        if key in seen:
+            continue
+        seen[key] = model
+        for field in model.model_fields.values():
+            for nested in _nested_models(field.annotation):
+                queue.append(nested)
+    return sorted(seen.values(), key=lambda m: m.__module__ + "." + m.__qualname__)
+
+
 @functools.lru_cache(maxsize=1)
 def content_schema_version() -> str:
     """Digest of the shape of what we store in ``messages.content``.
@@ -416,13 +455,20 @@ def content_schema_version() -> str:
     exactly a remembered step nobody remembered. Add a field and the digest
     moves on its own.
 
+    It covers the whole serialized *tree* (``_content_models``), not just the
+    entry types: ``model_dump()`` writes nested models too, so a digest over
+    the top-level union alone would leave the same hazard live one level
+    down — in the content-item models, which is where fields actually get
+    added. Measured while this was still top-level-only: a new field on
+    ``TextContent`` left the digest unmoved.
+
     Field *names* only — not types or ordering — so the digest is stable
     across Python and Pydantic versions and cannot mass-invalidate a 3 GB
     cache on a dependency upgrade. Semantic changes that keep every name are
     invisible here and are what ``_CONTENT_SCHEMA_SALT`` is for.
     """
     parts = [_CONTENT_SCHEMA_SALT]
-    for model in get_args(TranscriptEntry):
+    for model in _content_models():
         parts.append(model.__name__ + ":" + ",".join(sorted(model.model_fields)))
     digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
     return digest[:12]

--- a/claude_code_log/migrations/014_cached_file_content_version.sql
+++ b/claude_code_log/migrations/014_cached_file_content_version.sql
@@ -1,0 +1,30 @@
+-- Re-parse when the shape of what we cache changes
+-- Migration: 014
+-- Description: Add a `content_version` column to `cached_files`.
+-- `messages.content` holds zlib(json(entry.model_dump())), so a cached
+-- blob is only as complete as the model that produced it. Freshness
+-- keyed on source mtime, size and the sidecar fingerprint -- all
+-- properties of the file -- and nothing observed the shape of what we
+-- had written. Adding a field to a transcript model therefore left
+-- every unchanged transcript serving a blob without it, indefinitely.
+--
+-- Issue #320 is that bug's first sighting: `imagePasteIds` shipped as a
+-- new field, and on transcripts untouched since, it rehydrated as NULL
+-- while the JSONL plainly carried it -- so image placeholders that had
+-- a recorded association were reported as having none, rendered
+-- literally, and their images detached.
+--
+-- The column stores the digest returned by
+-- `cache.content_schema_version()`, derived from the entry models' own
+-- field names, so a future field moves it without anyone remembering to.
+--
+-- Backward compatibility differs DELIBERATELY from 007 and 011. Those
+-- accept a NULL as "no reason to think we missed anything", because the
+-- column they added described an input we might not have seen. This one
+-- describes the content we wrote: a NULL means the row predates the
+-- check and its completeness is unknown, which is exactly the #320
+-- state. NULL is therefore treated as STALE and the row re-parses once.
+-- That is a one-time full re-parse of an existing cache, and it is the
+-- point of the migration rather than a cost to be avoided.
+
+ALTER TABLE cached_files ADD COLUMN content_version TEXT;

--- a/claude_code_log/migrations/runner.py
+++ b/claude_code_log/migrations/runner.py
@@ -71,13 +71,29 @@ def get_available_migrations() -> List[Tuple[int, Path]]:
     sql_files = sorted(migrations_dir.glob("*.sql"))
 
     migrations: List[Tuple[int, Path]] = []
+    seen: dict[int, str] = {}
     for sql_file in sql_files:
         try:
             version = _parse_migration_number(sql_file.name)
-            migrations.append((version, sql_file))
         except ValueError:
             # Skip files that don't match the naming convention
             continue
+        # Two files sharing a number is not a style problem: `_schema_version`
+        # keys on the number alone, so on any database that already applied
+        # one of them the other is considered applied and its DDL never
+        # runs -- silently, permanently, and only on the caches that came
+        # through the first one. The pair cannot be seen from either branch
+        # while they are developed in parallel; they become visible in the
+        # same tree the moment both merge, which is where this fires.
+        if version in seen:
+            raise ValueError(
+                f"Duplicate migration number {version:03d}: "
+                f"{seen[version]} and {sql_file.name}. Two branches claimed "
+                f"the same number; renumber the later one, since a database "
+                f"that applied either will silently skip the other."
+            )
+        seen[version] = sql_file.name
+        migrations.append((version, sql_file))
 
     return migrations
 

--- a/test/test_cache_content_version.py
+++ b/test/test_cache_content_version.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""The cached-content version, and why file freshness alone is not enough.
+
+``messages.content`` holds ``zlib(json(entry.model_dump()))``, so a cached
+blob is only as complete as the model that produced it. Freshness used to key
+solely on source mtime, size and the sidecar fingerprint — all properties of
+the file — so adding a field to a transcript model left every *unchanged*
+transcript serving a blob written without it, with nothing to notice.
+
+Issue #320 is that bug's first sighting: ``imagePasteIds`` shipped, and on
+transcripts untouched since, it rehydrated as ``None`` while the JSONL carried
+it — so ``[Image #N]`` placeholders with a recorded association were reported
+as having none, rendered literally, and their images detached.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from claude_code_log.cache import (
+    CacheManager,
+    _cache_row_is_fresh,
+    content_schema_version,
+)
+from claude_code_log.models import UserTranscriptEntry
+
+
+def _entry(uuid: str, text: str) -> str:
+    return (
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2025-07-03T16:15:00Z",
+                "parentUuid": None,
+                "isSidechain": False,
+                "userType": "human",
+                "cwd": "/tmp",
+                "sessionId": "s1",
+                "version": "1.0.0",
+                "uuid": uuid,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+def _row(**overrides: object) -> sqlite3.Row:
+    """A cached_files row, fresh by default."""
+    fields = {
+        "source_mtime": 1000.0,
+        "source_size": 4096,
+        "subagents_fingerprint": "",
+        "content_version": content_schema_version(),
+    }
+    fields.update(overrides)
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    cols = ", ".join(fields)
+    con.execute(f"CREATE TABLE t ({cols})")
+    con.execute(
+        f"INSERT INTO t VALUES ({', '.join('?' * len(fields))})",
+        tuple(fields.values()),
+    )
+    return con.execute("SELECT * FROM t").fetchone()
+
+
+class TestContentVersionParticipatesInFreshness:
+    def test_matching_version_is_fresh(self):
+        assert _cache_row_is_fresh(_row(), 1000.0, lambda: "", 4096) is True
+
+    def test_a_different_version_is_stale(self):
+        """The whole point: the file has not changed, and the row is stale
+        anyway, because what we wrote about it no longer matches the shape we
+        would write today."""
+        assert (
+            _cache_row_is_fresh(
+                _row(content_version="deadbeef0000"), 1000.0, lambda: "", 4096
+            )
+            is False
+        )
+
+    def test_NULL_is_stale_not_accepted(self):
+        """Deliberately unlike the pre-007 fingerprint and pre-011 size
+        columns, which accept NULL as "no reason to think we missed
+        anything". Those describe an *input*; this describes the completeness
+        of our own output, so NULL means unknown-and-probably-incomplete —
+        the #320 state — and must re-parse once."""
+        assert (
+            _cache_row_is_fresh(_row(content_version=None), 1000.0, lambda: "", 4096)
+            is False
+        )
+
+
+class TestVersionTracksTheModels:
+    def test_adding_a_field_moves_the_version(self, monkeypatch: pytest.MonkeyPatch):
+        """The pin. A new field on a cached transcript model must invalidate
+        cached blobs, and this asserts the mechanism rather than a habit: the
+        version is *derived* from the declared field names, so nobody has to
+        remember to bump anything.
+
+        If this fails, the digest has stopped depending on the model fields
+        and #320's failure mode is reachable again.
+        """
+        before = content_schema_version()
+        content_schema_version.cache_clear()
+        monkeypatch.setitem(
+            UserTranscriptEntry.model_fields,
+            "someNewlyAddedField",
+            UserTranscriptEntry.model_fields["imagePasteIds"],
+        )
+        after = content_schema_version()
+        content_schema_version.cache_clear()
+        assert after != before, (
+            "adding a field to a cached model left the content version "
+            "unchanged, so existing cached blobs would keep being served "
+            "without it (issue #320)"
+        )
+
+    def test_version_is_stable_across_calls(self):
+        """It must not drift on its own: a digest that moved per process
+        would mass-invalidate a multi-gigabyte cache on every run."""
+        content_schema_version.cache_clear()
+        first = content_schema_version()
+        content_schema_version.cache_clear()
+        assert content_schema_version() == first
+
+    def test_version_is_short_and_opaque(self):
+        v = content_schema_version()
+        assert len(v) == 12 and all(c in "0123456789abcdef" for c in v)
+
+
+class TestBothFreshnessEntryPointsSeeTheColumn:
+    """Reaching the real SQL, which the hand-built rows above cannot.
+
+    ``_cache_row_is_fresh`` is fed by two different queries — the per-file
+    one behind ``is_file_cached()`` and the batched one behind
+    ``get_modified_files()``. A row that does not select ``content_version``
+    raises ``IndexError: No item with that key`` on a ``sqlite3.Row``, which
+    the CLI reports as "Error converting file", so a query left un-updated
+    breaks conversion outright rather than degrading. Tests that fabricate
+    rows are blind to that by construction; these go through the real
+    schema.
+    """
+
+    @staticmethod
+    def _stamp(db: Path, value: object) -> None:
+        con = sqlite3.connect(db)
+        con.execute("UPDATE cached_files SET content_version = ?", (value,))
+        con.commit()
+        con.close()
+
+    @pytest.fixture
+    def cached(self, tmp_path: Path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "s1.jsonl").write_text(_entry("u1", "first"), encoding="utf-8")
+        db = tmp_path / "c.db"
+        cm = CacheManager(project, "test-version", db_path=db)
+        cm.save_cached_entries(project / "s1.jsonl", [])
+        return cm, project / "s1.jsonl", db
+
+    def test_per_file_check_sees_a_foreign_version(self, cached):
+        cm, jsonl, db = cached
+        assert cm.is_file_cached(jsonl) is True, "sanity: freshly cached"
+        self._stamp(db, "deadbeef0000")
+        assert cm.is_file_cached(jsonl) is False
+
+    def test_batched_check_sees_a_foreign_version(self, cached):
+        cm, jsonl, db = cached
+        assert cm.get_modified_files([jsonl]) == [], "sanity: freshly cached"
+        self._stamp(db, "deadbeef0000")
+        assert cm.get_modified_files([jsonl]) == [jsonl]
+
+    def test_both_treat_the_migrated_NULL_as_stale(self, cached):
+        """The state migration 013 leaves behind on an existing cache: the
+        column exists, nothing has filled it, and every row must re-parse
+        once. This is the #320 state, so both paths must report it."""
+        cm, jsonl, db = cached
+        self._stamp(db, None)
+        assert cm.is_file_cached(jsonl) is False
+        assert cm.get_modified_files([jsonl]) == [jsonl]
+
+    def test_a_saved_row_records_the_current_version(self, cached):
+        """The write paths must stamp it, or every row stays permanently
+        stale and the cache never takes effect again."""
+        _cm, _jsonl, db = cached
+        con = sqlite3.connect(db)
+        con.row_factory = sqlite3.Row
+        stored = con.execute("SELECT content_version FROM cached_files").fetchone()[0]
+        con.close()
+        assert stored == content_schema_version()

--- a/test/test_cache_content_version.py
+++ b/test/test_cache_content_version.py
@@ -195,3 +195,41 @@ class TestBothFreshnessEntryPointsSeeTheColumn:
         stored = con.execute("SELECT content_version FROM cached_files").fetchone()[0]
         con.close()
         assert stored == content_schema_version()
+
+
+class TestDuplicateMigrationNumbersAreRejected:
+    """A migration number claimed twice must fail loudly, not silently.
+
+    ``_schema_version`` keys on the number alone, so a database that
+    applied one of a colliding pair records the number and skips the other
+    forever -- no error, no warning, and only on the caches that upgraded
+    through the first. This was met, not imagined: two branches in flight
+    both numbered a migration 013, and on a database carrying the other
+    one the ``content_version`` column was never added while the runner
+    reported the migration applied.
+
+    The collision is invisible from either branch alone and appears in one
+    tree only when both merge, so the check belongs where the files are
+    enumerated.
+    """
+
+    def test_a_repeated_number_raises(self, tmp_path: Path, monkeypatch):
+        from claude_code_log.migrations import runner
+
+        d = tmp_path / "migrations"
+        d.mkdir()
+        (d / "001_initial.sql").write_text("SELECT 1;", encoding="utf-8")
+        (d / "013_one_branch.sql").write_text("SELECT 1;", encoding="utf-8")
+        (d / "013_other_branch.sql").write_text("SELECT 1;", encoding="utf-8")
+        monkeypatch.setattr(runner, "_get_migrations_dir", lambda: d)
+
+        with pytest.raises(ValueError, match="Duplicate migration number 013"):
+            runner.get_available_migrations()
+
+    def test_the_shipped_migrations_have_no_duplicates(self):
+        """Guards the real directory, so a collision fails a test run rather
+        than reaching a user's cache."""
+        from claude_code_log.migrations import runner
+
+        versions = [v for v, _ in runner.get_available_migrations()]
+        assert len(versions) == len(set(versions))

--- a/test/test_cache_content_version.py
+++ b/test/test_cache_content_version.py
@@ -22,9 +22,10 @@ import pytest
 from claude_code_log.cache import (
     CacheManager,
     _cache_row_is_fresh,
+    _content_models,
     content_schema_version,
 )
-from claude_code_log.models import UserTranscriptEntry
+from claude_code_log.models import TextContent, UserTranscriptEntry
 
 
 def _entry(uuid: str, text: str) -> str:
@@ -121,6 +122,39 @@ class TestVersionTracksTheModels:
             "unchanged, so existing cached blobs would keep being served "
             "without it (issue #320)"
         )
+
+    def test_a_nested_field_moves_the_version(self, monkeypatch: pytest.MonkeyPatch):
+        """The same pin one level down, and the level that actually moves.
+
+        ``model_dump()`` serializes the whole tree, so a field added to a
+        *content-item* model is every bit as absent from an old blob as a
+        field added to the entry — and content items are where new fields
+        really appear. A digest over the top-level union alone did not move
+        for this case (measured), which is why the walk exists.
+        """
+        before = content_schema_version()
+        content_schema_version.cache_clear()
+        monkeypatch.setitem(
+            TextContent.model_fields,
+            "someNewNestedField",
+            TextContent.model_fields["text"],
+        )
+        after = content_schema_version()
+        content_schema_version.cache_clear()
+        assert after != before, (
+            "a field added to a nested content model left the content version "
+            "unchanged, so blobs written without it would keep being served "
+            "(issue #320, one level down)"
+        )
+
+    def test_the_walk_reaches_the_content_item_models(self):
+        """Canary on the traversal itself, independent of any digest value:
+        if the content items stop being reachable, the test above would keep
+        passing for the wrong reason only if some other model happened to
+        move — this names the requirement directly."""
+        reached = {m.__name__ for m in _content_models()}
+        assert "TextContent" in reached
+        assert "UserTranscriptEntry" in reached, "sanity: top level still covered"
 
     def test_version_is_stable_across_calls(self):
         """It must not drift on its own: a digest that moved per process


### PR DESCRIPTION
Fixes #320.

## The bug

`messages.content` stores `zlib(json(entry.model_dump()))`, but cache
invalidation observed only `source_mtime`, `source_size` and
`subagents_fingerprint` — every one of them a property of the *file*, none of
them a property of what we had written about it. Adding a field to a
transcript model therefore left every transcript unchanged since then serving
a blob without that field, for as long as the file stayed untouched.

`imagePasteIds` (#305/#306) is the first sighting. On a cache predating it the
field rehydrates as absent while the JSONL plainly carries it, so `[Image #N]`
placeholders that *do* have a recorded association are reported as having
none, rendered literally, and their images detached — the exact pre-#306
symptom, reinstated by the cache.

The warning in the issue is therefore accurate about what it was handed, and
wrong about the transcript.

## Blast radius

Measured on one real archive, over messages that have placeholders, images and
recorded ids:

| | count |
|---|---|
| candidates | 135 |
| holding stale blobs | 85 |
| warned, refused to resolve | 65 |
| silently took the positional fallback | 20 |
| … of those, resolved **correctly** | 20 |
| resolved to a **wrong** image | 0 |

The 20 are safe for the reason the fallback exists: on contiguous `1..k`
numbering the recorded and positional readings coincide.

In a 4000-blob sample, `imagePasteIds` was the *only* missing declared field —
this is the hazard's first instance, not one of many.

## The fix

`cached_files` gains a `content_version` column (migration 014) holding a
digest derived from the declared field names of every Pydantic model that can
reach a stored blob — the whole serialized tree, not just the entry types. A
row whose version differs is stale and re-parses once.

The tree matters: `model_dump()` writes nested models too, so a digest over
the top-level entry union alone left the same hazard live one level down, in
the content-item models where fields actually get added. Measured while it was
top-level-only, a new field on `TextContent` did not move the digest at all;
the walk (17 models rather than 8) is the third commit.

It is **derived, not remembered**: a future field moves the digest without
anyone bumping a constant. It keys on field *names* only, deliberately — so a
Pydantic or Python upgrade cannot mass-invalidate a multi-gigabyte cache. A
manual salt is available for the one case names cannot see: a field whose
meaning or serialized representation changes while keeping its name.

A NULL — the state migration 014 leaves on an existing cache — counts as
**stale**, unlike the NULL handling in migrations 007 and 011. Those columns
describe an *input* we might not have seen, so "no reason to think we missed
anything" is right. This one describes the completeness of our own *output*,
so unknown must mean incomplete. The one-time re-parse is the point of the
migration.

## Verification

End-to-end, both arms on identical database state (blobs stripped of the
field, `content_version` NULL, HTML cache cleared, **source file untouched**):

| | before | after |
|---|---|---|
| warnings | 2 | 0 |
| literal `[Image #N]` in the page | 6 | 0 |
| images rendered | — | 4 |
| blobs carrying the field | 0 | 634 |

12 tests, three layers: the freshness rule, the digest's dependence on the
models (the pin — a new field must move it), and both freshness entry points
against the real schema. Each guard was neutralised in turn and reddens only
its own tests.

**Gated on CI across the matrix** — ubuntu + windows × Python 3.10–3.14,
plus CodeQL and the strict docs build. That is deliberately the verdict rather
than a local run: the Windows jobs cover a class a Linux-only `just ci`
structurally cannot see, and a shared dev box under load produces
timing-sensitive failures that mimic regressions. Locally: 262 passed across
every cache and migration suite, `ruff format`/`ruff check`/`pyright` (0
errors)/`ty` clean.

### The digest value changing costs nothing

Migration 014 already invalidates every existing cache exactly once, and the
walk lands in the same release, so **no user ever observes the second
change**: `79ecbf36d800` existed only on this unmerged branch (no tag contains
either commit), and the only value a cache can be stamped with is
`63c49fa42d28`. One re-parse per cached file, total — not two.

## Second commit: migrations claiming the same number

`_schema_version` keys on the migration **number** alone, so on a database
that already applied one of a colliding pair the other counts as applied and
its DDL never runs — silently, and only on the caches that upgraded through
the first one. The failure surfaces far downstream, as `no such column`.

This is why the migration here is 014: 013 was claimed by
`perf/watch-tick-latency`, since merged as #321. On a database carrying that
one, `content_version` was never added while the runner reported the
migration applied.

Neither branch can see the collision from its own tree — the pair exists in
one tree only once both merge, which is where the new check fires. A second
test guards the shipped directory.

**Merge order: resolved.** #321 landed first, so 013 is its
`013_html_cache_combined_link.sql` (on `html_cache`) and this branch keeps
014 (on `cached_files`) — different tables, no ordering dependency, and
`get_pending_migrations` selects by set membership rather than a high-water
mark, so neither order skips anything. Rebased onto `d09fc52`; both files now
coexist in one tree, which is what the new guard's directory canary covers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached transcript data is refreshed when its content schema changes, including changes to nested content models.
  * Existing cache entries with missing or outdated schema versions are automatically reprocessed.
  * Duplicate database migration numbers now produce a clear error instead of being silently accepted.

* **Reliability**
  * Individual and batch cache checks now consistently detect stale data.
  * Cache updates record the current content schema version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


🤖 Generated with [Claude Code](https://claude.com/claude-code)



