### PR TITLE
Resolve commit SHAs from one rev-list per repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ export CLAUDE_CODE_LOG_GIT_LINK='https://{host}/{path}/-/commit/{sha}'
 claude-code-log --tui
 ```
 
-Placeholders: `{host}`, `{path}`, `{sha}`. The template fires only when the static map doesn't already know the host, so a mix of GitHub repos + self-hosted GitLab gets correct links from both. SHAs not reachable from any local remote-tracking ref render as plain text — local-only work-in-progress commits never produce broken links. The one exception: if `git` cannot list the repository's commits at all (it fails or times out) while the remote is still known, SHA-shaped tokens are linked as written without that check.
+Placeholders: `{host}`, `{path}`, `{sha}`. The template fires only when the static map doesn't already know the host, so a mix of GitHub repos + self-hosted GitLab gets correct links from both. SHAs not reachable from any local remote-tracking ref render as plain text — local-only work-in-progress commits never produce broken links.
 
 ## Project Hierarchy Output
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ export CLAUDE_CODE_LOG_GIT_LINK='https://{host}/{path}/-/commit/{sha}'
 claude-code-log --tui
 ```
 
-Placeholders: `{host}`, `{path}`, `{sha}`. The template fires only when the static map doesn't already know the host, so a mix of GitHub repos + self-hosted GitLab gets correct links from both. SHAs not reachable from any local remote-tracking ref render as plain text — local-only work-in-progress commits never produce broken links.
+Placeholders: `{host}`, `{path}`, `{sha}`. The template fires only when the static map doesn't already know the host, so a mix of GitHub repos + self-hosted GitLab gets correct links from both. SHAs not reachable from any local remote-tracking ref render as plain text — local-only work-in-progress commits never produce broken links. The one exception: if `git` cannot list the repository's commits at all (it fails or times out) while the remote is still known, SHA-shaped tokens are linked as written without that check.
 
 ## Project Hierarchy Output
 

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -349,7 +349,10 @@ def _commit_for(cwd: str, sha: str) -> Optional[str]:
 
     A miss against a list older than its trust window re-reads the list
     once, so commits fetched since it was read are found; a hit needs no
-    re-read.
+    re-read. The asymmetry is deliberate: a commit that *leaves* the
+    remote (force-push, deleted branch) keeps linking until the process
+    restarts, because re-reading on hits would bring back a ``git`` call
+    per token.
     """
     if not _SHA_SHAPE_RE.fullmatch(sha):
         return None

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -24,11 +24,12 @@ transcript doesn't sprout broken links for work-in-progress branches.
   cost a ``git branch -r --contains`` walk just to learn so (issue
   #327: 549 of those, ~22 ms each, against ~20 ms for the whole list).
 
-- When the list cannot be read at all (``git`` errors or times out)
-  but the remote is known, every SHA-shaped token links unvalidated,
-  as written — forges resolve short SHAs themselves. Both behaviours
-  go through ``_commit_for``, so what counts as a linkable token is
-  decided in one place.
+- When the list cannot be read (``git`` errors or times out), nothing
+  links: an unverifiable token stays plain text, as it did when the
+  per-candidate check failed. Linking unvalidated instead would make
+  every non-commit token a dead link — over a third of them — with
+  nothing on the page saying a check was skipped. ``_commit_for`` is
+  the one place that decides what links.
 
 - The list is held per process and re-read when a lookup misses and
   the list is older than ``_REMOTE_COMMITS_MAX_AGE_SECONDS``, so a
@@ -94,9 +95,8 @@ _HOST_URL_PATTERNS: dict[str, str] = {
 # map misses. Lets users wire up self-hosted GitLab / Gitea / Forgejo
 # / SourceHut etc. with a single template. Placeholders: ``{host}``
 # (parsed from the remote URL), ``{path}`` (owner/repo or
-# group/subgroup/repo), ``{sha}`` (the full SHA; the SHA as written when
-# the commit list is unreadable). The CLI ``--git-link`` flag is a UX
-# convenience that sets this env var.
+# group/subgroup/repo), ``{sha}`` (full SHA). The CLI ``--git-link``
+# flag is a UX convenience that sets this env var.
 _FALLBACK_TEMPLATE_ENV = "CLAUDE_CODE_LOG_GIT_LINK"
 
 # Wall-clock cap on the ``git config`` remote lookup. It is a safety
@@ -114,10 +114,9 @@ _GIT_TIMEOUT_SECONDS = 5
 
 # Wall-clock cap on ``git rev-list --remotes``. Longer than the lookup
 # cap because the walk scales with history (~20 ms at 1.6k commits,
-# ~0.1 s at 13k) and runs once per cwd rather than once per SHA — and
-# because a timeout here is not a silent "no link" but the unvalidated
-# fallback, which links every SHA-shaped token. Slow contention should
-# not flip a render into that mode.
+# ~0.1 s at 13k) and runs once per cwd rather than once per SHA, so a
+# generous cap costs nothing on a normal repo — while a timeout costs
+# every commit link on the page, which stay plain text.
 _GIT_LIST_TIMEOUT_SECONDS = 30
 
 # Floor on how long a commit list is trusted before a lookup miss
@@ -135,10 +134,10 @@ _REMOTE_COMMITS_REREAD_FACTOR = 20.0
 # visits one cwd per project.
 _REMOTE_COMMITS_MAX_CWDS = 32
 
-# What a token must look like to be linked at all — by either behaviour
-# of ``_commit_for``. Mirrors the plugins' ``SHA_PATTERN`` (git's 7-char
-# default abbreviation up to a full SHA-1), so the unvalidated fallback
-# cannot link anything the validated path would not have been asked about.
+# What a token must look like to be linked at all. Mirrors the plugins'
+# ``SHA_PATTERN`` (git's 7-char default abbreviation up to a full SHA-1),
+# so ``resolve_sha`` holds that contract whoever calls it: the prefix
+# search alone would accept uppercase hex and shorter abbreviations.
 _SHA_SHAPE_RE = re.compile(r"[0-9a-f]{7,40}")
 
 # Monotonic clock for list ages; a module attribute so tests can move time.
@@ -232,7 +231,7 @@ class _RemoteCommits:
     fixed ``width`` (20 bytes for SHA-1, 32 for SHA-256): one bytes
     object at the id's own size, rather than a list of ~90-byte hex
     strings — every render worker holds its own copy. ``ids is None``
-    means the list could not be read (see ``_commit_for``).
+    means the list could not be read, and finds nothing, like an empty one.
     """
 
     ids: Optional[bytes]
@@ -342,32 +341,22 @@ def _remote_commits(cwd: str, *, reread: bool = False) -> _RemoteCommits:
 def _commit_for(cwd: str, sha: str) -> Optional[str]:
     """The commit id to link ``sha`` to, or ``None`` to leave it as text.
 
-    The single definition of what gets linked, in both behaviours:
+    The single definition of what gets linked: a SHA-shaped token that
+    abbreviates exactly one commit reachable from a remote-tracking ref,
+    linked by that commit's full id. Everything else — local-only
+    commits, other repositories' SHAs, task ids, UUID fragments, and
+    every token when the list could not be read — stays plain text.
 
-    - **The commit list is readable** (the normal case): ``sha`` must
-      abbreviate exactly one commit reachable from a remote-tracking
-      ref, and the link carries that commit's full id. Everything else —
-      local-only commits, other repositories' SHAs, task ids, UUID
-      fragments — stays plain text.
-    - **It is not** (``git`` failed or timed out, though the remote is
-      known): nothing can be validated, so every SHA-shaped token links
-      as written. Forges resolve abbreviated SHAs themselves; tokens
-      that are not commits there become dead links, which is the price
-      of not having the list.
-
-    Either way the token must have the SHA shape first. A miss against
-    a list older than its trust window re-reads the list once, so
-    commits fetched since it was read are found; a hit needs no re-read.
+    A miss against a list older than its trust window re-reads the list
+    once, so commits fetched since it was read are found; a hit needs no
+    re-read.
     """
     if not _SHA_SHAPE_RE.fullmatch(sha):
         return None
     commits = _remote_commits(cwd)
     full = commits.find(sha)
     if full is None and commits.is_stale():
-        commits = _remote_commits(cwd, reread=True)
-        full = commits.find(sha)
-    if commits.ids is None:
-        return sha
+        full = _remote_commits(cwd, reread=True).find(sha)
     return full
 
 

--- a/claude_code_log/git_remote.py
+++ b/claude_code_log/git_remote.py
@@ -10,16 +10,30 @@ transcript doesn't sprout broken links for work-in-progress branches.
 
 - ``resolve_sha(cwd, sha)`` is the all-in-one resolver: from a working
   directory, look up ``origin``'s remote URL, classify the host
-  (currently GitHub only), check the SHA is reachable from a
-  remote-tracking branch (``git branch -r --contains``), expand short
-  SHA → full SHA via ``git rev-parse``, and return the canonical
-  commit URL. Returns ``None`` for any failure (no repo, no remote,
-  unknown host, unresolved SHA, etc.).
+  (static map, then the fallback template), find the commit the SHA
+  names, and return the canonical commit URL. Returns ``None`` for any
+  failure (no repo, no remote, unknown host, unresolved SHA, etc.).
 
-- All ``git`` invocations are wrapped in ``functools.lru_cache`` —
-  including the negative cases (``None``/``False`` results) — so a
-  large transcript with hundreds of repeated SHAs only pays the
-  subprocess cost once per (cwd, sha) tuple.
+- Commits are found in **one** ``git rev-list --remotes`` per working
+  directory (``_RemoteCommits``), not one subprocess per candidate: a
+  short SHA resolves by prefix lookup in that sorted list, and an
+  ambiguous prefix stays unresolved, as ``git rev-parse`` would leave
+  it. Set membership answers the negatives for free — and in real
+  transcripts over a third of the SHA-shaped tokens are not commits at
+  all (task ids, UUID fragments, digit runs), each of which used to
+  cost a ``git branch -r --contains`` walk just to learn so (issue
+  #327: 549 of those, ~22 ms each, against ~20 ms for the whole list).
+
+- When the list cannot be read at all (``git`` errors or times out)
+  but the remote is known, every SHA-shaped token links unvalidated,
+  as written — forges resolve short SHAs themselves. Both behaviours
+  go through ``_commit_for``, so what counts as a linkable token is
+  decided in one place.
+
+- The list is held per process and re-read when a lookup misses and
+  the list is older than ``_REMOTE_COMMITS_MAX_AGE_SECONDS``, so a
+  long-lived process (``watch``, the TUI) picks up commits fetched
+  after it started without re-reading on every miss.
 
 - A ``contextvars.ContextVar`` carries the per-render canonical cwd so
   the cached singleton mistune renderers don't have to be rebuilt per
@@ -59,6 +73,10 @@ import functools
 import os
 import re
 import subprocess
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Any, Iterator, Optional
 
 
@@ -76,13 +94,14 @@ _HOST_URL_PATTERNS: dict[str, str] = {
 # map misses. Lets users wire up self-hosted GitLab / Gitea / Forgejo
 # / SourceHut etc. with a single template. Placeholders: ``{host}``
 # (parsed from the remote URL), ``{path}`` (owner/repo or
-# group/subgroup/repo), ``{sha}`` (full 40-char SHA). The CLI
-# ``--git-link`` flag is a UX convenience that sets this env var.
+# group/subgroup/repo), ``{sha}`` (the full SHA; the SHA as written when
+# the commit list is unreadable). The CLI ``--git-link`` flag is a UX
+# convenience that sets this env var.
 _FALLBACK_TEMPLATE_ENV = "CLAUDE_CODE_LOG_GIT_LINK"
 
-# Wall-clock cap on each ``git`` invocation. It is a safety valve, not a
-# budget: the calls are sub-100ms on a normal repo and every one of them
-# is memoized per (cwd, sha), so the cap only ever bites when the
+# Wall-clock cap on the ``git config`` remote lookup. It is a safety
+# valve, not a budget: the call is sub-100ms on a normal repo and
+# memoized per cwd, so the cap only ever bites when the
 # environment — not the repo — is pathologically slow. It was 2s, which
 # the Windows CI runner exceeded under parallel test workers (git process
 # spawn there is slow enough on its own that ~2s of contention is
@@ -92,6 +111,38 @@ _FALLBACK_TEMPLATE_ENV = "CLAUDE_CODE_LOG_GIT_LINK"
 # codebase and buys ~2.5x headroom without making a genuinely broken git
 # stall a render for long.
 _GIT_TIMEOUT_SECONDS = 5
+
+# Wall-clock cap on ``git rev-list --remotes``. Longer than the lookup
+# cap because the walk scales with history (~20 ms at 1.6k commits,
+# ~0.1 s at 13k) and runs once per cwd rather than once per SHA — and
+# because a timeout here is not a silent "no link" but the unvalidated
+# fallback, which links every SHA-shaped token. Slow contention should
+# not flip a render into that mode.
+_GIT_LIST_TIMEOUT_SECONDS = 30
+
+# Floor on how long a commit list is trusted before a lookup miss
+# re-reads it. Staleness only matters to a long-lived process (``watch``,
+# the TUI) whose transcripts cite commits fetched after it started; the
+# floor bounds the re-reads that the non-commit tokens — a third of the
+# candidates — would otherwise trigger. A list that was slow to read is
+# trusted proportionally longer (``_REMOTE_COMMITS_REREAD_FACTOR`` times
+# its read time), so re-reading costs at most ~5% of wall time.
+_REMOTE_COMMITS_MAX_AGE_SECONDS = 60.0
+_REMOTE_COMMITS_REREAD_FACTOR = 20.0
+
+# Distinct working directories whose commit lists a process holds at
+# once. Each costs 20 bytes per commit; an all-projects run in one process
+# visits one cwd per project.
+_REMOTE_COMMITS_MAX_CWDS = 32
+
+# What a token must look like to be linked at all — by either behaviour
+# of ``_commit_for``. Mirrors the plugins' ``SHA_PATTERN`` (git's 7-char
+# default abbreviation up to a full SHA-1), so the unvalidated fallback
+# cannot link anything the validated path would not have been asked about.
+_SHA_SHAPE_RE = re.compile(r"[0-9a-f]{7,40}")
+
+# Monotonic clock for list ages; a module attribute so tests can move time.
+_now = time.monotonic
 
 
 # SSH form ``git@host:path`` or HTTPS ``https://host/path``. The trailing
@@ -169,50 +220,155 @@ def _git_remote_for(cwd: str) -> Optional[tuple[str, str]]:
     return _parse_git_url(result.stdout.strip())
 
 
-@functools.lru_cache(maxsize=4096)
-def _commit_reachable_from_remote(cwd: str, sha: str) -> bool:
-    """Whether ``sha`` is reachable from any remote-tracking branch.
+@dataclass(frozen=True)
+class _RemoteCommits:
+    """Every commit reachable from a remote-tracking ref of one cwd.
 
     Uses local refs only — no network round-trip. Trades freshness for
-    speed: if the user pushed a commit and hasn't fetched since,
-    ``--contains`` won't see it on a remote-tracking branch and we'll
-    render it as plain text. Documented elsewhere; the fallback is
-    correct (no broken links).
+    speed: a commit pushed but not yet fetched isn't on a remote-tracking
+    ref, so it renders as plain text (no broken link).
+
+    ``ids`` holds the binary object ids, sorted and concatenated at a
+    fixed ``width`` (20 bytes for SHA-1, 32 for SHA-256): one bytes
+    object at the id's own size, rather than a list of ~90-byte hex
+    strings — every render worker holds its own copy. ``ids is None``
+    means the list could not be read (see ``_commit_for``).
     """
+
+    ids: Optional[bytes]
+    width: int
+    read_at: float
+    trusted_for: float
+
+    def is_stale(self) -> bool:
+        return _now() - self.read_at >= self.trusted_for
+
+    def find(self, sha: str) -> Optional[str]:
+        """The full id of the one commit ``sha`` abbreviates, else ``None``.
+
+        ``None`` both when no commit starts with ``sha`` and when several
+        do: an ambiguous abbreviation stays unresolved, as ``git
+        rev-parse`` leaves it. Ambiguity is judged among the listed
+        commits only, where git also counts local-only commits and other
+        objects — so a prefix shared with an unpushed commit now links to
+        the pushed one instead of to nothing.
+        """
+        ids, width = self.ids, self.width
+        if not ids or len(sha) > 2 * width:
+            return None
+        # Every id starting with ``sha`` lies in [low, high].
+        low = bytes.fromhex(sha.ljust(2 * width, "0"))
+        high = bytes.fromhex(sha.ljust(2 * width, "f"))
+        count = len(ids) // width
+        lo, hi = 0, count
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if ids[mid * width : (mid + 1) * width] < low:
+                lo = mid + 1
+            else:
+                hi = mid
+        first = ids[lo * width : (lo + 1) * width]
+        if lo == count or first > high:
+            return None
+        if lo + 1 < count and ids[(lo + 1) * width : (lo + 2) * width] <= high:
+            return None
+        return first.hex()
+
+
+def _read_remote_commits(cwd: str) -> _RemoteCommits:
+    """One ``git rev-list --remotes`` for ``cwd``, as a ``_RemoteCommits``."""
+    started = _now()
+    ids: Optional[bytes] = None
+    width = 20
     try:
         result = subprocess.run(
-            ["git", "-C", cwd, "branch", "-r", "--contains", sha],
+            ["git", "-C", cwd, "rev-list", "--remotes"],
             capture_output=True,
             text=True,
-            timeout=_GIT_TIMEOUT_SECONDS,
+            timeout=_GIT_LIST_TIMEOUT_SECONDS,
             check=False,
         )
     except (OSError, subprocess.SubprocessError):
-        return False
-    return result.returncode == 0 and bool(result.stdout.strip())
+        result = None
+    if result is not None and result.returncode == 0:
+        lines = result.stdout.split()
+        if lines:
+            width = len(lines[0]) // 2
+        try:
+            decoded = sorted(bytes.fromhex(line) for line in lines)
+        except ValueError:
+            decoded = None
+        if decoded is not None and all(len(i) == width for i in decoded):
+            ids = b"".join(decoded)
+    finished = _now()
+    return _RemoteCommits(
+        ids=ids,
+        width=width,
+        read_at=finished,
+        trusted_for=max(
+            _REMOTE_COMMITS_MAX_AGE_SECONDS,
+            _REMOTE_COMMITS_REREAD_FACTOR * (finished - started),
+        ),
+    )
 
 
-@functools.lru_cache(maxsize=4096)
-def _expand_to_full_sha(cwd: str, sha: str) -> Optional[str]:
-    """Resolve a (possibly short) SHA to its full 40-char form.
+_remote_commits_by_cwd: OrderedDict[str, _RemoteCommits] = OrderedDict()
+_remote_commits_lock = threading.Lock()
 
-    The ``^{commit}`` peeling makes this fail cleanly when ``sha`` is
-    actually a tag or other ref name we shouldn't link to as a commit.
+
+def _remote_commits(cwd: str, *, reread: bool = False) -> _RemoteCommits:
+    """The held commit list for ``cwd``, reading it on first use.
+
+    ``reread`` forces a fresh read (the caller has decided the held list
+    is stale). Bounded to ``_REMOTE_COMMITS_MAX_CWDS`` lists, least
+    recently used evicted first.
     """
-    try:
-        result = subprocess.run(
-            ["git", "-C", cwd, "rev-parse", "--verify", f"{sha}^{{commit}}"],
-            capture_output=True,
-            text=True,
-            timeout=_GIT_TIMEOUT_SECONDS,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
+    with _remote_commits_lock:
+        held = None if reread else _remote_commits_by_cwd.get(cwd)
+        if held is not None:
+            _remote_commits_by_cwd.move_to_end(cwd)
+            return held
+    # Read outside the lock: a slow ``git`` must not serialize other
+    # cwds. Two threads racing on one cwd both read; the last one wins.
+    held = _read_remote_commits(cwd)
+    with _remote_commits_lock:
+        _remote_commits_by_cwd[cwd] = held
+        _remote_commits_by_cwd.move_to_end(cwd)
+        while len(_remote_commits_by_cwd) > _REMOTE_COMMITS_MAX_CWDS:
+            _remote_commits_by_cwd.popitem(last=False)
+    return held
+
+
+def _commit_for(cwd: str, sha: str) -> Optional[str]:
+    """The commit id to link ``sha`` to, or ``None`` to leave it as text.
+
+    The single definition of what gets linked, in both behaviours:
+
+    - **The commit list is readable** (the normal case): ``sha`` must
+      abbreviate exactly one commit reachable from a remote-tracking
+      ref, and the link carries that commit's full id. Everything else —
+      local-only commits, other repositories' SHAs, task ids, UUID
+      fragments — stays plain text.
+    - **It is not** (``git`` failed or timed out, though the remote is
+      known): nothing can be validated, so every SHA-shaped token links
+      as written. Forges resolve abbreviated SHAs themselves; tokens
+      that are not commits there become dead links, which is the price
+      of not having the list.
+
+    Either way the token must have the SHA shape first. A miss against
+    a list older than its trust window re-reads the list once, so
+    commits fetched since it was read are found; a hit needs no re-read.
+    """
+    if not _SHA_SHAPE_RE.fullmatch(sha):
         return None
-    if result.returncode != 0:
-        return None
-    full = result.stdout.strip()
-    return full if len(full) == 40 else None
+    commits = _remote_commits(cwd)
+    full = commits.find(sha)
+    if full is None and commits.is_stale():
+        commits = _remote_commits(cwd, reread=True)
+        full = commits.find(sha)
+    if commits.ids is None:
+        return sha
+    return full
 
 
 def _fallback_template() -> Optional[str]:
@@ -226,10 +382,10 @@ def _fallback_template() -> Optional[str]:
     eagerly with a loud error; this function is the defence-in-depth
     for the env-var-only path.
 
-    Note: ``resolve_sha`` is ``@lru_cache``-d, so flipping
-    ``CLAUDE_CODE_LOG_GIT_LINK`` mid-process won't re-resolve
-    already-cached SHAs. Call ``clear_resolver_caches()`` after
-    mutating the env var (the test fixtures already do).
+    Read on every resolve for a host the static map misses, so flipping
+    ``CLAUDE_CODE_LOG_GIT_LINK`` mid-process takes effect for SHAs
+    rendered afterwards — though the Markdown memo (``render_cache``)
+    still serves text it already rendered.
     """
     template = os.environ.get(_FALLBACK_TEMPLATE_ENV, "").strip()
     if not template:
@@ -239,7 +395,6 @@ def _fallback_template() -> Optional[str]:
     return template
 
 
-@functools.lru_cache(maxsize=4096)
 def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
     """Resolve a candidate SHA to a commit URL on a known remote.
 
@@ -249,14 +404,14 @@ def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
     - cwd isn't inside a git repo, or has no ``origin`` remote.
     - Remote URL doesn't match any host in ``_HOST_URL_PATTERNS``
       *and* no usable fallback template is set in the environment.
-    - SHA isn't reachable from any local remote-tracking branch.
-    - SHA can't be expanded to a full commit (e.g. it was actually a
-      tag, or shadows a non-commit ref).
+    - ``_commit_for`` declines it: not SHA-shaped, or — when the commit
+      list is readable — not an unambiguous abbreviation of a commit
+      reachable from a remote-tracking ref.
 
     The static host map is consulted first; the fallback template
-    fills in for self-hosted forges (in-house GitLab etc.). All
-    steps are cached, so repeated SHAs in one transcript pay cost
-    only on first encounter.
+    fills in for self-hosted forges (in-house GitLab etc.). Not
+    memoized itself: its ``git`` costs are (the remote per cwd, the
+    commit list per cwd), and what remains is a prefix search.
     """
     if not cwd:
         return None
@@ -273,13 +428,11 @@ def resolve_sha(cwd: Optional[str], sha: str) -> Optional[str]:
         if fallback is None:
             return None
         template = fallback
-    if not _commit_reachable_from_remote(cwd, sha):
-        return None
-    full = _expand_to_full_sha(cwd, sha)
-    if full is None:
+    commit = _commit_for(cwd, sha)
+    if commit is None:
         return None
     try:
-        return template.format(host=host, path=path, sha=full)
+        return template.format(host=host, path=path, sha=commit)
     except (KeyError, IndexError, ValueError):
         # Template has an unknown placeholder (``{foo}``), a positional
         # ``{0}``, or unbalanced braces. The CLI handler whitelists
@@ -355,13 +508,13 @@ def canonical_cwd_from_messages(messages: list[Any]) -> Optional[str]:
 
 
 def clear_resolver_caches() -> None:
-    """Drop all LRU caches in this module.
+    """Drop the remote lookups and commit lists this module holds.
 
     Useful for tests that mock subprocess and need each test to start
     from a clean cache state, and for long-running processes (e.g. the
-    TUI) where the user may swap branches and want stale URLs flushed.
+    TUI) that want a changed remote or freshly fetched commits seen
+    before the lists' own re-read window.
     """
     _git_remote_for.cache_clear()
-    _commit_reachable_from_remote.cache_clear()
-    _expand_to_full_sha.cache_clear()
-    resolve_sha.cache_clear()
+    with _remote_commits_lock:
+        _remote_commits_by_cwd.clear()

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -793,12 +793,13 @@ class _GitCalls:
         import claude_code_log.git_remote as gr
 
         self.subcommands: list[str] = []
+        self.fail = fail
         real_run = subprocess.run
 
         def run(argv, *args, **kwargs):
             # argv is ["git", "-C", cwd, <subcommand>, ...]
             self.subcommands.append(argv[3])
-            if argv[3] == fail:
+            if argv[3] == self.fail:
                 raise subprocess.TimeoutExpired(argv, 30)
             return real_run(argv, *args, **kwargs)
 
@@ -853,31 +854,42 @@ class TestRemoteCommitResolution:
         assert calls.subcommands == ["config", "rev-list"]
 
     def test_repository_with_no_remote_refs_links_nothing(self, tmp_path):
-        """An empty list is a readable list: nothing is pushed, so
-        nothing links — not the unvalidated fallback."""
+        """Nothing fetched, so nothing is pushed, so nothing links."""
         _git(tmp_path, "init", "-q")
         _git(tmp_path, "remote", "add", "origin", "https://github.com/owner/repo")
         commit = _commit(tmp_path, "never fetched")
         assert resolve_sha(str(tmp_path), commit[:7]) is None
         assert resolve_sha(str(tmp_path), "deadbee") is None
 
-    def test_unreadable_list_links_sha_shaped_tokens_as_written(
+    def test_unreadable_list_links_nothing_until_a_read_succeeds(
         self, tmp_path, monkeypatch
     ):
-        repo = _Repo(tmp_path)
-        _GitCalls(monkeypatch, fail="rev-list")
-        # Nothing can be validated: a pushed commit, a local one and a
-        # token that is no commit at all all link, as written.
-        for token in (repo.pushed[0][:7], repo.local[:7], "deadbee"):
-            assert resolve_sha(repo.cwd, token) == _url(token)
+        """A failed ``rev-list`` leaves every token plain text — not
+        linked unvalidated, which would make each non-commit token a
+        dead link — and a later stale miss retries the read."""
+        import claude_code_log.git_remote as gr
 
-    def test_unvalidated_fallback_still_requires_the_sha_shape(
-        self, tmp_path, monkeypatch
-    ):
-        """Both behaviours share one definition of a linkable token."""
         repo = _Repo(tmp_path)
-        _GitCalls(monkeypatch, fail="rev-list")
-        for token in ("DEADBEE", "abc123", "g123456", "a" * 41, "abc1234 "):
+        calls = _GitCalls(monkeypatch, fail="rev-list")
+        for token in (repo.pushed[0][:7], repo.pushed[1], "deadbee"):
+            assert resolve_sha(repo.cwd, token) is None
+        assert calls.count("rev-list") == 1
+
+        calls.fail = None
+        start = gr._now()
+        monkeypatch.setattr(
+            gr, "_now", lambda: start + gr._REMOTE_COMMITS_MAX_AGE_SECONDS + 1
+        )
+        assert resolve_sha(repo.cwd, repo.pushed[0][:7]) == _url(repo.pushed[0])
+        assert calls.count("rev-list") == 2
+
+    def test_only_sha_shaped_tokens_link(self, tmp_path):
+        """The shape contract holds even for tokens the prefix search
+        would accept: uppercase hex and abbreviations under 7 chars."""
+        repo = _Repo(tmp_path)
+        pushed = repo.pushed[0]
+        assert resolve_sha(repo.cwd, pushed[:7]) == _url(pushed)
+        for token in (pushed[:7].upper(), pushed[:6], pushed[:7] + " "):
             assert resolve_sha(repo.cwd, token) is None
 
     def test_commit_fetched_later_is_found_once_the_list_is_stale(

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -484,22 +484,21 @@ class TestRenderRepoContext:
 # Forge templates: static map + env-var fallback
 #
 # The resolver's URL-shape logic is unit-tested here by stubbing the
-# three subprocess-backed helpers (``_git_remote_for``,
-# ``_commit_reachable_from_remote``, ``_expand_to_full_sha``). This
+# two git-backed helpers (``_git_remote_for``, ``_commit_for``). This
 # isolates the host-classification + template-substitution logic
-# from the actual git plumbing — the integration class below covers
-# end-to-end resolution against this repo's real origin/main.
+# from the actual git plumbing — ``TestRemoteCommitResolution`` covers
+# commit lookup against throwaway repositories, and the integration
+# class below end-to-end resolution against this repo's real origin/main.
 
 
 class _StubResolverEnv:
-    """Monkeypatch fixture: pin the subprocess-backed helpers to known
+    """Monkeypatch fixture: pin the git-backed helpers to known
     answers so resolve_sha tests just exercise the URL-shape logic.
 
-    The three patched functions correspond to the three subprocess
-    boundaries inside resolve_sha:
+    The two patched functions correspond to the two git boundaries
+    inside resolve_sha:
     - ``_git_remote_for`` → (host, path) parsing
-    - ``_commit_reachable_from_remote`` → reachability check
-    - ``_expand_to_full_sha`` → short → full SHA peel
+    - ``_commit_for`` → which commit id the link carries
     """
 
     def __init__(self, monkeypatch, host: str, path: str, full_sha: str):
@@ -507,10 +506,7 @@ class _StubResolverEnv:
 
         clear_resolver_caches()
         monkeypatch.setattr(gr, "_git_remote_for", lambda _cwd: (host, path))
-        monkeypatch.setattr(
-            gr, "_commit_reachable_from_remote", lambda _cwd, _sha: True
-        )
-        monkeypatch.setattr(gr, "_expand_to_full_sha", lambda _cwd, _sha: full_sha)
+        monkeypatch.setattr(gr, "_commit_for", lambda _cwd, _sha: full_sha)
 
 
 class TestStaticForgeMap:
@@ -727,6 +723,263 @@ class TestGitLinkCliOption:
         # Click usage errors exit with 2.
         assert result.exit_code == 2
         assert "must contain a {sha} placeholder" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Commit lookup: one ``git rev-list --remotes`` per cwd (issue #327)
+#
+# Throwaway repositories rather than this one, so the pushed / local-only
+# split is known exactly: ``origin/main`` is set with ``update-ref``, no
+# network and no real remote involved.
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        [
+            "git",
+            "-C",
+            str(cwd),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "commit", "-q", "--allow-empty", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+class _Repo:
+    """A repository whose ``origin`` is github.com/owner/repo, with two
+    commits on ``origin/main`` and one local-only commit on top."""
+
+    def __init__(self, path: Path, *init_args: str):
+        self.path = path
+        _git(path, "init", "-q", *init_args)
+        _git(path, "remote", "add", "origin", "https://github.com/owner/repo.git")
+        self.pushed = [_commit(path, "one"), _commit(path, "two")]
+        _git(path, "update-ref", "refs/remotes/origin/main", self.pushed[-1])
+        self.local = _commit(path, "local only")
+
+    @property
+    def cwd(self) -> str:
+        return str(self.path)
+
+    def absent_prefix(self, candidate: str) -> str:
+        """``candidate``, after checking no commit here starts with it."""
+        assert not any(c.startswith(candidate) for c in [*self.pushed, self.local]), (
+            f"{candidate} happens to prefix a commit in the test repo"
+        )
+        return candidate
+
+
+def _url(sha: str) -> str:
+    return "https://github.com/owner/repo/commit/" + sha
+
+
+class _GitCalls:
+    """Count ``git`` subcommands the resolver runs, passing them through."""
+
+    def __init__(self, monkeypatch, fail: Optional[str] = None):
+        import claude_code_log.git_remote as gr
+
+        self.subcommands: list[str] = []
+        real_run = subprocess.run
+
+        def run(argv, *args, **kwargs):
+            # argv is ["git", "-C", cwd, <subcommand>, ...]
+            self.subcommands.append(argv[3])
+            if argv[3] == fail:
+                raise subprocess.TimeoutExpired(argv, 30)
+            return real_run(argv, *args, **kwargs)
+
+        monkeypatch.setattr(gr.subprocess, "run", run)
+
+    def count(self, subcommand: str) -> int:
+        return self.subcommands.count(subcommand)
+
+
+class TestRemoteCommitResolution:
+    def setup_method(self):
+        clear_resolver_caches()
+
+    def teardown_method(self):
+        clear_resolver_caches()
+
+    def test_pushed_commit_resolves_from_short_or_full_sha(self, tmp_path):
+        repo = _Repo(tmp_path)
+        for commit in repo.pushed:
+            assert resolve_sha(repo.cwd, commit[:7]) == _url(commit)
+            assert resolve_sha(repo.cwd, commit) == _url(commit)
+
+    def test_local_only_commit_stays_plain(self, tmp_path):
+        repo = _Repo(tmp_path)
+        assert resolve_sha(repo.cwd, repo.local[:7]) is None
+        assert resolve_sha(repo.cwd, repo.local) is None
+
+    def test_tokens_that_are_not_commits_stay_plain(self, tmp_path):
+        repo = _Repo(tmp_path)
+        for token in ("deadbee", "1234567", "a2be84b6ebd150622"):
+            assert resolve_sha(repo.cwd, repo.absent_prefix(token)) is None
+
+    def test_one_rev_list_answers_every_candidate(self, tmp_path, monkeypatch):
+        """The #327 cost: candidates, found or not, spawn no ``git``.
+
+        Before, each distinct candidate ran ``git branch -r --contains``
+        (plus ``rev-parse`` when found) — and over a third of real
+        candidates are not commits, so most of that proved a negative.
+        """
+        repo = _Repo(tmp_path)
+        calls = _GitCalls(monkeypatch)
+        candidates = [
+            repo.pushed[0][:7],
+            repo.pushed[1],
+            repo.local[:9],
+            *(repo.absent_prefix(f"{n:07d}") for n in range(10)),
+            repo.absent_prefix("deadbee"),
+        ]
+        for candidate in candidates:
+            resolve_sha(repo.cwd, candidate)
+        assert calls.count("rev-list") == 1
+        assert calls.subcommands == ["config", "rev-list"]
+
+    def test_repository_with_no_remote_refs_links_nothing(self, tmp_path):
+        """An empty list is a readable list: nothing is pushed, so
+        nothing links — not the unvalidated fallback."""
+        _git(tmp_path, "init", "-q")
+        _git(tmp_path, "remote", "add", "origin", "https://github.com/owner/repo")
+        commit = _commit(tmp_path, "never fetched")
+        assert resolve_sha(str(tmp_path), commit[:7]) is None
+        assert resolve_sha(str(tmp_path), "deadbee") is None
+
+    def test_unreadable_list_links_sha_shaped_tokens_as_written(
+        self, tmp_path, monkeypatch
+    ):
+        repo = _Repo(tmp_path)
+        _GitCalls(monkeypatch, fail="rev-list")
+        # Nothing can be validated: a pushed commit, a local one and a
+        # token that is no commit at all all link, as written.
+        for token in (repo.pushed[0][:7], repo.local[:7], "deadbee"):
+            assert resolve_sha(repo.cwd, token) == _url(token)
+
+    def test_unvalidated_fallback_still_requires_the_sha_shape(
+        self, tmp_path, monkeypatch
+    ):
+        """Both behaviours share one definition of a linkable token."""
+        repo = _Repo(tmp_path)
+        _GitCalls(monkeypatch, fail="rev-list")
+        for token in ("DEADBEE", "abc123", "g123456", "a" * 41, "abc1234 "):
+            assert resolve_sha(repo.cwd, token) is None
+
+    def test_commit_fetched_later_is_found_once_the_list_is_stale(
+        self, tmp_path, monkeypatch
+    ):
+        import claude_code_log.git_remote as gr
+
+        repo = _Repo(tmp_path)
+        assert resolve_sha(repo.cwd, repo.pushed[0][:7]) is not None
+        # "Fetch" a new commit after the list was read.
+        fetched = _commit(tmp_path, "fetched later")
+        _git(tmp_path, "update-ref", "refs/remotes/origin/main", fetched)
+        calls = _GitCalls(monkeypatch)
+
+        # Within the trust window a miss does not re-read: that is what
+        # keeps non-commit tokens from spawning a walk each.
+        assert resolve_sha(repo.cwd, fetched[:7]) is None
+        assert calls.count("rev-list") == 0
+
+        start = gr._now()
+        monkeypatch.setattr(
+            gr, "_now", lambda: start + gr._REMOTE_COMMITS_MAX_AGE_SECONDS + 1
+        )
+        # A hit never re-reads, stale or not ...
+        assert resolve_sha(repo.cwd, repo.pushed[0][:7]) is not None
+        assert calls.count("rev-list") == 0
+        # ... a miss on a stale list re-reads once, and finds the commit.
+        assert resolve_sha(repo.cwd, fetched[:7]) == _url(fetched)
+        assert calls.count("rev-list") == 1
+
+    def test_sha256_repository(self, tmp_path):
+        try:
+            repo = _Repo(tmp_path, "--object-format=sha256")
+        except subprocess.CalledProcessError:
+            pytest.skip("git without SHA-256 repository support")
+        assert len(repo.pushed[0]) == 64
+        assert resolve_sha(repo.cwd, repo.pushed[0][:7]) == _url(repo.pushed[0])
+        assert resolve_sha(repo.cwd, repo.local[:7]) is None
+
+    def test_held_lists_are_bounded_per_cwd(self, monkeypatch):
+        import claude_code_log.git_remote as gr
+
+        reads: list[str] = []
+
+        def read(cwd: str) -> gr._RemoteCommits:
+            reads.append(cwd)
+            return gr._RemoteCommits(
+                ids=b"", width=20, read_at=gr._now(), trusted_for=60.0
+            )
+
+        monkeypatch.setattr(gr, "_read_remote_commits", read)
+        monkeypatch.setattr(gr, "_REMOTE_COMMITS_MAX_CWDS", 2)
+        for cwd in ("a", "b", "a", "c", "a", "b"):
+            gr._remote_commits(cwd)
+        # "a" is refreshed by use, so "c" evicts "b", which is re-read.
+        assert reads == ["a", "b", "c", "b"]
+
+
+class TestRemoteCommitsFind:
+    """Prefix lookup in the sorted id list, on synthetic ids."""
+
+    @staticmethod
+    def _commits(*hexes: str):
+        from claude_code_log.git_remote import _RemoteCommits
+
+        return _RemoteCommits(
+            ids=b"".join(sorted(bytes.fromhex(h) for h in hexes)),
+            width=20,
+            read_at=0.0,
+            trusted_for=float("inf"),
+        )
+
+    def test_ambiguous_prefix_is_unresolved(self):
+        a = "abcdef0" + "1" * 33
+        b = "abcdef0" + "2" * 33
+        commits = self._commits("0" * 40, a, b, "f" * 40)
+        assert commits.find("abcdef0") is None
+        assert commits.find("abcdef01") == a
+        assert commits.find("abcdef02") == b
+
+    def test_first_last_and_absent(self):
+        low, mid, high = "0" * 40, "5" * 40, "f" * 40
+        commits = self._commits(high, mid, low)
+        assert commits.find("0000000") == low
+        assert commits.find("5555555") == mid
+        assert commits.find("fffffff") == high
+        assert commits.find("1111111") is None
+        assert commits.find("5555556") is None
+
+    def test_odd_length_prefix_matches_on_the_nibble(self):
+        commits = self._commits("abcdef7" + "0" * 33, "abcdef8" + "0" * 33)
+        assert commits.find("abcdef7") == "abcdef7" + "0" * 33
+        assert commits.find("abcdef8") == "abcdef8" + "0" * 33
+
+    def test_empty_and_unreadable_lists_find_nothing(self):
+        from claude_code_log.git_remote import _RemoteCommits
+
+        assert self._commits().find("abcdef0") is None
+        unreadable = _RemoteCommits(
+            ids=None, width=20, read_at=0.0, trusted_for=float("inf")
+        )
+        assert unreadable.find("abcdef0") is None
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_commit_linkifier.py
+++ b/test/test_commit_linkifier.py
@@ -888,8 +888,14 @@ class TestRemoteCommitResolution:
         would accept: uppercase hex and abbreviations under 7 chars."""
         repo = _Repo(tmp_path)
         pushed = repo.pushed[0]
-        assert resolve_sha(repo.cwd, pushed[:7]) == _url(pushed)
-        for token in (pushed[:7].upper(), pushed[:6], pushed[:7] + " "):
+        # Uppercasing only changes a prefix with a letter in it; an
+        # all-digit 7-char prefix (~4% of SHAs) is a valid token as is.
+        with_letter = next(
+            (pushed[:n] for n in range(7, 41) if not pushed[:n].isdigit()), pushed
+        )
+        assert with_letter.upper() != with_letter, "all-digit SHA"
+        assert resolve_sha(repo.cwd, with_letter) == _url(pushed)
+        for token in (with_letter.upper(), pushed[:6], pushed[:7] + " "):
             assert resolve_sha(repo.cwd, token) is None
 
     def test_commit_fetched_later_is_found_once_the_list_is_stale(


### PR DESCRIPTION
Closes #327.

Rendering with a git repository in context spent most of its "Markdown rendering" time in `git` subprocesses resolving commit-SHA links. Every distinct SHA-shaped token ran `git branch -r --contains` (plus `git rev-parse` when found), memoised per process, so each render worker repeated the whole set. Over a third of those tokens are not commits at all (task ids, UUID fragments, digit runs), so much of that time went into proving negatives.

### The change

`git_remote.py` now reads `git rev-list --remotes` **once per working directory** and resolves each candidate by prefix search in the sorted list (binary ids in one `bytes` object, 20 bytes per commit; SHA-256 repositories work too). One function, `_commit_for`, owns the rule: a token matching `[0-9a-f]{7,40}` that abbreviates exactly one commit reachable from a remote-tracking ref links by that commit's full id; everything else stays plain text. `resolve_sha`'s interface is unchanged.

### Same answers

- Old and new resolver in one process, over 1788 distinct SHA-shaped tokens from real transcripts of this project: **0 differences**. The old resolver spent 23.8 s on the 568 hits and 14.8 s on the 1220 misses; the new one a 27 ms list read plus ~5 ms of lookups.
- End to end, the rendered pages of a whole project are byte-identical between old and new (below), with 1599 commit links in both.

### Timings

Serial, uncached CLI conversion (`CLAUDE_CODE_LOG_RENDER_JOBS=1`, `--no-cache`, `CLAUDE_CODE_LOG_DEBUG_TIMING=1`) of a frozen 24-file / 40 109-message project, old and new module interleaved:

| run | wall | Markdown bucket | Pygments (control) |
|---|---:|---:|---:|
| old | 59.4 s | 32.1 s | 6.6 s |
| new | 36.9 s | 7.7 s | 7.1 s |
| old | 67.9 s | 36.6 s | 8.3 s |
| new | 37.0 s | 7.4 s | 7.2 s |

The Markdown and Pygments memo hit counts are identical in all four runs, so every run did the same work. The slower old run is slow on every bucket, Pygments included, so its extra time is machine load rather than the resolver. This is a different corpus from the one in #327, so compare the ratio, not the absolute figures.

### Decisions worth knowing

- **Ambiguity is judged among remote-reachable commits only.** Git would also count local-only commits, so a prefix shared by a pushed and an unpushed commit now links to the pushed one instead of to nothing. On this repository: 0 local-only commits whose 7-char prefix collides with a remote one (1589 remote, 275 local-only), and 0 ambiguous 7-char prefixes within the remote set. When it does happen, the result is a link to a real pushed commit, not a broken one.
- **Fail-closed when the list cannot be read.** If `git rev-list` fails or times out (30 s cap, since it runs once per directory), nothing links. Linking every SHA-shaped token unvalidated instead would turn a skipped check into a page of dead links — over a third of candidates are not commits — with nothing saying the check was skipped.
- **Freshness for long-lived processes** (`watch`, the TUI). The old per-token check saw commits fetched after startup; a list read once would not. A lookup miss re-reads the list once it is older than max(60 s, 20x its own read time); a hit never re-reads. So commits that *leave* the remote (force-push, deleted branch) keep linking until restart — deliberate, since re-reading on hits would bring back a `git` call per token. Both directions are pinned by tests.
- **Each render worker reads its own list** rather than being fed one through the pool initializer: ~20 ms here, ~0.1 s on a 13k-commit repository, against ~1 s of spawn and import per worker.

### Unchanged

The **missing-checkout precondition**: a transcript whose working directory no longer exists (or has no `origin`) still gets no commit links, because the remote URL comes from that checkout. Covering it would need the remote URL stored per project or a configured template, which is a separate feature.

### Interaction with #329

#329 replaces the Markdown linkifier that calls this resolver; its *Interaction with #327* section covers the combined tree.

### Review state

Approved at `70c7bca`, rebased onto `6eb8696` as `f383f45` with an identical patch. The approval was given at `7787d9a` and extended across two follow-ups: `8a0d820` is docstring-only (+4/-1 in `_commit_for`, recording the hit/miss asymmetry above; the code with docstrings stripped is AST-identical), and `70c7bca` is test-only (the uppercase shape test no longer depends on the commit's SHA having a letter in its first 7 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBfajJZtCtVDRA7hnMBp3E


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved commit link resolution for short and full commit identifiers.
  - Prevented local-only or ambiguous identifiers from being linked incorrectly.
  - Improved handling for repositories without remote references and repositories using SHA-256.
  - Added more reliable recovery when commit information is temporarily unavailable or outdated.

- **Performance**
  - Reduced repeated repository lookups, improving responsiveness when resolving multiple commit references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->