### PR TITLE
Render peer agent messages as teammate cards instead of steering (#309)

### DIFF
--- a/claude_code_log/factories/attachment_factory.py
+++ b/claude_code_log/factories/attachment_factory.py
@@ -17,6 +17,7 @@ grow their own factory branch here as needed.
 """
 
 import logging
+import re
 from typing import Any, NamedTuple, Optional, cast
 
 from ..models import (
@@ -25,12 +26,15 @@ from ..models import (
     HookAttachmentMessage,
     ImageContent,
     MessageContent,
+    TeammateMessage,
+    TeammateMessageBlock,
     TextContent,
     UserSteeringMessage,
     UserTextMessage,
 )
 from ..parser import extract_text_content
 from .meta_factory import create_meta
+from .teammate_factory import ATTR_RUN, SYSTEM_ID
 from .transcript_factory import USER_CONTENT_TYPES, create_message_content
 from .user_factory import create_user_message
 
@@ -174,6 +178,20 @@ def queued_command_prompt_items(
     )
 
 
+_AGENT_MESSAGE_WRAPPER_RE = re.compile(
+    rf"^\s*<agent-message\b{ATTR_RUN}>\s*(.*?)(?:\s*</agent-message>)?\s*$",
+    re.DOTALL,
+)
+
+
+def _strip_agent_message_wrapper(text: str) -> str:
+    """Strip outer ``<agent-message ...>`` wrapper tags if present."""
+    match = _AGENT_MESSAGE_WRAPPER_RE.match(text)
+    if match:
+        return match.group(1)
+    return text.strip()
+
+
 def _create_queued_command_message(
     transcript: AttachmentTranscriptEntry,
     payload: dict[str, Any],
@@ -187,8 +205,13 @@ def _create_queued_command_message(
     ``queued_command`` is seen). The steering text lives in
     ``payload["prompt"]``.
 
-    The text is routed through :func:`create_user_message` so it gets
-    the same classification + plugin-transformer pass as an
+    If the delivery carries ``origin.kind == "peer"`` (issue #309), it is
+    promoted to a ``TeammateMessage`` attributing the card to the sending
+    agent, using ``origin.body`` (or stripped ``prompt`` as fallback) and
+    recording ``origin.senderTaskId``.
+
+    Otherwise, the text is routed through :func:`create_user_message` so
+    it gets the same classification + plugin-transformer pass as an
     idle-delivered user prompt: a ``[monitor] …`` steering injection
     renders as the same demoted marker as its non-steering siblings. If
     no transformer rewrites it (the result is a *plain*
@@ -216,6 +239,32 @@ def _create_queued_command_message(
         )
 
     meta = create_meta(transcript)
+
+    origin_payload = payload.get("origin")
+    if isinstance(origin_payload, dict):
+        origin = cast(dict[str, Any], origin_payload)
+        if origin.get("kind") == "peer":
+            sender_val = origin.get("from") or origin.get("name")
+            sender = str(sender_val) if sender_val is not None else ""
+            sender_task_id_val = origin.get("senderTaskId")
+            sender_task_id = (
+                str(sender_task_id_val) if isinstance(sender_task_id_val, str) else None
+            )
+            body_val = origin.get("body")
+            body: str
+            if isinstance(body_val, str):
+                body = body_val
+            else:
+                text = extract_text_content(prompt.items)
+                body = _strip_agent_message_wrapper(text)
+            block = TeammateMessageBlock(
+                teammate_id=sender,
+                body=body,
+                sender_task_id=sender_task_id,
+                is_system=(sender == SYSTEM_ID),
+            )
+            return TeammateMessage(meta=meta, blocks=[block])
+
     result = create_user_message(
         meta,
         prompt.items,

--- a/claude_code_log/factories/teammate_factory.py
+++ b/claude_code_log/factories/teammate_factory.py
@@ -43,7 +43,6 @@ from ..models import (
 # and the matching quote — anything else is in the value. The original
 # naïve ``[^>]*`` truncated openings at the first literal ``>``.
 ATTR_RUN = r'(?:\s+[\w][\w-]*(?:\s*=\s*(?:"[^"<]*"|\'[^\'<]*\'))?)*\s*'
-_ATTR_RUN = ATTR_RUN
 
 # One full <teammate-message ...>...</teammate-message> block. Attribute
 # parsing happens on the opening tag's attribute run (captured group 1).
@@ -58,7 +57,6 @@ _ATTR_RE = re.compile(r'(\w[\w-]*)\s*=\s*"([^"]*)"|(\w[\w-]*)\s*=\s*\'([^\']*)\'
 
 # System teammate_id marks terminate/status notifications.
 SYSTEM_ID = "system"
-_SYSTEM_ID = SYSTEM_ID
 
 
 def has_teammate_message(text: str) -> bool:
@@ -77,7 +75,7 @@ def iter_teammate_blocks(text: str) -> Iterable[TeammateMessageBlock]:
             body=body,
             color=attrs.get("color"),
             summary=attrs.get("summary"),
-            is_system=(teammate_id == _SYSTEM_ID),
+            is_system=(teammate_id == SYSTEM_ID),
         )
 
 

--- a/claude_code_log/factories/teammate_factory.py
+++ b/claude_code_log/factories/teammate_factory.py
@@ -42,13 +42,14 @@ from ..models import (
 # ("15% -> 96% coverage"), so the only character we reject is ``<``
 # and the matching quote — anything else is in the value. The original
 # naïve ``[^>]*`` truncated openings at the first literal ``>``.
-_ATTR_RUN = r'(?:\s+[\w][\w-]*(?:\s*=\s*(?:"[^"<]*"|\'[^\'<]*\'))?)*\s*'
+ATTR_RUN = r'(?:\s+[\w][\w-]*(?:\s*=\s*(?:"[^"<]*"|\'[^\'<]*\'))?)*\s*'
+_ATTR_RUN = ATTR_RUN
 
 # One full <teammate-message ...>...</teammate-message> block. Attribute
 # parsing happens on the opening tag's attribute run (captured group 1).
 # Using DOTALL so the body may contain newlines (typically does).
 _BLOCK_RE = re.compile(
-    rf"<teammate-message\b({_ATTR_RUN})>(.*?)</teammate-message>",
+    rf"<teammate-message\b({ATTR_RUN})>(.*?)</teammate-message>",
     re.DOTALL,
 )
 
@@ -56,7 +57,8 @@ _BLOCK_RE = re.compile(
 _ATTR_RE = re.compile(r'(\w[\w-]*)\s*=\s*"([^"]*)"|(\w[\w-]*)\s*=\s*\'([^\']*)\'')
 
 # System teammate_id marks terminate/status notifications.
-_SYSTEM_ID = "system"
+SYSTEM_ID = "system"
+_SYSTEM_ID = SYSTEM_ID
 
 
 def has_teammate_message(text: str) -> bool:

--- a/claude_code_log/models.py
+++ b/claude_code_log/models.py
@@ -930,10 +930,14 @@ class UserSteeringMessage(UserTextMessage):
 
 @dataclass
 class TeammateMessageBlock:
-    """A single <teammate-message> block extracted from a User entry.
+    """A single <teammate-message> block extracted from a User entry
+    or from a peer agent queued_command attachment (#309).
 
     `is_system=True` corresponds to blocks with teammate_id="system"
     (e.g. teammate_terminated notifications).
+    `sender_task_id` is recorded for a future subagent transcript linker
+    (resolves to <session>/subagents/agent-<id>.jsonl when present; absent
+    on roughly a quarter of peer messages; unused by renderers today).
 
     This is a plain data container — the renderer-facing MessageContent
     wrapper is TeammateMessage (which holds one or more of these blocks).
@@ -944,6 +948,7 @@ class TeammateMessageBlock:
     color: Optional[str] = None
     summary: Optional[str] = None
     is_system: bool = False
+    sender_task_id: Optional[str] = None
 
 
 @dataclass

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -841,8 +841,7 @@ class TestPeerQueuedCommand:
             ]
         )
         assert "System notification." in html
-        assert "system" in html
-        assert "teammate-system" in html
+        assert 'class="teammate-message teammate-system"' in html
 
     def test_human_and_absent_origin_keep_user_steering_card(self):
         """Human origins (or absent origin keys) continue to render as

--- a/test/test_steering_queued_command.py
+++ b/test/test_steering_queued_command.py
@@ -113,20 +113,36 @@ def _remove(text, *, sid=_SID):
     }
 
 
-def _queued_command(uuid, parent, prompt, *, version=_MODERN, sid=_SID, paste_ids=None):
+_DEFAULT_ORIGIN = {"kind": "human"}
+_NO_ORIGIN = object()
+
+
+def _queued_command(
+    uuid,
+    parent,
+    prompt,
+    *,
+    version=_MODERN,
+    sid=_SID,
+    paste_ids=None,
+    origin=_DEFAULT_ORIGIN,
+):
     """Modern in-DAG queued_command attachment paired with a 'remove'.
 
     ``prompt=None`` omits the prompt key entirely (a promptless, non-
     renderable attachment). ``paste_ids`` sets ``imagePasteIds`` *inside the
     attachment payload* — this record is its own carrier, unlike a user entry
     where the field sits at top level beside ``message``.
+    ``origin`` controls the ``origin`` payload dict (pass ``origin=_NO_ORIGIN``
+    to omit the key entirely for older transcript tests).
     """
     attachment = {
         "type": "queued_command",
         "commandMode": "prompt",
-        "origin": {"kind": "human"},
         "timestamp": "2026-07-11T07:00:00.000Z",
     }
+    if origin is not _NO_ORIGIN:
+        attachment["origin"] = origin
     if prompt is not None:
         attachment["prompt"] = prompt
     if paste_ids is not None:
@@ -153,6 +169,20 @@ def _render(entries, title="Steering Test"):
     try:
         messages = load_transcript(path)
         return generate_html(messages, title)
+    finally:
+        path.unlink()
+
+
+def _render_markdown(entries, title="Steering Test"):
+    from claude_code_log.markdown.renderer import MarkdownRenderer
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+        path = Path(f.name)
+    try:
+        messages = load_transcript(path)
+        return MarkdownRenderer().generate(messages, title)
     finally:
         path.unlink()
 
@@ -681,3 +711,165 @@ class TestSteeringPasteIds:
         assert html.index("ZZBLOCKBETAZZ") < html.index("ZZBLOCKALPHAZZ"), (
             "placeholders resolved positionally, not from the recorded ids"
         )
+
+
+# --------------------------------------------------------------------------
+# (e) Peer agent messages (origin.kind == "peer", issue #309)
+# --------------------------------------------------------------------------
+class TestPeerQueuedCommand:
+    """Peer agent messages arrive as queued_command attachments carrying
+    origin.kind == 'peer'. They must render as TeammateMessage cards attributed
+    to the sender agent without leaked markup.
+    """
+
+    def test_peer_queued_command_renders_as_teammate_message_in_html(self):
+        """A peer queued_command attachment renders as a TeammateMessage card:
+        attributed to the sending agent with no leaked <agent-message> tags, and
+        is not labeled 'User (steering)'.
+        """
+        origin = {
+            "kind": "peer",
+            "from": "dep-scan-03",
+            "senderTaskId": "adep-scan-03-fbd685bdcccfa4ce",
+            "name": "dep-scan-03",
+            "body": "DEBUG_HTML — 11 matches. All paths relative to root.",
+        }
+        prompt = (
+            '<agent-message from="dep-scan-03">\n'
+            "DEBUG_HTML — 11 matches. All paths relative to root.\n"
+            "</agent-message>"
+        )
+        html = _render(
+            [
+                _user("u1", None, "start scan"),
+                _assistant("a1", "u1", "scanning"),
+                _queued_command("qc1", "a1", prompt, origin=origin),
+                _assistant("a2", "qc1", "processing peer result"),
+            ]
+        )
+
+        # Misattribution fixed: not attributed to human steering.
+        assert "User (steering)" not in html
+
+        # Sender identity attributed in the badge.
+        assert "dep-scan-03" in html
+
+        # Clean body text rendered.
+        assert "DEBUG_HTML — 11 matches. All paths relative to root." in html
+
+        # No markup leaked.
+        assert "<agent-message" not in html
+        assert "&lt;agent-message" not in html
+        assert "</agent-message>" not in html
+        assert "&lt;/agent-message&gt;" not in html
+
+        # Teammate card structure is present.
+        assert "teammate-message" in html
+        assert "teammate-badge" in html
+
+    def test_peer_queued_command_renders_in_markdown(self):
+        """Markdown output renders the peer message with sender attribution
+        and blockquoted body, without leaked tags.
+        """
+        origin = {
+            "kind": "peer",
+            "from": "dep-scan-03",
+            "senderTaskId": "adep-scan-03-fbd685bdcccfa4ce",
+            "name": "dep-scan-03",
+            "body": "DEBUG_HTML — 11 matches. All paths relative to root.",
+        }
+        prompt = (
+            '<agent-message from="dep-scan-03">\n'
+            "DEBUG_HTML — 11 matches. All paths relative to root.\n"
+            "</agent-message>"
+        )
+        md = _render_markdown(
+            [
+                _user("u1", None, "start scan"),
+                _assistant("a1", "u1", "scanning"),
+                _queued_command("qc1", "a1", prompt, origin=origin),
+                _assistant("a2", "qc1", "processing peer result"),
+            ]
+        )
+
+        assert "<agent-message" not in md
+        assert "dep-scan-03" in md
+        assert "DEBUG_HTML — 11 matches" in md
+
+    def test_peer_fallback_when_body_missing_in_origin(self):
+        """When origin.body is absent, the fallback strips <agent-message>
+        wrapper from prompt text, including when attributes contain '>'
+        (e.g. arrows in summary values).
+        """
+        origin = {
+            "kind": "peer",
+            "from": "dep-scan-03",
+            "senderTaskId": "adep-scan-03-fbd685bdcccfa4ce",
+        }
+        prompt = (
+            '<agent-message from="dep-scan-03" summary="15% -> 96% coverage">\n'
+            "Fallback clean body.\n"
+            "</agent-message>"
+        )
+        html = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _queued_command("qc1", "a1", prompt, origin=origin),
+                _assistant("a2", "qc1", "ok"),
+            ]
+        )
+
+        assert "Fallback clean body." in html
+        assert "<agent-message" not in html
+        assert "&lt;agent-message" not in html
+        assert "96% coverage" not in html
+
+    def test_peer_system_origin_sets_is_system(self):
+        """A peer message with sender 'system' produces is_system=True on the block."""
+        origin = {
+            "kind": "peer",
+            "from": "system",
+            "body": "System notification.",
+        }
+        html = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _queued_command("qc1", "a1", "System notification.", origin=origin),
+                _assistant("a2", "qc1", "ok"),
+            ]
+        )
+        assert "System notification." in html
+        assert "system" in html
+        assert "teammate-system" in html
+
+    def test_human_and_absent_origin_keep_user_steering_card(self):
+        """Human origins (or absent origin keys) continue to render as
+        'User (steering)' cards.
+        """
+        # (1) Explicit origin.kind == "human"
+        html_human = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _queued_command(
+                    "qc1", "a1", "stop immediately", origin={"kind": "human"}
+                ),
+                _assistant("a2", "qc1", "stopping"),
+            ]
+        )
+        assert html_human.count("User (steering)") == 1
+        assert "stop immediately" in html_human
+
+        # (2) Absent origin key (older transcripts)
+        html_no_origin = _render(
+            [
+                _user("u1", None, "start"),
+                _assistant("a1", "u1", "working"),
+                _queued_command("qc1", "a1", "stop immediately", origin=_NO_ORIGIN),
+                _assistant("a2", "qc1", "stopping"),
+            ]
+        )
+        assert html_no_origin.count("User (steering)") == 1
+        assert "stop immediately" in html_no_origin

--- a/work/agent-message-origin.md
+++ b/work/agent-message-origin.md
@@ -1,0 +1,182 @@
+# Peer agent messages render as "User (steering)" (#309)
+
+**Status:** specified, not implemented. Branch `dev/agent-message-origin`,
+based on `dev/agent-spawn-linking` (PR #316).
+
+## The defect
+
+A message sent by a peer agent to the session it reports into is rendered
+as a **"User (steering)"** card — i.e. attributed to the human — with the
+raw wrapper markup visible in the card body:
+
+```
+User (steering)                                    08/15/2026 09:04:06
+<agent-message from="dep-scan-03">
+DEBUG_HTML — 11 matches. All paths relative to …
+```
+
+That screenshot *is* issue #309. Two distinct defects in one card:
+
+1. **Misattribution.** A peer agent's message is shown as the user
+   steering the session. The sender's identity is present in the data and
+   discarded.
+2. **Leaked markup.** The `<agent-message from="…">` wrapper is rendered
+   literally instead of being parsed into card structure — exactly what
+   `<teammate-message>` already avoids.
+
+## Why this sits on top of PR #316, not on `main`
+
+The two changes share no code (see "Files" below) and could land in either
+order. The reason to stack is the **payoff**, not a compile dependency:
+
+`origin.senderTaskId` is an agentId in the *same namespace* that #316
+links, and it resolves to the sender's subagent transcript **29 times out
+of 29** on the reference archive. So the natural finished form of this
+feature — an agent-message card that links through to the sender's
+transcript — only renders as a live link once #316 makes those
+transcripts present. Built on `main` alone, the link target does not
+exist and the feature stops at re-labelling the card.
+
+Build the parsing and attribution so they do **not** require #316; build
+the cross-link so it degrades to plain text when the target is absent.
+
+## The data
+
+The carrier is **not** a message. It is `type: "attachment"` with
+`attachment.type: "queued_command"`:
+
+```json
+{"type": "queued_command",
+ "prompt": "<agent-message from=\"dep-scan-03\">\nDEBUG_HTML — 11 matches…",
+ "commandMode": "prompt",
+ "isMeta": true,
+ "origin": {"kind": "peer",
+            "from": "dep-scan-03",
+            "senderTaskId": "adep-scan-03-fbd685bdcccfa4ce",
+            "name": "dep-scan-03",
+            "body": "DEBUG_HTML — 11 matches…"}}
+```
+
+Everything needed is already parsed in `origin`:
+
+| field | use |
+|---|---|
+| `kind` | discriminator — `"peer"` vs `"human"` |
+| `from` / `name` | sender attribution for the card header |
+| `senderTaskId` | agentId of the sender's `subagents/agent-<id>.jsonl` |
+| `body` | the message **without** the wrapper — no regex needed |
+
+`prompt` carries the wrapper-wrapped form; `origin.body` carries the clean
+body. Prefer `origin.body`, fall back to stripping `prompt`.
+
+## Census (structural, whole reference archive)
+
+`origin.kind` on `queued_command` attachments:
+
+| kind | count | sessions |
+|---|---|---|
+| `human` | 2554 | 83 |
+| *(no `origin` key)* | 2431 | 130 |
+| `peer` | **29** | **3** |
+
+`peer` `senderTaskId` → subagent file: **29 resolved, 0 unresolved.**
+
+> **Measure this structurally, never with a raw-text grep.** The `origin`
+> object is mirrored into a companion `user` entry, so `rg '"kind":"peer"'`
+> double-counts (58 raw vs 29 real). Parse the line, check
+> `type == "attachment"` and `attachment.type == "queued_command"`, then
+> read `attachment.origin.kind`.
+
+### `channel` is out of scope
+
+A third kind, `channel` (6 occurrences, `{"kind":"channel","server":
+"plugin:…"}`), appears **only inside `user` entries and never on a
+`queued_command` attachment**. It is a different delivery path and needs
+its own investigation. Do not fold it into this branch.
+
+## Current behaviour
+
+`claude_code_log/factories/attachment_factory.py` **never reads `origin`** —
+zero references to the key. `_create_queued_command_message` promotes every
+`queued_command` to the same steering message regardless of who sent it,
+so all three kinds collapse into one card type.
+
+## Files
+
+Nothing here overlaps PR #316, which touches
+`converter.py:_link_subagents_by_prompt_hash` /
+`_collect_unresolved_task_results` (roughly lines 636–810).
+
+- `factories/attachment_factory.py` — `_create_queued_command_message`
+  (~L177) and the dispatch at ~L277. The branch point.
+- `models.py` — a message model for a peer message, if the existing
+  steering model cannot carry sender fields.
+- `html/…_formatter.py` + the markdown renderer — **both** output formats
+  need the new card; a change that only lands in HTML is half done.
+- `renderer.py` — CSS class generation, and the timeline's message-type
+  detection in `templates/components/timeline.html` must stay in step
+  (see the note in `CLAUDE.md`).
+
+## Prior art to follow
+
+`<teammate-message>` is the same feature one layer over: see
+`factories/teammate_factory.py` (`has_teammate_message`,
+`iter_teammate_blocks`, `find_team_lead_body`) and
+`html/teammate_formatter.py`. Match its card vocabulary so a peer message
+and a teammate message read as siblings rather than as two inventions.
+
+**But do not copy its parsing.** `teammate_factory` regexes a wrapper out
+of free text because that is all it has. Here `origin` is already
+structured — reaching for the regex would be re-deriving what the harness
+handed you.
+
+## Risks
+
+`work/steering-queued-command.md` is the prior design note for this path
+and documents that it is delicate: plugin transformers rewriting
+`UserTextMessage` subclasses into fields with `items=[]`, an empty-card
+bug, and the `queued_command` ↔ queue-operation `remove` pairing. Read it
+before editing. A change that looks like a small `if` on `origin.kind` can
+interact with all three.
+
+Watch specifically:
+
+- **Do not regress `human`.** It is 2554 of 2583 origin-carrying cases;
+  `peer` is 29. The common path must be untouched.
+- **`origin` absent** (2431 cases, older transcripts) must keep today's
+  behaviour exactly.
+- **Cache.** If the change alters parsed entries, it needs a
+  `breaking_changes` entry in `cache.py` the same way #316 did — a stale
+  cache otherwise serves the old cards. Verify by writing a cache under
+  the old code and reading it back under the new. Note single-file
+  conversion never builds a `CacheManager` (`if use_cache and
+  input_path.is_dir()`), so a single-file render proves nothing about
+  cached behaviour.
+
+## Tests
+
+- Synthetic fixtures in `test/test_data/`, built by hand as in
+  `test_teammates_parsing.py` — a `queued_command` attachment per
+  `origin.kind`: `peer`, `human`, and one with `origin` absent.
+- Assert `peer` produces a sender-attributed card, that no literal
+  `<agent-message` survives into either output format, and that `human`
+  and origin-absent cases are byte-identical to before.
+- **Mutation-check every new guard**: neutralise it and confirm the test
+  goes red. A test that passes with the discriminator disabled is pinning
+  something else.
+- Snapshot updates run serially: `pytest … -n0 --snapshot-update`.
+
+## Reference data
+
+Issue #309 carries the screenshot. The reference session is
+`b149fbff-f9ed-4c50-a5d0-d25ccee5f37f` under a local
+`~/.claude/projects/<project>/` tree; the entry in the screenshot is uuid
+`39fc5996-f5d4-…`. That session has **8** `peer` attachments in its trunk,
+rendering today as 8 "User (steering)" cards, and its
+`subagents/` directory holds the ten `dep-scan-*` transcripts the messages
+come from — which makes it the natural end-to-end check for the
+cross-link once #316 has merged.
+
+Verify a candidate fix against real data as well as fixtures: re-render
+that session and confirm zero literal `<agent-message` occurrences remain
+and the sender names appear as attribution.

--- a/work/agent-message-origin.md
+++ b/work/agent-message-origin.md
@@ -168,14 +168,12 @@ Watch specifically:
 
 ## Reference data
 
-Issue #309 carries the screenshot. The reference session is
-a local session with 8 `peer` attachments in its trunk under a local
-`~/.claude/projects/<project>/` tree; the entry is the entry shown in the
-issue's screenshot. That session has **8** `peer` attachments in its trunk,
-rendering today as 8 "User (steering)" cards, and its
-`subagents/` directory holds the ten `dep-scan-*` transcripts the messages
-come from — which makes it the natural end-to-end check for the
-cross-link once #316 has merged.
+Issue #309 carries the screenshot, and the entry shown in it is the one the
+fixture covers. The reference session lives under a local
+`~/.claude/projects/<project>/` tree and has **8** `peer` attachments in its
+trunk, rendering today as 8 "User (steering)" cards; its `subagents/`
+directory holds the ten `dep-scan-*` transcripts the messages come from —
+which makes it the natural end-to-end check for the cross-link.
 
 Verify a candidate fix against real data as well as fixtures: re-render
 that session and confirm zero literal `<agent-message` occurrences remain

--- a/work/agent-message-origin.md
+++ b/work/agent-message-origin.md
@@ -169,9 +169,9 @@ Watch specifically:
 ## Reference data
 
 Issue #309 carries the screenshot. The reference session is
-`b149fbff-f9ed-4c50-a5d0-d25ccee5f37f` under a local
-`~/.claude/projects/<project>/` tree; the entry in the screenshot is uuid
-`39fc5996-f5d4-…`. That session has **8** `peer` attachments in its trunk,
+a local session with 8 `peer` attachments in its trunk under a local
+`~/.claude/projects/<project>/` tree; the entry is the entry shown in the
+issue's screenshot. That session has **8** `peer` attachments in its trunk,
 rendering today as 8 "User (steering)" cards, and its
 `subagents/` directory holds the ten `dep-scan-*` transcripts the messages
 come from — which makes it the natural end-to-end check for the


### PR DESCRIPTION
## Summary

Closes #309.

Issue #309 shows a peer agent message arriving as a `queued_command` attachment with `origin.kind == "peer"` being rendered as "User (steering)" with the outer `<agent-message>` XML wrapper tags leaked into the card body (the issue screenshot displays the exact fixture uuid covered by our test case).

This change:
- Reuses `TeammateMessage` and `TeammateMessageBlock` for peer `queued_command` attachments.
- Sets `teammate_id` from `origin.from` or `origin.name`, and preserves `sender_task_id` (`origin.senderTaskId`) on `TeammateMessageBlock` for subagent transcript correlation.
- Extracts clean body prose from `origin.body`, with fallback to unwrapping outer `<agent-message>` tags via `ATTR_RUN` from `teammate_factory` (ensuring attribute values containing `>` do not truncate the opening tag).
- Preserves the `is_system` invariant when the peer sender is `system`.
- Preserves existing `UserSteeringMessage` handling for human steering (`origin.kind == "human"`) and legacy origin-less attachments.

## Validation
- Synthetic test suite added in `test/test_steering_queued_command.py` covering HTML and Markdown rendering, attribute parsing with `>`, `is_system` class rendering, and human/absent origin retention.
- Mutation tested: verified that reverting regex or `is_system` logic causes targeted tests to fail.
- All unit, TUI, browser, integration, and benchmark tests pass cleanly (`just ci`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer-agent messages in queued commands are displayed as teammate message cards with sender identity, task information, system status, and message content.
  * Peer-message attribution is supported in HTML and Markdown output.
  * Message wrapper markup is removed from displayed peer-message text.

* **Bug Fixes**
  * Human-authored and legacy queued-command messages continue to appear as user steering cards.
  * Peer messages without message bodies now fall back gracefully.

* **Documentation**
  * Added documentation covering peer-agent message attribution and supported message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->