### PR TITLE
Apply the cache's write pragmas to every writing connection

### DIFF
--- a/claude_code_log/cache.py
+++ b/claude_code_log/cache.py
@@ -19,7 +19,7 @@ from packaging import version
 from pydantic import BaseModel
 
 from .factories import create_transcript_entry
-from .migrations.runner import run_migrations
+from .migrations.runner import apply_write_pragmas, run_migrations
 from .models import (
     AssistantTranscriptEntry,
     QueueOperationTranscriptEntry,
@@ -646,13 +646,9 @@ def _configure_connection(conn: sqlite3.Connection, *, read_only: bool) -> None:
         # reader needs neither pragma: the writing parent already
         # keeps the database in WAL.
         return
-    conn.execute("PRAGMA journal_mode = WAL")
-    # synchronous=NORMAL is the recommended pairing for WAL: it keeps
-    # durability across application crashes (only a power/OS crash can lose
-    # the last committed transaction) while skipping an fsync on every
-    # commit. The cache is fully regenerable from the JSONL source, so that
-    # residual risk is acceptable.
-    conn.execute("PRAGMA synchronous = NORMAL")
+    # Shared with the migration runner's own connection — see
+    # apply_write_pragmas for why WAL and synchronous=NORMAL are a pair.
+    apply_write_pragmas(conn)
 
 
 def _open_connection(

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -2271,6 +2271,12 @@ def _build_search_index(
 
     conn = sqlite3.connect(db_path)
     try:
+        if not fts5_available(conn):
+            click.echo(
+                "This SQLite build has no FTS5; archive search is unavailable.",
+                err=True,
+            )
+            return
         # A writer to the cache database, like the migration runner and every
         # CacheManager connection — and one that commits once per transcript
         # file, so at SQLite's default synchronous=FULL the build pays an
@@ -2278,13 +2284,14 @@ def _build_search_index(
         # cache, so NORMAL's residual risk (a power/OS crash losing the last
         # commits, which only costs the resumed backfill some ground) is the
         # same trade made everywhere else.
+        #
+        # After the FTS5 probe, not before: `journal_mode = WAL` writes to the
+        # database header and raises on a corrupt cache, where the probe
+        # swallows the error and returns False. Setting the pragmas first
+        # turned this function's graceful degradation into an unhandled
+        # DatabaseError — the corrupt-cache handler is the inner try below —
+        # and so made `--no-convert` on a corrupt cache refuse to start.
         apply_write_pragmas(conn)
-        if not fts5_available(conn):
-            click.echo(
-                "This SQLite build has no FTS5; archive search is unavailable.",
-                err=True,
-            )
-            return
         bar: Optional[Any] = None
 
         def report(done: int, total: int) -> None:

--- a/claude_code_log/cli.py
+++ b/claude_code_log/cli.py
@@ -41,6 +41,7 @@ from .cache import (
     get_library_version,
     is_corrupt_database_error,
 )
+from .migrations.runner import apply_write_pragmas
 from .models import RenderingDepth
 from .render_pool import resolve_render_jobs
 from .search import (
@@ -2270,6 +2271,14 @@ def _build_search_index(
 
     conn = sqlite3.connect(db_path)
     try:
+        # A writer to the cache database, like the migration runner and every
+        # CacheManager connection — and one that commits once per transcript
+        # file, so at SQLite's default synchronous=FULL the build pays an
+        # fsync per file. The index is rebuildable from the same JSONL as the
+        # cache, so NORMAL's residual risk (a power/OS crash losing the last
+        # commits, which only costs the resumed backfill some ground) is the
+        # same trade made everywhere else.
+        apply_write_pragmas(conn)
         if not fts5_available(conn):
             click.echo(
                 "This SQLite build has no FTS5; archive search is unavailable.",

--- a/claude_code_log/migrations/runner.py
+++ b/claude_code_log/migrations/runner.py
@@ -186,14 +186,22 @@ def run_migrations(db_path: Path) -> int:
         Number of migrations applied
     """
     conn = sqlite3.connect(db_path, timeout=30.0)
-    conn.execute("PRAGMA foreign_keys = ON")
-    # This connection writes the whole migration chain, and on a brand-new
-    # database that is the first thing to touch the file — so without these
-    # the entire chain runs at SQLite's defaults (delete journal, fsync per
-    # commit) and only later connections get WAL.
-    apply_write_pragmas(conn)
-
+    # Everything after the connect goes inside the try, so no failure can
+    # leave the handle open. That matters most for the pragmas: they are the
+    # first statements here that touch the file, so they are what raises on a
+    # corrupt database — and a leaked handle there is not merely untidy.
+    # Windows refuses to delete an open file, so it would defeat
+    # `CacheManager._rebuild_corrupt_database`, whose whole job is to discard
+    # an unreadable cache and rebuild it. The same care is taken for the same
+    # reason in `cache.py::_open_connection`.
     try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        # This connection writes the whole migration chain, and on a brand-new
+        # database that is the first thing to touch the file — so without these
+        # the entire chain runs at SQLite's defaults (delete journal, fsync per
+        # commit) and only later connections get WAL.
+        apply_write_pragmas(conn)
+
         _ensure_schema_version_table(conn)
         pending = get_pending_migrations(conn)
 

--- a/claude_code_log/migrations/runner.py
+++ b/claude_code_log/migrations/runner.py
@@ -8,6 +8,30 @@ from pathlib import Path
 from typing import List, Tuple
 
 
+def apply_write_pragmas(conn: sqlite3.Connection) -> None:
+    """Apply the durability pragmas every *writing* cache connection uses.
+
+    The two go together and must not be set separately:
+
+    - ``journal_mode = WAL`` persists in the database file, so it only has
+      to be set once — but it is not the whole fix on its own, because
+    - ``synchronous`` is per-connection and defaults to FULL, i.e. an fsync
+      on every commit. WAL at FULL still pays that (measured ~4x slower
+      than the pair over a full migration chain).
+
+    NORMAL keeps durability across application crashes — only a power or
+    OS crash can lose the last committed transaction — and the cache is
+    fully regenerable from the JSONL source, so that residual risk is
+    acceptable.
+
+    Lives here rather than in ``cache.py`` because ``cache.py`` imports
+    this module; both writers share this one definition so the pragma
+    pair cannot drift between them.
+    """
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+
+
 def _get_migrations_dir() -> Path:
     """Get the migrations directory path."""
     return Path(__file__).parent
@@ -159,6 +183,11 @@ def run_migrations(db_path: Path) -> int:
     """
     conn = sqlite3.connect(db_path, timeout=30.0)
     conn.execute("PRAGMA foreign_keys = ON")
+    # This connection writes the whole migration chain, and on a brand-new
+    # database that is the first thing to touch the file — so without these
+    # the entire chain runs at SQLite's defaults (delete journal, fsync per
+    # commit) and only later connections get WAL.
+    apply_write_pragmas(conn)
 
     try:
         _ensure_schema_version_table(conn)

--- a/claude_code_log/migrations/runner.py
+++ b/claude_code_log/migrations/runner.py
@@ -25,11 +25,15 @@ def apply_write_pragmas(conn: sqlite3.Connection) -> None:
     acceptable.
 
     Lives here rather than in ``cache.py`` because ``cache.py`` imports
-    this module; both writers share this one definition so the pragma
+    this module; every writer shares this one definition so the pragma
     pair cannot drift between them.
+
+    ``synchronous`` is set first because the switch into WAL is itself a
+    write: at the default FULL it fsyncs for its own transition, which
+    costs one of the eight fsyncs a fresh database otherwise pays.
     """
-    conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA synchronous = NORMAL")
+    conn.execute("PRAGMA journal_mode = WAL")
 
 
 def _get_migrations_dir() -> Path:

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -209,9 +209,17 @@ regenerable cache). Both pragmas come from
 connection applies — including the migration runner's own, which opens
 outside `CacheManager` and is what touches a brand-new database first;
 at the SQLite defaults it ran the whole migration chain at an fsync per
-commit (120 ms/db against 12 ms/db, measured over 20 fresh databases).
-Setting only `journal_mode` is not the fix: it persists in the file, but
-`synchronous` is per-connection and stays at FULL (47 ms/db). A
+commit: 120 ms/db against 12 ms/db. Setting only `journal_mode` is not
+the fix: it persists in the file, but `synchronous` is per-connection
+and stays at FULL (47 ms/db). Those are 20 fresh databases per arm on
+an idle disk; re-derive with `scripts/bench_migration_pragmas.py`
+rather than trusting them, because the ratio is not a constant. Fsync
+cost scales with device contention, so on a loaded box the same arms
+measured 1382 ms against 46 ms — while a `synchronous=OFF` control
+stayed at 10-12 ms/db across every load, which is what identifies the
+cost as fsync rather than migration work. A single-threaded run like
+that one therefore *understates* what the pairing is worth during a
+parallel test suite. A
 `mode=ro` reader applies neither — it cannot switch journal modes and
 needs neither pragma. The runner's connection is outside the lifecycle
 described below and adds nothing to it: `_migrated_db_paths` memoises

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -209,15 +209,19 @@ regenerable cache). Both pragmas come from
 connection applies — including the migration runner's own, which opens
 outside `CacheManager` and is what touches a brand-new database first;
 at the SQLite defaults it ran the whole migration chain at an fsync per
-commit: 120 ms/db against 12 ms/db. Setting only `journal_mode` is not
+commit: 128 ms/db against 13 ms/db. Setting only `journal_mode` is not
 the fix: it persists in the file, but `synchronous` is per-connection
-and stays at FULL (47 ms/db). Those are 20 fresh databases per arm on
+and stays at FULL (50 ms/db). Those are 20 fresh databases per arm on
 an idle disk; re-derive with `scripts/bench_migration_pragmas.py`
 rather than trusting them, because the ratio is not a constant. Fsync
 cost scales with device contention, so on a loaded box the same arms
 measured 1382 ms against 46 ms — while a `synchronous=OFF` control
 stayed at 10-12 ms/db across every load, which is what identifies the
-cost as fsync rather than migration work. A single-threaded run like
+cost as fsync rather than migration work. It also means **each
+migration added to the chain costs a further fsync** at the defaults:
+adding one (013) moved the default arm 111 → 128 ms/db while that
+control moved 9.7 → 10.1, so the cost is the extra commit, not the
+extra SQL. A single-threaded run like
 that one therefore *understates* what the pairing is worth during a
 parallel test suite. A
 `mode=ro` reader applies neither — it cannot switch journal modes and

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -222,9 +222,26 @@ migration added to the chain costs a further fsync** at the defaults:
 adding one (013) moved the default arm 111 → 128 ms/db while that
 control moved 9.7 → 10.1, so the cost is the extra commit, not the
 extra SQL. A single-threaded run like
-that one therefore *understates* what the pairing is worth during a
-parallel test suite. A
-`mode=ro` reader applies neither — it cannot switch journal modes and
+that one therefore badly *understates* what the pairing is worth during
+a parallel test suite: the unit leg creates ~402 databases, and with the
+runner's pragmas removed it takes **~130 s against ~51 s**, three
+interleaved pairs with no overlap between the arms. That is ~195 ms
+saved per database — well above the ~110 ms an idle bench predicts,
+because fsync does not parallelise. Sixteen `-n auto` workers do not get
+sixteen devices; they queue at one, and at `synchronous=FULL` each
+worker's commits lengthen every other worker's, so the contention the
+pragmas remove is largely self-inflicted.
+
+That measurement also carries a diagnostic worth more than the ratio.
+The slow arm was the *stable* one (±1.6%) while the fast arm swung
+±16%, which inverts the usual expectation — because the slow arm is
+fsync-bound and therefore pinned by the device, indifferent to whatever
+else is on the box, while the fast arm is CPU-bound and exposed to it.
+**Stability is not evidence of a quiet box; it can be evidence of a
+saturated resource.** It is also why box load could not swamp the
+comparison: the noise lived entirely in the arm that got faster.
+
+A `mode=ro` reader applies neither — it cannot switch journal modes and
 needs neither pragma. The runner's connection is outside the lifecycle
 described below and adds nothing to it: `_migrated_db_paths` memoises
 the migration check, so it opens once per process and database rather

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -226,9 +226,9 @@ migrations:
 
 | migrations | pre-fix | shipped |
 |-----------:|--------:|--------:|
-| 12 | 228 | 8 |
-| 13 | 236 | 8 |
-| 14 | 244 | 8 |
+| 12 | 228 | 7 |
+| 13 | 236 | 7 |
+| 14 | 244 | 7 |
 
 **Every migration added to the chain costs 8 more fsyncs at the
 defaults, and none with the pragmas** — the runner's cost grows with the

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -206,8 +206,9 @@ Connections run in WAL mode with `synchronous=NORMAL` (durable across
 app crashes; only a power/OS crash can lose the last commit — fine for a
 regenerable cache). Both pragmas come from
 `migrations.runner.apply_write_pragmas`, which every *writing*
-connection applies — including the migration runner's own, which opens
-outside `CacheManager` and is what touches a brand-new database first;
+connection applies — the two that open outside `CacheManager` included:
+the migration runner's own, which is what touches a brand-new database
+first, and the FTS index builder's. As to the runner,
 at the SQLite defaults it ran the whole migration chain at an fsync per
 commit: 128 ms/db against 13 ms/db. Setting only `journal_mode` is not
 the fix: it persists in the file, but `synchronous` is per-connection
@@ -238,6 +239,21 @@ itself once. Don't infer that slope from timings: what an fsync *costs*
 swings by more than 10x with contention, so per-migration wall-clock
 deltas measured on different days are incoherent (one such pair read
 +16 ms and the next −0.7 ms), while the counts above are stable.
+
+The FTS index builder (`cli.py::_build_search_index`) is the same shape
+one file over. It commits once per transcript file so an interrupted
+backfill resumes, which at the defaults is an fsync per file — 33 / 43 /
+63 / 103 fsyncs over 10 / 20 / 40 / 80 files, against a flat 16 once it
+applies the pragmas. Small in absolute terms (~0.65 ms/file, roughly 1%
+of a real build, where decompress and tokenise dominate), and included
+because the *slope* is what the pragmas remove.
+
+Which writer applies them is pinned rather than asserted:
+`TestConnectionCensus` enumerates every `sqlite3.connect` in the package
+by AST and fails until each is classified as a configured writer or a
+reader. Prose could not hold that claim — the migration runner was
+missed when these pragmas were first written, and the FTS builder was
+missed again while fixing the runner.
 
 A single-threaded run like
 that one therefore badly *understates* what the pairing is worth during

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -204,7 +204,19 @@ list against the cached `page_sessions` rows and reports
 
 Connections run in WAL mode with `synchronous=NORMAL` (durable across
 app crashes; only a power/OS crash can lose the last commit — fine for a
-regenerable cache). By default `_get_connection()` opens and closes a
+regenerable cache). Both pragmas come from
+`migrations.runner.apply_write_pragmas`, which every *writing*
+connection applies — including the migration runner's own, which opens
+outside `CacheManager` and is what touches a brand-new database first;
+at the SQLite defaults it ran the whole migration chain at an fsync per
+commit (120 ms/db against 12 ms/db, measured over 20 fresh databases).
+Setting only `journal_mode` is not the fix: it persists in the file, but
+`synchronous` is per-connection and stays at FULL (47 ms/db). A
+`mode=ro` reader applies neither — it cannot switch journal modes and
+needs neither pragma. The runner's connection is outside the lifecycle
+described below and adds nothing to it: `_migrated_db_paths` memoises
+the migration check, so it opens once per process and database rather
+than per call. By default `_get_connection()` opens and closes a
 connection per call, so no file handle lingers to block temp-dir cleanup
 on Windows. A build issues ~190 such opens, which dominates cache-build
 cost, so the converter wraps its hotspots (`ensure_fresh_cache`, the

--- a/dev-docs/application_model.md
+++ b/dev-docs/application_model.md
@@ -217,11 +217,29 @@ rather than trusting them, because the ratio is not a constant. Fsync
 cost scales with device contention, so on a loaded box the same arms
 measured 1382 ms against 46 ms — while a `synchronous=OFF` control
 stayed at 10-12 ms/db across every load, which is what identifies the
-cost as fsync rather than migration work. It also means **each
-migration added to the chain costs a further fsync** at the defaults:
-adding one (013) moved the default arm 111 → 128 ms/db while that
-control moved 9.7 → 10.1, so the cost is the extra commit, not the
-extra SQL. A single-threaded run like
+cost as fsync rather than migration work.
+
+Count the syscalls instead of timing them and the shape is exact, with
+no dependence on what the disk was doing — `strace -c -e trace=fsync`
+over one `run_migrations`, with the chain truncated to its lowest N
+migrations:
+
+| migrations | pre-fix | shipped |
+|-----------:|--------:|--------:|
+| 12 | 228 | 8 |
+| 13 | 236 | 8 |
+| 14 | 244 | 8 |
+
+**Every migration added to the chain costs 8 more fsyncs at the
+defaults, and none with the pragmas** — the runner's cost grows with the
+chain while the shipped one stays flat, so this bounds a cost that
+would otherwise rise with every schema change, rather than paying for
+itself once. Don't infer that slope from timings: what an fsync *costs*
+swings by more than 10x with contention, so per-migration wall-clock
+deltas measured on different days are incoherent (one such pair read
++16 ms and the next −0.7 ms), while the counts above are stable.
+
+A single-threaded run like
 that one therefore badly *understates* what the pairing is worth during
 a parallel test suite: the unit leg creates ~402 databases, and with the
 runner's pragmas removed it takes **~130 s against ~51 s**, three

--- a/scripts/bench_migration_pragmas.py
+++ b/scripts/bench_migration_pragmas.py
@@ -81,10 +81,12 @@ def _no_pragmas(conn: sqlite3.Connection) -> None:
 
 
 def _wal_only(conn: sqlite3.Connection) -> None:
+    """The trap arm: WAL without the pairing that makes it pay off."""
     conn.execute("PRAGMA journal_mode = WAL")
 
 
 def _synchronous_off(conn: sqlite3.Connection) -> None:
+    """The floor arm: no fsync at all. For scale, not as a proposal."""
     conn.execute("PRAGMA synchronous = OFF")
 
 
@@ -147,6 +149,7 @@ def _time_arm(
 
 
 def main() -> None:
+    """Parse arguments, time every arm per repeat, report medians."""
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/scripts/bench_migration_pragmas.py
+++ b/scripts/bench_migration_pragmas.py
@@ -179,6 +179,14 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # Both are divisors: `--databases 0` divides by zero in _time_arm, and
+    # `--repeats 0` leaves statistics.median() no samples. Fail through the
+    # parser rather than deep in a benchmark that has already run.
+    if args.databases < 1:
+        parser.error("--databases must be at least 1")
+    if args.repeats < 1:
+        parser.error("--repeats must be at least 1")
+
     arms = _arms()
     if args.reverse_arms:
         arms = list(reversed(arms))

--- a/scripts/bench_migration_pragmas.py
+++ b/scripts/bench_migration_pragmas.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Benchmark the migration runner's connection pragmas.
+
+Times `run_migrations` over N fresh cache databases under four pragma
+arms, to answer one question: how much does the runner's own connection
+cost when it is *not* configured as the writer it is?
+
+    uv run python scripts/bench_migration_pragmas.py
+
+It needs no data — every arm builds throwaway databases from the
+migration chain alone — so it runs anywhere in a few seconds. That is
+why it is a separate script rather than part of `bench_render.py`, which
+copies a real projects tree.
+
+Why this is worth keeping: the fix it measures
+(`migrations.runner.apply_write_pragmas`, documented in
+`dev-docs/application_model.md` § cache connections) rests on a ~10x
+figure quoted in more than one place, and a figure that outlives its
+method gets re-derived or quietly doubted.
+
+## Reading the arms
+
+    default             what the runner did before the fix: `foreign_keys`
+                        only, so SQLite's defaults — delete journal,
+                        `synchronous=FULL`, an fsync per write transaction.
+    journal_mode=WAL    WAL alone. **Not the fix**, and the interesting
+                        row: `journal_mode` persists in the database file,
+                        but `synchronous` is per-connection and stays at
+                        FULL, so most of the fsync cost survives while the
+                        journal mode makes it look done.
+    WAL + NORMAL        the shipped pairing.
+    synchronous=OFF     the floor, for scale only — not a proposal.
+
+The baseline arm is produced by substituting `apply_write_pragmas` with a
+no-op, which is exactly what the pre-fix runner did; the arms are not
+re-implementations of the runner.
+
+Every row is self-verifying: after the timed loop each arm's pragma
+function is applied to one more connection and both pragmas are read
+back, so the reported `journal_mode`/`synchronous` are what the arm
+actually achieved, not what it tried to set. A row whose timing moved
+but whose pragmas did not is a broken arm, not a finding.
+
+## Controls
+
+The cost being measured is fsync, not CPU. Two ways to see that:
+
+    # tmpfs has no fsync to pay: every arm should collapse to the
+    # fast arm's time.
+    uv run python scripts/bench_migration_pragmas.py --tmpdir /dev/shm
+
+    # arm order is fixed across repeats, so a systematic ordering
+    # artifact would not show up as variance. Reversing must not
+    # change the ranking.
+    uv run python scripts/bench_migration_pragmas.py --reverse-arms
+
+Expect the absolute numbers to move with your disk, and expect the gap
+to *widen* under concurrent load: fsync cost scales with device
+contention, so a single-threaded run like this one understates the win
+during a parallel test suite.
+"""
+
+import argparse
+import sqlite3
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from claude_code_log.migrations import runner
+
+PragmaFn = Callable[[sqlite3.Connection], None]
+
+# 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA
+_SYNCHRONOUS_NAMES = {0: "OFF", 1: "NORMAL", 2: "FULL", 3: "EXTRA"}
+
+
+def _no_pragmas(conn: sqlite3.Connection) -> None:
+    """The pre-fix runner: `foreign_keys` only, set by run_migrations itself."""
+
+
+def _wal_only(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode = WAL")
+
+
+def _synchronous_off(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA synchronous = OFF")
+
+
+def _arms() -> List[Tuple[str, PragmaFn]]:
+    """The arms, in reporting order. `apply_write_pragmas` is the real one."""
+    return [
+        ("default (pre-fix)", _no_pragmas),
+        ("journal_mode=WAL only", _wal_only),
+        ("WAL + synchronous=NORMAL", runner.apply_write_pragmas),
+        ("synchronous=OFF only", _synchronous_off),
+    ]
+
+
+def _observed_pragmas(db_path: Path, pragma_fn: PragmaFn) -> Tuple[str, str]:
+    """Apply an arm to a real connection and read both pragmas back.
+
+    `synchronous` is per-connection and unobservable once the handle is
+    closed, so it has to be read from a connection the arm configured —
+    reading it from a fresh default connection would report FULL for every
+    arm and look like the arms had no effect.
+    """
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        pragma_fn(conn)
+        journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0])
+        raw = int(conn.execute("PRAGMA synchronous").fetchone()[0])
+    finally:
+        conn.close()
+    return journal_mode, _SYNCHRONOUS_NAMES.get(raw, str(raw))
+
+
+def _time_arm(
+    pragma_fn: PragmaFn, databases: int, tmpdir: Optional[Path]
+) -> Tuple[float, str, str]:
+    """Return (ms per database, journal_mode, synchronous) for one arm."""
+    original = runner.apply_write_pragmas
+    # Substituting the runner's own pragma function is the point of the
+    # benchmark: `run_migrations` looks the name up in module globals at
+    # call time, so each arm swaps what the real runner applies rather
+    # than re-implementing it. setattr, because ty reads a plain
+    # assignment here as an accidental shadowing of the function.
+    setattr(runner, "apply_write_pragmas", pragma_fn)
+    try:
+        with tempfile.TemporaryDirectory(dir=tmpdir) as td:
+            root = Path(td)
+            # Warm up outside the timed loop: the first database in a fresh
+            # directory pays costs (imports, directory metadata) that would
+            # otherwise be charged to whichever arm runs first.
+            runner.run_migrations(root / "warmup.db")
+
+            started = time.perf_counter()
+            for i in range(databases):
+                runner.run_migrations(root / f"db{i}.db")
+            elapsed = time.perf_counter() - started
+
+            journal_mode, synchronous = _observed_pragmas(root / "db0.db", pragma_fn)
+    finally:
+        setattr(runner, "apply_write_pragmas", original)
+    return elapsed / databases * 1000, journal_mode, synchronous
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--databases",
+        type=int,
+        default=20,
+        help="fresh databases migrated per arm per repeat (default: 20)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="times to run the whole set of arms (default: 3)",
+    )
+    parser.add_argument(
+        "--tmpdir",
+        type=Path,
+        default=None,
+        help=(
+            "where to build the throwaway databases (default: the system "
+            "temp dir). Point it at a tmpfs such as /dev/shm for the "
+            "no-fsync control."
+        ),
+    )
+    parser.add_argument(
+        "--reverse-arms",
+        action="store_true",
+        help="run the arms in reverse order — the ordering-artifact control",
+    )
+    args = parser.parse_args()
+
+    arms = _arms()
+    if args.reverse_arms:
+        arms = list(reversed(arms))
+
+    where = args.tmpdir if args.tmpdir is not None else Path(tempfile.gettempdir())
+    print(
+        f"{args.databases} fresh databases per arm, {args.repeats} repeats, "
+        f"under {where}"
+    )
+    print()
+
+    timings: Dict[str, List[float]] = {name: [] for name, _ in arms}
+    pragmas: Dict[str, Tuple[str, str]] = {}
+    for repeat in range(1, args.repeats + 1):
+        print(f"repeat {repeat}")
+        for name, pragma_fn in arms:
+            ms, journal_mode, synchronous = _time_arm(
+                pragma_fn, args.databases, args.tmpdir
+            )
+            timings[name].append(ms)
+            pragmas[name] = (journal_mode, synchronous)
+            print(
+                f"  {name:26s} {ms:7.1f} ms/db   "
+                f"journal_mode={journal_mode}, synchronous={synchronous}"
+            )
+        print()
+
+    print("median ms/db")
+    medians = {name: statistics.median(values) for name, values in timings.items()}
+    fastest = min(medians.values())
+    for name, _ in arms:
+        journal_mode, synchronous = pragmas[name]
+        print(
+            f"  {name:26s} {medians[name]:7.1f}   "
+            f"{medians[name] / fastest:5.1f}x the fastest arm   "
+            f"journal_mode={journal_mode}, synchronous={synchronous}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -651,13 +651,17 @@ class TestConnectionCensus:
     anywhere in the package fails this test until it is classified here,
     which is the moment to ask whether it writes.
 
-    That sentence is itself unconditional, so the two ways it could quietly
-    become false are closed rather than hoped about — both of which fail
-    *open*, the dangerous direction for a guard whose job is catching an
-    omission. A second connection inside an already-classified function is
-    caught because `EXPECTED` pins the count, not just the function; an
-    import shape the AST walk cannot see is forbidden outright by
-    `test_no_import_shape_the_census_cannot_see`.
+    That sentence is itself unconditional, so the three ways it could
+    quietly become false are closed rather than hoped about — all of which
+    fail *open*, the dangerous direction for a guard whose job is catching
+    an omission. **Count:** a second connection inside an
+    already-classified function is caught because `EXPECTED` pins how many
+    each has, not merely that it has some. **Import shape:** the forms the
+    AST walk cannot see are forbidden outright by
+    `test_no_import_shape_the_census_cannot_see`. **Attribution:** a call
+    at module scope, in a class body, or in a nested function once went
+    uncounted or double-counted — see `_connect_sites`, which now
+    attributes each call exactly once, to its innermost scope.
     """
 
     # (module, enclosing function) -> (how many connects there, and why each

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -650,6 +650,14 @@ class TestConnectionCensus:
     So the claim is pinned rather than asserted. Adding a `sqlite3.connect`
     anywhere in the package fails this test until it is classified here,
     which is the moment to ask whether it writes.
+
+    That sentence is itself unconditional, so the two ways it could quietly
+    become false are closed rather than hoped about — both of which fail
+    *open*, the dangerous direction for a guard whose job is catching an
+    omission. A second connection inside an already-classified function is
+    caught because `EXPECTED` pins the count, not just the function; an
+    import shape the AST walk cannot see is forbidden outright by
+    `test_no_import_shape_the_census_cannot_see`.
     """
 
     # (module, enclosing function) -> (how many connects there, and why each
@@ -696,6 +704,44 @@ class TestConnectionCensus:
                         key = (path.relative_to(package).as_posix(), node.name)
                         found[key] = found.get(key, 0) + 1
         return found
+
+    def test_no_import_shape_the_census_cannot_see(self):
+        """Keep the census's own claim true by construction.
+
+        The walk matches `sqlite3.connect(...)` — an attribute call on the
+        name `sqlite3`. `from sqlite3 import connect` and
+        `import sqlite3 as sq` both open connections it cannot see, and both
+        fail *open*: the census stays green while an unclassified writer
+        ships. Widening the matcher to bare `connect(...)` would catch other
+        libraries' connects instead, so forbid the shapes rather than chase
+        them. There are none today, so this costs nothing until someone
+        writes one — at which point the census's docstring would have
+        started lying.
+        """
+        package = Path(__file__).parents[1] / "claude_code_log"
+        offenders: list[str] = []
+        modules = 0
+        for path in sorted(package.rglob("*.py")):
+            modules += 1
+            rel = path.relative_to(package).as_posix()
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if isinstance(node, ast.ImportFrom) and node.module == "sqlite3":
+                    names = ", ".join(a.name for a in node.names)
+                    offenders.append(f"{rel}: from sqlite3 import {names}")
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "sqlite3" and alias.asname:
+                            offenders.append(f"{rel}: import sqlite3 as {alias.asname}")
+
+        # The sweep must have looked at something.
+        assert modules >= 10, f"only walked {modules} modules; the sweep is broken"
+
+        assert not offenders, (
+            "sqlite3 imported in a shape TestConnectionCensus cannot see: "
+            f"{offenders}. The census matches `sqlite3.connect(...)` only, so "
+            "these would let an unclassified connection ship unnoticed. Use "
+            "`import sqlite3` and call `sqlite3.connect(...)`."
+        )
 
     def test_every_connect_site_is_classified(self):
         """A new `sqlite3.connect` must be classified before it can ship."""

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -652,19 +652,29 @@ class TestConnectionCensus:
     which is the moment to ask whether it writes.
     """
 
-    # (module, enclosing function) -> why it does not need the pragmas, or
-    # how it gets them.
-    EXPECTED: ClassVar[dict[tuple[str, str], str]] = {
-        (
-            "cache.py",
-            "_open_connection",
-        ): "applies `configure`, i.e. _configure_connection",
-        ("cache.py", "get_all_cached_projects"): "read-only: one SELECT, then close",
-        ("cache.py", "find_session_in_cache"): "read-only: one SELECT, then close",
-        ("migrations/runner.py", "run_migrations"): "applies apply_write_pragmas",
-        ("cli.py", "_build_search_index"): "applies apply_write_pragmas",
-        ("cli.py", "serve"): "in-memory FTS5 capability probe, not the cache",
-        ("api.py", "connection"): "mode=ro reader; cannot switch journal modes",
+    # (module, enclosing function) -> (how many connects there, and why each
+    # is safe). The count is part of the claim: a function that already
+    # connects is exactly where a second, unconfigured connection is most
+    # likely to be added, and `_open_connection`'s legitimate two would
+    # otherwise license any number.
+    EXPECTED: ClassVar[dict[tuple[str, str], tuple[int, str]]] = {
+        ("cache.py", "_open_connection"): (
+            2,
+            "read-only and read-write arms; both run `configure`, "
+            "i.e. _configure_connection",
+        ),
+        ("cache.py", "get_all_cached_projects"): (
+            1,
+            "read-only: one SELECT, then close",
+        ),
+        ("cache.py", "find_session_in_cache"): (1, "read-only: one SELECT, then close"),
+        ("migrations/runner.py", "run_migrations"): (
+            1,
+            "applies apply_write_pragmas",
+        ),
+        ("cli.py", "_build_search_index"): (1, "applies apply_write_pragmas"),
+        ("cli.py", "serve"): (1, "in-memory FTS5 capability probe, not the cache"),
+        ("api.py", "connection"): (1, "mode=ro reader; cannot switch journal modes"),
     }
 
     def _connect_sites(self) -> dict[tuple[str, str], int]:
@@ -694,7 +704,9 @@ class TestConnectionCensus:
         # The census must find something, or it is passing on an empty set.
         assert len(found) >= 5, f"census found too few sites to be working: {found}"
 
-        unclassified = sorted(set(found) - set(self.EXPECTED))
+        expected_counts = {key: count for key, (count, _) in self.EXPECTED.items()}
+
+        unclassified = sorted(set(found) - set(expected_counts))
         assert not unclassified, (
             "new sqlite3.connect site(s) not classified in "
             f"TestConnectionCensus.EXPECTED: {unclassified}. If the connection "
@@ -703,10 +715,26 @@ class TestConnectionCensus:
             "docstring. If it does not write, say so there."
         )
 
-        vanished = sorted(set(self.EXPECTED) - set(found))
+        vanished = sorted(set(expected_counts) - set(found))
         assert not vanished, (
             f"classified connect site(s) no longer exist: {vanished}. Remove "
             "them from EXPECTED so the census keeps meaning something."
+        )
+
+        # Compare counts, not just which functions connect. Without this a
+        # second, unconfigured connection added *inside* an already-classified
+        # function passes — and a function that already connects is the most
+        # likely place for one to appear.
+        grew = sorted(
+            (key, expected_counts[key], found[key])
+            for key in expected_counts
+            if found[key] != expected_counts[key]
+        )
+        assert not grew, (
+            "sqlite3.connect count changed in classified function(s) "
+            f"(site, classified, found): {grew}. A new connection in a "
+            "function that already had one is still a new connection: "
+            "classify it by updating the count and the reason."
         )
 
 

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -682,27 +682,51 @@ class TestConnectionCensus:
         ),
         ("cli.py", "_build_search_index"): (1, "applies apply_write_pragmas"),
         ("cli.py", "serve"): (1, "in-memory FTS5 capability probe, not the cache"),
-        ("api.py", "connection"): (1, "mode=ro reader; cannot switch journal modes"),
+        ("api.py", "SearchApi.connection"): (
+            1,
+            "mode=ro reader; cannot switch journal modes",
+        ),
     }
 
+    @staticmethod
+    def _is_sqlite_connect(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "connect"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "sqlite3"
+        )
+
     def _connect_sites(self) -> dict[tuple[str, str], int]:
+        """Every `sqlite3.connect` in the package, by module and scope.
+
+        Each call is attributed **once**, to its innermost enclosing
+        class/function, or to `<module>` when it sits at module level.
+        Both matter now that the count is part of the claim: walking every
+        function and re-walking its body counted a call in a nested
+        function twice (once for the inner scope, once for the outer), and
+        a module-level connection was not seen at all — which failed open,
+        the direction that lets an unclassified writer ship.
+        """
         package = Path(__file__).parents[1] / "claude_code_log"
         found: dict[tuple[str, str], int] = {}
+
+        def visit(node: ast.AST, rel: str, scope: tuple[str, ...]) -> None:
+            if self._is_sqlite_connect(node):
+                key = (rel, ".".join(scope) if scope else "<module>")
+                found[key] = found.get(key, 0) + 1
+            for child in ast.iter_child_nodes(node):
+                child_scope = scope
+                if isinstance(
+                    child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                ):
+                    child_scope = scope + (child.name,)
+                visit(child, rel, child_scope)
+
         for path in sorted(package.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"))
-            for node in ast.walk(tree):
-                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    continue
-                for inner in ast.walk(node):
-                    if (
-                        isinstance(inner, ast.Call)
-                        and isinstance(inner.func, ast.Attribute)
-                        and inner.func.attr == "connect"
-                        and isinstance(inner.func.value, ast.Name)
-                        and inner.func.value.id == "sqlite3"
-                    ):
-                        key = (path.relative_to(package).as_posix(), node.name)
-                        found[key] = found.get(key, 0) + 1
+            visit(tree, path.relative_to(package).as_posix(), ())
         return found
 
     def test_no_import_shape_the_census_cannot_see(self):

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -638,8 +638,35 @@ class TestMessageFileRelationship:
 class TestWALMode:
     """Tests for WAL journal mode."""
 
-    def test_wal_journal_mode_enabled(self, cache_manager):
-        """Verify WAL mode is active."""
+    def test_wal_journal_mode_enabled(self, cache_manager, isolated_db_path: Path):
+        """A cache connection is what puts the database into WAL.
+
+        `journal_mode` persists in the file, and the migration runner now
+        leaves a brand-new database in WAL already
+        (`migrations.runner.apply_write_pragmas`), so reading `wal` back off
+        a fresh cache connection proves only that *someone* set it — this
+        assertion stayed green with `_configure_connection`'s pragmas
+        removed. Forcing the file out of WAL first restores the
+        discrimination: only a connection that applies the pragma itself
+        can bring it back.
+
+        `synchronous` needs no such treatment: it is per-connection, so
+        `test_synchronous_normal` below cannot be satisfied by what another
+        connection did.
+        """
+        with cache_manager._get_connection() as conn:
+            conn.execute("PRAGMA journal_mode = DELETE")
+
+        # Positive control. Leaving WAL requires no other connection to be
+        # open and silently does nothing if one is, which would leave the
+        # file in WAL and make the assertion below pass vacuously again.
+        # Confirm from outside that the file really left WAL.
+        raw = sqlite3.connect(isolated_db_path)
+        try:
+            assert raw.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        finally:
+            raw.close()
+
         with cache_manager._get_connection() as conn:
             row = conn.execute("PRAGMA journal_mode").fetchone()
             assert row[0] == "wal"

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """Comprehensive SQL-level integrity tests for SQLite cache."""
 
+import ast
 import json
 import shutil
 import sqlite3
 import threading
 import time
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -633,6 +635,79 @@ class TestMessageFileRelationship:
 
         assert file_row["message_count"] == actual_count
         assert file_row["message_count"] == len(entries)
+
+
+class TestConnectionCensus:
+    """Every connection to the cache database is classified, on purpose.
+
+    `apply_write_pragmas` documents itself as what *every writing* cache
+    connection applies. That is an unconditional claim about the whole
+    package, and prose cannot keep it true: the migration runner was
+    missed when the pragmas were first written, and the FTS index builder
+    was missed again when the runner was fixed — twice, by people looking
+    straight at the problem.
+
+    So the claim is pinned rather than asserted. Adding a `sqlite3.connect`
+    anywhere in the package fails this test until it is classified here,
+    which is the moment to ask whether it writes.
+    """
+
+    # (module, enclosing function) -> why it does not need the pragmas, or
+    # how it gets them.
+    EXPECTED: ClassVar[dict[tuple[str, str], str]] = {
+        (
+            "cache.py",
+            "_open_connection",
+        ): "applies `configure`, i.e. _configure_connection",
+        ("cache.py", "get_all_cached_projects"): "read-only: one SELECT, then close",
+        ("cache.py", "find_session_in_cache"): "read-only: one SELECT, then close",
+        ("migrations/runner.py", "run_migrations"): "applies apply_write_pragmas",
+        ("cli.py", "_build_search_index"): "applies apply_write_pragmas",
+        ("cli.py", "serve"): "in-memory FTS5 capability probe, not the cache",
+        ("api.py", "connection"): "mode=ro reader; cannot switch journal modes",
+    }
+
+    def _connect_sites(self) -> dict[tuple[str, str], int]:
+        package = Path(__file__).parents[1] / "claude_code_log"
+        found: dict[tuple[str, str], int] = {}
+        for path in sorted(package.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for inner in ast.walk(node):
+                    if (
+                        isinstance(inner, ast.Call)
+                        and isinstance(inner.func, ast.Attribute)
+                        and inner.func.attr == "connect"
+                        and isinstance(inner.func.value, ast.Name)
+                        and inner.func.value.id == "sqlite3"
+                    ):
+                        key = (path.relative_to(package).as_posix(), node.name)
+                        found[key] = found.get(key, 0) + 1
+        return found
+
+    def test_every_connect_site_is_classified(self):
+        """A new `sqlite3.connect` must be classified before it can ship."""
+        found = self._connect_sites()
+
+        # The census must find something, or it is passing on an empty set.
+        assert len(found) >= 5, f"census found too few sites to be working: {found}"
+
+        unclassified = sorted(set(found) - set(self.EXPECTED))
+        assert not unclassified, (
+            "new sqlite3.connect site(s) not classified in "
+            f"TestConnectionCensus.EXPECTED: {unclassified}. If the connection "
+            "writes to the cache database it must apply "
+            "`migrations.runner.apply_write_pragmas` — see that function's "
+            "docstring. If it does not write, say so there."
+        )
+
+        vanished = sorted(set(self.EXPECTED) - set(found))
+        assert not vanished, (
+            f"classified connect site(s) no longer exist: {vanished}. Remove "
+            "them from EXPECTED so the census keeps meaning something."
+        )
 
 
 class TestWALMode:

--- a/test/test_cache_sqlite_integrity.py
+++ b/test/test_cache_sqlite_integrity.py
@@ -694,6 +694,7 @@ class TestConnectionCensus:
 
     @staticmethod
     def _is_sqlite_connect(node: ast.AST) -> bool:
+        """Is this node a literal `sqlite3.connect(...)` call?"""
         return (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
@@ -717,6 +718,9 @@ class TestConnectionCensus:
         found: dict[tuple[str, str], int] = {}
 
         def visit(node: ast.AST, rel: str, scope: tuple[str, ...]) -> None:
+            """Count this node if it connects, then recurse, deepening
+            `scope` at each class or function so a call is attributed to
+            the innermost one enclosing it."""
             if self._is_sqlite_connect(node):
                 key = (rel, ".".join(scope) if scope else "<module>")
                 found[key] = found.get(key, 0) + 1

--- a/test/test_migrations.py
+++ b/test/test_migrations.py
@@ -412,6 +412,7 @@ class TestRunMigrationsPragmas:
 
         class RecordingConnection(sqlite3.Connection):
             def close(self) -> None:
+                """Sample both pragmas off this handle before it goes."""
                 # `run_migrations` closes in a `finally`, so this runs on its
                 # error path too — where the handle may be unusable. Let the
                 # original exception through rather than masking it with a
@@ -431,6 +432,7 @@ class TestRunMigrationsPragmas:
         real_connect = sqlite3.connect
 
         def recording_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            """Open through the recording subclass instead of the default."""
             kwargs["factory"] = RecordingConnection
             return real_connect(*args, **kwargs)  # ty: ignore[no-matching-overload]
 
@@ -471,6 +473,7 @@ class TestRunMigrationsConnectionLifecycle:
         real_connect = sqlite3.connect
 
         def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            """Open normally, but keep every handle so it can be inspected."""
             conn = real_connect(*args, **kwargs)  # ty: ignore[no-matching-overload]
             opened.append(conn)
             return conn

--- a/test/test_migrations.py
+++ b/test/test_migrations.py
@@ -412,12 +412,20 @@ class TestRunMigrationsPragmas:
 
         class RecordingConnection(sqlite3.Connection):
             def close(self) -> None:
-                recorded["synchronous"] = self.execute("PRAGMA synchronous").fetchone()[
-                    0
-                ]
-                recorded["journal_mode"] = self.execute(
-                    "PRAGMA journal_mode"
-                ).fetchone()[0]
+                # `run_migrations` closes in a `finally`, so this runs on its
+                # error path too — where the handle may be unusable. Let the
+                # original exception through rather than masking it with a
+                # failure to sample: `recorded` then stays empty, and the
+                # assertion below says so plainly.
+                try:
+                    recorded["synchronous"] = self.execute(
+                        "PRAGMA synchronous"
+                    ).fetchone()[0]
+                    recorded["journal_mode"] = self.execute(
+                        "PRAGMA journal_mode"
+                    ).fetchone()[0]
+                except sqlite3.Error:
+                    pass
                 super().close()
 
         real_connect = sqlite3.connect

--- a/test/test_migrations.py
+++ b/test/test_migrations.py
@@ -365,3 +365,76 @@ class TestGetCurrentVersion:
         assert version == expected_version
 
         conn.close()
+
+
+class TestRunMigrationsPragmas:
+    """The runner's own connection is a writer and must be configured as one.
+
+    `run_migrations` opens its own connection rather than going through
+    `CacheManager._configure_connection`, so on a brand-new cache database
+    the whole migration chain used to run at SQLite's defaults
+    (`journal_mode=delete`, `synchronous=FULL` — an fsync per commit)
+    before anything switched the file to WAL. Measured over 20 fresh
+    databases on a quiet disk: 121 ms/db at the defaults against 12 ms/db
+    with the pair, and the gap widens under concurrent load.
+
+    Both pragmas are pinned, because either alone is not the fix:
+    `journal_mode` persists in the file but `synchronous` is
+    per-connection, so WAL at FULL still pays the fsync (51.5 ms/db).
+    """
+
+    def test_fresh_database_ends_up_in_wal_mode(self, tmp_path: Path):
+        """A database created by the runner is left in WAL mode."""
+        db_path = tmp_path / "fresh.db"
+
+        run_migrations(db_path)
+
+        # journal_mode persists in the file, so an independent connection
+        # reports what the runner left behind.
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        finally:
+            conn.close()
+
+    def test_runner_connection_is_synchronous_normal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The runner's *own* connection runs at synchronous=NORMAL.
+
+        `synchronous` is per-connection and unobservable once the handle is
+        gone, so the value has to be sampled from that connection while it
+        is still open — hence the recording subclass and the sample taken
+        in `close()`, just before the runner closes it.
+        """
+        db_path = tmp_path / "fresh.db"
+        recorded: dict[str, object] = {}
+
+        class RecordingConnection(sqlite3.Connection):
+            def close(self) -> None:
+                recorded["synchronous"] = self.execute("PRAGMA synchronous").fetchone()[
+                    0
+                ]
+                recorded["journal_mode"] = self.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0]
+                super().close()
+
+        real_connect = sqlite3.connect
+
+        def recording_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            kwargs["factory"] = RecordingConnection
+            return real_connect(*args, **kwargs)  # ty: ignore[no-matching-overload]
+
+        monkeypatch.setattr(sqlite3, "connect", recording_connect)
+        run_migrations(db_path)
+        monkeypatch.undo()
+
+        # An empty dict would mean the spy never saw a close: fail loudly
+        # rather than vacuously pass.
+        assert recorded, "the runner's connection was never observed"
+        # 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA
+        assert recorded["synchronous"] == 1, (
+            f"expected synchronous=NORMAL (1), got {recorded['synchronous']}"
+        )
+        assert recorded["journal_mode"] == "wal"

--- a/test/test_migrations.py
+++ b/test/test_migrations.py
@@ -446,3 +446,45 @@ class TestRunMigrationsPragmas:
             f"expected synchronous=NORMAL (1), got {recorded['synchronous']}"
         )
         assert recorded["journal_mode"] == "wal"
+
+
+class TestRunMigrationsConnectionLifecycle:
+    """`run_migrations` must not leak its handle when a statement raises.
+
+    The pragmas are the first statements in `run_migrations` that touch the
+    file, so on a corrupt database they are what raises. Leaving the
+    connection open there is not merely untidy: Windows refuses to delete an
+    open file, so it defeats `CacheManager._rebuild_corrupt_database`, whose
+    entire job is to discard an unreadable cache and rebuild it. Linux
+    deletes open files happily, so no Linux run can reproduce the symptom —
+    which is why the *invariant* is pinned here rather than the symptom.
+    """
+
+    def test_a_raising_pragma_still_closes_the_connection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A corrupt database raises, and leaves no open handle behind."""
+        db_path = tmp_path / "corrupt.db"
+        db_path.write_bytes(b"this is definitely not a database" * 500)
+
+        opened: list[sqlite3.Connection] = []
+        real_connect = sqlite3.connect
+
+        def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            conn = real_connect(*args, **kwargs)  # ty: ignore[no-matching-overload]
+            opened.append(conn)
+            return conn
+
+        monkeypatch.setattr(sqlite3, "connect", tracking_connect)
+        with pytest.raises(sqlite3.DatabaseError):
+            run_migrations(db_path)
+        monkeypatch.undo()
+
+        # An empty list would mean the spy never saw a connect, so the
+        # assertion below would be vacuously true.
+        assert opened, "run_migrations never opened a connection"
+        for conn in opened:
+            # Asks the connection's actual state rather than trusting a
+            # recorded close() call: a closed handle refuses to operate.
+            with pytest.raises(sqlite3.ProgrammingError):
+                conn.execute("SELECT 1")

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1045,6 +1045,7 @@ class TestBuildSearchIndexConnection:
 
         class RecordingConnection(sqlite3.Connection):
             def close(self) -> None:
+                """Sample both pragmas off this handle before it goes."""
                 try:
                     recorded["synchronous"] = self.execute(
                         "PRAGMA synchronous"
@@ -1057,6 +1058,7 @@ class TestBuildSearchIndexConnection:
                 super().close()
 
         def recording_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            """Open through the recording subclass instead of the default."""
             kwargs["factory"] = RecordingConnection
             return real_connect(*args, **kwargs)  # ty: ignore[no-matching-overload]
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1010,15 +1010,35 @@ class TestBuildSearchIndexConnection:
     def test_healthy_cache_still_gets_the_write_pragmas(self, tmp_path: Path):
         """Moving the call after the FTS5 probe must not strand it.
 
-        `synchronous` is per-connection, so it is sampled from the function's
-        own handle as it closes rather than read back from a fresh one, which
-        would report FULL whatever happened here.
+        Both pragmas are sampled from the function's own handle as it closes.
+        `synchronous` has to be: it is per-connection, so a fresh handle would
+        report FULL whatever happened here. `journal_mode` needs the opposite
+        care — it *persists in the file*, and `run_migrations` already leaves
+        the database in WAL, so asserting it without first forcing the file
+        back to `delete` passes even if the builder stops setting it. (It did:
+        with `apply_write_pragmas` swapped for a bare `synchronous` pragma,
+        this test still passed before the file was forced.)
         """
         from claude_code_log.cli import _build_search_index
         from claude_code_log.migrations.runner import run_migrations
 
         db_path = tmp_path / "cache.db"
         run_migrations(db_path)
+
+        # Take the file out of WAL first, so only a builder that applies the
+        # pragma itself can put it back.
+        forced = sqlite3.connect(db_path)
+        try:
+            forced.execute("PRAGMA journal_mode = DELETE")
+        finally:
+            forced.close()
+        # Positive control: leaving WAL silently does nothing while another
+        # connection is open, which would restore the vacuous pass.
+        check = sqlite3.connect(db_path)
+        try:
+            assert check.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        finally:
+            check.close()
 
         recorded: dict[str, object] = {}
         real_connect = sqlite3.connect
@@ -1028,6 +1048,9 @@ class TestBuildSearchIndexConnection:
                 try:
                     recorded["synchronous"] = self.execute(
                         "PRAGMA synchronous"
+                    ).fetchone()[0]
+                    recorded["journal_mode"] = self.execute(
+                        "PRAGMA journal_mode"
                     ).fetchone()[0]
                 except sqlite3.Error:
                     pass
@@ -1045,4 +1068,7 @@ class TestBuildSearchIndexConnection:
         # 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA
         assert recorded["synchronous"] == 1, (
             f"expected synchronous=NORMAL (1), got {recorded['synchronous']}"
+        )
+        assert recorded["journal_mode"] == "wal", (
+            f"expected the builder to restore WAL, got {recorded['journal_mode']}"
         )

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -974,3 +974,75 @@ def _entry_line(text: str) -> str:
         )
         + "\n"
     )
+
+
+class TestBuildSearchIndexConnection:
+    """`cli._build_search_index` opens its own connection, outside CacheManager.
+
+    Neither of these paths had coverage, which is how applying the write
+    pragmas to that connection silently broke the corrupt-cache one: the
+    pragmas were set before the FTS5 probe, `journal_mode = WAL` writes to
+    the database header, and an unreadable file turned a graceful
+    degradation into an unhandled `DatabaseError`.
+    """
+
+    def test_corrupt_cache_degrades_instead_of_raising(self, tmp_path: Path):
+        """A corrupt cache leaves search unavailable, not the command dead.
+
+        The function deliberately does not delete the database here — see its
+        inner handler — because the only route to this path is
+        `--no-convert`, the one flag that asked us to touch nothing. Serving
+        the pages without search beats refusing to start, so this must not
+        raise.
+        """
+        from claude_code_log.cli import _build_search_index
+
+        db_path = tmp_path / "cache.db"
+        db_path.write_bytes(b"not a sqlite database, not even close" * 64)
+
+        # Positive control: the file really is unreadable as a database, so a
+        # pass here cannot come from having written something valid.
+        with pytest.raises(sqlite3.DatabaseError):
+            sqlite3.connect(db_path).execute("SELECT * FROM sqlite_master").fetchone()
+
+        _build_search_index(db_path, ("text",), rebuild=False)
+
+    def test_healthy_cache_still_gets_the_write_pragmas(self, tmp_path: Path):
+        """Moving the call after the FTS5 probe must not strand it.
+
+        `synchronous` is per-connection, so it is sampled from the function's
+        own handle as it closes rather than read back from a fresh one, which
+        would report FULL whatever happened here.
+        """
+        from claude_code_log.cli import _build_search_index
+        from claude_code_log.migrations.runner import run_migrations
+
+        db_path = tmp_path / "cache.db"
+        run_migrations(db_path)
+
+        recorded: dict[str, object] = {}
+        real_connect = sqlite3.connect
+
+        class RecordingConnection(sqlite3.Connection):
+            def close(self) -> None:
+                try:
+                    recorded["synchronous"] = self.execute(
+                        "PRAGMA synchronous"
+                    ).fetchone()[0]
+                except sqlite3.Error:
+                    pass
+                super().close()
+
+        def recording_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+            kwargs["factory"] = RecordingConnection
+            return real_connect(*args, **kwargs)  # ty: ignore[no-matching-overload]
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sqlite3, "connect", recording_connect)
+            _build_search_index(db_path, ("text",), rebuild=False)
+
+        assert recorded, "the builder's connection was never observed"
+        # 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA
+        assert recorded["synchronous"] == 1, (
+            f"expected synchronous=NORMAL (1), got {recorded['synchronous']}"
+        )


### PR DESCRIPTION
`cache.py` has always configured its connections with `journal_mode=WAL` +
`synchronous=NORMAL`, with a comment explaining that the cache is regenerable
so the reduced durability is fine. Two other connections to the same database
never went through that helper, and both are writers.

### The migration runner

`run_migrations` opens its own `sqlite3.connect` and set only
`PRAGMA foreign_keys = ON`. On a brand-new cache database that connection is
the *first* thing to touch the file, so the entire migration chain ran at
SQLite's defaults — `journal_mode=delete`, `synchronous=FULL`, an fsync per
write transaction — and only later connections got WAL.

Counted rather than timed, because the claim is structural and a count needs no
quiet disk (`strace -c -e trace=fsync` over one `run_migrations`, with the
chain truncated to its lowest N migrations):

| migrations | before | after |
|-----------:|-------:|------:|
| 12 | 228 | 7 |
| 13 | 236 | 7 |
| 14 | 244 | 7 |

**Every migration added to the chain costs 8 more fsyncs at the defaults, and
none with the pragmas.** So this bounds a cost that would otherwise rise with
every schema change, rather than paying for itself once.

Don't infer that slope from wall-clock: what an fsync *costs* swings by more
than 10x with device contention, so per-migration timing deltas measured on
different days are incoherent, while the counts above are stable.

### The search-index builder

`cli.py::_build_search_index` opens its own connection too, and
`ensure_index` commits once per transcript file by design, so an interrupted
backfill resumes rather than restarting. At `synchronous=FULL` that is an fsync
per indexed file:

| indexed files | 10 | 20 | 40 | 80 |
|---|---|---|---|---|
| before | 33 | 43 | 63 | 103 |
| after | 16 | 16 | 16 | 16 |

Small in absolute terms — around 0.65 ms/file, roughly 1% of a real index build
where decompressing and tokenising dominate — and fixed for the shape rather
than the size: the count grows with the archive and the pragmas make it
constant.

The call sits *after* the FTS5 probe deliberately. `journal_mode = WAL` writes
the database header and raises on a corrupt cache, where the probe swallows the
error and returns `False`; setting the pragmas first turned this function's
graceful degradation into an unhandled `DatabaseError`, so `--no-convert` on a
corrupt cache refused to start.

### What it is worth to the test suite

The unit leg creates ~402 databases. With the runner's pragmas removed it runs
**~130 s against ~51 s** under `-n auto` — three interleaved A/B pairs, no
overlap between the arms. That is ~195 ms saved per database, well above the
~110 ms an idle bench predicts, because fsync does not parallelise: sixteen
workers do not get sixteen devices, they queue at one, and at
`synchronous=FULL` each worker's commits lengthen every other worker's.

**This figure is author-measured and was not independently reproduced** — it
needs two full unit runs on an otherwise idle machine. The fsync counts above
are on a different footing: both were re-derived during review with a *separate*
harness rather than by re-running this one, which is what makes them independent
rather than merely repeated. `scripts/bench_render.py`
has company: `scripts/bench_migration_pragmas.py` re-derives the per-database
arms in a few seconds and needs no data, with `--tmpdir` and `--reverse-arms`
for the no-fsync and arm-order controls.

### Tests

- Two guards on the runner's own connection: a database it creates comes out
  `journal_mode=wal`, and the connection itself is at `synchronous=NORMAL`
  (sampled from that connection as it closes — `synchronous` is per-connection,
  so a fresh handle would report `FULL` whatever happened).
- `TestWALMode::test_wal_journal_mode_enabled` had quietly become a tautology:
  once the runner leaves a new database in WAL, and `journal_mode` persists in
  the file, the assertion read `wal` back regardless of what
  `_configure_connection` did. It now forces the file out of WAL first, with a
  positive control that the switch took effect.
- `_build_search_index` had no coverage at all; both of its paths are now
  pinned — a corrupt cache must not raise, and a healthy one must still come
  out at `synchronous=NORMAL`.
- `TestConnectionCensus` walks every `sqlite3.connect` in the package by AST and
  fails until each is classified as a configured writer or a reader. The
  docstring makes an unconditional claim, so the three ways it could quietly
  become false are closed: the expected count per site is pinned, the import
  shapes the walk cannot see are forbidden, and each call is attributed exactly
  once to its innermost scope.

Two connections deliberately unchanged: `get_all_cached_projects` and
`find_session_in_cache` open, `SELECT`, and close, so they run no write
transaction and have no fsync to save.

Surfaced during review and filed separately, not fixed here: `fts5_available`
cannot distinguish a missing FTS5 build from an unreadable database, so a
corrupt cache is reported to the user as "This SQLite build has no FTS5"
(#324).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache and search-index database handling for more reliable operation.
  - Search indexing now degrades gracefully when the cache file is corrupted instead of terminating the command.
  - Database migrations now detect duplicate migration versions and report a clear error.
  - Improved database connection cleanup when migration setup encounters an error.

- **Performance**
  - Improved migration and search-index write performance through optimized SQLite configuration.
  - Enhanced support for concurrent database reads and writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->